### PR TITLE
refactor: Signup flows and minor updates in subscription flows

### DIFF
--- a/dashboard/src/views/saas/RemoteLoginSuccess.vue
+++ b/dashboard/src/views/saas/RemoteLoginSuccess.vue
@@ -9,8 +9,7 @@ export default {
 		login: () => {
 			const params = new URLSearchParams(window.location.search)
 			localStorage.setItem('current_team', params.get("team"))
-			localStorage.setItem('saas_login', true);
-			window.location.href = '/dashboard/saas/apps';
+			window.location.href = `/dashboard/sites/${params.get("site")}/overview`;
 		}
 	},
 	created() {

--- a/press/api/developer/marketplace.py
+++ b/press/api/developer/marketplace.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.utils import get_url
 from typing import Dict
 
 from press.api.developer import raise_invalid_key_error
@@ -50,6 +51,41 @@ class DeveloperApiHandler:
 
 		return filtered_dict
 
+	def get_login_url(self):
+		# check for active tokens
+		team = frappe.db.get_value("Site", self.app_subscription_doc.site, "team")
+		if frappe.db.exists(
+			"Saas Remote Login",
+			{
+				"team": team,
+				"status": "Attempted",
+				"expires_on": (">", frappe.utils.now()),
+			},
+		):
+			doc = frappe.get_doc(
+				"Saas Remote Login",
+				{
+					"team": team,
+					"status": "Attempted",
+					"expires_on": (">", frappe.utils.now()),
+				},
+			)
+			token = doc.token
+		else:
+			token = frappe.generate_hash("Saas Remote Login", 50)
+			frappe.get_doc(
+				{
+					"doctype": "Saas Remote Login",
+					"team": team,
+					"token": token,
+				}
+			).insert(ignore_permissions=True)
+			frappe.db.commit()
+
+		return get_url(
+			f"/api/method/press.api.marketplace.login_via_token?token={token}&team={team}&site={self.app_subscription_doc.site}"
+		)
+
 
 # ------------------------------------------------------------
 # API ENDPOINTS
@@ -64,3 +100,9 @@ def get_subscription_status(secret_key: str) -> str:
 def get_subscription_info(secret_key: str) -> Dict:
 	api_handler = DeveloperApiHandler(secret_key)
 	return api_handler.get_subscription_info()
+
+
+@frappe.whitelist(allow_guest=True)
+def get_login_url(secret_key):
+	api_handler = DeveloperApiHandler(secret_key)
+	return api_handler.get_login_url()

--- a/press/marketplace/doctype/marketplace_app_subscription/marketplace_app_subscription.py
+++ b/press/marketplace/doctype/marketplace_app_subscription/marketplace_app_subscription.py
@@ -6,6 +6,7 @@ import json
 
 from press.utils import log_error
 from frappe.model.document import Document
+from frappe.utils import get_url
 from press.press.doctype.site.site import Site
 
 
@@ -72,14 +73,22 @@ class MarketplaceAppSubscription(Document):
 	def after_insert(self):
 		# TODO: Check if this key already exists
 		if not self.while_site_creation:
-			self.set_secret_key_in_site_config()
+			self.set_keys_in_site_config()
 
-	def set_secret_key_in_site_config(self):
+	def set_keys_in_site_config(self):
 		site_doc: Site = frappe.get_doc("Site", self.site)
 
-		key = f"sk_{self.app}"
-		value = self.secret_key
-		config = {key: value}
+		key_id = f"sk_{self.app}"
+		secret_key = self.secret_key
+
+		config = {
+			key_id: secret_key,
+			"login_url": get_url(
+				f"/api/method/press.api.developer.marketplace.get_login_url?secret_key={secret_key}"
+			),
+		}
+		if self.expiry:
+			config.update({"expiry": str(self.expiry)})
 
 		site_doc.update_site_config(config)
 

--- a/press/saas/doctype/saas_setup_account_generator/saas_setup_account_generator.py
+++ b/press/saas/doctype/saas_setup_account_generator/saas_setup_account_generator.py
@@ -13,7 +13,7 @@ class SaasSetupAccountGenerator(WebsiteGenerator):
 	)
 
 	def get_context(self, context):
-		context.parents = [{"name": "Saas App"}]
+		context.parents = [{"name": "Marketplace App"}]
 
 	def validate(self):
 		if not self.custom_route:

--- a/press/saas/doctype/saas_signup_generator/saas_signup_generator.py
+++ b/press/saas/doctype/saas_signup_generator/saas_signup_generator.py
@@ -13,7 +13,7 @@ class SaasSignupGenerator(WebsiteGenerator):
 	)
 
 	def get_context(self, context):
-		context.parents = [{"name": "Saas App"}]
+		context.parents = [{"name": "Marketplace App"}]
 
 	def validate(self):
 		if not self.custom_route:


### PR DESCRIPTION
- [ ] Set two site config keys for trial signups **login_url** and **expiry**. These keys will be used for easy navigation from site to dashboard. And showing subscription related info like a floating banner when subscription is in trial or grace period.
- [ ] UI refresh for signup templates