### PR TITLE
feat: realtime app server replication

### DIFF
--- a/press/patches/v0_0_1/set_document_type_in_plan.py
+++ b/press/patches/v0_0_1/set_document_type_in_plan.py
@@ -7,4 +7,4 @@ import frappe
 
 def execute():
 	frappe.reload_doc("press", "doctype", "plan")
-	frappe.db.sql('update tabPlan set document_type = "Site", interval = "Daily"')
+	frappe.db.sql('update tabPlan set document_type = "Site", `interval` = "Daily"')

--- a/press/playbooks/replication.yml
+++ b/press/playbooks/replication.yml
@@ -1,0 +1,8 @@
+---
+- name: Setup Replication for App Server
+  hosts: all
+  become: yes
+  become_user: root
+  gather_facts: yes
+  roles:
+    - role: lsyncd

--- a/press/playbooks/roles/essentials/tasks/main.yml
+++ b/press/playbooks/roles/essentials/tasks/main.yml
@@ -16,6 +16,7 @@
       - ntp
       - postfix
       - python3-dev
+      - python3-setuptools
       - python3-pip
       - virtualenv
       - redis-server

--- a/press/playbooks/roles/lsyncd/files/lsyncd
+++ b/press/playbooks/roles/lsyncd/files/lsyncd
@@ -1,0 +1,1 @@
+LSYNCD_OPTIONS="/etc/lsyncd/lsyncd.conf.lua"

--- a/press/playbooks/roles/lsyncd/files/lsyncd.service
+++ b/press/playbooks/roles/lsyncd/files/lsyncd.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Live Syncing (Mirror) Daemon
+After=network.target
+
+[Service]
+Type=simple
+User=frappe
+EnvironmentFile=-/etc/default/lsyncd
+ExecStart=/usr/bin/lsyncd -nodaemon $LSYNCD_OPTIONS
+
+[Install]
+WantedBy=multi-user.target

--- a/press/playbooks/roles/lsyncd/tasks/main.yml
+++ b/press/playbooks/roles/lsyncd/tasks/main.yml
@@ -1,0 +1,70 @@
+---
+- name: Remove Primary from Known Hosts
+  known_hosts:
+    name: "{{ replica_server_ip }}"
+    state: absent
+
+- name: Add Primary to Known Hosts
+  shell: ssh-keyscan {{ replica_server_ip }} >> /root/.ssh/known_hosts
+
+- name: install lsyncd
+  apt:
+    state: present
+    force: yes
+    pkg:
+      - lsyncd
+
+- name: Create Logs Directory
+  file:
+    dest: /var/log/lsyncd
+    state: directory
+    owner: frappe
+    group: frappe
+
+- name: Touch log and status files
+  file:
+    dest: /var/log/lsyncd/{{ item }}
+    state: touch
+    owner: frappe
+    group: frappe
+  with_items:
+    - lsyncd.logs
+    - lsyncd.status
+
+- name: Setup environment variables
+  copy:
+    src: files/lsyncd
+    dest: /etc/default/lsyncd
+
+- name: Setup config dir under etc
+  file:
+    dest: /etc/lsyncd
+    state: directory
+
+- name: Add lsyncd config under /etc/lsyncd
+  template:
+    src: lsyncd.conf
+    dest: /etc/lsyncd/lsyncd.conf.lua
+    owner: root
+    group: root
+
+- name: Setup lsyncd service for frappe user
+  copy:
+    src: files/lsyncd.service
+    dest: /etc/systemd/system/lsyncd.service
+
+- name: Get total file count for initial sync
+  shell: 'cd /home/frappe && find . -type f | wc -l'
+  register: file_count
+
+- name: Set max_user_watches
+  sysctl:
+    name: fs.inotify.max_user_watches
+    value: '{{ file_count.stdout | string }}'
+    state: present
+
+- name: Enable and Start lsyncd service
+  systemd:
+    name: lsyncd
+    state: started
+    enabled: True

--- a/press/playbooks/roles/lsyncd/templates/lsyncd.conf
+++ b/press/playbooks/roles/lsyncd/templates/lsyncd.conf
@@ -1,0 +1,26 @@
+settings {
+    logfile = "/var/log/lsyncd/lsyncd.logs",
+    statusFile = "/var/log/lsyncd/lsyncd.status"
+    }
+
+sync{
+    default.rsyncssh,
+    source="/home/frappe",
+    host="{{ replica_server_ip }}",
+    targetdir="/home/frappe/",
+    exclude = {
+        '.ssh/*',
+        '*/bench.egg-info/*' ,
+        'locks/*.lock'
+    },
+    rsync = {
+        archive = true,
+        acls = true,
+        xattrs = true,
+        compress = true,
+        rsh ="/usr/bin/ssh -l frappe -i /home/frappe/.ssh/id_rsa",
+    },
+    ssh = {
+        port = {{ ssh_port }}
+    }
+}

--- a/press/playbooks/setup_authorized_keys.yml
+++ b/press/playbooks/setup_authorized_keys.yml
@@ -1,0 +1,12 @@
+
+- name: Setup SSH Access for frappe user
+  hosts: all
+  become: yes
+  become_user: frappe
+  gather_facts: yes
+  tasks:
+    - name: Add Public Key to Authorized Keys
+      authorized_key:
+        user: frappe
+        key: "{{ frappe_public_key }}"
+        state: present

--- a/press/press/doctype/server/server.js
+++ b/press/press/doctype/server/server.js
@@ -9,6 +9,7 @@ frappe.ui.form.on('Server', {
 			[__('Update Agent'), "update_agent", true, frm.doc.is_server_setup],
 			[__('Setup Server'), "setup_server", true, !frm.doc.is_server_setup],
 			[__('Add to Proxy'), "add_upstream_to_proxy", true, frm.doc.is_server_setup && !frm.doc.is_upstream_setup],
+			[__('Setup Replication'), "setup_replication", true, frm.doc.is_server_setup && frm.doc.is_replica && frm.doc.replication_status!='Active'],
 		].forEach(([label, method, confirm, condition]) => {
 			if (typeof condition === "undefined" || condition) {
 				frm.add_custom_button(

--- a/press/press/doctype/server/server.json
+++ b/press/press/doctype/server/server.json
@@ -24,9 +24,15 @@
   "column_break_16",
   "is_database_client_setup",
   "ssh_section",
+  "ssh_port",
   "root_public_key",
   "column_break_20",
-  "frappe_public_key"
+  "frappe_public_key",
+  "replication_section",
+  "is_replica",
+  "replication_status",
+  "column_break_24",
+  "primary_server"
  ],
  "fields": [
   {
@@ -153,10 +159,47 @@
   {
    "fieldname": "column_break_20",
    "fieldtype": "Column Break"
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval:doc.is_replica",
+   "fieldname": "replication_section",
+   "fieldtype": "Section Break",
+   "label": "Replication"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_replica",
+   "fieldtype": "Check",
+   "label": "Is Replica"
+  },
+  {
+   "fieldname": "column_break_24",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "primary_server",
+   "fieldtype": "Link",
+   "label": "Primary Server",
+   "options": "Server"
+  },
+  {
+   "default": "22",
+   "fieldname": "ssh_port",
+   "fieldtype": "Int",
+   "label": "SSH Port"
+  },
+  {
+   "default": "Pending",
+   "fieldname": "replication_status",
+   "fieldtype": "Select",
+   "label": "Replication Status",
+   "options": "Pending\nInstalling\nActive\nBroken\nDeactivated",
+   "read_only": 1
   }
  ],
  "links": [],
- "modified": "2020-10-09 18:14:55.805169",
+ "modified": "2020-11-30 16:36:17.329906",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Server",


### PR DESCRIPTION
1. create a record for replication setup
    <img width="1191" alt="Screenshot 2020-11-30 at 5 12 32 PM" src="https://user-images.githubusercontent.com/3784093/100616719-8313c800-333f-11eb-8c02-b9d6bdf24873.png">

1. Setup pre-requisites on the server via `Setup Server` action

1. Configure Replication
    <img width="923" alt="Screenshot 2020-11-30 at 5 12 45 PM" src="https://user-images.githubusercontent.com/3784093/100616820-a9d1fe80-333f-11eb-9c7c-0c729b38648f.png">

1. Run `Setup Replication` to enable lsyncd replication
    <img width="980" alt="Screenshot 2020-11-30 at 5 20 54 PM" src="https://user-images.githubusercontent.com/3784093/100616924-ca9a5400-333f-11eb-8d11-70fa32b357c1.png">
    - This will add,
      - Primary Server's frappe user public key to Replica Server
      - Install Lsyncd package
      - Add lsyncd configurations and log files
      - enable lsyncd service
      - <img width="672" alt="Screenshot 2020-11-30 at 7 16 26 PM" src="https://user-images.githubusercontent.com/3784093/100617547-b014aa80-3340-11eb-8474-c66e6e2d5b7f.png">

