### PR TITLE
feat(UX): Notification toast on site update schedule

### DIFF
--- a/dashboard/src/components/AlertSiteUpdate.vue
+++ b/dashboard/src/components/AlertSiteUpdate.vue
@@ -51,6 +51,14 @@ export default {
 				method: 'press.api.site.update',
 				params: {
 					name: this.site.name
+				},
+				onSuccess() {
+					this.showUpdatesDialog = false;
+					this.$notify({
+						title: 'Site update scheduled successfully!',
+						icon: 'check',
+						color: 'green'
+					});
 				}
 			};
 		}


### PR DESCRIPTION
Before this, the site update dialog remained open even after a successful schedule.