### PR TITLE
fix: show proper commit-wise diff [minor]

### DIFF
--- a/dashboard/src/components/AppUpdateCard.vue
+++ b/dashboard/src/components/AppUpdateCard.vue
@@ -29,7 +29,7 @@
 			<a
 				v-if="deployFrom(app)"
 				class="flex cursor-pointer flex-col justify-center"
-				:href="`${app.repository_url}/compare/${app.current_hash}..${app.next_hash}`"
+				:href="`${app.repository_url}/compare/${app.current_hash}...${app.next_hash}`"
 				target="_blank"
 			>
 				<FeatherIcon name="arrow-right" class="w-4" />


### PR DESCRIPTION
2 dots - absolute diff
3 dots - diff assuming it shares a base parent commit somewhere in history. So it shows the commits too.
