### PR TITLE
feat: new child table for last actives

### DIFF
--- a/press/press/doctype/site_analytics/site_analytics.json
+++ b/press/press/doctype/site_analytics/site_analytics.json
@@ -21,8 +21,13 @@
   "backup_size",
   "files_size",
   "section_break_17",
+  "logged_in_users",
+  "column_break_18",
+  "active_users",
+  "section_break_20",
   "users",
   "last_logins",
+  "last_active",
   "installed_apps",
   "erpnext_section",
   "activation_level",
@@ -182,11 +187,36 @@
   {
    "fieldname": "column_break_26",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "logged_in_users",
+   "fieldtype": "Int",
+   "label": "Users Logged In Today"
+  },
+  {
+   "fieldname": "column_break_18",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "active_users",
+   "fieldtype": "Int",
+   "label": "Active Users"
+  },
+  {
+   "fieldname": "section_break_20",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "last_active",
+   "fieldtype": "Table",
+   "label": "Last Active",
+   "options": "Site Analytics Active",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-05-05 09:29:20.505913",
+ "modified": "2022-09-29 17:11:33.611117",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site Analytics",

--- a/press/press/doctype/site_analytics/site_analytics.json
+++ b/press/press/doctype/site_analytics/site_analytics.json
@@ -21,10 +21,6 @@
   "backup_size",
   "files_size",
   "section_break_17",
-  "logged_in_users",
-  "column_break_18",
-  "active_users",
-  "section_break_20",
   "users",
   "last_logins",
   "last_active",
@@ -189,24 +185,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "logged_in_users",
-   "fieldtype": "Int",
-   "label": "Users Logged In Today"
-  },
-  {
-   "fieldname": "column_break_18",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "active_users",
-   "fieldtype": "Int",
-   "label": "Active Users"
-  },
-  {
-   "fieldname": "section_break_20",
-   "fieldtype": "Section Break"
-  },
-  {
    "fieldname": "last_active",
    "fieldtype": "Table",
    "label": "Last Active",
@@ -216,7 +194,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-09-29 17:11:33.611117",
+ "modified": "2022-09-29 18:13:51.797874",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site Analytics",

--- a/press/press/doctype/site_analytics/site_analytics.py
+++ b/press/press/doctype/site_analytics/site_analytics.py
@@ -35,6 +35,14 @@ def create_site_analytics(site, data):
 				)
 		return sales_data
 
+	def get_last_active(analytics):
+		last_active = []
+		for user in analytics.get("users", []):
+			if user and user.get("enabled") == 1:
+				last_active.append(user)
+
+		return last_active
+
 	timestamp = data["timestamp"]
 	analytics = data["analytics"]
 	if not frappe.db.exists("Site Analytics", {"site": site, "timestamp": timestamp}):
@@ -56,6 +64,7 @@ def create_site_analytics(site, data):
 				"installed_apps": analytics.get("installed_apps", []),
 				"users": analytics.get("users", []),
 				"last_logins": get_last_logins(analytics),
+				"last_active": get_last_active(analytics),
 				"company": analytics.get("company"),
 				"domain": analytics.get("domain"),
 				"activation_level": analytics.get("activation", {}).get("activation_level"),

--- a/press/press/doctype/site_analytics_active/site_analytics_active.json
+++ b/press/press/doctype/site_analytics_active/site_analytics_active.json
@@ -1,0 +1,78 @@
+{
+ "actions": [],
+ "autoname": "autoincrement",
+ "creation": "2022-09-29 17:09:45.285414",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "email",
+  "full_name",
+  "last_active",
+  "last_login",
+  "enabled",
+  "is_system_manager",
+  "language",
+  "time_zone"
+ ],
+ "fields": [
+  {
+   "fieldname": "email",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Email"
+  },
+  {
+   "fieldname": "full_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Full Name"
+  },
+  {
+   "fieldname": "last_active",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "Last Active"
+  },
+  {
+   "fieldname": "last_login",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "Last Login"
+  },
+  {
+   "default": "0",
+   "fieldname": "enabled",
+   "fieldtype": "Check",
+   "label": "Enabled"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_system_manager",
+   "fieldtype": "Check",
+   "label": "Is System Manager"
+  },
+  {
+   "fieldname": "language",
+   "fieldtype": "Data",
+   "label": "Language"
+  },
+  {
+   "fieldname": "time_zone",
+   "fieldtype": "Data",
+   "label": "Time Zone"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2022-09-30 11:41:01.033086",
+ "modified_by": "Administrator",
+ "module": "Press",
+ "name": "Site Analytics Active",
+ "naming_rule": "Autoincrement",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/press/press/doctype/site_analytics_active/site_analytics_active.py
+++ b/press/press/doctype/site_analytics_active/site_analytics_active.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2022, Frappe and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class SiteAnalyticsActive(Document):
+	pass


### PR DESCRIPTION
New child table in site analytics which shows the last active timestamp only for enabled system users