### PR TITLE
fix: Change branch app source multiple versions

### DIFF
--- a/press/press/doctype/app_source/app_source.py
+++ b/press/press/doctype/app_source/app_source.py
@@ -5,6 +5,7 @@
 import frappe
 import requests
 
+from typing import List
 from frappe.model.document import Document
 from frappe.model.naming import make_autoname
 from press.api.github import get_access_token
@@ -102,7 +103,7 @@ class AppSource(Document):
 
 
 def create_app_source(
-	app: str, repository_url: str, branch: str, version: str
+	app: str, repository_url: str, branch: str, versions: List[str]
 ) -> AppSource:
 	team = get_current_team()
 
@@ -113,7 +114,7 @@ def create_app_source(
 			"repository_url": repository_url,
 			"branch": branch,
 			"team": team,
-			"versions": [{"version": version}],
+			"versions": [{"version": version} for version in versions],
 		}
 	)
 

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -304,12 +304,12 @@ class ReleaseGroup(Document):
 		if required_app_source:
 			required_app_source = required_app_source[0]
 		else:
-			version = frappe.get_all(
+			versions = frappe.get_all(
 				"App Source Version", filters={"parent": current_app_source.name}, pluck="version"
-			)[0]
+			)
 
 			required_app_source = create_app_source(
-				app, current_app_source.repository_url, to_branch, version
+				app, current_app_source.repository_url, to_branch, versions
 			)
 
 			required_app_source.github_installation_id = (


### PR DESCRIPTION
Before: Only a single Frappe Version (1st one) was carried over to the new app source when branch was changed.

After: All the supported versions of the current app source are copied over.﻿
