### PR TITLE
feat: prometheus report for server stats

### DIFF
--- a/press/api/server.py
+++ b/press/api/server.py
@@ -192,6 +192,31 @@ def usage(name):
 	return result
 
 
+@protected(["Server", "Database Server"])
+def total_resource(name):
+	query_map = {
+		"vcpu": (
+			f"""(count(count(node_cpu_seconds_total{{instance="{name}",job="node"}}) by (cpu)))""",
+			lambda x: x,
+		),
+		"disk": (
+			f"""(node_filesystem_size_bytes{{instance="{name}", job="node", mountpoint="/"}}) / (1024 * 1024 * 1024)""",
+			lambda x: x,
+		),
+		"memory": (
+			f"""(node_memory_MemTotal_bytes{{instance="{name}",job="node"}}) / (1024 * 1024)""",
+			lambda x: x,
+		),
+	}
+
+	result = {}
+	for usage_type, query in query_map.items():
+		response = prometheus_query(query[0], query[1], "Asia/Kolkata", 120, 120)["datasets"]
+		if response:
+			result[usage_type] = response[0]["values"][-1]
+	return result
+
+
 @frappe.whitelist()
 @protected(["Server", "Database Server"])
 def analytics(name, query, timezone, duration):

--- a/press/press/report/server_stats/server_stats.js
+++ b/press/press/report/server_stats/server_stats.js
@@ -1,0 +1,9 @@
+// Copyright (c) 2022, Frappe and contributors
+// For license information, please see license.txt
+/* eslint-disable */
+
+frappe.query_reports["Server Stats"] = {
+	"filters": [
+
+	]
+};

--- a/press/press/report/server_stats/server_stats.json
+++ b/press/press/report/server_stats/server_stats.json
@@ -1,0 +1,48 @@
+{
+ "add_total_row": 0,
+ "columns": [],
+ "creation": "2022-12-15 09:04:10.284944",
+ "disable_prepared_report": 0,
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [
+  {
+   "fieldname": "server",
+   "fieldtype": "Link",
+   "label": "Server",
+   "mandatory": 0,
+   "wildcard_filter": 0
+  },
+  {
+   "fieldname": "duration",
+   "fieldtype": "Select",
+   "label": "Duration",
+   "mandatory": 0,
+   "options": "1 Hour\n6 Hour\n24 Hour\n7 Days\n15 Days",
+   "wildcard_filter": 0
+  }
+ ],
+ "idx": 0,
+ "is_standard": "Yes",
+ "modified": "2022-12-15 09:13:58.516665",
+ "modified_by": "Administrator",
+ "module": "Press",
+ "name": "Server Stats",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Server",
+ "report_name": "Server Stats",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "System Manager"
+  },
+  {
+   "role": "Press Member"
+  },
+  {
+   "role": "Press Admin"
+  }
+ ]
+}

--- a/press/press/report/server_stats/server_stats.json
+++ b/press/press/report/server_stats/server_stats.json
@@ -6,26 +6,10 @@
  "disabled": 0,
  "docstatus": 0,
  "doctype": "Report",
- "filters": [
-  {
-   "fieldname": "server",
-   "fieldtype": "Link",
-   "label": "Server",
-   "mandatory": 0,
-   "wildcard_filter": 0
-  },
-  {
-   "fieldname": "duration",
-   "fieldtype": "Select",
-   "label": "Duration",
-   "mandatory": 0,
-   "options": "1 Hour\n6 Hour\n24 Hour\n7 Days\n15 Days",
-   "wildcard_filter": 0
-  }
- ],
+ "filters": [],
  "idx": 0,
  "is_standard": "Yes",
- "modified": "2022-12-15 09:13:58.516665",
+ "modified": "2022-12-16 15:05:05.883836",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Server Stats",

--- a/press/press/report/server_stats/server_stats.py
+++ b/press/press/report/server_stats/server_stats.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2022, Frappe and contributors
+# For license information, please see license.txt
+
+import frappe
+from press.api.server import usage, total_resource
+
+
+def execute(filters=None):
+	frappe.only_for("System Manager")
+	columns = [
+		{
+			"fieldname": "server",
+			"label": frappe._("Server"),
+			"fieldtype": "Float",
+			"width": 70,
+		},
+		{
+			"fieldname": "cpu",
+			"label": frappe._("CPU"),
+			"fieldtype": "Float",
+			"width": 70,
+		},
+		{
+			"fieldname": "disk",
+			"label": frappe._("Space"),
+			"fieldtype": "Float",
+			"width": 70,
+		},
+		{
+			"fieldname": "memory",
+			"label": frappe._("Memory"),
+			"fieldtype": "Float",
+			"width": 70,
+		},
+	]
+
+	data = get_data()
+	return columns, data
+
+
+def get_data():
+	servers = frappe.get_all("Server", dict(status="Active"), pluck="name")
+
+	rows = []
+	for server in servers:
+		used_data = usage(server)
+		available_data = total_resource(server)
+
+		rows.append(
+			{
+				"cpu": (used_data["vcpu"] / available_data["datasets"][0]["values"][-1]) * 100,
+				"disk": (used_data["disk"] / available_data["datasets"][0]["values"][-1]) * 100,
+				"memory": (used_data["memory"] / available_data["datasets"][0]["values"][-1]) * 100,
+			}
+		)
+
+	return rows


### PR DESCRIPTION
* New Report for having overview of server stats. Currently, it will only display cpu, memory, disk usage in percent.
* Added  a new method in `/api/server.py` to calculate total available resources.