### PR TITLE
fix: compare only paid sites for backup audit

### DIFF
--- a/press/press/audit.py
+++ b/press/press/audit.py
@@ -122,7 +122,12 @@ class BackupRecordCheck(Audit):
 		all_sites = set(
 			frappe.get_all(
 				"Site",
-				{"status": "Active", "creation": ("<=", interval_hrs_ago), "is_standby": False, "plan": ("not in", trial_plans)},
+				{
+					"status": "Active",
+					"creation": ("<=", interval_hrs_ago),
+					"is_standby": False,
+					"plan": ("not in", trial_plans),
+				},
 				pluck="name",
 			)
 		)

--- a/press/tests/test_audit.py
+++ b/press/tests/test_audit.py
@@ -35,7 +35,9 @@ class TestBackupRecordCheck(TestAudit):
 		audit_log = frappe.get_last_doc(
 			"Audit Log", {"audit_type": BackupRecordCheck.audit_type}
 		)
-		failed_backup_audit_sites = json.loads(audit_log.log)["Sites with no backup in 24 hrs"]
+		failed_backup_audit_sites = json.loads(audit_log.log)[
+			"Sites with no backup in 24 hrs"
+		]
 		self.assertTrue(site.name not in failed_backup_audit_sites)
 
 	def test_audit_succeeds_when_backup_in_interval_exists(self):


### PR DESCRIPTION
Compare only paid sites for backup audit.

Test Changes:
* The test seems wrong since it was assuming the backup record would exist and it failed.
* Fixed it.