### PR TITLE
feat: Automate Payout Order Creation

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -185,6 +185,7 @@ scheduler_events = {
 		"press.press.doctype.bench.bench.sync_analytics",
 		"press.saas.doctype.saas_app_subscription.saas_app_subscription.suspend_prepaid_subscriptions",
 		"press.press.doctype.backup_restoration_test.backup_test.archive_backup_test_sites",
+		"press.press.doctype.payout_order.payout_order.create_marketplace_payout_orders",
 	],
 	"hourly": [
 		"press.press.doctype.site.backups.cleanup_local",

--- a/press/press/doctype/invoice_item/invoice_item.json
+++ b/press/press/doctype/invoice_item/invoice_item.json
@@ -12,7 +12,8 @@
   "quantity",
   "rate",
   "amount",
-  "site"
+  "site",
+  "has_marketplace_payout_completed"
  ],
  "fields": [
   {
@@ -69,12 +70,18 @@
    "fieldtype": "Link",
    "label": "Site",
    "options": "Site"
+  },
+  {
+   "default": "0",
+   "fieldname": "has_marketplace_payout_completed",
+   "fieldtype": "Check",
+   "label": "Has Marketplace Payout Completed?"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-07-27 16:09:23.959145",
+ "modified": "2022-10-30 23:47:46.159944",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Invoice Item",

--- a/press/press/doctype/marketplace_app/test_marketplace_app.py
+++ b/press/press/doctype/marketplace_app/test_marketplace_app.py
@@ -5,15 +5,16 @@
 import frappe
 import unittest
 
+from typing import Optional
 from press.press.doctype.marketplace_app.utils import (
 	number_k_format,
 	get_rating_percentage_distribution,
 )
 
 
-def create_test_marketplace_app(app: str):
+def create_test_marketplace_app(app: str, team: Optional[str] = None):
 	return frappe.get_doc(
-		{"doctype": "Marketplace App", "app": app, "description": "Test App"}
+		{"doctype": "Marketplace App", "app": app, "description": "Test App", "team": team}
 	).insert(ignore_if_duplicate=True)
 
 

--- a/press/press/doctype/payout_order/payout_order.json
+++ b/press/press/doctype/payout_order/payout_order.json
@@ -8,10 +8,12 @@
  "engine": "InnoDB",
  "field_order": [
   "recipient",
+  "period_start",
   "due_date",
   "status",
   "column_break_4",
   "mode_of_payment",
+  "period_end",
   "frappe_purchase_order",
   "amended_from",
   "section_break_8",
@@ -37,6 +39,7 @@
   {
    "fieldname": "due_date",
    "fieldtype": "Date",
+   "hidden": 1,
    "label": "Due Date"
   },
   {
@@ -118,12 +121,22 @@
   {
    "fieldname": "section_break_14",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "period_start",
+   "fieldtype": "Date",
+   "label": "Period Start"
+  },
+  {
+   "fieldname": "period_end",
+   "fieldtype": "Date",
+   "label": "Period End"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-07-07 07:13:08.811782",
+ "modified": "2022-10-31 00:37:58.102707",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Payout Order",

--- a/press/press/doctype/payout_order/payout_order.py
+++ b/press/press/doctype/payout_order/payout_order.py
@@ -105,6 +105,7 @@ def create_payout_order_from_invoice_items(
 		po.append(
 			"items",
 			{
+				"invoice_item": invoice_item.name,
 				"invoice": invoice_item.parent,
 				"document_type": invoice_item.document_type,
 				"document_name": invoice_item.document_name,

--- a/press/press/doctype/payout_order/payout_order.py
+++ b/press/press/doctype/payout_order/payout_order.py
@@ -86,6 +86,10 @@ def get_invoice_item_for_po_item(
 
 
 def create_marketplace_payout_orders_monthly():
+	today = frappe.utils.today()
+	period_start = frappe.utils.data.get_first_day(today)
+	period_end = frappe.utils.data.get_last_day(today)
+
 	# Get all marketplace app invoice items
 	invoice = frappe.qb.DocType("Invoice")
 	invoice_item = frappe.qb.DocType("Invoice Item")
@@ -109,10 +113,6 @@ def create_marketplace_payout_orders_monthly():
 	# Group by teams
 	for app_team, items in groupby(items, key=lambda x: x["app_team"]):
 		item_names = [i.name for i in items]
-
-		today = frappe.utils.today()
-		period_start = frappe.utils.data.get_first_day(today)
-		period_end = frappe.utils.data.get_last_day(today)
 
 		po_exists = frappe.db.exists(
 			"Payout Order", {"recipient": app_team, "period_end": period_end}

--- a/press/press/doctype/payout_order/payout_order.py
+++ b/press/press/doctype/payout_order/payout_order.py
@@ -198,3 +198,14 @@ def create_payout_order_from_invoice_items(
 def create_payout_order_from_invoice_item_names(item_names, *args, **kwargs):
 	invoice_items = (frappe.get_doc("Invoice Item", i) for i in item_names)
 	return create_payout_order_from_invoice_items(invoice_items, *args, **kwargs)
+
+
+def create_marketplace_payout_orders():
+	# ONLY RUN ON LAST DAY OF THE MONTH
+	today = frappe.utils.today()
+	period_end = frappe.utils.data.get_last_day(today)
+
+	if today != period_end:
+		return
+
+	create_marketplace_payout_orders_monthly()

--- a/press/press/doctype/payout_order/payout_order.py
+++ b/press/press/doctype/payout_order/payout_order.py
@@ -120,3 +120,8 @@ def create_payout_order_from_invoice_items(
 		po.insert()
 
 	return po
+
+
+def create_payout_order_from_invoice_item_names(item_names, *args, **kwargs):
+	invoice_items = (frappe.get_doc("Invoice Item", i) for i in item_names)
+	return create_payout_order_from_invoice_items(invoice_items, *args, **kwargs)

--- a/press/press/doctype/payout_order/test_payout_order.py
+++ b/press/press/doctype/payout_order/test_payout_order.py
@@ -64,15 +64,15 @@ class TestPayoutOrder(FrappeTestCase):
 			status="Paid",
 		).insert()
 
-		self.test_usage_record = frappe.get_doc(
-			doctype="Usage Record", team=self.test_team.name, amount=500
-		).insert()
+		# create test marketplace app
+		test_app = create_test_app("test_app")
+		test_mp_app = create_test_marketplace_app(test_app.name, self.test_team.name)
 
 		self.test_invoice.append(
 			"items",
 			{
-				"document_type": "Usage Record",
-				"document_name": self.test_usage_record.name,
+				"document_type": "Marketplace App",
+				"document_name": test_mp_app.name,
 				"rate": 20,
 				"plan": "INR 100",
 				"quantity": 2,
@@ -97,43 +97,9 @@ class TestPayoutOrder(FrappeTestCase):
 			exchange_rate=70,
 		).insert()
 
-		self.test_usage_record = frappe.get_doc(
-			doctype="Usage Record", team=self.test_team.name, amount=15
-		).insert()
-
-		self.test_invoice.append(
-			"items",
-			{
-				"document_type": "Usage Record",
-				"document_name": self.test_usage_record.name,
-				"rate": 10,
-				"plan": "USD 25",
-				"quantity": 2,
-			},
-		)
-
-		self.test_invoice.save()
-		self.test_invoice.submit()
-
-	def test_create_marketplace_monthly_payout_order(self):
-		# create test invoice with marketplace app
-		self.test_team = frappe.get_doc(
-			doctype="Team", name="testuserusd@example.com", country="United States", enabled=1
-		).insert()
-
 		# create test marketplace app
 		test_app = create_test_app("test_app")
 		test_mp_app = create_test_marketplace_app(test_app.name, self.test_team.name)
-
-		self.test_invoice = frappe.get_doc(
-			doctype="Invoice",
-			team=self.test_team.name,
-			transaction_amount=1800,
-			transaction_fee=1260,
-			amount_paid=25,
-			status="Paid",
-			exchange_rate=70,
-		).insert()
 
 		self.test_invoice.append(
 			"items",
@@ -148,6 +114,9 @@ class TestPayoutOrder(FrappeTestCase):
 
 		self.test_invoice.save()
 		self.test_invoice.submit()
+
+	def test_create_marketplace_monthly_payout_order(self):
+		self.create_test_usd_invoice()
 
 		# No payout order before running the job
 		self.assertFalse(frappe.db.exists("Payout Order", {"recipient": self.test_team.name}))

--- a/press/press/doctype/payout_order/test_payout_order.py
+++ b/press/press/doctype/payout_order/test_payout_order.py
@@ -167,5 +167,11 @@ class TestPayoutOrder(FrappeTestCase):
 		)
 		self.assertTrue(marked_completed)
 
+		# Re-run should not create a new PO
+		# Since all items are already accounted for
+		create_marketplace_payout_orders_monthly()
+		po_count = frappe.db.count("Payout Order", {"recipient": self.test_team.name})
+		self.assertEqual(po_count, 1)
+
 	def tearDown(self):
 		frappe.db.rollback()

--- a/press/press/doctype/payout_order/test_payout_order.py
+++ b/press/press/doctype/payout_order/test_payout_order.py
@@ -17,8 +17,18 @@ from press.press.doctype.payout_order.payout_order import (
 class TestPayoutOrder(FrappeTestCase):
 	def test_net_amount_calculations_inr(self):
 		self.create_test_inr_invoice()
+		# Create a PO for this period
+		today = frappe.utils.today()
+		period_start = frappe.utils.data.get_first_day(today)
+		period_end = frappe.utils.data.get_last_day(today)
+
 		po = create_payout_order_from_invoice_items(
-			self.test_invoice.items, self.test_team.name, mode_of_payment="Internal", save=True
+			self.test_invoice.items,
+			self.test_team.name,
+			period_start=period_start,
+			period_end=period_end,
+			mode_of_payment="Internal",
+			save=True,
 		)
 
 		self.assertEqual(len(po.items), 1)
@@ -34,8 +44,18 @@ class TestPayoutOrder(FrappeTestCase):
 	def test_net_amount_calculations_usd(self):
 		self.create_test_usd_invoice()
 
+		# Create a PO for this period
+		today = frappe.utils.today()
+		period_start = frappe.utils.data.get_first_day(today)
+		period_end = frappe.utils.data.get_last_day(today)
+
 		po = create_payout_order_from_invoice_items(
-			self.test_invoice.items, self.test_team.name, mode_of_payment="Internal", save=True
+			self.test_invoice.items,
+			self.test_team.name,
+			period_start=period_start,
+			period_end=period_end,
+			mode_of_payment="Internal",
+			save=True,
 		)
 
 		self.assertEqual(len(po.items), 1)

--- a/press/press/doctype/payout_order_item/payout_order_item.json
+++ b/press/press/doctype/payout_order_item/payout_order_item.json
@@ -21,7 +21,8 @@
   "net_amount",
   "site",
   "column_break_13",
-  "currency"
+  "currency",
+  "invoice_item"
  ],
  "fields": [
   {
@@ -113,12 +114,19 @@
    "fieldname": "quantity",
    "fieldtype": "Float",
    "label": "quantity"
+  },
+  {
+   "fieldname": "invoice_item",
+   "fieldtype": "Link",
+   "label": "Invoice Item",
+   "options": "Invoice Item",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-07-28 06:46:22.107482",
+ "modified": "2022-10-31 00:19:23.739873",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Payout Order Item",


### PR DESCRIPTION
# Automatic Creation of Payout Orders

At the end of every month, automatically create a **Payout Order** for each marketplace app publisher with items that have been paid (Invoice Items' from Paid Invoices) during this month.

Instead of a due date, Payout Order DocType now has two fields: `period_start` and `period_end` to track the period for which the **Payout Order** was created.

A new field has been added to **Invoice Item** DocType to track whether the item was accounted into a **Payout Order** or not. Invoice Items are marked accounted after the PO has been created that has this item.

The payout order creation job does not create a duplicate for a given period if it already exists.

In summary:

 - [x] Field in Invoice Item to track whether the item has been entered in a Payout Order
 - [x] Period Start and End fields in Payout Order
 - [x] Utility methods/functions for creating payout order from invoice item names 
 - [x] Tests (TDD!!)