### PR TITLE
feat: Backup restore test

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -180,6 +180,7 @@ scheduler_events = {
 		"press.press.doctype.invoice.invoice.finalize_unpaid_prepaid_credit_invoices",
 		"press.press.doctype.bench.bench.sync_analytics",
 		"press.saas.doctype.saas_app_subscription.saas_app_subscription.suspend_prepaid_subscriptions",
+		"press.press.doctype.backup_restoration_test.backup_test.archive_backup_test_sites"
 	],
 	"hourly": [
 		"press.press.doctype.site.backups.cleanup_local",
@@ -223,6 +224,9 @@ scheduler_events = {
 		"15 2,4 * * *": [
 			"press.press.doctype.team_deletion_request.team_deletion_request.process_team_deletion_requests",
 		],
+		"0 0 1 */3 *": [
+			"press.press.doctype.backup_restoration_test.backup_test.run_backup_restore_test",
+		]
 	},
 }
 

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -180,7 +180,7 @@ scheduler_events = {
 		"press.press.doctype.invoice.invoice.finalize_unpaid_prepaid_credit_invoices",
 		"press.press.doctype.bench.bench.sync_analytics",
 		"press.saas.doctype.saas_app_subscription.saas_app_subscription.suspend_prepaid_subscriptions",
-		"press.press.doctype.backup_restoration_test.backup_test.archive_backup_test_sites"
+		"press.press.doctype.backup_restoration_test.backup_test.archive_backup_test_sites",
 	],
 	"hourly": [
 		"press.press.doctype.site.backups.cleanup_local",
@@ -225,8 +225,8 @@ scheduler_events = {
 			"press.press.doctype.team_deletion_request.team_deletion_request.process_team_deletion_requests",
 		],
 		"0 0 1 */3 *": [
-			"press.press.doctype.backup_restoration_test.backup_test.run_backup_restore_test",
-		]
+			"press.press.doctype.backup_restoration_test.backup_test.run_backup_restore_test"
+		],
 	},
 }
 

--- a/press/press/doctype/backup_restoration_test/backup_restoration_test.js
+++ b/press/press/doctype/backup_restoration_test/backup_restoration_test.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2022, Frappe and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Backup Restoration Test', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/press/press/doctype/backup_restoration_test/backup_restoration_test.json
+++ b/press/press/doctype/backup_restoration_test/backup_restoration_test.json
@@ -9,13 +9,13 @@
  "field_order": [
   "date",
   "status",
-  "site_archived",
   "column_break_3",
   "site",
   "test_site"
  ],
  "fields": [
   {
+   "default": "Today",
    "fieldname": "date",
    "fieldtype": "Date",
    "in_list_view": 1,
@@ -29,13 +29,8 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Pending\nRunning\nSuccess\nFailure\nUndelivered\nArchive Successful\nArchive Failed"
-  },
-  {
-   "default": "0",
-   "fieldname": "site_archived",
-   "fieldtype": "Check",
-   "label": "Test Site Archived"
+   "options": "Pending\nRunning\nSuccess\nFailure\nUndelivered\nArchive Successful\nArchive Failed",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_3",
@@ -53,12 +48,13 @@
    "fieldname": "test_site",
    "fieldtype": "Link",
    "label": "Test Site",
-   "options": "Site"
+   "options": "Site",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-07-25 12:02:28.181011",
+ "modified": "2022-07-27 10:51:47.263608",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Backup Restoration Test",

--- a/press/press/doctype/backup_restoration_test/backup_restoration_test.json
+++ b/press/press/doctype/backup_restoration_test/backup_restoration_test.json
@@ -1,0 +1,84 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:BRT-{DD}-{MM}-{YYYY}-{###}",
+ "creation": "2022-07-25 12:02:28.181011",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "date",
+  "status",
+  "site_archived",
+  "column_break_3",
+  "site",
+  "test_site"
+ ],
+ "fields": [
+  {
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Date"
+  },
+  {
+   "default": "Pending",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Pending\nRunning\nSuccess\nFailure\nUndelivered\nArchive Successful\nArchive Failed"
+  },
+  {
+   "default": "0",
+   "fieldname": "site_archived",
+   "fieldtype": "Check",
+   "label": "Test Site Archived"
+  },
+  {
+   "fieldname": "column_break_3",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "site",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Site",
+   "options": "Site"
+  },
+  {
+   "fieldname": "test_site",
+   "fieldtype": "Link",
+   "label": "Test Site",
+   "options": "Site"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2022-07-25 12:02:28.181011",
+ "modified_by": "Administrator",
+ "module": "Press",
+ "name": "Backup Restoration Test",
+ "naming_rule": "Expression (old style)",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/press/press/doctype/backup_restoration_test/backup_restoration_test.py
+++ b/press/press/doctype/backup_restoration_test/backup_restoration_test.py
@@ -4,8 +4,8 @@
 from frappe.model.document import Document
 from press.api.site import _new
 from typing import Dict
-from random import choice
 import frappe
+
 
 class BackupRestorationTest(Document):
 	def before_insert(self):
@@ -20,15 +20,23 @@ class BackupRestorationTest(Document):
 
 	def check_duplicate_test(self):
 		# check if another backup restoration is already running
-		backups = frappe.get_all("Backup Restoration Test", dict(status=("in",["Running", "Started"]), site=self.site, name=("!=", self.name)), pluck="name")
+		backups = frappe.get_all(
+			"Backup Restoration Test",
+			dict(status=("in", ["Running", "Started"]), site=self.site, name=("!=", self.name)),
+			pluck="name",
+		)
 		if backups:
 			frappe.throw(f"Backup Restoration Test for {self.site} is already running.")
 
 	def check_duplicate_active_site(self):
 		# check if any active backup restoration test site is active
-		sites = frappe.get_all("Site", dict(status="Active", name=self.test_site), pluck="name")
+		sites = frappe.get_all(
+			"Site", dict(status="Active", name=self.test_site), pluck="name"
+		)
 		if sites:
-			frappe.throw(f"Site {self.test_site} is already active. Please archive the site first.")
+			frappe.throw(
+				f"Site {self.test_site} is already active. Please archive the site first."
+			)
 
 	def create_test_site(self) -> None:
 		self.status = "Running"
@@ -38,20 +46,28 @@ class BackupRestorationTest(Document):
 			site_job = _new(site_dict, server)
 			self.test_site = site_job.get("site")
 			self.save()
-		except:
+		except Exception:
 			frappe.log_error("Site Creation Error")
 
+
 def prepare_site(site: str) -> Dict:
+	# prepare site details
 	doc = frappe.get_doc("Site", site)
 	sitename = "brt-" + doc.subdomain
 	app_plans = [app.app for app in doc.apps]
-	backups = frappe.get_all("Site Backup", dict(status="Success", with_files=1, site=site, files_availability="Available", offsite=1), pluck="name")
+	backups = frappe.get_all(
+		"Site Backup",
+		dict(
+			status="Success", with_files=1, site=site, files_availability="Available", offsite=1
+		),
+		pluck="name",
+	)
 	backup = frappe.get_doc("Site Backup", backups[0])
 	files = {
-		"config": '', # not necessary for test sites
+		"config": "",  # not necessary for test sites
 		"database": backup.remote_database_file,
 		"public": backup.remote_public_file,
-		"private": backup.remote_private_file
+		"private": backup.remote_private_file,
 	}
 	site_dict = {
 		"domain": frappe.db.get_single_value("Press Settings", "domain"),
@@ -60,7 +76,7 @@ def prepare_site(site: str) -> Dict:
 		"group": doc.group,
 		"selected_app_plans": {},
 		"apps": app_plans,
-		"files": files
+		"files": files,
 	}
 
 	return site_dict

--- a/press/press/doctype/backup_restoration_test/backup_restoration_test.py
+++ b/press/press/doctype/backup_restoration_test/backup_restoration_test.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2022, Frappe and contributors
+# For license information, please see license.txt
+
+from press.press.audit import get_benches_in_server
+from press.press.doctype.server.server import Server
+from frappe.model.document import Document
+from press.agent import Agent
+from press.api.site import _new
+from typing import List, Dict
+from random import choice
+import frappe
+
+class BackupRestorationTest(Document):
+	def before_insert(self):
+		self.new_sitename = "brt-" + str(self.site)
+
+	def validate(self):
+		self.check_duplicate_test()
+		self.check_duplicate_active_site()
+
+	def after_insert(self):
+		self.create_test_site()
+
+	def check_duplicate_test(self):
+		# check if another backup restoration is already running
+		backups = frappe.get_all("Backup Restoration Test", dict(status=("in",["Running", "Started"]), site=self.site, name=self.name), pluck="name")
+		if backups:
+			frappe.throw(f"Backup Restoration Test for {self.site} is already running.")
+
+	def check_duplicate_active_site(self):
+		# check if any active backup restoration test site is active
+		sites = frappe.get_all("Site", dict(status="Active", name=self.new_sitename), pluck="name")
+		if sites:
+			frappe.throw(f"Site {self.new_sitename} is already active. Please archive the site first.")
+
+	def create_test_site(self) -> None:
+		self.status = "Running"
+		site_dict = prepare_site(self.site)
+		server = frappe.get_value("Site", self.site, "server")
+		try:
+			site_job = _new(site_dict, server)
+			# print(site_job)
+			self.test_site = site_job.get("site")
+		except:
+			frappe.log_error("Site Creation Error")
+			# self.status = "Failed"
+
+def prepare_site(site: str) -> Dict:
+	doc = frappe.get_doc("Site", site)
+	sitename = "brt-" + doc.subdomain
+	app_plans = [app.app for app in doc.apps]
+	backups = frappe.get_all("Site Backup", dict(status="Success", with_files=1, site=site, files_availability="Available", offsite=1), pluck="name")
+	backup = frappe.get_doc("Site Backup", backups[0])
+	files = {
+		"config": '', #json.dumps(doc.config), # frappe.get_site_config()
+		"database": backup.remote_database_file,
+		"public": backup.remote_public_file,
+		"private": backup.remote_private_file
+	}
+	site_dict = {
+		"domain": frappe.db.get_single_value("Press Settings", "domain"),
+		"plan": doc.plan,
+		"name": sitename,
+		"group": doc.group,
+		"selected_app_plans": {},
+		"apps": app_plans,
+		"files": files
+	}
+
+	return site_dict

--- a/press/press/doctype/backup_restoration_test/backup_restoration_test.py
+++ b/press/press/doctype/backup_restoration_test/backup_restoration_test.py
@@ -26,9 +26,9 @@ class BackupRestorationTest(Document):
 
 	def check_duplicate_active_site(self):
 		# check if any active backup restoration test site is active
-		sites = frappe.get_all("Site", dict(status="Active", name=self.new_sitename), pluck="name")
+		sites = frappe.get_all("Site", dict(status="Active", name=self.test_site), pluck="name")
 		if sites:
-			frappe.throw(f"Site {self.new_sitename} is already active. Please archive the site first.")
+			frappe.throw(f"Site {self.test_site} is already active. Please archive the site first.")
 
 	def create_test_site(self) -> None:
 		self.status = "Running"

--- a/press/press/doctype/backup_restoration_test/backup_restoration_test.py
+++ b/press/press/doctype/backup_restoration_test/backup_restoration_test.py
@@ -1,12 +1,9 @@
 # Copyright (c) 2022, Frappe and contributors
 # For license information, please see license.txt
 
-from press.press.audit import get_benches_in_server
-from press.press.doctype.server.server import Server
 from frappe.model.document import Document
-from press.agent import Agent
 from press.api.site import _new
-from typing import List, Dict
+from typing import Dict
 from random import choice
 import frappe
 
@@ -23,7 +20,7 @@ class BackupRestorationTest(Document):
 
 	def check_duplicate_test(self):
 		# check if another backup restoration is already running
-		backups = frappe.get_all("Backup Restoration Test", dict(status=("in",["Running", "Started"]), site=self.site, name=self.name), pluck="name")
+		backups = frappe.get_all("Backup Restoration Test", dict(status=("in",["Running", "Started"]), site=self.site, name=("!=", self.name)), pluck="name")
 		if backups:
 			frappe.throw(f"Backup Restoration Test for {self.site} is already running.")
 
@@ -39,11 +36,10 @@ class BackupRestorationTest(Document):
 		server = frappe.get_value("Site", self.site, "server")
 		try:
 			site_job = _new(site_dict, server)
-			# print(site_job)
 			self.test_site = site_job.get("site")
+			self.save()
 		except:
 			frappe.log_error("Site Creation Error")
-			# self.status = "Failed"
 
 def prepare_site(site: str) -> Dict:
 	doc = frappe.get_doc("Site", site)
@@ -52,7 +48,7 @@ def prepare_site(site: str) -> Dict:
 	backups = frappe.get_all("Site Backup", dict(status="Success", with_files=1, site=site, files_availability="Available", offsite=1), pluck="name")
 	backup = frappe.get_doc("Site Backup", backups[0])
 	files = {
-		"config": '', #json.dumps(doc.config), # frappe.get_site_config()
+		"config": '', # not necessary for test sites
 		"database": backup.remote_database_file,
 		"public": backup.remote_public_file,
 		"private": backup.remote_private_file

--- a/press/press/doctype/backup_restoration_test/backup_test.py
+++ b/press/press/doctype/backup_restoration_test/backup_test.py
@@ -19,9 +19,7 @@ class BackupTest:
         servers = Server.get_all_primary_prod()
         for server in servers:
             benches = self.get_benches(server)
-            # print(benches)
             for bench in benches:
-                # print(frappe.get_all("Site", dict(status="Active", plan=("not in", self.trial_plans), bench=bench), pluck="name"))
                 site = choice(frappe.get_all("Site", dict(status="Active", plan=("not in", self.trial_plans), bench=bench), pluck="name"))
                 sites.append(site)
 
@@ -29,13 +27,12 @@ class BackupTest:
 
     def start(self):
         for site in self.sites:
-            # site_dict = perpare_site(site)
             try:
                 frappe.get_doc({
                     "doctype": "Backup Restoration Test",
                     "date": frappe.utils.now_datetime(),
                     "site": site,
-                    "status": "Running",
+                    "status": "Running"
                 }).insert()
             except:
                 frappe.log_error("Backup Restore Test insertion failed")

--- a/press/press/doctype/backup_restoration_test/backup_test.py
+++ b/press/press/doctype/backup_restoration_test/backup_test.py
@@ -74,7 +74,9 @@ class BackupTest:
 
 def archive_backup_test_sites():
 	backup_tests = frappe.get_all(
-		"Backup Restoration Test", dict(site_archived=0), pluck="test_site"
+		"Backup Restoration Test",
+		dict(status=("in", ("Archive Failed", "Success"))),
+		pluck="test_site",
 	)
 	if backup_tests:
 		for test_site in backup_tests:

--- a/press/press/doctype/backup_restoration_test/backup_test.py
+++ b/press/press/doctype/backup_restoration_test/backup_test.py
@@ -8,59 +8,80 @@ from random import choice
 
 import frappe
 
+
 class BackupTest:
+	def __init__(self) -> None:
+		self.trial_plans = frappe.get_all(
+			"Plan", dict(enabled=1, is_trial_plan=1), pluck="name"
+		)
+		self.sites = self.get_random_sites()
 
-    def __init__(self) -> None:
-        self.trial_plans = frappe.get_all("Plan", dict(enabled=1, is_trial_plan=1), pluck="name")
-        self.sites = self.get_random_sites()
+	def get_random_sites(self) -> List:
+		sites = []
+		servers = Server.get_all_primary_prod()
+		for server in servers:
+			benches = self.get_benches(server)
+			for bench in benches:
+				site = choice(
+					frappe.get_all(
+						"Site",
+						dict(status="Active", plan=("not in", self.trial_plans), bench=bench),
+						pluck="name",
+					)
+				)
+				sites.append(site)
 
-    def get_random_sites(self) -> List:
-        sites = []
-        servers = Server.get_all_primary_prod()
-        for server in servers:
-            benches = self.get_benches(server)
-            for bench in benches:
-                site = choice(frappe.get_all("Site", dict(status="Active", plan=("not in", self.trial_plans), bench=bench), pluck="name"))
-                sites.append(site)
+		return sites
 
-        return sites
+	def start(self):
+		for site in self.sites:
+			try:
+				frappe.get_doc(
+					{
+						"doctype": "Backup Restoration Test",
+						"date": frappe.utils.now_datetime(),
+						"site": site,
+						"status": "Running",
+					}
+				).insert()
+			except Exception:
+				frappe.log_error("Backup Restore Test insertion failed")
 
-    def start(self):
-        for site in self.sites:
-            try:
-                frappe.get_doc({
-                    "doctype": "Backup Restoration Test",
-                    "date": frappe.utils.now_datetime(),
-                    "site": site,
-                    "status": "Running"
-                }).insert()
-            except:
-                frappe.log_error("Backup Restore Test insertion failed")
+	def get_benches(self, server: str) -> List[str]:
+		benches = get_benches_in_server(server)
 
-    def get_benches(self, server: str) -> List[str]:
-        benches = get_benches_in_server(server)
+		# select all benches
+		release_groups = frappe.get_all(
+			"Release Group", dict(enabled=1, public=1), pluck="name"
+		)
+		central_groups = frappe.get_all(
+			"Release Group", dict(enabled=1, central_bench=1), pluck="name"
+		)
+		groups = release_groups + central_groups
 
-        release_groups = frappe.get_all("Release Group", dict(enabled=1, public=1), pluck="name")
-        central_groups = frappe.get_all("Release Group", dict(enabled=1, central_bench=1), pluck="name")
-        groups = release_groups + central_groups
+		bench_list = []
+		for group in groups:
+			group_benches = frappe.get_all(
+				"Bench", dict(status="Active", group=group), pluck="name"
+			)
 
-        bench_list = []
-        for group in groups:
-            group_benches = frappe.get_all("Bench", dict(status="Active", group=group), pluck="name")
+			for bench in benches.keys():
+				if bench in group_benches:
+					bench_list.append(bench)
 
-            for bench in benches.keys():
-                if bench in group_benches:
-                    bench_list.append(bench)
+		return bench_list
 
-        return bench_list
 
 def archive_backup_test_sites():
-    backup_tests = frappe.get_all("Backup Restoration Test", dict(site_archived=0), pluck="test_site")
-    if backup_tests:
-        for test_site in backup_tests:
-            site = frappe.get_doc("Site", test_site)
-            if site.status == "Active":
-                site.archive(reason="Backup Restoration Test")
+	backup_tests = frappe.get_all(
+		"Backup Restoration Test", dict(site_archived=0), pluck="test_site"
+	)
+	if backup_tests:
+		for test_site in backup_tests:
+			site = frappe.get_doc("Site", test_site)
+			if site.status == "Active":
+				site.archive(reason="Backup Restoration Test")
+
 
 def run_backup_restore_test():
 	backup_restoration_test = BackupTest()

--- a/press/press/doctype/backup_restoration_test/backup_test.py
+++ b/press/press/doctype/backup_restoration_test/backup_test.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2022, Frappe and contributors
+# For license information, please see license.txt
+
+from press.press.audit import get_benches_in_server
+from press.press.doctype.server.server import Server
+from typing import List
+from random import choice
+
+import frappe
+
+class BackupTest:
+
+    def __init__(self) -> None:
+        self.trial_plans = frappe.get_all("Plan", dict(enabled=1, is_trial_plan=1), pluck="name")
+        self.sites = self.get_random_sites()
+
+    def get_random_sites(self) -> List:
+        sites = []
+        servers = Server.get_all_primary_prod()
+        for server in servers:
+            benches = self.get_benches(server)
+            # print(benches)
+            for bench in benches:
+                # print(frappe.get_all("Site", dict(status="Active", plan=("not in", self.trial_plans), bench=bench), pluck="name"))
+                site = choice(frappe.get_all("Site", dict(status="Active", plan=("not in", self.trial_plans), bench=bench), pluck="name"))
+                sites.append(site)
+
+        return sites
+
+    def start(self):
+        for site in self.sites:
+            # site_dict = perpare_site(site)
+            try:
+                frappe.get_doc({
+                    "doctype": "Backup Restoration Test",
+                    "date": frappe.utils.now_datetime(),
+                    "site": site,
+                    "status": "Running",
+                }).insert()
+            except:
+                frappe.log_error("Backup Restore Test insertion failed")
+
+    def get_benches(self, server: str) -> List[str]:
+        benches = get_benches_in_server(server)
+
+        release_groups = frappe.get_all("Release Group", dict(enabled=1, public=1), pluck="name")
+        central_groups = frappe.get_all("Release Group", dict(enabled=1, central_bench=1), pluck="name")
+        groups = release_groups + central_groups
+
+        bench_list = []
+        for group in groups:
+            group_benches = frappe.get_all("Bench", dict(status="Active", group=group), pluck="name")
+
+            for bench in benches.keys():
+                if bench in group_benches:
+                    bench_list.append(bench)
+
+        return bench_list
+
+def archive_backup_test_sites():
+    backup_tests = frappe.get_all("Backup Restoration Test", dict(site_archived=0), pluck="test_site")
+    if backup_tests:
+        for test_site in backup_tests:
+            site = frappe.get_doc("Site", test_site)
+            if site.status == "Active":
+                site.archive(reason="Backup Restoration Test")
+
+def run_backup_restore_test():
+	backup_restoration_test = BackupTest()
+	backup_restoration_test.start()

--- a/press/press/doctype/backup_restoration_test/test_backup_restoration_test.py
+++ b/press/press/doctype/backup_restoration_test/test_backup_restoration_test.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2022, Frappe and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestBackupRestorationTest(FrappeTestCase):
+	pass

--- a/press/press/doctype/release_group/release_group.json
+++ b/press/press/doctype/release_group/release_group.json
@@ -14,6 +14,7 @@
   "enabled",
   "default",
   "public",
+  "central_bench",
   "saas_bench",
   "saas_app",
   "section_break_7",
@@ -156,10 +157,16 @@
    "fieldtype": "Link",
    "label": "SaaS App",
    "options": "Saas App"
+  },
+  {
+   "default": "0",
+   "fieldname": "central_bench",
+   "fieldtype": "Check",
+   "label": "Central Bench"
   }
  ],
  "links": [],
- "modified": "2022-05-20 21:23:06.309616",
+ "modified": "2022-07-25 12:09:11.054459",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Release Group",

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1246,7 +1246,9 @@ def process_archive_site_job_update(job):
 
 	# backup restoration test
 	backup_tests = frappe.get_all(
-		"Backup Restoration Test", dict(test_site=job.site, site_archived=0), pluck="name"
+		"Backup Restoration Test",
+		dict(test_site=job.site, status=("in", ("Success", "Archive Failed"))),
+		pluck="name",
 	)
 
 	if "Success" == first == second:
@@ -1264,7 +1266,7 @@ def process_archive_site_job_update(job):
 				frappe.db.set_value(
 					"Backup Restoration Test",
 					backup_tests[0],
-					{"status": "Archive Successful", "site_archived": 1},
+					{"status": "Archive Successful"},
 				)
 			site_cleanup_after_archive(job.site)
 		elif updated_status == "Broken" and backup_tests:

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1253,7 +1253,10 @@ def process_archive_site_job_update(job):
 		frappe.db.set_value("Site", job.site, "status", updated_status)
 		if updated_status == "Archived":
 			if backup_tests:
-				frappe.db.set_value("Backup Restoration Test", backup_tests[0], "status", "Archive Successful")
+				frappe.db.set_value("Backup Restoration Test", backup_tests[0], {
+					"status": "Archive Successful",
+					"site_archived": 1
+				})
 			site_cleanup_after_archive(job.site)
 		elif updated_status == "Broken" and backup_tests:
 			frappe.db.set_value("Backup Restoration Test", backup_tests[0], "status", "Archive Failed")

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1200,7 +1200,9 @@ def process_new_site_job_update(job):
 		filters={"job_type": ("in", other_job_types), "site": job.site},
 	)[0].status
 
-	backup_tests = frappe.get_all("Backup Restoration Test", dict(test_site=job.site, status="Running"), pluck="name")
+	backup_tests = frappe.get_all(
+		"Backup Restoration Test", dict(test_site=job.site, status="Running"), pluck="name"
+	)
 
 	if "Success" == first == second:
 		updated_status = "Active"
@@ -1215,16 +1217,19 @@ def process_new_site_job_update(job):
 		"Active": "Success",
 		"Broken": "Failure",
 		"Installing": "Running",
-		"Pending": "Running"
+		"Pending": "Running",
 	}
 
 	site_status = frappe.get_value("Site", job.site, "status")
 	if updated_status != site_status:
 		if backup_tests:
-			frappe.db.set_value("Backup Restoration Test", backup_tests[0], "status", status_map[updated_status])
+			frappe.db.set_value(
+				"Backup Restoration Test", backup_tests[0], "status", status_map[updated_status]
+			)
 			frappe.db.commit()
 
 		frappe.db.set_value("Site", job.site, "status", updated_status)
+
 
 def process_archive_site_job_update(job):
 	other_job_type = {
@@ -1239,7 +1244,10 @@ def process_archive_site_job_update(job):
 		filters={"job_type": other_job_type, "site": job.site},
 	)[0].status
 
-	backup_tests = frappe.get_all("Backup Restoration Test", dict(test_site=job.site, site_archived=0), pluck="name")
+	# backup restoration test
+	backup_tests = frappe.get_all(
+		"Backup Restoration Test", dict(test_site=job.site, site_archived=0), pluck="name"
+	)
 
 	if "Success" == first == second:
 		updated_status = "Archived"
@@ -1253,15 +1261,17 @@ def process_archive_site_job_update(job):
 		frappe.db.set_value("Site", job.site, "status", updated_status)
 		if updated_status == "Archived":
 			if backup_tests:
-				frappe.db.set_value("Backup Restoration Test", backup_tests[0], {
-					"status": "Archive Successful",
-					"site_archived": 1
-				})
+				frappe.db.set_value(
+					"Backup Restoration Test",
+					backup_tests[0],
+					{"status": "Archive Successful", "site_archived": 1},
+				)
 			site_cleanup_after_archive(job.site)
 		elif updated_status == "Broken" and backup_tests:
-			frappe.db.set_value("Backup Restoration Test", backup_tests[0], "status", "Archive Failed")
+			frappe.db.set_value(
+				"Backup Restoration Test", backup_tests[0], "status", "Archive Failed"
+			)
 		frappe.db.commit()
-
 
 
 def process_install_app_site_job_update(job):

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1222,11 +1222,9 @@ def process_new_site_job_update(job):
 	if updated_status != site_status:
 		if backup_tests:
 			frappe.db.set_value("Backup Restoration Test", backup_tests[0], "status", status_map[updated_status])
+			frappe.db.commit()
 
 		frappe.db.set_value("Site", job.site, "status", updated_status)
-	elif updated_status == site_status and backup_tests:
-		frappe.db.set_value("Backup Restoration Test", backup_tests[0], "status", status_map[updated_status])
-
 
 def process_archive_site_job_update(job):
 	other_job_type = {
@@ -1250,12 +1248,6 @@ def process_archive_site_job_update(job):
 	else:
 		updated_status = "Pending"
 
-	status_map = {
-		"Archived": "Success",
-		"Broken": "Failure",
-		"Pending": "Running"
-	}
-
 	site_status = frappe.get_value("Site", job.site, "status")
 	if updated_status != site_status:
 		frappe.db.set_value("Site", job.site, "status", updated_status)
@@ -1265,6 +1257,7 @@ def process_archive_site_job_update(job):
 			site_cleanup_after_archive(job.site)
 		elif updated_status == "Broken" and backup_tests:
 			frappe.db.set_value("Backup Restoration Test", backup_tests[0], "status", "Archive Failed")
+		frappe.db.commit()
 
 
 


### PR DESCRIPTION
## Backup Restoration Test
 * Selects a random site from each bench (currently only works for public benches and central bench)
 * Creates a new test site with the prefix "brt-" appended.
 * Once the test site is successfully created the backup test is marked as a Success.
 * A daily clean-up job deletes all test sites created for the backup tests.
 * Backup restore test runs once every quarter.

### Images:
<img width="1284" alt="Screenshot 2022-07-26 at 5 41 02 PM" src="https://user-images.githubusercontent.com/30501401/181041148-8885c812-e31d-4adc-8437-f99fcdfebd50.png">

<img width="1300" alt="Screenshot 2022-07-26 at 5 40 34 PM" src="https://user-images.githubusercontent.com/30501401/181041172-70d0649b-b579-4d0f-8df2-a581d7d8a990.png">

<img width="1290" alt="Screenshot 2022-07-26 at 5 37 33 PM" src="https://user-images.githubusercontent.com/30501401/181041235-a8fd9ce1-20e3-4e16-a2fa-4079fc003d18.png">


<img width="1296" alt="Screenshot 2022-07-26 at 5 37 44 PM" src="https://user-images.githubusercontent.com/30501401/181041210-16f48b91-a2a0-4205-997a-2eafd8c1ded6.png">

