### PR TITLE
fix: Make all signup fields as mandatory

### DIFF
--- a/press/www/signup.html
+++ b/press/www/signup.html
@@ -126,12 +126,21 @@
 				return "Site name should contain lowercase alphabets, numbers, and hyphens";
 			}
 		},
-		plan: (value) => {
+		first_name: value => {
 			if (!value) {
-				return 'Please select a plan';
+				return 'First Name is required'
+			}
+		},
+		last_name: value => {
+			if (!value) {
+				return 'Last Name is required'
 			}
 		},
 		phone_number: (value) => {
+			if (!value) {
+				return 'Phone Number is required'
+			}
+
 			let regExp = /[a-zA-Z]/g;
 			if (regExp.test(value)) {
 				return "Phone number cannot contain alphabets";


### PR DESCRIPTION
While signing up via frappecloud.com/signup, First Name and Last Name can be left blank which will later break while setting up account. These fields should be mandatory.