### PR TITLE
fix: Stripe invoice link for pay now

### DIFF
--- a/dashboard/src/views/Sites.vue
+++ b/dashboard/src/views/Sites.vue
@@ -37,7 +37,7 @@
 						<Button
 							icon-left="external-link"
 							type="primary"
-							:link="latestUnpaidStripeUrl"
+							:link="latestUnpaidInvoiceStripeUrl"
 						>
 							Pay now
 						</Button>


### PR DESCRIPTION
There was a typo in the variable name. 

Note: Skipping build step, since only `JS` has changed.