### PR TITLE
fix: Update state on dialog close event

### DIFF
--- a/dashboard/src/components/ChangeAppBranchDialog.vue
+++ b/dashboard/src/components/ChangeAppBranchDialog.vue
@@ -3,6 +3,7 @@
 		v-if="app"
 		:show="bench && app"
 		:title="`Change branch for ${app.title}`"
+		v-on:close="dialogClosed"
 	>
 		<div>
 			<Button
@@ -86,6 +87,10 @@ export default {
 				app: this.app.name,
 				to_branch: this.selectedBranch
 			});
+		},
+		dialogClosed() {
+			this.$emit('update:app', null);
+			this.$resources.changeBranch.reset();
 		}
 	}
 };

--- a/dashboard/src/views/BenchOverviewApps.vue
+++ b/dashboard/src/views/BenchOverviewApps.vue
@@ -72,7 +72,7 @@
 			</p>
 		</Dialog>
 
-		<ChangeAppBranchDialog :bench="bench.name" :app="appToChangeBranchOf" />
+		<ChangeAppBranchDialog :bench="bench.name" :app.sync="appToChangeBranchOf" />
 	</Card>
 </template>
 <script>


### PR DESCRIPTION
Due to a bug, the change app branch dialog didn't close on clicking outside it. This PR fixes that bug.