### PR TITLE
fix: only update required keys in site_config limits

### DIFF
--- a/press/press/doctype/erpnext_site_settings/erpnext_site_settings.py
+++ b/press/press/doctype/erpnext_site_settings/erpnext_site_settings.py
@@ -2,21 +2,22 @@
 # For license information, please see license.txt
 
 import frappe
+import json
 from frappe.model.document import Document
 
 
 class ERPNextSiteSettings(Document):
 	def on_update(self):
-		limits = {
-			"users": self.users,
-			"expiry": self.expiry,
-			"emails": self.emails,
-			"space": self.space,
-			"current_plan": self.plan,
-		}
+		config_keys = ("users", "expiry", "emails", "space", "current_plan")
+		values = (self.users, self.expiry, self.emails, self.space, self.plan)
+
+		site = frappe.get_doc("Site", self.site)
+		config = json.loads(site.config)
+		limits = config["limits"]
+
+		limits.update(dict(zip(config_keys, values)))
 
 		# remove null/empty values
 		limits = {k: v for k, v in limits.items() if v}
 
-		site = frappe.get_doc("Site", self.site)
 		site.update_site_config({"limits": limits})


### PR DESCRIPTION
Earlier `on_update` method used to override the limits value in site_config.

for example:
if there are two keys in limits and only `a` needs to be updated, then `on_update` method overrides entire limits dict
```
limits: {
  "a": "x",
  "b": "y"
}
```

to
```
limits: {
  "a": "x"
}
```

This change will still update keys like users, emails, space etc but won't remove the other keys in limits.