### PR TITLE
fix: Add support link in mobile view

### DIFF
--- a/dashboard/src/components/Navbar.vue
+++ b/dashboard/src/components/Navbar.vue
@@ -116,10 +116,17 @@
 						</div>
 					</div>
 				</div>
-				<div class="px-2 mt-3">
+				<div class="px-2 mt-3 space-y-3">
+					<a
+						href="/support/tickets"
+						target="_blank"
+						class="block px-3 pt-4 text-base font-medium rounded-md focus:outline-none"
+					>
+						Support
+					</a>
 					<a
 						href="#"
-						class="block px-3 py-2 text-base font-medium rounded-md focus:outline-none"
+						class="block px-3 text-base font-medium rounded-md focus:outline-none"
 						@click.prevent="$auth.logout"
 					>
 						Logout


### PR DESCRIPTION
Support page's link was missing from mobile view.

Fixed:

![Screen Shot 2021-12-15 at 12 56 20](https://user-images.githubusercontent.com/34810212/146142589-11ab0771-d5a7-49af-99cd-ad641c5c9372.png)

