### PR TITLE
fix: Site Update for only installed apps

### DIFF
--- a/press/api/site.py
+++ b/press/api/site.py
@@ -473,7 +473,13 @@ def check_for_updates(name):
 	out.apps = get_updates_between_current_and_next_apps(
 		bench.apps, destination_candidate.apps
 	)
-	out.update_available = any([app["update_available"] for app in out.apps])
+
+	# Filter for this site
+	site_apps = [app.app for app in site.apps]
+	out.apps = [a for a in out.apps if (a["app"] in site_apps)]
+
+	out.update_available = any(a["update_available"] for a in out.apps)
+
 	return out
 
 


### PR DESCRIPTION
Ref: https://frappe.io/app/backlog/BCK-LG-2021-0254

Before:

Updates were shown even when an app was not installed on a particular site, but was updated in the bench.

After:

Updates are only shown if an app installed on the site is actually going to update.