### PR TITLE
feat: proxy replica

### DIFF
--- a/press/agent.py
+++ b/press/agent.py
@@ -44,6 +44,12 @@ class Agent:
 			"Archive Bench", f"benches/{bench.name}/archive", bench=bench.name
 		)
 
+	def restart_nginx(self):
+		return self.create_agent_job(
+			"Reload NGINX",
+			"server/reload",
+		)
+
 	def restart_bench(self, bench, web_only=False):
 		return self.create_agent_job(
 			"Bench Restart",

--- a/press/fixtures/agent_job_type.json
+++ b/press/fixtures/agent_job_type.json
@@ -2,6 +2,22 @@
  {
   "docstatus": 0,
   "doctype": "Agent Job Type",
+  "modified": "2022-10-19 14:45:01.606264",
+  "name": "Reload NGINX",
+  "request_method": "POST",
+  "request_path": "/server/reload",
+  "steps": [
+   {
+    "parent": "Reload NGINX",
+    "parentfield": "steps",
+    "parenttype": "Agent Job Type",
+    "step_name": "Reload NGINX"
+   }
+  ]
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Agent Job Type",
   "modified": "2021-06-16 20:39:50.568363",
   "name": "Rename Upstream",
   "request_method": "POST",

--- a/press/playbooks/primary_proxy.yml
+++ b/press/playbooks/primary_proxy.yml
@@ -1,0 +1,8 @@
+---
+- name: Setup Primary Proxy Server
+  hosts: all
+  become: yes
+  become_user: root
+
+  roles:
+    - role: primary_proxy

--- a/press/playbooks/roles/primary_proxy/tasks/main.yml
+++ b/press/playbooks/roles/primary_proxy/tasks/main.yml
@@ -1,0 +1,57 @@
+---
+- name: Remove Primary Proxy Server from Known Hosts
+  become: yes
+  become_user: frappe
+  known_hosts:
+    name: "{{ secondary_private_ip }}"
+    state: absent
+
+- name: Add Primary Proxy Server to Known Hosts
+  become: yes
+  become_user: frappe
+  shell: ssh-keyscan {{ secondary_private_ip }} >> /home/frappe/.ssh/known_hosts
+
+- name: Install Lsyncd
+  apt:
+    state: present
+    pkg:
+      - lsyncd
+
+- name: Create Lsyncd Directory
+  become: yes
+  become_user: frappe
+  file:
+    dest: /home/frappe/lsyncd
+    state: directory
+
+- name: Create Lsyncd Log and Status File
+  become: yes
+  become_user: frappe
+  file:
+    dest: /home/frappe/lsyncd/{{ item }}
+    state: touch
+  with_items:
+    - lsyncd.logs
+    - lsyncd.status
+
+- name: Create Lsynd Config File
+  become: yes
+  become_user: frappe
+  template:
+    src: lsyncd.conf
+    dest: /home/frappe/lsyncd/lsyncd.conf.lua
+
+- name: Setup lsyncd service for frappe user
+  template:
+    src: lsyncd.service
+    dest: /etc/systemd/system/lsyncd.service
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Restart Lsyncd service
+  systemd:
+    daemon_reload: true
+    name: lsyncd
+    state: restarted
+    enabled: True

--- a/press/playbooks/roles/primary_proxy/templates/lsyncd.conf
+++ b/press/playbooks/roles/primary_proxy/templates/lsyncd.conf
@@ -8,10 +8,10 @@ sync {
     source="/home/frappe/agent/nginx",
     host="{{ secondary_private_ip }}",
     targetdir="/home/frappe/agent/nginx",
-    # rsync = {
-    #     archive = true,
-    #     acls = true,
-    #     xattrs = true,
-    #     compress = true,
-    # },
+    rsync = {
+        archive = true,
+        acls = true,
+        xattrs = true,
+        compress = true,
+    },
 } 

--- a/press/playbooks/roles/primary_proxy/templates/lsyncd.conf
+++ b/press/playbooks/roles/primary_proxy/templates/lsyncd.conf
@@ -1,0 +1,17 @@
+settings {
+    logfile = "/home/frappe/lsyncd/lsyncd.logs",
+    statusFile = "/home/frappe/lsyncd/lsyncd.status"
+}
+
+sync {
+    default.rsyncssh,
+    source="/home/frappe/agent/nginx",
+    host="{{ secondary_private_ip }}",
+    targetdir="/home/frappe/agent/nginx",
+    # rsync = {
+    #     archive = true,
+    #     acls = true,
+    #     xattrs = true,
+    #     compress = true,
+    # },
+} 

--- a/press/playbooks/roles/primary_proxy/templates/lsyncd.service
+++ b/press/playbooks/roles/primary_proxy/templates/lsyncd.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Live Syncing (Mirror) Daemon
+After=network-online.target
+
+[Service]
+Type=simple
+User=frappe
+Group=frappe
+ExecStart=/usr/bin/lsyncd -nodaemon /home/frappe/lsyncd/lsyncd.conf.lua
+
+[Install]
+WantedBy=multi-user.target 

--- a/press/playbooks/roles/secondary_proxy/tasks/main.yml
+++ b/press/playbooks/roles/secondary_proxy/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Add Primary Proxy Server Public Key to Authorized Keys
+  become: yes
+  become_user: frappe
+  authorized_key:
+    user: frappe
+    key: "{{ primary_public_key }}"
+    state: present

--- a/press/playbooks/secondary_proxy.yml
+++ b/press/playbooks/secondary_proxy.yml
@@ -1,0 +1,8 @@
+---
+- name: Setup Secondary Proxy Server
+  hosts: all
+  become: yes
+  become_user: root
+
+  roles:
+    - role: secondary_proxy

--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -271,6 +271,9 @@ def process_job_updates(job_name):
 			process_remove_ssh_user_job_update,
 		)
 		from press.press.doctype.server.server import process_new_server_job_update
+		from press.press.doctype.proxy_server.proxy_server import (
+			process_update_nginx_job_update,
+		)
 		from press.press.doctype.site.erpnext_site import (
 			process_setup_erpnext_site_job_update,
 		)
@@ -351,6 +354,8 @@ def process_job_updates(job_name):
 			process_add_proxysql_user_job_update(job)
 		elif job.job_type == "Remove User from ProxySQL":
 			process_remove_proxysql_user_job_update(job)
+		elif job.job_type == "Reload NGINX":
+			process_update_nginx_job_update(job)
 
 	except Exception as e:
 		log_error("Agent Job Callback Exception", job=job.as_dict())

--- a/press/press/doctype/proxy_server/proxy_server.js
+++ b/press/press/doctype/proxy_server/proxy_server.js
@@ -15,6 +15,7 @@ frappe.ui.form.on('Proxy Server', {
 			[__('Setup ProxySQL Monitor'), "setup_proxysql_monitor", true, frm.doc.is_proxysql_setup],
 			[__('Setup Wildcard Hosts'), "setup_wildcard_hosts", true, frm.doc.is_server_setup],
 			[__('Fetch Keys'), "fetch_keys", false, frm.doc.is_server_setup && (!frm.doc.frappe_public_key || !frm.doc.root_public_key)],
+			[__('Setup Replica'), "setup_replication", true, frm.doc.is_server_setup && !frm.doc.is_primary && !frm.doc.is_replication_setup],
 		].forEach(([label, method, confirm, condition]) => {
 			if (typeof condition === "undefined" || condition) {
 				frm.add_custom_button(

--- a/press/press/doctype/proxy_server/proxy_server.js
+++ b/press/press/doctype/proxy_server/proxy_server.js
@@ -15,7 +15,8 @@ frappe.ui.form.on('Proxy Server', {
 			[__('Setup ProxySQL Monitor'), "setup_proxysql_monitor", true, frm.doc.is_proxysql_setup],
 			[__('Setup Wildcard Hosts'), "setup_wildcard_hosts", true, frm.doc.is_server_setup],
 			[__('Fetch Keys'), "fetch_keys", false, frm.doc.is_server_setup && (!frm.doc.frappe_public_key || !frm.doc.root_public_key)],
-			[__('Setup Replica'), "setup_replication", true, frm.doc.is_server_setup && !frm.doc.is_primary && !frm.doc.is_replication_setup],
+			[__('Setup Replication'), "setup_replication", true, frm.doc.is_server_setup && !frm.doc.is_primary && !frm.doc.is_replication_setup],
+			[__('Trigger Failover'), "trigger_failover", true, frm.doc.is_server_setup && !frm.doc.is_primary && frm.doc.is_replication_setup],
 		].forEach(([label, method, confirm, condition]) => {
 			if (typeof condition === "undefined" || condition) {
 				frm.add_custom_button(

--- a/press/press/doctype/proxy_server/proxy_server.json
+++ b/press/press/doctype/proxy_server/proxy_server.json
@@ -266,13 +266,14 @@
   },
   {
    "default": "0",
+   "depends_on": "eval: doc.is_primary != 1",
    "fieldname": "is_replication_setup",
    "fieldtype": "Check",
    "label": "Is Replication Setup"
   }
  ],
  "links": [],
- "modified": "2022-10-18 11:36:21.070101",
+ "modified": "2022-10-19 15:42:47.402179",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Proxy Server",

--- a/press/press/doctype/proxy_server/proxy_server.json
+++ b/press/press/doctype/proxy_server/proxy_server.json
@@ -22,6 +22,10 @@
   "private_vlan_id",
   "agent_section",
   "agent_password",
+  "replica_section",
+  "is_primary",
+  "primary",
+  "is_replication_setup",
   "ssh_section",
   "frappe_user_password",
   "frappe_public_key",
@@ -240,10 +244,35 @@
    "fieldtype": "Link",
    "label": "Team",
    "options": "Team"
+  },
+  {
+   "fieldname": "replica_section",
+   "fieldtype": "Section Break",
+   "label": "Replica"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_primary",
+   "fieldtype": "Check",
+   "label": "Is Primary"
+  },
+  {
+   "depends_on": "eval: doc.is_primary != 1",
+   "fieldname": "primary",
+   "fieldtype": "Link",
+   "label": "Primary",
+   "mandatory_depends_on": "eval: doc.is_primary != 1",
+   "options": "Proxy Server"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_replication_setup",
+   "fieldtype": "Check",
+   "label": "Is Replication Setup"
   }
  ],
  "links": [],
- "modified": "2022-09-22 04:57:56.086153",
+ "modified": "2022-10-18 11:36:21.070101",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Proxy Server",


### PR DESCRIPTION
### Changes:

* Added Provision to setup replica for a proxy server (logic is same as app server)
* Lsyncd is used to sync the proxy configuration files from primary to replica and gets set up on primary on `setup replication`
* Trigger Failover does the following:
            - Updates DNS record
        - reloads nginx
        - updates all app server 