### PR TITLE
fix: Limit plans for sites in private bench

### DIFF
--- a/dashboard/src/views/SiteOverviewPlan.vue
+++ b/dashboard/src/views/SiteOverviewPlan.vue
@@ -104,9 +104,14 @@ export default {
 		};
 	},
 	resources: {
-		plans: {
-			method: 'press.api.site.get_plans',
-			default: []
+		plans() {
+			return {
+				method: 'press.api.site.get_plans',
+				params: {
+					name: this.site.name
+				},
+				default: []
+			};
 		},
 		changePlan() {
 			return {


### PR DESCRIPTION
Sites in private (paywalled) benches should not be allowed to switch to $10 plan.