### PR TITLE
fix: Add created label to site list

### DIFF
--- a/dashboard/src/views/SiteList.vue
+++ b/dashboard/src/views/SiteList.vue
@@ -1,5 +1,7 @@
 <template>
-	<div class="sm:py-1 sm:border sm:border-gray-100 sm:rounded-md sm:shadow sm:px-2">
+	<div
+		class="sm:py-1 sm:border sm:border-gray-100 sm:rounded-md sm:shadow sm:px-2"
+	>
 		<div class="py-2 text-base text-gray-600 sm:px-2" v-if="sites.length === 0">
 			No sites in this bench
 		</div>
@@ -16,7 +18,7 @@
 						<Badge class="pointer-events-none" v-bind="siteBadge(site)" />
 					</div>
 					<div class="hidden w-2/12 text-sm text-gray-600 sm:block">
-						{{ formatDate(site.creation, 'relative') }}
+						Created {{ formatDate(site.creation, 'relative') }}
 					</div>
 					<div class="hidden w-2/12 text-base text-right sm:block">
 						<Link


### PR DESCRIPTION
Helps gives some context on the date duration shown in site list item.

<img width="1100" alt="Screenshot 2021-10-13 at 1 36 28 PM" src="https://user-images.githubusercontent.com/34810212/137092965-d27bb1d9-8f65-4231-87dc-8feeb6834724.png">


Fixes #121 