### PR TITLE
feat: Users can change SSH keys

### DIFF
--- a/dashboard/src/components/Popover.vue
+++ b/dashboard/src/components/Popover.vue
@@ -7,7 +7,7 @@
 			<div
 				ref="popover"
 				:class="popoverClass"
-				class="popover-container relative rounded-md border bg-white shadow-md"
+				class="popover-container relative z-50 rounded-md border bg-white shadow-md"
 				v-show="isOpen"
 			>
 				<div v-if="!hideArrow" class="popover-arrow" ref="popover-arrow"></div>

--- a/dashboard/src/views/settings/AccountSSHKey.vue
+++ b/dashboard/src/views/settings/AccountSSHKey.vue
@@ -23,6 +23,7 @@
 			<Button v-if="!$account.ssh_key" @click="showAddNewKeyDialog = true">
 				New SSH Key
 			</Button>
+			<Button v-else @click="showAddNewKeyDialog = true"> Change SSH Key </Button>
 		</template>
 		<FrappeUIDialog
 			:options="{ title: 'New SSH Key' }"

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -305,9 +305,12 @@ def get():
 
 
 def get_ssh_key(user):
-	ssh_keys = frappe.get_all("User SSH Key", {"user": user})
+	ssh_keys = frappe.get_all(
+		"User SSH Key", {"user": user, "is_default": True}, order_by="creation desc", limit=1
+	)
 	if ssh_keys:
 		return frappe.get_doc("User SSH Key", ssh_keys[0])
+
 	return None
 
 

--- a/press/api/bench.py
+++ b/press/api/bench.py
@@ -624,7 +624,7 @@ def certificate(name):
 @protected("Release Group")
 def generate_certificate(name):
 	user_ssh_key = frappe.get_all(
-		"User SSH Key", {"user": frappe.session.user}, pluck="name"
+		"User SSH Key", {"user": frappe.session.user, "is_default": True}, pluck="name"
 	)[0]
 	return frappe.get_doc(
 		{

--- a/press/press/doctype/user_ssh_key/user_ssh_key.json
+++ b/press/press/doctype/user_ssh_key/user_ssh_key.json
@@ -7,6 +7,9 @@
  "engine": "InnoDB",
  "field_order": [
   "user",
+  "column_break_2",
+  "is_default",
+  "section_break_4",
   "ssh_public_key",
   "ssh_fingerprint"
  ],
@@ -31,11 +34,25 @@
    "in_list_view": 1,
    "label": "SSH Fingerprint",
    "read_only": 1
+  },
+  {
+   "default": "1",
+   "fieldname": "is_default",
+   "fieldtype": "Check",
+   "label": "Is Default"
+  },
+  {
+   "fieldname": "column_break_2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_4",
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-01-31 10:41:42.423892",
+ "modified": "2022-10-11 15:57:00.071186",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "User SSH Key",


### PR DESCRIPTION
Users can now Change SSH keys from settings. This action does not edit the existing **User SSH Key** document, instead it creates a new one. 

Added a new field `is_default` in  **User SSH Key** DocType to track the default key for the user. Currently, only the default key is shown in the dashboard. We can show all the added keys as a list later.

When a new key is added, it is set to default and others become non-default.

Fixes: #507 (sort of), #535