### PR TITLE
fix(Dockerfile): Upgrade pip after setting up virtualenv

### DIFF
--- a/press/docker/Dockerfile
+++ b/press/docker/Dockerfile
@@ -127,6 +127,7 @@ RUN mkdir -p apps logs sites config/pids
 
 # Create virtual environment for bench
 RUN virtualenv -p python${PYTHON_VERSION} env `#stage-bench-env`
+RUN env/bin/pip install --upgrade pip
 
 COPY --chown=frappe:frappe common_site_config.json /home/frappe/frappe-bench/sites/common_site_config.json
 RUN git config --global advice.detachedHead false


### PR DESCRIPTION
This guarantees pip's new and better dependency resolver (available from 20.3 onwards) within the bench virtualenv.

## Before
![image](https://user-images.githubusercontent.com/25403045/139183619-1c229a8d-62bb-43bc-8612-275843434f0f.png)
## After
![image](https://user-images.githubusercontent.com/25403045/139183678-2c8f37f3-698e-4d71-a469-2dc2d0d7261e.png)

