### PR TITLE
chore: Get frappe client connection as Admin

### DIFF
--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -602,6 +602,12 @@ class Site(Document):
 		log_site_activity(self.name, "Login as Administrator", reason=reason)
 		return self.get_login_sid()
 
+	def get_connection_as_admin(self):
+		password = get_decrypted_password("Site", self.name, "admin_password")
+		conn = FrappeClient(f"https://{self.name}", "Administrator", password)
+
+		return conn
+
 	def get_login_sid(self):
 		password = get_decrypted_password("Site", self.name, "admin_password")
 		response = requests.post(


### PR DESCRIPTION
Get Frappe Client connection for admin to fetch telemetry data
get_list method doesn't work with just sid and needs a proper connection
