### PR TITLE
perf: faster versions

### DIFF
--- a/press/api/bench.py
+++ b/press/api/bench.py
@@ -315,6 +315,7 @@ def versions(name):
 					app.source,
 					["branch", "repository", "repository_owner", "repository_url"],
 					as_dict=1,
+					cache=True,
 				)
 			)
 			app.tag = get_app_tag(app.repository, app.repository_owner, app.hash)

--- a/press/api/bench.py
+++ b/press/api/bench.py
@@ -313,7 +313,7 @@ def versions(name):
 				frappe.db.get_value(
 					"App Source",
 					app.source,
-					["branch", "repository", "repository_owner", "repository_url"],
+					("branch", "repository", "repository_owner", "repository_url"),
 					as_dict=1,
 					cache=True,
 				)

--- a/press/utils/__init__.py
+++ b/press/utils/__init__.py
@@ -58,6 +58,7 @@ def get_current_team(get_doc=False):
 	return team
 
 
+@functools.lru_cache(maxsize=1024)
 def get_app_tag(repository, repository_owner, hash):
 	return frappe.db.get_value(
 		"App Tag",


### PR DESCRIPTION
WARNING: I've not tested this AT ALL as I do not have setup for press.

The main reason for slowness isn't just O(M*N) queries, it's probably just repeated queries.

1. App's repo details can't possibly change during a request so use `db.value_cache` to reuse already queried data.
2. Most deploys share same apps so cache tag info using functools.lru_cache.
   This is not safe for other apps but press is single-tenant app so it's fine.


This should convert it to O(M+N) queries which is fine I guess? Converting to single query will require some hackery which I can't do without a proper locla setup.

_Maybe_ closes https://github.com/frappe/press/issues/533