### PR TITLE
fix(UX): Marketplace avatar image & card

### DIFF
--- a/dashboard/src/components/MarketplaceAppCard.vue
+++ b/dashboard/src/components/MarketplaceAppCard.vue
@@ -11,7 +11,7 @@
 		/>
 		<div class="ml-3 w-full">
 			<div class="flex items-center justify-between">
-				<h2 class="text-xl font-bold">
+				<h2 class="text-xl text-left font-bold">
 					{{ app.title }}
 				</h2>
 				<Badge :status="app.status">{{ app.status }}</Badge>

--- a/dashboard/src/components/MarketplaceAppProfile.vue
+++ b/dashboard/src/components/MarketplaceAppProfile.vue
@@ -1,7 +1,7 @@
 <template>
 	<Card title="App Profile" subtitle="Your app's primary profile">
 		<div class="flex items-center">
-			<div class="relative">
+			<div class="relative group">
 				<Avatar
 					size="lg"
 					shape="square"
@@ -21,11 +21,16 @@
 						<div class="ml-4">
 							<button
 								@click="openFileSelector()"
-								class="absolute inset-0 grid w-full text-xs font-semibold text-white bg-black rounded-lg opacity-0 focus:outline-none focus:opacity-50 hover:opacity-50 place-items-center"
+								class="absolute inset-0 grid w-full text-xs font-semibold text-white bg-black rounded-lg opacity-0 focus:outline-none focus:opacity-50 group-hover:opacity-50 place-items-center"
 								:class="{ 'opacity-50': uploading }"
 							>
 								<span v-if="uploading">{{ progress }}%</span>
 								<span v-else>Edit</span>
+							</button>
+							<button
+								class="absolute text-opacity-70 bottom-0 left-0 grid w-full text-xs font-semibold place-items-center bg-gray-900 text-white opacity-80 rounded-md group-hover:opacity-0"
+							>
+								<span>Edit</span>
 							</button>
 						</div>
 					</template>


### PR DESCRIPTION
**Problem**: Users were not able to figure out how to they upload a logo for their app since the `Edit` text only showed up when hovered.

**Solution**: Add a small text below the avatar image, more visibility. 

![hh](https://user-images.githubusercontent.com/34810212/140043714-3801c3c4-76ec-4bb4-bef1-99549061bfbf.png)

Also, fixed the text alignment issue with app card.
