### PR TITLE
fix: CSS styling of referral link text

### DIFF
--- a/dashboard/src/views/AccountReferral.vue
+++ b/dashboard/src/views/AccountReferral.vue
@@ -8,10 +8,10 @@
 			<div
 				class="p-2 items-center rounded-lg flex flex-row border-2 justify-between"
 			>
-				<p class="text-sm text-gray-800 font-mono">
+				<p class="text-sm text-gray-800 font-mono overflow-hidden">
 					{{ referralLink }}
 				</p>
-				<Button icon="copy" @click="copyReferralLink" />
+				<Button class="ml-1" icon="copy" @click="copyReferralLink" />
 			</div>
 			<h3 class="text-base text-gray-700">
 				When someone sign's up using the above link and spents atleast


### PR DESCRIPTION
* The problem was on mobile view 🙈

BEFORE:
<img width="543" alt="Screenshot 2021-11-19 at 10 41 17 PM" src="https://user-images.githubusercontent.com/34810212/142663383-744dcc08-ee13-4251-a07a-1be23faf44e2.png">

AFTER:
<img width="543" alt="Screenshot 2021-11-19 at 10 40 58 PM" src="https://user-images.githubusercontent.com/34810212/142663386-84a988c6-9220-4179-8eac-ece5d66ab5c8.png">
