### PR TITLE
fix(Deploy): Create deploy candidate difference after bench creation

### DIFF
--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -138,6 +138,11 @@ class Bench(Document):
 
 	def after_insert(self):
 		self.create_agent_request()
+		frappe.enqueue(
+			"press.press.doctype.deploy.deploy.create_deploy_candidate_differences",
+			bench=self,
+			enqueue_after_commit=True,
+		)
 
 	def create_agent_request(self):
 		agent = Agent(self.server)

--- a/press/press/doctype/deploy/deploy.py
+++ b/press/press/doctype/deploy/deploy.py
@@ -31,11 +31,6 @@ class Deploy(Document):
 			).insert()
 			bench.bench = new.name
 
-			frappe.enqueue(
-				"press.press.doctype.deploy.deploy.create_deploy_candidate_differences",
-				bench=new,
-				enqueue_after_commit=True,
-			)
 		self.save()
 
 


### PR DESCRIPTION
Earlier, when Benches are created by manual intervention, deploy
candidate differences won't get created. This will fix that.
