### PR TITLE
fix: revert side menu and activities ui in sites and release group doctypes.

### DIFF
--- a/press/press/doctype/release_group/release_group.json
+++ b/press/press/doctype/release_group/release_group.json
@@ -131,9 +131,8 @@
    "fieldtype": "Column Break"
   }
  ],
- "hide_toolbar": 1,
  "links": [],
- "modified": "2021-12-05 10:41:26.091333",
+ "modified": "2021-12-07 21:39:10.575131",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Release Group",

--- a/press/press/doctype/site/site.json
+++ b/press/press/doctype/site/site.json
@@ -61,7 +61,8 @@
   "column_break_51",
   "update_on_weekday",
   "update_end_of_month",
-  "update_on_day_of_month"
+  "update_on_day_of_month",
+  "column_break_57"
  ],
  "fields": [
   {
@@ -447,9 +448,12 @@
   {
    "fieldname": "column_break_12",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_57",
+   "fieldtype": "Column Break"
   }
  ],
- "hide_toolbar": 1,
  "links": [
   {
    "group": "Usage",
@@ -497,7 +501,7 @@
    "link_fieldname": "site"
   }
  ],
- "modified": "2021-12-05 10:26:30.834316",
+ "modified": "2021-12-07 21:38:35.662512",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site",


### PR DESCRIPTION
Since the side menu bar and the activities in form view for **Site** and **Release Group** doctypes in #265. This PR reverts these changes as a part of '**undo dashboard-to-desk**'

## side menu
![image](https://user-images.githubusercontent.com/22856401/146319920-00231869-dcb8-49f9-89fd-697d3b5e5c0e.png)

## activities
![image](https://user-images.githubusercontent.com/22856401/146320070-256bb452-c2f7-4120-80d7-b62d4f90239d.png)