### PR TITLE
fix: Handle finalizing empty invoices

### DIFF
--- a/press/press/doctype/invoice/invoice.json
+++ b/press/press/doctype/invoice/invoice.json
@@ -84,7 +84,7 @@
    "fieldtype": "Select",
    "label": "Status",
    "no_copy": 1,
-   "options": "Draft\nInvoice Created\nUnpaid\nPaid\nRefunded\nUncollectible"
+   "options": "Draft\nInvoice Created\nUnpaid\nPaid\nRefunded\nUncollectible\nEmpty"
   },
   {
    "fieldname": "total",
@@ -310,7 +310,7 @@
    "link_fieldname": "invoice"
   }
  ],
- "modified": "2021-04-30 12:31:01.440953",
+ "modified": "2021-07-17 12:38:21.448518",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Invoice",

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -28,12 +28,17 @@ class Invoice(Document):
 		self.validate_amount()
 
 	def before_submit(self):
-		if self.status != "Paid":
+		if self.total > 0 and self.status != "Paid":
 			frappe.throw("Invoice must be Paid to be submitted")
 
 	@frappe.whitelist()
 	def finalize_invoice(self):
 		if self.type == "Prepaid Credits":
+			return
+
+		if self.total == 0:
+			self.status = "Empty"
+			self.submit()
 			return
 
 		# set as unpaid by default


### PR DESCRIPTION
Invoices with total equal to 0 can be submitted directly. Their status is set to Empty.