### PR TITLE
show only paid sites in daily backup audit

### DIFF
--- a/press/press/audit.py
+++ b/press/press/audit.py
@@ -99,7 +99,7 @@ class BackupRecordCheck(Audit):
 	def __init__(self):
 		log = {self.list_key: []}
 		interval_hrs_ago = datetime.now() - timedelta(hours=self.interval)
-		trial_plans = tuple(frappe.get_all("Plan", dict(disable_backups=1), pluck="name"))
+		trial_plans = tuple(frappe.get_all("Plan", dict(is_trial_plan=1), pluck="name"))
 		cond_filters = " AND site.plan NOT IN {trial_plans}" if trial_plans else ''
 		tuples = frappe.db.sql(
 			f"""

--- a/press/press/doctype/plan/plan.json
+++ b/press/press/doctype/plan/plan.json
@@ -20,8 +20,8 @@
   "max_database_usage",
   "max_storage_usage",
   "column_break_13",
+  "is_trial_plan",
   "offsite_backups",
-  "disable_backups",
   "private_benches",
   "database_access",
   "roles_section",
@@ -134,14 +134,14 @@
   },
   {
    "default": "0",
-   "fieldname": "disable_backups",
+   "fieldname": "is_trial_plan",
    "fieldtype": "Check",
-   "label": "Disable Backups"
+   "label": "Is Trial Plan"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-06-29 17:32:32.101383",
+ "modified": "2022-06-29 18:27:35.201726",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Plan",


### PR DESCRIPTION
Also, check_bench_fields was broken for some reason. Fixed it.
#### Traceback
```python3
Traceback (most recent call last):
  File "apps/frappe/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py", line 84, in execute
    frappe.get_attr(self.method)()
  File "apps/press/press/press/audit.py", line 176, in check_bench_fields
    BenchFieldCheck()
  File "apps/press/press/press/audit.py", line 56, in __init__
    log[bench_name].update({"Sites on press only": sites_on_press_only})
KeyError: 'bench-0001-003543-f3-bahrain'```