### PR TITLE
fix: Only create user if not already exists

### DIFF
--- a/press/api/account.py
+++ b/press/api/account.py
@@ -97,7 +97,14 @@ def setup_account(
 		doc.create_user_for_member(first_name, last_name, email, password, role)
 	else:
 		# Team doesn't exist, create it
-		Team.create_new(account_request, first_name, last_name, password, country=country, user_exists=bool(user_exists))
+		Team.create_new(
+			account_request,
+			first_name,
+			last_name,
+			password,
+			country=country,
+			user_exists=bool(user_exists),
+		)
 
 	frappe.local.login_manager.login_as(email)
 

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -99,7 +99,7 @@ class Team(Document):
 		country: str = None,
 		is_us_eu: bool = False,
 		via_erpnext: bool = False,
-		user_exists: bool = False
+		user_exists: bool = False,
 	):
 		"""Create new team along with user (user created first)."""
 		team = frappe.get_doc(


### PR DESCRIPTION
> We don't know for how long this has existed 🙈

## Problem

When someone is part of a team as a team member and does not have a `Team` for herself, when she tries to sign up again to get a team, we were trying to create a `User` again (although the `User` already existed with "Press Member" role). An error was getting thrown:

![image](https://user-images.githubusercontent.com/34810212/176177040-82228df8-7181-4280-a422-a1a2b4c39c38.png)

## Solution 

Only create a `User` doc if not already exists. Otherwise just add the new role (`Press Admin` to be specific) coming via the account request.