### PR TITLE
fix: Remove __future__ unicode imports

### DIFF
--- a/press/__init__.py
+++ b/press/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 __version__ = "0.7.0"

--- a/press/agent.py
+++ b/press/agent.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import json
 import os

--- a/press/api/__init__.py
+++ b/press/api/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import frappe
 from press.utils import get_minified_script
 

--- a/press/api/analytics.py
+++ b/press/api/analytics.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 import requests

--- a/press/api/app.py
+++ b/press/api/app.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2019, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import json
 import frappe
 from press.utils import get_current_team

--- a/press/api/dashboard.py
+++ b/press/api/dashboard.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/api/monitoring.py
+++ b/press/api/monitoring.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from itertools import groupby

--- a/press/api/payment.py
+++ b/press/api/payment.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2019, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/commands.py
+++ b/press/commands.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals, absolute_import
+from __future__ import absolute_import
 import click
 
 import frappe

--- a/press/config/desktop.py
+++ b/press/config/desktop.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 from frappe import _
 
 

--- a/press/config/press.py
+++ b/press/config/press.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from frappe import _
 
 

--- a/press/install.py
+++ b/press/install.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2019, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 

--- a/press/notifications.py
+++ b/press/notifications.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 

--- a/press/overrides.py
+++ b/press/overrides.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2019, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from frappe.utils import cint
 from frappe.handler import is_whitelisted

--- a/press/patches/v0_0_1/add_domains_in_site_config_preview.py
+++ b/press/patches/v0_0_1/add_domains_in_site_config_preview.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
 
 from itertools import groupby
 

--- a/press/patches/v0_0_1/add_domains_to_site_config.py
+++ b/press/patches/v0_0_1/add_domains_to_site_config.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from frappe.utils.fixtures import sync_fixtures
 

--- a/press/patches/v0_0_1/add_site_index_to_site_migration.py
+++ b/press/patches/v0_0_1/add_site_index_to_site_migration.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/add_site_to_remote_file.py
+++ b/press/patches/v0_0_1/add_site_to_remote_file.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/create_app_release_difference_from_deploy_candidate_difference.py
+++ b/press/patches/v0_0_1/create_app_release_difference_from_deploy_candidate_difference.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/create_app_source_from_app.py
+++ b/press/patches/v0_0_1/create_app_source_from_app.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from frappe.utils.fixtures import sync_fixtures
 

--- a/press/patches/v0_0_1/create_backup_uploads_folder.py
+++ b/press/patches/v0_0_1/create_backup_uploads_folder.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 from frappe.core.doctype.file.file import create_new_folder
 
 

--- a/press/patches/v0_0_1/create_balance_transactions.py
+++ b/press/patches/v0_0_1/create_balance_transactions.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from frappe.utils import update_progress_bar
 from press.api.billing import get_stripe

--- a/press/patches/v0_0_1/create_balance_transactions_from_stripe.py
+++ b/press/patches/v0_0_1/create_balance_transactions_from_stripe.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from press.api.billing import get_stripe

--- a/press/patches/v0_0_1/create_certificate_authorities.py
+++ b/press/patches/v0_0_1/create_certificate_authorities.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from press.install import create_certificate_authorities

--- a/press/patches/v0_0_1/create_default_cluster.py
+++ b/press/patches/v0_0_1/create_default_cluster.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/create_invoice_for_past_ples.py
+++ b/press/patches/v0_0_1/create_invoice_for_past_ples.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from datetime import datetime
 from press.api.billing import get_stripe

--- a/press/patches/v0_0_1/create_root_domain_from_press_settings.py
+++ b/press/patches/v0_0_1/create_root_domain_from_press_settings.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/create_site_plan_change_log.py
+++ b/press/patches/v0_0_1/create_site_plan_change_log.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/create_site_subscriptions.py
+++ b/press/patches/v0_0_1/create_site_subscriptions.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from frappe.utils import update_progress_bar
 

--- a/press/patches/v0_0_1/delete_logs_from_archived_sites.py
+++ b/press/patches/v0_0_1/delete_logs_from_archived_sites.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from press.press.doctype.site.site import delete_logs
 

--- a/press/patches/v0_0_1/enable_partner_privileges.py
+++ b/press/patches/v0_0_1/enable_partner_privileges.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/make_apps_in_public_release_group_public.py
+++ b/press/patches/v0_0_1/make_apps_in_public_release_group_public.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2019, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/make_default_site_domain.py
+++ b/press/patches/v0_0_1/make_default_site_domain.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/mark_deployed_app_releases_as_approved_and_deployable.py
+++ b/press/patches/v0_0_1/mark_deployed_app_releases_as_approved_and_deployable.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2019, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/move_domains_from_archived_to_active_sites.py
+++ b/press/patches/v0_0_1/move_domains_from_archived_to_active_sites.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/new_onboarding.py
+++ b/press/patches/v0_0_1/new_onboarding.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from frappe.utils import update_progress_bar
 

--- a/press/patches/v0_0_1/patch_invoice.py
+++ b/press/patches/v0_0_1/patch_invoice.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/ple_to_usage_record.py
+++ b/press/patches/v0_0_1/ple_to_usage_record.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/remove_domains_linked_to_archived_sites.py
+++ b/press/patches/v0_0_1/remove_domains_linked_to_archived_sites.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/remove_obsolete_doctypes.py
+++ b/press/patches/v0_0_1/remove_obsolete_doctypes.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/rename_archived_sites.py
+++ b/press/patches/v0_0_1/rename_archived_sites.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from press.press.doctype.site.site import release_name
 

--- a/press/patches/v0_0_1/rename_columns_in_tls_certificate.py
+++ b/press/patches/v0_0_1/rename_columns_in_tls_certificate.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from frappe.model.utils.rename_field import rename_field

--- a/press/patches/v0_0_1/rename_deploy_candidate_app_release_to_deploy_candidate_app.py
+++ b/press/patches/v0_0_1/rename_deploy_candidate_app_release_to_deploy_candidate_app.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/rename_frappe_app_to_app.py
+++ b/press/patches/v0_0_1/rename_frappe_app_to_app.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2019, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/rename_installed_app_to_bench_app.py
+++ b/press/patches/v0_0_1/rename_installed_app_to_bench_app.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/rename_release_group_frappe_app_to_release_group_app.py
+++ b/press/patches/v0_0_1/rename_release_group_frappe_app_to_release_group_app.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 

--- a/press/patches/v0_0_1/rename_release_groups.py
+++ b/press/patches/v0_0_1/rename_release_groups.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/rename_site_backup_fields.py
+++ b/press/patches/v0_0_1/rename_site_backup_fields.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/rename_transaction_currency_to_currency.py
+++ b/press/patches/v0_0_1/rename_transaction_currency_to_currency.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from frappe.model.utils.rename_field import rename_field
 

--- a/press/patches/v0_0_1/rename_workers_to_background_workers.py
+++ b/press/patches/v0_0_1/rename_workers_to_background_workers.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from frappe.model.utils.rename_field import rename_field

--- a/press/patches/v0_0_1/set_app_title_from_custom_field.py
+++ b/press/patches/v0_0_1/set_app_title_from_custom_field.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/set_app_title_in_deploy_candidate_app.py
+++ b/press/patches/v0_0_1/set_app_title_in_deploy_candidate_app.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/set_billing_name_for_teams.py
+++ b/press/patches/v0_0_1/set_billing_name_for_teams.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/set_cluster_in_press_settings.py
+++ b/press/patches/v0_0_1/set_cluster_in_press_settings.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/set_dependencies_in_release_group.py
+++ b/press/patches/v0_0_1/set_dependencies_in_release_group.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/set_document_type_in_plan.py
+++ b/press/patches/v0_0_1/set_document_type_in_plan.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/set_domain_in_site.py
+++ b/press/patches/v0_0_1/set_domain_in_site.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/set_host_name_for_sites_with_domains.py
+++ b/press/patches/v0_0_1/set_host_name_for_sites_with_domains.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/set_hostname_in_server.py
+++ b/press/patches/v0_0_1/set_hostname_in_server.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/set_marketplace_app_app_field_from_name.py
+++ b/press/patches/v0_0_1/set_marketplace_app_app_field_from_name.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/set_monitoring_password_in_cluster.py
+++ b/press/patches/v0_0_1/set_monitoring_password_in_cluster.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/set_public_field_in_app_release_based_on_app_source_public.py
+++ b/press/patches/v0_0_1/set_public_field_in_app_release_based_on_app_source_public.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/set_rate_limit_config_based_on_plan.py
+++ b/press/patches/v0_0_1/set_rate_limit_config_based_on_plan.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from press.press.doctype.plan.plan import get_plan_config
 from press.utils import log_error

--- a/press/patches/v0_0_1/set_release_group_in_site.py
+++ b/press/patches/v0_0_1/set_release_group_in_site.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/set_release_group_version_and_title_from_custom_field.py
+++ b/press/patches/v0_0_1/set_release_group_version_and_title_from_custom_field.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/set_release_in_bench_app.py
+++ b/press/patches/v0_0_1/set_release_in_bench_app.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/set_remote_file_location.py
+++ b/press/patches/v0_0_1/set_remote_file_location.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from frappe.desk.doctype.tag.tag import add_tag
 

--- a/press/patches/v0_0_1/set_repository_in_frappe_app.py
+++ b/press/patches/v0_0_1/set_repository_in_frappe_app.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2019, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/set_team_field_for_permission_checks.py
+++ b/press/patches/v0_0_1/set_team_field_for_permission_checks.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/set_team_field_in_tls_certificate_based_on_domain_team.py
+++ b/press/patches/v0_0_1/set_team_field_in_tls_certificate_based_on_domain_team.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/site_history_to_site_activity.py
+++ b/press/patches/v0_0_1/site_history_to_site_activity.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2019, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/site_usage_convert_history.py
+++ b/press/patches/v0_0_1/site_usage_convert_history.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
 
 from math import ceil
 

--- a/press/patches/v0_0_1/track_offsite_backups_via_remote_files.py
+++ b/press/patches/v0_0_1/track_offsite_backups_via_remote_files.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 import json
 from frappe.desk.doctype.tag.tag import add_tag

--- a/press/patches/v0_0_1/truncate_server_status_table.py
+++ b/press/patches/v0_0_1/truncate_server_status_table.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_1/update_proxy_for_suspended_and_inactive_sites.py
+++ b/press/patches/v0_0_1/update_proxy_for_suspended_and_inactive_sites.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from frappe.utils.fixtures import sync_fixtures
 

--- a/press/patches/v0_0_1/use_private_ip_for_upstreams.py
+++ b/press/patches/v0_0_1/use_private_ip_for_upstreams.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from press.agent import Agent

--- a/press/patches/v0_0_1/user_account_to_team.py
+++ b/press/patches/v0_0_1/user_account_to_team.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/patches/v0_0_4/remove_legacy_billing_doctypes.py
+++ b/press/patches/v0_0_4/remove_legacy_billing_doctypes.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/press/doctype/account_request/account_request.py
+++ b/press/press/doctype/account_request/account_request.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2019, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from frappe.model.document import Document
 from frappe.utils import random_string, get_url

--- a/press/press/doctype/account_request/test_account_request.py
+++ b/press/press/doctype/account_request/test_account_request.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2021, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 import unittest
 from datetime import datetime

--- a/press/press/doctype/agent_job/agent_job_dashboard.py
+++ b/press/press/doctype/agent_job/agent_job_dashboard.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 from frappe import _
 
 

--- a/press/press/doctype/agent_job/test_agent_job.py
+++ b/press/press/doctype/agent_job/test_agent_job.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/agent_job_step/test_agent_job_step.py
+++ b/press/press/doctype/agent_job_step/test_agent_job_step.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/agent_job_type/test_agent_job_type.py
+++ b/press/press/doctype/agent_job_type/test_agent_job_type.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/agent_job_type_step/agent_job_type_step.py
+++ b/press/press/doctype/agent_job_type_step/agent_job_type_step.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/ansible_play/ansible_play.py
+++ b/press/press/doctype/ansible_play/ansible_play.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/ansible_play/ansible_play_dashboard.py
+++ b/press/press/doctype/ansible_play/ansible_play_dashboard.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
 
 from frappe import _
 

--- a/press/press/doctype/ansible_play/test_ansible_play.py
+++ b/press/press/doctype/ansible_play/test_ansible_play.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/ansible_task/ansible_task.py
+++ b/press/press/doctype/ansible_task/ansible_task.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/ansible_task/test_ansible_task.py
+++ b/press/press/doctype/ansible_task/test_ansible_task.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/app/app.py
+++ b/press/press/doctype/app/app.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2019, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/app/app_dashboard.py
+++ b/press/press/doctype/app/app_dashboard.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
-
 
 def get_data():
 	return {

--- a/press/press/doctype/app/test_app.py
+++ b/press/press/doctype/app/test_app.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2019, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 import frappe
 import unittest

--- a/press/press/doctype/app_release_difference/app_release_difference.py
+++ b/press/press/doctype/app_release_difference/app_release_difference.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from frappe.model.document import Document
 import re

--- a/press/press/doctype/app_release_difference/test_app_release_difference.py
+++ b/press/press/doctype/app_release_difference/test_app_release_difference.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/app_source/app_source_dashboard.py
+++ b/press/press/doctype/app_source/app_source_dashboard.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
-
 
 def get_data():
 	return {

--- a/press/press/doctype/app_source_version/app_source_version.py
+++ b/press/press/doctype/app_source_version/app_source_version.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/app_tag/app_tag.py
+++ b/press/press/doctype/app_tag/app_tag.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/app_tag/test_app_tag.py
+++ b/press/press/doctype/app_tag/test_app_tag.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/audit_log/test_audit_log.py
+++ b/press/press/doctype/audit_log/test_audit_log.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2021, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/balance_transaction/balance_transaction.py
+++ b/press/press/doctype/balance_transaction/balance_transaction.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/balance_transaction/test_balance_transaction.py
+++ b/press/press/doctype/balance_transaction/test_balance_transaction.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 import frappe
 import unittest

--- a/press/press/doctype/balance_transaction_allocation/balance_transaction_allocation.py
+++ b/press/press/doctype/balance_transaction_allocation/balance_transaction_allocation.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/bench/bench_dashboard.py
+++ b/press/press/doctype/bench/bench_dashboard.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 from frappe import _
 
 

--- a/press/press/doctype/bench/test_bench.py
+++ b/press/press/doctype/bench/test_bench.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2019, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 import unittest
 from unittest.mock import Mock, patch

--- a/press/press/doctype/bench_app/bench_app.py
+++ b/press/press/doctype/bench_app/bench_app.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2019, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/bench_app/test_bench_app.py
+++ b/press/press/doctype/bench_app/test_bench_app.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2019, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/certificate_authority/certificate_authority.py
+++ b/press/press/doctype/certificate_authority/certificate_authority.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import os
 import secrets

--- a/press/press/doctype/certificate_authority/test_certificate_authority.py
+++ b/press/press/doctype/certificate_authority/test_certificate_authority.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/cluster/cluster.py
+++ b/press/press/doctype/cluster/cluster.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import ipaddress
 from typing import Dict, List

--- a/press/press/doctype/cluster/test_cluster.py
+++ b/press/press/doctype/cluster/test_cluster.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2021, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 import frappe
 import unittest

--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from press.press.doctype.server.server import BaseServer
 from press.runner import Ansible

--- a/press/press/doctype/database_server/database_server_dashboard.py
+++ b/press/press/doctype/database_server/database_server_dashboard.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 from frappe import _
 
 

--- a/press/press/doctype/database_server/test_database_server.py
+++ b/press/press/doctype/database_server/test_database_server.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 import frappe
 import unittest

--- a/press/press/doctype/deploy/deploy.py
+++ b/press/press/doctype/deploy/deploy.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from frappe.model.document import Document
 from press.utils import log_error

--- a/press/press/doctype/deploy/test_deploy.py
+++ b/press/press/doctype/deploy/test_deploy.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/deploy_bench/deploy_bench.py
+++ b/press/press/doctype/deploy_bench/deploy_bench.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/deploy_bench/test_deploy_bench.py
+++ b/press/press/doctype/deploy_bench/test_deploy_bench.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/deploy_candidate/deploy_candidate_dashboard.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate_dashboard.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
-
 
 def get_data():
 	return {

--- a/press/press/doctype/deploy_candidate/test_deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/test_deploy_candidate.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 from press.press.doctype.release_group.release_group import ReleaseGroup
 
 import unittest

--- a/press/press/doctype/deploy_candidate_app/deploy_candidate_app.py
+++ b/press/press/doctype/deploy_candidate_app/deploy_candidate_app.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/deploy_candidate_build_step/deploy_candidate_build_step.py
+++ b/press/press/doctype/deploy_candidate_build_step/deploy_candidate_build_step.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/deploy_candidate_difference/deploy_candidate_difference.py
+++ b/press/press/doctype/deploy_candidate_difference/deploy_candidate_difference.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from frappe.model.document import Document
 from frappe.core.utils import find

--- a/press/press/doctype/deploy_candidate_difference/test_deploy_candidate_difference.py
+++ b/press/press/doctype/deploy_candidate_difference/test_deploy_candidate_difference.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/deploy_candidate_difference_app/deploy_candidate_difference_app.py
+++ b/press/press/doctype/deploy_candidate_difference_app/deploy_candidate_difference_app.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/drip_email/drip_email.py
+++ b/press/press/doctype/drip_email/drip_email.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2015, Web Notes and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 from datetime import date, timedelta
 from typing import Dict, List

--- a/press/press/doctype/drip_email/test_drip_email.py
+++ b/press/press/doctype/drip_email/test_drip_email.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2015, Web Notes and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 from datetime import date, timedelta
 import unittest

--- a/press/press/doctype/erpnext_app/erpnext_app.py
+++ b/press/press/doctype/erpnext_app/erpnext_app.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/erpnext_consultant/erpnext_consultant.py
+++ b/press/press/doctype/erpnext_consultant/erpnext_consultant.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2019, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/erpnext_consultant/test_erpnext_consultant.py
+++ b/press/press/doctype/erpnext_consultant/test_erpnext_consultant.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2019, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 import unittest
 

--- a/press/press/doctype/erpnext_consultant_region/erpnext_consultant_region.py
+++ b/press/press/doctype/erpnext_consultant_region/erpnext_consultant_region.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/feedback/feedback.py
+++ b/press/press/doctype/feedback/feedback.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/feedback/test_feedback.py
+++ b/press/press/doctype/feedback/test_feedback.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/frappe_version/frappe_version.py
+++ b/press/press/doctype/frappe_version/frappe_version.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/frappe_version/test_frappe_version.py
+++ b/press/press/doctype/frappe_version/test_frappe_version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 import frappe
 import unittest

--- a/press/press/doctype/github_webhook_log/github_webhook_log.py
+++ b/press/press/doctype/github_webhook_log/github_webhook_log.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 import hmac

--- a/press/press/doctype/github_webhook_log/test_github_webhook_log.py
+++ b/press/press/doctype/github_webhook_log/test_github_webhook_log.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 import unittest
 
 

--- a/press/press/doctype/invoice/mark_as_uncollectible.py
+++ b/press/press/doctype/invoice/mark_as_uncollectible.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/press/doctype/invoice/patches/set_free_credits.py
+++ b/press/press/doctype/invoice/patches/set_free_credits.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from frappe.utils import update_progress_bar
 

--- a/press/press/doctype/invoice/patches/set_transaction_details.py
+++ b/press/press/doctype/invoice/patches/set_transaction_details.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/press/doctype/invoice/test_invoice.py
+++ b/press/press/doctype/invoice/test_invoice.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 import frappe
 import unittest

--- a/press/press/doctype/invoice_credit_allocation/invoice_credit_allocation.py
+++ b/press/press/doctype/invoice_credit_allocation/invoice_credit_allocation.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/invoice_item/invoice_item.py
+++ b/press/press/doctype/invoice_item/invoice_item.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/invoice_transaction_fee/invoice_transaction_fee.py
+++ b/press/press/doctype/invoice_transaction_fee/invoice_transaction_fee.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/marketplace_app_category/marketplace_app_category.py
+++ b/press/press/doctype/marketplace_app_category/marketplace_app_category.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 from frappe.model.document import Document
 from frappe.website.utils import cleanup_page_name

--- a/press/press/doctype/marketplace_app_category/test_marketplace_app_category.py
+++ b/press/press/doctype/marketplace_app_category/test_marketplace_app_category.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/module_setup_guide/module_setup_guide.py
+++ b/press/press/doctype/module_setup_guide/module_setup_guide.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/module_setup_guide/test_module_setup_guide.py
+++ b/press/press/doctype/module_setup_guide/test_module_setup_guide.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/monitor_server/monitor_server.py
+++ b/press/press/doctype/monitor_server/monitor_server.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 import json
 

--- a/press/press/doctype/monitor_server/test_monitor_server.py
+++ b/press/press/doctype/monitor_server/test_monitor_server.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2021, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/plan/plan.py
+++ b/press/press/doctype/plan/plan.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 from typing import List
 
 import frappe

--- a/press/press/doctype/press_settings/press_settings.py
+++ b/press/press/doctype/press_settings/press_settings.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from boto3.session import Session

--- a/press/press/doctype/press_settings/test_press_settings.py
+++ b/press/press/doctype/press_settings/test_press_settings.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 import frappe
 import unittest

--- a/press/press/doctype/proxy_server/proxy_server.py
+++ b/press/press/doctype/proxy_server/proxy_server.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from press.press.doctype.server.server import BaseServer

--- a/press/press/doctype/proxy_server/proxy_server_dashboard.py
+++ b/press/press/doctype/proxy_server/proxy_server_dashboard.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 from frappe import _
 
 

--- a/press/press/doctype/proxy_server/test_proxy_server.py
+++ b/press/press/doctype/proxy_server/test_proxy_server.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 from press.press.doctype.proxy_server.proxy_server import ProxyServer
 
 import unittest

--- a/press/press/doctype/proxy_server_domain/proxy_server_domain.py
+++ b/press/press/doctype/proxy_server_domain/proxy_server_domain.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/region/region.py
+++ b/press/press/doctype/region/region.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2018, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 from frappe.model.document import Document
 

--- a/press/press/doctype/region/test_region.py
+++ b/press/press/doctype/region/test_region.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2018, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 import unittest
 

--- a/press/press/doctype/registry_server/registry_server.py
+++ b/press/press/doctype/registry_server/registry_server.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from press.press.doctype.server.server import BaseServer
 from press.runner import Ansible

--- a/press/press/doctype/registry_server/test_registry_server.py
+++ b/press/press/doctype/registry_server/test_registry_server.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2021, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/release_group/release_group_dashboard.py
+++ b/press/press/doctype/release_group/release_group_dashboard.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
-
 
 def get_data():
 	return {

--- a/press/press/doctype/release_group_app/release_group_app.py
+++ b/press/press/doctype/release_group_app/release_group_app.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/release_group_server/release_group_server.py
+++ b/press/press/doctype/release_group_server/release_group_server.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/remote_file/remote_file.py
+++ b/press/press/doctype/remote_file/remote_file.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import json
 

--- a/press/press/doctype/remote_file/test_remote_file.py
+++ b/press/press/doctype/remote_file/test_remote_file.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 import unittest
 from datetime import datetime

--- a/press/press/doctype/remote_operation_log/remote_operation_log.py
+++ b/press/press/doctype/remote_operation_log/remote_operation_log.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/remote_operation_log/test_remote_operation_log.py
+++ b/press/press/doctype/remote_operation_log/test_remote_operation_log.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/root_domain/root_domain.py
+++ b/press/press/doctype/root_domain/root_domain.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 from datetime import datetime, timedelta
 import json
 from typing import Iterable, List

--- a/press/press/doctype/root_domain/test_root_domain.py
+++ b/press/press/doctype/root_domain/test_root_domain.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2021, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 from datetime import datetime, timedelta
 
 import json

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2019, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/server/server_dashboard.py
+++ b/press/press/doctype/server/server_dashboard.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 from frappe import _
 
 

--- a/press/press/doctype/server/test_server.py
+++ b/press/press/doctype/server/test_server.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2019, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 import unittest
 

--- a/press/press/doctype/site/backups.py
+++ b/press/press/doctype/site/backups.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import functools
 from collections import deque

--- a/press/press/doctype/site/erpnext_site.py
+++ b/press/press/doctype/site/erpnext_site.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 

--- a/press/press/doctype/site/pool.py
+++ b/press/press/doctype/site/pool.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from frappe.model.naming import make_autoname

--- a/press/press/doctype/site/test_site.py
+++ b/press/press/doctype/site/test_site.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2019, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 import unittest
 from datetime import datetime

--- a/press/press/doctype/site_activity/site_activity.py
+++ b/press/press/doctype/site_activity/site_activity.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/site_activity/test_site_activity.py
+++ b/press/press/doctype/site_activity/test_site_activity.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/site_app/site_app.py
+++ b/press/press/doctype/site_app/site_app.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/site_backup/site_backup.py
+++ b/press/press/doctype/site_backup/site_backup.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import json
 from datetime import datetime, timedelta

--- a/press/press/doctype/site_backup/test_site_backup.py
+++ b/press/press/doctype/site_backup/test_site_backup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 import unittest
 from datetime import datetime

--- a/press/press/doctype/site_config/site_config.py
+++ b/press/press/doctype/site_config/site_config.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from frappe.model.document import Document
 

--- a/press/press/doctype/site_config_key/site_config_key.py
+++ b/press/press/doctype/site_config_key/site_config_key.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 from frappe.model.document import Document
 
 

--- a/press/press/doctype/site_config_key/test_site_config_key.py
+++ b/press/press/doctype/site_config_key/test_site_config_key.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/site_config_key_blacklist/site_config_key_blacklist.py
+++ b/press/press/doctype/site_config_key_blacklist/site_config_key_blacklist.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 from frappe.model.document import Document
 
 

--- a/press/press/doctype/site_config_key_blacklist/test_site_config_key_blacklist.py
+++ b/press/press/doctype/site_config_key_blacklist/test_site_config_key_blacklist.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/site_domain/site_domain.py
+++ b/press/press/doctype/site_domain/site_domain.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/site_domain/test_site_domain.py
+++ b/press/press/doctype/site_domain/test_site_domain.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 import unittest
 from unittest.mock import Mock, call, patch

--- a/press/press/doctype/site_migration/site_migration.py
+++ b/press/press/doctype/site_migration/site_migration.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from frappe.core.utils import find

--- a/press/press/doctype/site_migration/test_site_migration.py
+++ b/press/press/doctype/site_migration/test_site_migration.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2021, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/site_migration_step/site_migration_step.py
+++ b/press/press/doctype/site_migration_step/site_migration_step.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/site_migration_step/test_site_migration_step.py
+++ b/press/press/doctype/site_migration_step/test_site_migration_step.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2021, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/site_plan_change/site_plan_change.py
+++ b/press/press/doctype/site_plan_change/site_plan_change.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from frappe import _
 from frappe.model.document import Document

--- a/press/press/doctype/site_plan_change/test_site_plan_change.py
+++ b/press/press/doctype/site_plan_change/test_site_plan_change.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/site_update/test_site_update.py
+++ b/press/press/doctype/site_update/test_site_update.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/site_usage/site_usage.py
+++ b/press/press/doctype/site_usage/site_usage.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/site_usage/test_site_usage.py
+++ b/press/press/doctype/site_usage/test_site_usage.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/stripe_payment_method/stripe_payment_method.py
+++ b/press/press/doctype/stripe_payment_method/stripe_payment_method.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/stripe_payment_method/test_stripe_payment_method.py
+++ b/press/press/doctype/stripe_payment_method/test_stripe_payment_method.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/stripe_webhook_log/test_stripe_webhook_log.py
+++ b/press/press/doctype/stripe_webhook_log/test_stripe_webhook_log.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/subscription/subscription.py
+++ b/press/press/doctype/subscription/subscription.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+
 from typing import List
 from press.press.doctype.plan.plan import Plan
 

--- a/press/press/doctype/subscription/test_subscription.py
+++ b/press/press/doctype/subscription/test_subscription.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 import unittest
 from unittest.mock import patch

--- a/press/press/doctype/team/patches/set_payment_mode.py
+++ b/press/press/doctype/team/patches/set_payment_mode.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/press/doctype/team/suspend_sites.py
+++ b/press/press/doctype/team/suspend_sites.py
@@ -15,7 +15,7 @@ Defaulters are identified based on the following conditions:
 The `execute` method is the main method which is run by the scheduler daily.
 """
 
-from __future__ import unicode_literals
+
 import frappe
 from frappe.utils.data import flt
 

--- a/press/press/doctype/team/team_invoice.py
+++ b/press/press/doctype/team/team_invoice.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 from press.utils import log_error
 from frappe.utils import getdate

--- a/press/press/doctype/team/test_team.py
+++ b/press/press/doctype/team/test_team.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 import unittest
 from unittest.mock import patch

--- a/press/press/doctype/team_member/team_member.py
+++ b/press/press/doctype/team_member/team_member.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/team_member_deletion_request/team_member_deletion_request.py
+++ b/press/press/doctype/team_member_deletion_request/team_member_deletion_request.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/team_member_deletion_request/test_team_member_deletion_request.py
+++ b/press/press/doctype/team_member_deletion_request/test_team_member_deletion_request.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2021, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/team_member_impersonation/team_member_impersonation.py
+++ b/press/press/doctype/team_member_impersonation/team_member_impersonation.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/team_member_impersonation/test_team_member_impersonation.py
+++ b/press/press/doctype/team_member_impersonation/test_team_member_impersonation.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/team_onboarding/team_onboarding.py
+++ b/press/press/doctype/team_onboarding/team_onboarding.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 # import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/tls_certificate/test_tls_certificate.py
+++ b/press/press/doctype/tls_certificate/test_tls_certificate.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 from press.press.doctype.root_domain.test_root_domain import create_test_root_domain
 from press.press.doctype.tls_certificate.tls_certificate import (
 	LetsEncrypt,

--- a/press/press/doctype/tls_certificate/tls_certificate.py
+++ b/press/press/doctype/tls_certificate/tls_certificate.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import os
 import shlex

--- a/press/press/doctype/usage_record/test_usage_record.py
+++ b/press/press/doctype/usage_record/test_usage_record.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/usage_record/usage_record.py
+++ b/press/press/doctype/usage_record/usage_record.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 from frappe.model.document import Document

--- a/press/press/doctype/user_ssh_certificate/test_user_ssh_certificate.py
+++ b/press/press/doctype/user_ssh_certificate/test_user_ssh_certificate.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2019, Frappe and Contributors
 # See license.txt
-from __future__ import unicode_literals
+
 
 # import frappe
 import unittest

--- a/press/press/doctype/user_ssh_certificate/user_ssh_certificate.py
+++ b/press/press/doctype/user_ssh_certificate/user_ssh_certificate.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2019, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import base64
 import binascii

--- a/press/telegram_utils.py
+++ b/press/telegram_utils.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 
 import frappe
 import telegram

--- a/press/tests/before_test.py
+++ b/press/tests/before_test.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 import os
 

--- a/press/www/dashboard.py
+++ b/press/www/dashboard.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 base_template_path = "templates/www/dashboard.html"

--- a/press/www/github/authorize.py
+++ b/press/www/github/authorize.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import json
 import frappe
 import requests

--- a/press/www/github/redirect.py
+++ b/press/www/github/redirect.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 import requests
 from press.utils import log_error

--- a/press/www/internal/index.py
+++ b/press/www/internal/index.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 import frappe
 
 

--- a/press/www/signup.py
+++ b/press/www/signup.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+
 from frappe.geo.country_info import get_country_info
 
 


### PR DESCRIPTION
Remove this line from all python files:

```python
from __future__ import unicode_literals
```

No longer required in python 3.