### PR TITLE
feat: click on compare app update arrow to see diff

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# Root editor config file
+root = true
+
+# Common settings
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+# python, js indentation settings
+[{*.py}]
+indent_style = tab
+indent_size = 4
+
+
+[{*.js,*.vue}]
+indent_style = tab
+indent_size = 2

--- a/dashboard/src/components/AppUpdateCard.vue
+++ b/dashboard/src/components/AppUpdateCard.vue
@@ -37,7 +37,7 @@
 			</a>
 			<a
 				v-if="deployFrom(app)"
-				class="block cursor-pointer"
+				class="flex cursor-pointer flex-col justify-center"
 				:href="`${app.repository_url}/compare/${app.current_hash}..${app.next_hash}`"
 				target="_blank"
 			>

--- a/dashboard/src/components/AppUpdateCard.vue
+++ b/dashboard/src/components/AppUpdateCard.vue
@@ -35,7 +35,14 @@
 					{{ deployFrom(app) }}
 				</Badge>
 			</a>
-			<FeatherIcon v-if="deployFrom(app)" name="arrow-right" class="w-4" />
+			<a
+				v-if="deployFrom(app)"
+				class="block cursor-pointer"
+				:href="`${app.repository_url}/compare/${app.current_hash}..${app.next_hash}`"
+				target="_blank"
+			>
+				<FeatherIcon name="arrow-right" class="w-4" />
+			</a>
 			<Badge color="green" v-else>First Deploy</Badge>
 			<a
 				class="block cursor-pointer"


### PR DESCRIPTION
Github has special URL for showing diff between two commits. While upgrading you
can now click on the tiny arrow to see the diff.


<img width="569" alt="Screenshot 2022-08-16 at 5 36 42 PM" src="https://user-images.githubusercontent.com/9079960/184875706-df4d7f66-a8aa-4bcb-a8a7-3bea334c7898.png">


Example URL: https://github.com/frappe/frappe/compare/cadbf91c5874af6b95165d299039cac26eb6cb10..3ec4a618e3a9c56b56c26f11cd76e157dddd3179 



CAUTION / note to reviewer: 
- I do not have local setup, I've edited this totally #YOLO. So please don't trust my vuejs skillz 
- Some styles _might_ be broken since this moves arrow one level down in element tree)



Other changes:
- Added [.editorconfig](https://editorconfig.org/) so contributors don't need to modify their settings when they work on this project. Inline with other frappe projects. Make sure this is okay for you, I only added basic things based on black and prettier settings. 