### PR TITLE
fix: Candidates API returns same candidate

### DIFF
--- a/press/api/bench.py
+++ b/press/api/bench.py
@@ -290,7 +290,7 @@ def versions(name):
 def candidates(name, start=0):
 	result = frappe.get_all(
 		"Deploy Candidate",
-		["name", "creation", "status", "`tabDeploy Candidate App`.app"],
+		["name", "creation", "status"],
 		{"group": name, "status": ("!=", "Draft")},
 		order_by="creation desc",
 		start=start,
@@ -300,8 +300,13 @@ def candidates(name, start=0):
 	for d in result:
 		candidates.setdefault(d.name, {})
 		candidates[d.name].update(d)
-		candidates[d.name].setdefault("apps", [])
-		candidates[d.name]["apps"].append(d.app)
+		dc_apps = frappe.get_all(
+			"Deploy Candidate App",
+			filters={"parent": d.name},
+			pluck="app",
+			order_by="creation desc",
+		)
+		candidates[d.name]["apps"] = dc_apps
 
 	return candidates.values()
 


### PR DESCRIPTION
**Problem**: (Same deploy candidate coming up with different number / list of apps)


![big_candidates_api](https://user-images.githubusercontent.com/34810212/143041862-0ad6acc8-7185-428a-96c1-7a613575a6bd.gif)

**Cause**: 
_What we expect is_: last 10 deploy candidates with apps.

<img width="796" alt="Screenshot 2021-11-23 at 7 51 34 PM" src="https://user-images.githubusercontent.com/34810212/143041474-12c88a92-53cc-4625-b64d-01921433ed83.png">

_What we actually get_: Each `Deploy Candidate App` gets its own row. The limit is applied to apps instead of the deploy candidate itself.

**Fix**: This PR.

**After**:

![fix_candidates_api](https://user-images.githubusercontent.com/34810212/143044724-b20fa56c-1679-4a01-a355-b25c6ce6392a.gif)


