### PR TITLE
fix: disable all subs for inactive sites

### DIFF
--- a/press/patches.txt
+++ b/press/patches.txt
@@ -84,3 +84,4 @@ press.press.doctype.proxy_server.patches.generate_proxysql_monitor_password
 press.press.doctype.virtual_machine.patches.populate_volumes_table
 press.press.doctype.release_group.patches.set_bench_dependency_in_release_group
 press.press.doctype.press_settings.patches.move_stripe_credentials_to_press_settings
+press.patches.v0_0_4.disable_subscriptions_for_inactive_sites

--- a/press/patches/v0_0_4/disable_subscriptions_for_inactive_sites.py
+++ b/press/patches/v0_0_4/disable_subscriptions_for_inactive_sites.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
+# For license information, please see license.txt
+
+import frappe
+
+
+def execute():
+	subscription = frappe.qb.DocType("Subscription")
+	site = frappe.qb.DocType("Site")
+
+	inactive_sites = (
+		frappe.qb.from_(subscription)
+		.left_join(site)
+		.on(subscription.document_name == site.name)
+		.select(subscription.name)
+		.where(site.status.isin(["Archived", "Broken", "Suspended"]))
+	).run(pluck=True)
+
+	(
+		frappe.qb.update(subscription)
+		.set(subscription.enabled, 0)
+		.where(subscription.enabled == 1)
+		.where(subscription.name.isin(inactive_sites))
+	).run()

--- a/press/press/doctype/subscription/subscription.py
+++ b/press/press/doctype/subscription/subscription.py
@@ -30,12 +30,18 @@ class Subscription(Document):
 			doc.save()
 
 	def enable(self):
-		self.enabled = True
-		self.save()
+		try:
+			self.enabled = True
+			self.save()
+		except Exception:
+			frappe.log_error(title="Enable Subscription Error")
 
 	def disable(self):
-		self.enabled = False
-		self.save()
+		try:
+			self.enabled = False
+			self.save()
+		except Exception:
+			frappe.log_error(title="Disable Subscription Error")
 
 	@frappe.whitelist()
 	def create_usage_record(self):
@@ -144,7 +150,7 @@ def create_usage_records():
 		"Subscription", filters={"enabled": True}, pluck="name"
 	)
 	for name in subscriptions:
-		subscription = frappe.get_doc("Subscription", name)
+		subscription = frappe.get_cached_doc("Subscription", name)
 		try:
 			subscription.create_usage_record()
 			frappe.db.commit()


### PR DESCRIPTION
For some weird reasons, on-site update subscriptions were not disabled and there was no error log for the same.
Due to this lots of subscriptions remain enabled, even for suspended and archived sites, which in turn causes timeout while creating `usage_record` in loop here:

https://github.com/frappe/press/blob/master/press/press/doctype/subscription/subscription.py#L146-L153