### PR TITLE
feat: Micro charges for card testing/confidence

### DIFF
--- a/dashboard/src/components/StripeCard.vue
+++ b/dashboard/src/components/StripeCard.vue
@@ -195,6 +195,7 @@ export default {
 
 						this.addingCard = false;
 					} catch (error) {
+						console.error(error);
 						this.addingCard = false;
 						this.errorMessage = error.messages.join('\n');
 					}
@@ -218,7 +219,7 @@ export default {
 			}
 		},
 
-		async _verifyWithMicroCharge() {
+		async _verifyWithMicroCharge(paymentMethodName) {
 			this.tryingMicroCharge = true;
 
 			const paymentIntent = await this.$call(

--- a/dashboard/src/components/StripeCard.vue
+++ b/dashboard/src/components/StripeCard.vue
@@ -7,33 +7,42 @@
 			<Spinner class="h-5 w-5 text-gray-600" />
 		</div>
 		<div :class="{ 'opacity-0': !ready }">
-			<label class="block">
-				<span class="text-sm leading-4 text-gray-700">
-					Credit or Debit Card
-				</span>
-				<div
-					class="form-input mt-2 block w-full py-2 pl-3"
-					ref="card-element"
-				></div>
-				<ErrorMessage class="mt-1" :error="cardErrorMessage" />
-			</label>
-			<Input
-				class="mt-4"
-				label="Name on Card"
-				type="text"
-				v-model="billingInformation.cardHolderName"
-			/>
-			<AddressForm
-				v-if="!withoutAddress"
-				class="mt-4"
-				v-model:address="billingInformation"
-				ref="address-form"
-			/>
-			<ErrorMessage class="mt-2" :error="errorMessage" />
-
-			<div v-show="tryingMicroCharge">
-				<Button :loading="true">Trying Test Charge</Button>
+			<div v-show="!tryingMicroCharge">
+				<label class="block">
+					<span class="text-sm leading-4 text-gray-700">
+						Credit or Debit Card
+					</span>
+					<div
+						class="form-input mt-2 block w-full py-2 pl-3"
+						ref="card-element"
+					></div>
+					<ErrorMessage class="mt-1" :error="cardErrorMessage" />
+				</label>
+				<Input
+					class="mt-4"
+					label="Name on Card"
+					type="text"
+					v-model="billingInformation.cardHolderName"
+				/>
+				<AddressForm
+					v-if="!withoutAddress"
+					class="mt-4"
+					v-model:address="billingInformation"
+					ref="address-form"
+				/>
 			</div>
+
+			<div class="mt-3" v-show="tryingMicroCharge">
+				<p class="text-lg text-gray-800">
+					We are attempting to charge your card with
+					<strong>{{ formattedMicroChargeAmount }}</strong> to make sure the card works. This
+					amount will be <strong>refunded</strong> back to your account.
+				</p>
+
+				<Button class="mt-2" :loading="true">Attempting Test Charge</Button>
+			</div>
+
+			<ErrorMessage class="mt-2" :error="errorMessage" />
 
 			<div class="mt-6 flex items-center justify-between">
 				<Button appearance="primary" @click="submit" :loading="addingCard">
@@ -248,6 +257,12 @@ export default {
 				d => d.name === country
 			).code;
 			return code.toUpperCase();
+		}
+	},
+	computed: {
+		formattedMicroChargeAmount() {
+			const isINR = this.$account.team.currency === 'INR';
+			return isINR ? '₹50' : '$0.5';
 		}
 	}
 };

--- a/dashboard/src/controllers/account.js
+++ b/dashboard/src/controllers/account.js
@@ -9,6 +9,7 @@ export default class Account {
 		this.team_members = [];
 		this.onboarding = null;
 		this.balance = 0;
+		this.feature_flags = {};
 	}
 
 	async fetchAccount() {
@@ -24,6 +25,7 @@ export default class Account {
 			this.team_members = result.team_members;
 			this.onboarding = result.onboarding;
 			this.balance = result.balance;
+			this.feature_flags = result.feature_flags;
 		} catch (e) {
 			localStorage.removeItem('current_team');
 		}

--- a/dashboard/src/views/billing/AccountBillingCards.vue
+++ b/dashboard/src/views/billing/AccountBillingCards.vue
@@ -101,10 +101,11 @@ export default {
 				message: 'Set this card as the default payment method?',
 				actionLabel: 'Set as default',
 				resource: this.$resources.setAsDefault,
-				action: () => {
-					this.$resources.setAsDefault
-						.submit({ name: card.name })
-						.then(() => this.$resources.paymentMethods.reload());
+				action: closeDialog => {
+					this.$resources.setAsDefault.submit({ name: card.name }).then(() => {
+						this.$resources.paymentMethods.reload();
+						closeDialog();
+					});
 				}
 			});
 		},

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -301,6 +301,11 @@ def get():
 		"teams": list(set(teams)),
 		"onboarding": team_doc.get_onboarding(),
 		"balance": team_doc.get_balance(),
+		"feature_flags": {
+			"verify_cards_with_micro_charge": frappe.db.get_single_value(
+				"Press Settings", "verify_cards_with_micro_charge"
+			)
+		},
 	}
 
 

--- a/press/api/billing.py
+++ b/press/api/billing.py
@@ -199,10 +199,10 @@ def get_customer_details(team):
 def create_payment_intent_for_micro_debit(payment_method_name):
 	team = get_current_team(True)
 	stripe = get_stripe()
-	amount = 0.50 if team.currency == "USD" else 50
+	amount = 50 if team.currency == "USD" else 5000
 
 	intent = stripe.PaymentIntent.create(
-		amount=amount * 100,
+		amount=amount,
 		currency=team.currency.lower(),
 		customer=team.stripe_customer_id,
 		description="Micro-Debit Card Test Charge",

--- a/press/api/billing.py
+++ b/press/api/billing.py
@@ -196,6 +196,25 @@ def get_customer_details(team):
 
 
 @frappe.whitelist()
+def create_payment_intent_for_micro_debit(payment_method_name):
+	team = get_current_team(True)
+	stripe = get_stripe()
+	amount = 0.50 if team.currency == "USD" else 50
+
+	intent = stripe.PaymentIntent.create(
+		amount=amount * 100,
+		currency=team.currency.lower(),
+		customer=team.stripe_customer_id,
+		description="Micro-Debit Card Test Charge",
+		metadata={
+			"payment_for": "micro_debit_test_charge",
+			"payment_method_name": payment_method_name,
+		},
+	)
+	return {"client_secret": intent["client_secret"]}
+
+
+@frappe.whitelist()
 def create_payment_intent_for_buying_credits(amount):
 	team = get_current_team(True)
 	stripe = get_stripe()
@@ -382,10 +401,14 @@ def setup_intent_success(setup_intent, address=None):
 	setup_intent = frappe._dict(setup_intent)
 	team = get_current_team(True)
 	clear_setup_intent()
-	team.create_payment_method(setup_intent.payment_method, set_default=True)
+	payment_method = team.create_payment_method(
+		setup_intent.payment_method, set_default=True
+	)
 	if address:
 		address = frappe._dict(address)
 		team.update_billing_details(address)
+
+	return {"payment_method_name": payment_method.name}
 
 
 @frappe.whitelist()

--- a/press/press/doctype/press_settings/press_settings.json
+++ b/press/press/doctype/press_settings/press_settings.json
@@ -141,7 +141,9 @@
   "monitor_server",
   "column_break_100",
   "monitor_token",
-  "log_server"
+  "log_server",
+  "feature_flags_tab",
+  "verify_cards_with_micro_charge"
  ],
  "fields": [
   {
@@ -885,11 +887,23 @@
   {
    "fieldname": "column_break_48",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "feature_flags_tab",
+   "fieldtype": "Tab Break",
+   "label": "Feature Flags"
+  },
+  {
+   "default": "No",
+   "fieldname": "verify_cards_with_micro_charge",
+   "fieldtype": "Select",
+   "label": "Verify Cards with Micro Charge",
+   "options": "No\nOnly INR\nOnly USD\nBoth INR and USD"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2022-10-04 12:46:23.086698",
+ "modified": "2022-10-17 15:57:24.551328",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Press Settings",

--- a/press/press/doctype/stripe_micro_charge_record/stripe_micro_charge_record.js
+++ b/press/press/doctype/stripe_micro_charge_record/stripe_micro_charge_record.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2022, Frappe and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Stripe Micro Charge Record', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/press/press/doctype/stripe_micro_charge_record/stripe_micro_charge_record.js
+++ b/press/press/doctype/stripe_micro_charge_record/stripe_micro_charge_record.js
@@ -2,7 +2,22 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Stripe Micro Charge Record', {
-	// refresh: function(frm) {
-
-	// }
+	refresh: function (frm) {
+		if (!frm.doc.has_been_refunded) {
+			const btn = frm.add_custom_button('Refund', () => {
+				frm
+					.call({
+						doc: frm.doc,
+						method: 'refund',
+						btn,
+					})
+					.then((r) => {
+						if (r.message) {
+							frappe.msgprint(`Refunded Successfully.`);
+						}
+						frm.refresh();
+					});
+			});
+		}
+	},
 });

--- a/press/press/doctype/stripe_micro_charge_record/stripe_micro_charge_record.json
+++ b/press/press/doctype/stripe_micro_charge_record/stripe_micro_charge_record.json
@@ -9,7 +9,8 @@
   "team",
   "stripe_payment_method",
   "column_break_3",
-  "has_been_refunded"
+  "has_been_refunded",
+  "stripe_payment_intent_id"
  ],
  "fields": [
   {
@@ -40,11 +41,18 @@
   {
    "fieldname": "column_break_3",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "stripe_payment_intent_id",
+   "fieldtype": "Data",
+   "label": "Stripe Payment Intent ID",
+   "read_only": 1,
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-10-17 16:29:44.366456",
+ "modified": "2022-10-17 18:32:32.528763",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Stripe Micro Charge Record",

--- a/press/press/doctype/stripe_micro_charge_record/stripe_micro_charge_record.json
+++ b/press/press/doctype/stripe_micro_charge_record/stripe_micro_charge_record.json
@@ -1,0 +1,53 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2022-10-14 19:22:39.833212",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "stripe_payment_method",
+  "has_been_refunded"
+ ],
+ "fields": [
+  {
+   "fieldname": "stripe_payment_method",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Stripe Payment Method",
+   "options": "Stripe Payment Method",
+   "reqd": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "has_been_refunded",
+   "fieldtype": "Check",
+   "label": "Refunded?"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2022-10-14 19:22:39.833212",
+ "modified_by": "Administrator",
+ "module": "Press",
+ "name": "Stripe Micro Charge Record",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/press/press/doctype/stripe_micro_charge_record/stripe_micro_charge_record.json
+++ b/press/press/doctype/stripe_micro_charge_record/stripe_micro_charge_record.json
@@ -6,7 +6,9 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "team",
   "stripe_payment_method",
+  "column_break_3",
   "has_been_refunded"
  ],
  "fields": [
@@ -16,18 +18,33 @@
    "in_list_view": 1,
    "label": "Stripe Payment Method",
    "options": "Stripe Payment Method",
+   "read_only": 1,
    "reqd": 1
   },
   {
    "default": "0",
    "fieldname": "has_been_refunded",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "Refunded?"
+  },
+  {
+   "fetch_from": "stripe_payment_method.team",
+   "fetch_if_empty": 1,
+   "fieldname": "team",
+   "fieldtype": "Link",
+   "label": "Team",
+   "options": "Team",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_3",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-10-14 19:22:39.833212",
+ "modified": "2022-10-17 16:29:44.366456",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Stripe Micro Charge Record",
@@ -49,5 +66,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "title_field": "team"
 }

--- a/press/press/doctype/stripe_micro_charge_record/stripe_micro_charge_record.py
+++ b/press/press/doctype/stripe_micro_charge_record/stripe_micro_charge_record.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2022, Frappe and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class StripeMicroChargeRecord(Document):
+	pass

--- a/press/press/doctype/stripe_micro_charge_record/stripe_micro_charge_record.py
+++ b/press/press/doctype/stripe_micro_charge_record/stripe_micro_charge_record.py
@@ -8,6 +8,10 @@ from press.utils.billing import get_stripe
 
 
 class StripeMicroChargeRecord(Document):
+	def after_insert(self):
+		# Auto-refund
+		self.refund()
+
 	@frappe.whitelist()
 	def refund(self):
 		stripe = get_stripe()

--- a/press/press/doctype/stripe_micro_charge_record/stripe_micro_charge_record.py
+++ b/press/press/doctype/stripe_micro_charge_record/stripe_micro_charge_record.py
@@ -1,9 +1,18 @@
 # Copyright (c) 2022, Frappe and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+
 from frappe.model.document import Document
+from press.utils.billing import get_stripe
 
 
 class StripeMicroChargeRecord(Document):
-	pass
+	@frappe.whitelist()
+	def refund(self):
+		stripe = get_stripe()
+		refund = stripe.Refund.create(payment_intent=self.stripe_payment_intent_id)
+
+		if refund.status == "succeeded":
+			self.has_been_refunded = True
+			self.save()

--- a/press/press/doctype/stripe_micro_charge_record/test_stripe_micro_charge_record.py
+++ b/press/press/doctype/stripe_micro_charge_record/test_stripe_micro_charge_record.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2022, Frappe and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestStripeMicroChargeRecord(FrappeTestCase):
+	pass

--- a/press/press/doctype/stripe_payment_method/stripe_payment_method.json
+++ b/press/press/doctype/stripe_payment_method/stripe_payment_method.json
@@ -81,13 +81,14 @@
    "default": "0",
    "fieldname": "is_verified_with_micro_charge",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "Verified with Micro Charge",
    "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-10-14 19:15:36.163837",
+ "modified": "2022-10-17 17:20:24.776635",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Stripe Payment Method",

--- a/press/press/doctype/stripe_payment_method/stripe_payment_method.json
+++ b/press/press/doctype/stripe_payment_method/stripe_payment_method.json
@@ -15,7 +15,8 @@
   "stripe_payment_method_id",
   "is_default",
   "column_break_9",
-  "address_html"
+  "address_html",
+  "is_verified_with_micro_charge"
  ],
  "fields": [
   {
@@ -75,14 +76,22 @@
    "fieldname": "address_html",
    "fieldtype": "HTML",
    "label": "Address HTML"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_verified_with_micro_charge",
+   "fieldtype": "Check",
+   "label": "Verified with Micro Charge",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-08-20 16:16:40.273163",
+ "modified": "2022-10-14 19:15:36.163837",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Stripe Payment Method",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {
@@ -109,5 +118,6 @@
  "search_fields": "team, name_on_card, last_4, expiry_month, expiry_year",
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -23,6 +23,7 @@ from press.utils.billing import (
 	get_erpnext_com_connection,
 	get_frappe_io_connection,
 	get_stripe,
+	process_micro_debit_test_charge,
 )
 
 
@@ -435,6 +436,8 @@ class Team(Document):
 		# allocate credits if not already allocated
 		self.allocate_free_credits()
 
+		return doc
+
 	def get_payment_methods(self):
 		return frappe.db.get_all(
 			"Stripe Payment Method",
@@ -789,6 +792,10 @@ def process_stripe_webhook(doc, method):
 
 	if payment_for and payment_for == "prepaid_marketplace":
 		process_prepaid_marketplace_payment(event)
+		return
+
+	if payment_for and payment_for == "micro_debit_test_charge":
+		process_micro_debit_test_charge(event)
 		return
 
 	team: Team = frappe.get_doc("Team", {"stripe_customer_id": payment_intent["customer"]})

--- a/press/utils/billing.py
+++ b/press/utils/billing.py
@@ -4,7 +4,7 @@ import stripe
 import razorpay
 
 from frappe.utils import fmt_money
-from press.utils import get_current_team
+from press.utils import get_current_team, log_error
 from press.exceptions import CentralServerNotSet, FrappeioServerNotSet
 
 
@@ -205,16 +205,19 @@ def get_razorpay_client():
 
 
 def process_micro_debit_test_charge(stripe_event):
-	payment_intent = stripe_event["data"]["object"]
-	metadata = payment_intent.get("metadata")
-	payment_method_name = metadata.get("payment_method_name")
+	try:
+		payment_intent = stripe_event["data"]["object"]
+		metadata = payment_intent.get("metadata")
+		payment_method_name = metadata.get("payment_method_name")
 
-	frappe.db.set_value(
-		"Stripe Payment Method", payment_method_name, "is_verified_with_micro_charge", True
-	)
+		frappe.db.set_value(
+			"Stripe Payment Method", payment_method_name, "is_verified_with_micro_charge", True
+		)
 
-	frappe.get_doc(
-		doctype="Stripe Micro Charge Record",
-		stripe_payment_method=payment_method_name,
-		stripe_payment_intent_id=payment_intent.get("id"),
-	).insert(ignore_permissions=True)
+		frappe.get_doc(
+			doctype="Stripe Micro Charge Record",
+			stripe_payment_method=payment_method_name,
+			stripe_payment_intent_id=payment_intent.get("id"),
+		).insert(ignore_permissions=True)
+	except Exception:
+		log_error("Error Processing Stripe Micro Debit Charge", body=stripe_event)

--- a/press/utils/billing.py
+++ b/press/utils/billing.py
@@ -205,7 +205,6 @@ def get_razorpay_client():
 
 
 def process_micro_debit_test_charge(stripe_event):
-	print("Micro Charge event received.")
 	payment_intent = stripe_event["data"]["object"]
 	metadata = payment_intent.get("metadata")
 	payment_method_name = metadata.get("payment_method_name")
@@ -215,5 +214,7 @@ def process_micro_debit_test_charge(stripe_event):
 	)
 
 	frappe.get_doc(
-		doctype="Stripe Micro Charge Record", stripe_payment_method=payment_method_name
+		doctype="Stripe Micro Charge Record",
+		stripe_payment_method=payment_method_name,
+		stripe_payment_intent_id=payment_intent.get("id"),
 	).insert(ignore_permissions=True)

--- a/press/utils/billing.py
+++ b/press/utils/billing.py
@@ -202,3 +202,18 @@ def get_razorpay_client():
 		frappe.local.press_razorpay_client_object = razorpay.Client(auth=(key_id, key_secret))
 
 	return frappe.local.press_razorpay_client_object
+
+
+def process_micro_debit_test_charge(stripe_event):
+	print("Micro Charge event received.")
+	payment_intent = stripe_event["data"]["object"]
+	metadata = payment_intent.get("metadata")
+	payment_method_name = metadata.get("payment_method_name")
+
+	frappe.db.set_value(
+		"Stripe Payment Method", payment_method_name, "is_verified_with_micro_charge", True
+	)
+
+	frappe.get_doc(
+		doctype="Stripe Micro Charge Record", stripe_payment_method=payment_method_name
+	).insert(ignore_permissions=True)


### PR DESCRIPTION
## Use Case

Many times the cards (payment method) added by the users turn out to be not fit for payment at the end of billing cycle. This can happen due to a variety of reasons, for instance, "This card does not support this kind of transaction" (common), "Non Chargeable", "Insufficient Funds", "Bank Issue", etc. We and the users come to know this only when we try to attempt to charge the card at the end of the billing cycle, leading to **many payment failures.**

This can **hurt both** the users (realizing about the payment failures late leads to site suspension) and us (we have very less confidence on the payment method/card added). 

## Solution

At the time of adding a card, we will try to charge the card with the **smallest possible amount** (hence, micro) stripe allows (which is $0.50). The **refund** of this amount will be triggered from out end immediately after the successful verification. 

Currently, I have added a Feature toggle in **Press Settings** to turn this on conditionally. Also, it is not a required step yet (so the payment method will be added even if the micro charge fails). Once we are sure this works, we can make it mandatory.

### How are we tracking the micro charge verification?
1. **Stripe Micro Charge Record** DocType

<img width="1317" alt="image" src="https://user-images.githubusercontent.com/34810212/196319686-99a35158-dcfb-4b39-9b0c-33329c02b3a5.png">

You can trigger a manual refund from desk (if for some reason the automatic refund fails):

<img width="1317" alt="image" src="https://user-images.githubusercontent.com/34810212/196319886-2b90ea94-198c-4e59-a9ab-5e545655f479.png"> 

2. A new check field has been added to the **Stripe Payment Method** to record whether it is verified with a micro charge or not.

<img width="1317" alt="image" src="https://user-images.githubusercontent.com/34810212/196319334-ec801abd-2ced-4732-a367-44ed1db91ce4.png">


### UI/UX

A very simple message with a progress indicator is shown to the user:

<img width="1200" alt="image" src="https://user-images.githubusercontent.com/34810212/196319054-19d2c4c8-f049-4034-ab2b-abcd5e64d437.png">

> I know, I know, two spinners do not look good. **Eventually, we have to split the card addition process into two steps** 
