### PR TITLE
feat: Manage SAAS subscriptions directly from site

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
 		"test": "cd dashboard && yarn test",
 		"watch": "yarn dev",
 		"build": "NODE_ENV=production yarn run build-all",
-		"build-all": "yarn run build-app && yarn run build-email-css && yarn run build-marketplace-css",
+		"build-all": "yarn run build-app && yarn run build-email-css && yarn run build-marketplace-css && yarn run build-saas-css",
 		"build-app": "cd dashboard && yarn build",
 		"build-email-css": "npx tailwindcss -i ./press/public/email/style.css -o ./press/public/css/email.css --config ./press/public/email/tailwind.config.js",
 		"build-marketplace-css": "npx tailwindcss -i ./press/public/marketplace/style.css -o ./press/public/css/marketplace-next.css --config ./press/public/marketplace/tailwind.config.js",
+		"build-saas-css": "npx tailwindcss -i ./press/public/marketplace/style.css -o ./press/public/css/saas-next.css --config ./press/templates/saas/tailwind.config.js",
 		"postinstall": "cd dashboard && yarn install"
 	},
 	"devDependencies": {

--- a/press/api/developer/marketplace.py
+++ b/press/api/developer/marketplace.py
@@ -171,7 +171,7 @@ def update_billing_info(secret_key: str, data: Dict) -> str:
 
 
 @frappe.whitelist(allow_guest=True)
-def make_payment(secret_key: str, data: Dict) -> str:
+def saas_payment(secret_key: str, data: Dict) -> str:
 	data = frappe.parse_json(data)
 	api_handler = DeveloperApiHandler(secret_key)
 	return api_handler.saas_payment(data)

--- a/press/api/developer/marketplace.py
+++ b/press/api/developer/marketplace.py
@@ -128,7 +128,7 @@ class DeveloperApiHandler:
 			data["new_plan"]["name"],
 			data["total"],
 			data["total"],
-			data["billing"],
+			12 if data["billing"] == "annual" else 1,
 			False,
 		)
 

--- a/press/api/developer/marketplace.py
+++ b/press/api/developer/marketplace.py
@@ -93,10 +93,7 @@ class DeveloperApiHandler:
 
 		team = self.app_subscription_doc.team
 		currency, address = frappe.db.get_value("Team", team, ["currency", "billing_address"])
-		response = {
-			"currency": currency,
-			"address": True if address else False
-		}
+		response = {"currency": currency, "address": True if address else False}
 		response["subscriptions"] = [
 			s.update(
 				{
@@ -122,9 +119,18 @@ class DeveloperApiHandler:
 
 		return "success"
 
-	def make_payment(self, data):
+	def saas_payment(self, data):
 		self.login_as_team()
-		prepaid_saas_payment(data)
+		return prepaid_saas_payment(
+			self.app_subscription_name,
+			self.app_subscription_doc.app,
+			self.app_subscription_doc.site,
+			data["new_plan"]["name"],
+			data["total"],
+			data["total"],
+			data["billing"],
+			False,
+		)
 
 	def login_as_team(self):
 		frappe.local.login_manager.login_as(self.app_subscription_doc.team)
@@ -168,4 +174,4 @@ def update_billing_info(secret_key: str, data: Dict) -> str:
 def make_payment(secret_key: str, data: Dict) -> str:
 	data = frappe.parse_json(data)
 	api_handler = DeveloperApiHandler(secret_key)
-	return api_handler.update_billing_info(data)
+	return api_handler.saas_payment(data)

--- a/press/press/doctype/marketplace_app/marketplace_app.py
+++ b/press/press/doctype/marketplace_app/marketplace_app.py
@@ -303,6 +303,7 @@ def get_plans_for_app(
 			"name",
 			"plan",
 			"discount_percent",
+			"gst",
 			"marked_most_popular",
 			"is_free",
 			"enabled",

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1402,7 +1402,7 @@ def process_rename_site_job_update(job):
 	)[0].status
 
 	if job.status == "Failure":
-		rename_step_name = "Rename Site" # for Rename Site job
+		rename_step_name = "Rename Site"  # for Rename Site job
 		if job.job_type == "Rename Site on Upstream":
 			rename_step_name = "Rename Site File in Upstream Directory"
 		rename_step_status = frappe.db.get_value(

--- a/press/templates/saas/billing_layout.html
+++ b/press/templates/saas/billing_layout.html
@@ -1,0 +1,38 @@
+{%- extends "templates/base.html" -%}
+
+{%- block favicon -%}
+<link rel="stylesheet" href="/assets/press/css/marketplace-next.css" />
+{%- endblock -%}
+
+{%- block navbar -%}
+{%- endblock -%}
+
+{%- block footer -%}
+{%- endblock -%}
+
+{%- block content -%}
+{%- endblock -%}
+
+{%- block script -%}
+{{ super() }}
+{%- endblock -%}
+
+{%- block style -%}
+<style>
+	body {
+		<!--background-color: var(--gray-50);-->
+	}
+	p {
+		font-size: var(--text-sm);
+		margin-bottom: 2px;
+	}
+	.active-btn:hover {
+		color: white;
+		background-color: var(--blue-500);
+	}
+
+	input {
+		border-radius: 15px;
+	}
+</style>
+{%- endblock -%}

--- a/press/templates/saas/billing_layout.html
+++ b/press/templates/saas/billing_layout.html
@@ -1,7 +1,7 @@
 {%- extends "templates/base.html" -%}
 
 {%- block favicon -%}
-<link rel="stylesheet" href="/assets/press/css/marketplace-next.css" />
+<link rel="stylesheet" href="/assets/press/css/saas-next.css" />
 {%- endblock -%}
 
 {%- block navbar -%}

--- a/press/templates/saas/macros.html
+++ b/press/templates/saas/macros.html
@@ -89,20 +89,30 @@
 
 <!-- Cards -->
 {% macro success_card() %}
-<div id="success-wrapper" class="mx-auto my-auto hidden">
-	<h2 class="font-size-base">Payment Request Received</h2>
+<div id="success-wrapper" class="mx-auto my-auto hidden w-1/2">
+	<div class="flex">
+		<div class="mr-2 grid h-4 w-4 shrink-0 place-items-center rounded-full border border-green-500 bg-green-50">
+			<svg width="10" height="8" viewBox="0 0 10 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<path d="M1.26562 3.86686L3.93229 6.53353L9.26562 1.2002" stroke="#38A160" stroke-miterlimit="10"
+					stroke-linecap="round" stroke-linejoin="round" />
+			</svg>
+		</div>
+		<h2 class="font-size-base mb-2">Payment Request Received</h2>
+	</div>
 	<span>Thank you for your payment request. We will send you a confirmation email shortly. In the meantime if you have any queries please reach us at 
-		our <a href="https://frappecloud.com/support">support page</a>.</span>
+		our <a href="https://frappecloud.com/support" class="text-blue-500 hover:text-blue-500">support page</a>.</span>
 </div>
 {% endmacro %}
 
 {% macro error_card() %}
-<div id="error-wrapper" class="mx-auto my-auto hidden">
-	<h2 class="font-size-base">Payment Request Received</h2>
-	<span>Thank you for your payment request. We will send you a confirmation email shortly. In the meantime if you have any queries please reach us at 
-		our <a href="https://frappecloud.com/support">support page</a>.</span>
+<div id="error-wrapper" class="mx-auto my-auto hidden w-1/2">
+	<div>
+		<h2 class="font-size-base mb-2">Something Went Wrong</h2>
+	</div>
+	<span>For some reason the payment request was could not complete. Please contact <a href="https://frappecloud.com/support" class="text-blue-500">support</a> in order to get a resolution at the earliest.</span>
 </div>
 {% endmacro %}
+
 
 {% macro stripe_wrapper() %}
 	<div id="stripe-wrapper" class="hidden">

--- a/press/templates/saas/macros.html
+++ b/press/templates/saas/macros.html
@@ -39,7 +39,8 @@
 				<p>Postal Code</p>
 				<input type="text" name="postal-code" class="form-control" />
 			</div>
-			<div>
+			<div class="flex justify-content-between my-2">
+				<span></span>
 				<button type="button" class="btn btn-primary" onclick="updateBillingInfo()">
 					Save
 				</button>

--- a/press/templates/saas/macros.html
+++ b/press/templates/saas/macros.html
@@ -74,11 +74,11 @@
 			<span>Discount</span>
 			<span class="discount text-green-500">-</span>
 		</div>
+		<hr class="my-4">
 		<div class="flex justify-content-between my-2">
 			<span>Total</span>
 			<span class="total font-semibold"></span>
 		</div>
-		<hr class="my-4">
 		<form class="flex justify-content-between my-2">
 			<span></span>
 			<button type="button" class="btn btn-primary w-36" onclick="setupStripe()">PROCEED TO PAY</span>
@@ -95,7 +95,15 @@
 </div>
 {% endmacro %}
 
-{% macro success_card() %}
+{% macro error_card() %}
+<div id="error-wrapper" class="mx-auto my-auto hidden">
+	<h2 class="font-size-base">Payment Request Received</h2>
+	<span>Thank you for your payment request. We will send you a confirmation email shortly. In the meantime if you have any queries please reach us at 
+		our <a href="https://frappecloud.com/support">support page</a>.</span>
+</div>
+{% endmacro %}
+
+{% macro stripe_wrapper() %}
 	<div id="stripe-wrapper" class="hidden">
 		<div id="card" class="hidden" ref="card-element"></div>
 		<button id="pay-btn" type="button" class="btn btn-primary w-full mt-6 py-3 rounded-lg" onclick="handlePayment()">

--- a/press/templates/saas/macros.html
+++ b/press/templates/saas/macros.html
@@ -1,0 +1,118 @@
+<!-- Wrapper Macros -->
+{% macro subs_wrapper() %}
+<div id="subs-wrapper" class="flex flex-row justify-center flex-wrap hidden mx-auto my-auto h-fit"></div>
+{% endmacro %}
+
+{% macro plans_wrapper() %}
+<div id="plans-wrapper" class="grid gap-2 grid-cols-3 justify-content-start flex-wrap hidden m-auto"></div>
+{% endmacro %}
+
+{% macro address_wrapper() %}
+	<div id="address-card-wrapper" class="flex container hidden mx-auto my-auto justify-content-center">
+		<form>
+			<div class="form-group">
+				<p>Billing Name</p>
+				<input type="text" name="billing-name" class="form-control" />
+			</div>
+			<div class="form-group">
+				<p>Address</p>
+				<input type="text" name="address" placeholder="Address" class="form-control" />
+			</div>
+			<div class="form-group">
+				<p>Country</p>
+				<select id="country" class="custom-select" name="country" class="form-control">
+					<option disabled selected>Select Country</option>
+					{%- for country in frappe.db.get_all('Country') -%}
+					<option>{{ country.name }}</option>
+					{%- endfor -%}
+				</select>
+			</div>
+			<div class="form-group">
+				<p>City</p>
+				<input type="text" name="city" class="form-control" />
+			</div>
+			<div class="form-group">
+				<p>State/Province/Region</p>
+				<input type="text" name="state" class="form-control" />
+			</div>
+			<div class="form-group">
+				<p>Postal Code</p>
+				<input type="text" name="postal-code" class="form-control" />
+			</div>
+			<div>
+				<button type="button" class="btn btn-primary" onclick="updateBillingInfo()">
+					Save
+				</button>
+			</div>
+		</form>
+	</div>
+{% endmacro %}
+
+{% macro checkout_wrapper() %}
+	<div id="checkout-wrapper" class="flex flex-col w-2/3 hidden mx-20 text-sm">
+		<div class="flex justify-content-between my-2">
+			<span>Plan</span>
+			<span class="new-plan"></span>
+		</div>
+		<div class="flex justify-content-between my-2">
+			<span>Amount / mo.</span>
+			<span class="new-plan-price"></span>
+		</div>
+		<div class="flex justify-content-between my-2">
+			<span>Billing:</span>
+			<select class="rounded px-2 pr-8" onchange="setTotal(this.value)">
+				<option class="pr-4" value="monthly">Monthly</option>
+				<option class="pr-4" value="annual">Annual</option>
+			</select>
+		</div>
+		<hr class="my-4">
+		<div class="flex justify-content-between my-2">
+			<span>GST (if applicable)</span>
+			<span class="gst text-red-600">-</span>
+		</div>
+		<div class="flex justify-content-between my-2">
+			<span>Discount</span>
+			<span class="discount text-green-500">-</span>
+		</div>
+		<div class="flex justify-content-between my-2">
+			<span>Total</span>
+			<span class="total font-semibold"></span>
+		</div>
+		<hr class="my-4">
+		<form class="flex justify-content-between my-2">
+			<span></span>
+			<button type="button" class="btn btn-primary w-36" onclick="setupStripe()">PROCEED TO PAY</span>
+		</form>
+	</div>
+{% endmacro %}
+
+<!-- Cards -->
+{% macro success_card() %}
+<div id="success-wrapper" class="mx-auto my-auto hidden">
+	<h2 class="font-size-base">Payment Request Received</h2>
+	<span>Thank you for your payment request. We will send you a confirmation email shortly. In the meantime if you have any queries please reach us at 
+		our <a href="https://frappecloud.com/support">support page</a>.</span>
+</div>
+{% endmacro %}
+
+{% macro success_card() %}
+	<div id="stripe-wrapper" class="hidden">
+		<div id="card" class="hidden" ref="card-element"></div>
+		<button id="pay-btn" type="button" class="btn btn-primary w-full mt-6 py-3 rounded-lg" onclick="handlePayment()">
+			<span id="pay-btn-spinner" class="spinner-border spinner-border-sm mr-3 hidden"></span>
+			<span id="pay-btn-text">PAY</span>
+		</button>
+	</div>
+{% endmacro %}
+
+{% macro load_stripe() %}
+<div id="loading-stripe" class="mx-auto my-auto hidden">
+	<span class="spinner-border spinner-border-sm mr-3" role="status"></span><span>Processing payment request</span>
+</div>
+{% endmacro %}
+
+{% macro load_subs() %}
+<div id="loading" class="mx-auto my-auto">
+	<span class="spinner-border spinner-border-sm mr-3" role="status"></span><span>Loading Susbcriptions </span>
+</div>
+{% endmacro %}

--- a/press/templates/saas/tailwind.config.js
+++ b/press/templates/saas/tailwind.config.js
@@ -1,0 +1,10 @@
+const config = require('../../../dashboard/tailwind.config');
+
+module.exports = {
+	theme: config.theme,
+	plugins: config.plugins,
+	content: [
+		'./press/**/saas/*.html',
+		'./press/**/saas/*.html',
+	],
+};

--- a/press/www/saas/billing.html
+++ b/press/www/saas/billing.html
@@ -1,7 +1,7 @@
 {% extends 'templates/saas/billing_layout.html' %} {% block content %}
 <div class="flex justify-content-center mx-auto my-auto h-100 w-100">
-	<div id="subs-wrapper" class="flex flex-row hidden mx-auto my-auto h-fit"></div>
-	<div id="plans-wrapper" class="flex justify-content-start flex-wrap hidden" style="margin: auto;"></div>
+	<div id="subs-wrapper" class="flex flex-row justify-center flex-wrap hidden mx-auto my-auto h-fit"></div>
+	<div id="plans-wrapper" class="grid gap-2 grid-cols-3 justify-content-start flex-wrap hidden m-auto"></div>
 	<div id="address-card-wrapper" class="flex container hidden mx-auto my-auto justify-content-center">
 		<form>
 			<div class="form-group">
@@ -41,7 +41,7 @@
 		</form>
 	</div>
 
-	<div id="checkout-wrapper" class="flex flex-col w-100 hidden mx-20">
+	<div id="checkout-wrapper" class="flex flex-col w-2/3 hidden mx-20 text-sm">
 		<div class="flex justify-content-between my-2">
 			<span>Plan</span>
 			<span class="new-plan"></span>
@@ -51,12 +51,13 @@
 			<span class="new-plan-price"></span>
 		</div>
 		<div class="flex justify-content-between my-2">
-			<span>Billing: </span>
-			<select class="rounded py-0" onchange="setTotal(this.value)">
-				<option value="monthly">Monthly</option>
-				<option value="annual">Annual</option>
+			<span>Billing:</span>
+			<select class="rounded px-2 pr-8" onchange="setTotal(this.value)">
+				<option class="pr-4" value="monthly">Monthly</option>
+				<option class="pr-4" value="annual">Annual</option>
 			</select>
 		</div>
+		<hr class="my-4">
 		<div class="flex justify-content-between my-2">
 			<span>GST (if applicable)</span>
 			<span class="gst text-red-600">-</span>
@@ -69,9 +70,10 @@
 			<span>Total</span>
 			<span class="total font-semibold"></span>
 		</div>
+		<hr class="my-4">
 		<form class="flex justify-content-between my-2">
 			<span></span>
-			<button type="button" class="btn btn-primary" onclick="setupStripe()">Pay Amount</span>
+			<button type="button" class="btn btn-primary w-32" onclick="setupStripe()">PAY</span>
 		</form>
 	</div>
 
@@ -113,12 +115,11 @@
 
 						for (let i in subscriptions) {
 							$('#subs-wrapper').append(`
-						<div class="transition ease-in-out delay-150 flex flex-row m-2 p-6 border border-gray-100 rounded-lg cursor-pointer hover:shadow-lg" onclick='showPlans(${JSON.stringify(
+						<div class="flex flex-row items-center m-2 p-4 w-2/7 border border-gray-100 rounded cursor-pointer transition-all hover:shadow-lg" onclick='showPlans(${JSON.stringify(
 								subscriptions[i]
 							)})'>
-							<img src="${subscriptions[i].image
-								}" alt="Logo" style="height: 34px;" class="rounded mr-2">
-							${subscriptions[i].title}
+							<img src="${subscriptions[i].image}" alt="Logo" style="height: 38px;" class="rounded mr-2">
+							<span class="text-base">${subscriptions[i].title}</span>
 						</div>
 						`);
 						}
@@ -131,11 +132,10 @@
 				$('#plans-wrapper').toggleClass('hidden');
 
 				let plans = sub.available_plans;
-				let classes =
+				let style =
 					'flex flex-col flex-1 justify-content-between m-2 border rounded col-md-auto shadow-sm';
 
 				for (let i in plans) {
-					let style = classes;
 					let features = "";
 					plans[i].features.map((f) => {
 						features += `<div class="flex my-1">
@@ -152,17 +152,17 @@
 					<div class="${style} ${sub.marketplace_app_plan === plans[i].name ? 'border-primary' : ''
 						}" style="width: 220px;" >
 						<div>
-							<p class="mt-4 font-semibold" style="font-size: 14px;">${plans[i].plan}</p>
-							<h3 class="my-4">${response.currency === 'INR' ? '₹' : '$'}${plans[i][`price_${response.currency.toLowerCase()}`]}</h3>
+							<p class="mt-4 font-semibold text-sm">${plans[i].plan}</p>
+							<h3 class="my-4 font-bold text-xl">${response.currency === 'INR' ? '₹' : '$'}${plans[i][`price_${response.currency.toLowerCase()}`]}</h3>
 						<div class="flex flex-col">
 							${features}
 						</div>
 						</div>
-						<button class='rounded my-4 w-full bg-gray-300 btn ${sub.marketplace_app_plan === plans[i].name
+						<button class='rounded my-4 w-full bg-gray-100 btn ${sub.marketplace_app_plan === plans[i].name
 							? 'btn-primary disabled'
 							: 'active-btn'
 						}' onclick='selectPlan(${JSON.stringify(plans[i])}, "${sub.name}")'>
-						${sub.marketplace_app_plan === plans[i].name ? 'Current Plan' : 'Buy this plan'}
+						${sub.marketplace_app_plan === plans[i].name ? 'Current Plan' : 'BUY NOW'}
 					</button>
 				</div>
 				`);
@@ -229,7 +229,6 @@
 				response.new_plan = new_plan
 				response.sub = sub
 				$('#plans-wrapper').toggleClass('hidden');
-				// if address is already added then skip to stripe payment screen
 				if (address) {
 					$('#checkout-wrapper').toggleClass('hidden');
 					setTotal()

--- a/press/www/saas/billing.html
+++ b/press/www/saas/billing.html
@@ -43,8 +43,16 @@
 
 	<div id="checkout-wrapper" class="flex flex-col w-100 hidden mx-20">
 		<div class="flex justify-content-between my-2">
-			<label for="cars">Billing: </label>
-			<select class="rounded" onchange="setTotal(this.value)">
+			<span>Plan</span>
+			<span class="new-plan"></span>
+		</div>
+		<div class="flex justify-content-between my-2">
+			<span>Amount / mo.</span>
+			<span class="new-plan-price"></span>
+		</div>
+		<div class="flex justify-content-between my-2">
+			<span>Billing: </span>
+			<select class="rounded py-0" onchange="setTotal(this.value)">
 				<option value="monthly">Monthly</option>
 				<option value="annual">Annual</option>
 			</select>
@@ -71,6 +79,9 @@
 		<div id="card" class="hidden" ref="card-element">Card</div>
 	</div>
 
+	<div id="loading-stripe" class="mx-auto my-auto hidden">
+		<span class="spinner-border spinner-border-sm mr-3" role="status"></span><span>Processing payment request</span>
+	</div>
 	<div id="loading" class="mx-auto my-auto">
 		<span class="spinner-border spinner-border-sm mr-3" role="status"></span><span>Loading Susbcriptions </span>
 	</div>
@@ -141,7 +152,7 @@
 					<div class="${style} ${sub.marketplace_app_plan === plans[i].name ? 'border-primary' : ''
 						}" style="width: 220px;" >
 						<div>
-							<p class="mt-4">${plans[i].plan}</p>
+							<p class="mt-4 font-semibold" style="font-size: 14px;">${plans[i].plan}</p>
 							<h3 class="my-4">${response.currency === 'INR' ? '₹' : '$'}${plans[i][`price_${response.currency.toLowerCase()}`]}</h3>
 						<div class="flex flex-col">
 							${features}
@@ -162,6 +173,9 @@
 				let total = 0;
 				const plan_price = response.new_plan[`price_${response.currency.toLowerCase()}`]
 				total = billing === 'annual' ? plan_price * 12 : plan_price
+				$('.new-plan').text(response.new_plan.plan)
+				$('.new-plan-price').text(`${response.currency === 'INR' ? '₹' : '$'} ${plan_price}`)
+
 				if (response.new_plan.discounted && billing === 'annual') {
 					let discount_percent = response.new_plan.discount_percent
 					$('.discount').text(`${discount_percent}%`)
@@ -184,10 +198,12 @@
 			function setupStripe() {
 				$("#checkout-wrapper").toggleClass("hidden");
 
+				$("#loading-stripe").toggleClass("hidden");
 				call('press.api.developer.marketplace.saas_payment', {
 					secret_key: secret_key,
 					data: response,
 				}).then((r) => {
+					$("#loading-stripe").toggleClass("hidden");
 					if (r.message) {
 
 						r = r.message;

--- a/press/www/saas/billing.html
+++ b/press/www/saas/billing.html
@@ -1,0 +1,226 @@
+{% extends 'templates/saas/billing_layout.html' %} {% block content %}
+<div class="flex justify-content-center mx-auto my-auto h-100 w-100">
+	<div id="subs-wrapper" class="flex flex-row hidden mx-auto my-auto h-fit"></div>
+	<div id="plans-wrapper" class="flex flex-wrap hidden justify-content-center"></div>
+	<div id="address-card-wrapper" class="flex container hidden mx-auto my-auto justify-content-center">
+		<form>
+			<div class="form-group">
+				<p>Billing Name</p>
+				<input type="text" name="billing-name" class="form-control" />
+			</div>
+			<div class="form-group">
+				<p>Address</p>
+				<input type="text" name="address" placeholder="Address" class="form-control" />
+			</div>
+			<div class="form-group">
+				<p>Country</p>
+				<select id="country" class="custom-select" name="country" class="form-control">
+					<option disabled selected>Select Country</option>
+					{%- for country in frappe.db.get_all('Country') -%}
+					<option>{{ country.name }}</option>
+					{%- endfor -%}
+				</select>
+			</div>
+			<div class="form-group">
+				<p>City</p>
+				<input type="text" name="city" class="form-control" />
+			</div>
+			<div class="form-group">
+				<p>State/Province/Region</p>
+				<input type="text" name="state" class="form-control" />
+			</div>
+			<div class="form-group">
+				<p>Postal Code</p>
+				<input type="text" name="postal-code" class="form-control" />
+			</div>
+			<div>
+				<button type="button" class="btn btn-primary" onclick="updateBillingInfo()">
+					Save
+				</button>
+			</div>
+		</form>
+	</div>
+
+	<div id="checkout-wrapper" class="flex flex-col w-100 hidden mx-20">
+		<div class="flex justify-content-between my-2">
+			<label for="cars">Billing: </label>
+			<select class="rounded" onchange="setTotal(this.value)">
+				<option value="monthly">Monthly</option>
+				<option value="annual">Annual</option>
+			</select>
+		</div>
+		<div class="flex justify-content-between my-2">
+			<span>GST (if applicable)</span>
+			<span class="gst text-red-600">-</span>
+		</div>
+		<div class="flex justify-content-between my-2">
+			<span>Discount</span>
+			<span class="discount text-green-500">-</span>
+		</div>
+		<div class="flex justify-content-between my-2">
+			<span>Total</span>
+			<span class="total font-semibold"></span>
+		</div>
+		<form class="flex justify-content-between my-2">
+			<span></span>
+			<button type="button" class="btn btn-primary" onclick="setupStripe()">Pay Amount</span>
+		</form>
+	</div>
+
+	<div class="stripe-wrapper">
+	</div>
+
+	<div id="loading" class="mx-auto my-auto">
+		<span class="spinner-border spinner-border-sm mr-3" role="status"></span><span>Loading Susbcriptions </span>
+	</div>
+	<div>
+		{%- endblock -%} {%- block script -%}
+		<!--<script src="https://js.stripe.com/v3/"></script>-->
+		<script>
+
+			const url_args = frappe.utils.get_query_params();
+			let secret_key = url_args.secret_key
+			let address = null;
+			let response = {}
+
+			if (secret_key.length >= 0 && secret_key != null) {
+				setup();
+			}
+
+			function setup() {
+				return call('press.api.developer.marketplace.get_subscriptions', {
+					secret_key: secret_key,
+				}).then((r) => {
+					let data = r.message;
+					address = data.address;
+					let subscriptions = data.subscriptions;
+					response.currency = data.currency
+
+					if (subscriptions.length >= 0) {
+						$('#loading').toggleClass('hidden');
+						$('#subs-wrapper').toggleClass('hidden');
+
+						for (let i in subscriptions) {
+							$('#subs-wrapper').append(`
+						<div class="transition ease-in-out delay-150 flex flex-row m-2 p-6 border border-gray-100 rounded-lg cursor-pointer hover:shadow-lg" onclick='showPlans(${JSON.stringify(
+								subscriptions[i]
+							)})'>
+							<img src="${subscriptions[i].image
+								}" alt="Logo" style="height: 34px;" class="rounded mr-2">
+							${subscriptions[i].title}
+						</div>
+						`);
+						}
+					}
+				});
+			}
+
+			function showPlans(sub) {
+				$('#subs-wrapper').toggleClass('hidden');
+				$('#plans-wrapper').toggleClass('hidden');
+
+				let plans = sub.available_plans;
+				let classes =
+					'flex-row justify-content-between mx-4 my-auto border rounded col-md-auto';
+
+				for (let i in plans) {
+					let style = classes;
+					let features = plans[i].features;
+					$('#plans-wrapper').append(`
+					<div class="${style} ${sub.marketplace_app_plan === plans[i].name ? 'border-primary' : ''
+						}" style="width: 200px; height: fit-content" >
+						<div>
+							<p class="mt-4">${plans[i].plan}</p>
+							<h3 class="my-4">${plans[i].price_inr}</h3>
+						<div>
+							${features}
+						</div>
+						</div>
+						<button class='rounded my-4 w-full bg-gray-300 btn ${sub.marketplace_app_plan === plans[i].name
+							? 'btn-primary disabled'
+							: 'active-btn'
+						}' onclick='selectPlan(${JSON.stringify(plans[i])}, "${sub.name}")'>
+						${sub.marketplace_app_plan === plans[i].name ? 'Current Plan' : 'Buy this plan'}
+					</button>
+				</div>
+				`);
+				}
+			}
+
+			function setTotal(billing) {
+				let total = 0;
+
+				const plan_price = response.new_plan[`price_${response.currency.toLowerCase()}`]
+				total = billing === 'annual' ? plan_price * 12 : plan_price
+				if (response.new_plan.discounted && billing === 'annual') {
+					let discount_percent = response.new_plan.discount_percent
+					$('.discount').text(`${discount_percent}%`)
+					total -= total * (discount_percent / 100)
+				} else {
+					$('.discount').text("-")
+				}
+				if (response.currency === "INR" && response.new_plan.gst === 1) {
+					$('.gst').text('18%')
+					total += total * .18
+				} else {
+					$('gst').text("-")
+				}
+				
+				$('.total').text(`${response.currency === 'INR' ? '₹' : '$'} ${total}`)
+			}
+
+			function setupStripe() {
+				console.log("Setting up stripe")
+			}
+
+			function selectPlan(new_plan, sub) {
+				response.new_plan = new_plan
+				response.sub = sub
+				$('#plans-wrapper').toggleClass('hidden');
+				// if address is already added then skip to stripe payment screen
+				if (address) {
+					$('#checkout-wrapper').toggleClass('hidden');
+					setTotal()
+				}
+				else {
+					$('#address-card-wrapper').toggleClass('hidden');
+				}
+			}
+
+			function updateBillingInfo() {
+				let billing_info = {
+					billing_name: $('input[name="billing-name"]').val(),
+					address: $('input[name="address"]').val(),
+					country: $('select[name="country"]').val(),
+					city: $('input[name="city"]').val(),
+					state: $('input[name="state"]').val(),
+					postal_code: $('input[name="postal-code"]').val(),
+				};
+
+				call('press.api.developer.marketplace.update_billing_info', {
+					secret_key: secret_key,
+					data: billing_info,
+				}).then((r) => {
+					console.log(r);
+				});
+			}
+
+			function call(method, args) {
+				return frappe
+					.call({
+						method: method,
+						args: args,
+						type: 'POST',
+					})
+					.then((r) => {
+						if (r.exc) {
+							console.error('An error occurred', r.exc);
+							return;
+						}
+						return r;
+					});
+			}
+		</script>
+		{% endblock %}
+	</div>
+</div>

--- a/press/www/saas/billing.html
+++ b/press/www/saas/billing.html
@@ -1,7 +1,7 @@
 {% extends 'templates/saas/billing_layout.html' %} {% block content %}
 <div class="flex justify-content-center mx-auto my-auto h-100 w-100">
 	<div id="subs-wrapper" class="flex flex-row hidden mx-auto my-auto h-fit"></div>
-	<div id="plans-wrapper" class="flex flex-wrap hidden justify-content-center"></div>
+	<div id="plans-wrapper" class="flex justify-content-start flex-wrap hidden" style="margin: auto;"></div>
 	<div id="address-card-wrapper" class="flex container hidden mx-auto my-auto justify-content-center">
 		<form>
 			<div class="form-group">
@@ -68,11 +68,7 @@
 	</div>
 
 	<div id="stripe-wrapper" class="hidden">
-		<div
-			id="card"
-			class="hidden"
-			ref="card-element"
-		>Card</div>
+		<div id="card" class="hidden" ref="card-element">Card</div>
 	</div>
 
 	<div id="loading" class="mx-auto my-auto">
@@ -82,7 +78,6 @@
 		{%- endblock -%} {%- block script -%}
 		<script src="https://js.stripe.com/v3/"></script>
 		<script>
-
 			const url_args = frappe.utils.get_query_params();
 			let secret_key = url_args.secret_key
 			let address = null;
@@ -126,18 +121,29 @@
 
 				let plans = sub.available_plans;
 				let classes =
-					'flex-row justify-content-between mx-4 my-auto border rounded col-md-auto';
+					'flex flex-col flex-1 justify-content-between m-2 border rounded col-md-auto shadow-sm';
 
 				for (let i in plans) {
 					let style = classes;
-					let features = plans[i].features;
+					let features = "";
+					plans[i].features.map((f) => {
+						features += `<div class="flex my-1">
+								<div class="mr-2 grid h-4 w-4 shrink-0 place-items-center rounded-full border border-green-500 bg-green-50">
+									<svg width="10" height="8" viewBox="0 0 10 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+										<path d="M1.26562 3.86686L3.93229 6.53353L9.26562 1.2002" stroke="#38A160" stroke-miterlimit="10"
+											stroke-linecap="round" stroke-linejoin="round" />
+									</svg>
+								</div>
+								<p>${f}</p>
+							</div>`;
+					});
 					$('#plans-wrapper').append(`
 					<div class="${style} ${sub.marketplace_app_plan === plans[i].name ? 'border-primary' : ''
-						}" style="width: 200px; height: fit-content" >
+						}" style="width: 220px;" >
 						<div>
 							<p class="mt-4">${plans[i].plan}</p>
-							<h3 class="my-4">${plans[i].price_inr}</h3>
-						<div>
+							<h3 class="my-4">${response.currency === 'INR' ? '₹' : '$'}${plans[i][`price_${response.currency.toLowerCase()}`]}</h3>
+						<div class="flex flex-col">
 							${features}
 						</div>
 						</div>
@@ -154,7 +160,6 @@
 
 			function setTotal(billing) {
 				let total = 0;
-
 				const plan_price = response.new_plan[`price_${response.currency.toLowerCase()}`]
 				total = billing === 'annual' ? plan_price * 12 : plan_price
 				if (response.new_plan.discounted && billing === 'annual') {
@@ -170,7 +175,7 @@
 				} else {
 					$('gst').text("-")
 				}
-				
+
 				response.total = total
 				response.billing = billing
 				$('.total').text(`${response.currency === 'INR' ? '₹' : '$'} ${total}`)
@@ -186,9 +191,7 @@
 					if (r.message) {
 
 						r = r.message;
-						stripeVars = r.message
 						$("#stripe-wrapper").toggleClass("hidden");
-
 						const stripe = Stripe(r.publishable_key)
 						const options = {
 							clientSecret: r.client_secret,
@@ -197,7 +200,6 @@
 							},
 						};
 						let elements = stripe.elements(options);
-
 						const paymentElement = elements.create('payment');
 						paymentElement.mount('#card');
 

--- a/press/www/saas/billing.html
+++ b/press/www/saas/billing.html
@@ -1,99 +1,30 @@
-{% extends 'templates/saas/billing_layout.html' %} {% block content %}
+{%- extends "templates/saas/billing_layout.html" -%} 
+{%- from "templates/saas/macros.html" import subs_wrapper, plans_wrapper, success_card, load_stripe, load_subs, checkout_wrapper, address_wrapper -%}
+
+{% block content %}
 <div class="flex justify-content-center mx-auto my-auto h-100 w-100">
-	<div id="subs-wrapper" class="flex flex-row justify-center flex-wrap hidden mx-auto my-auto h-fit"></div>
-	<div id="plans-wrapper" class="grid gap-2 grid-cols-3 justify-content-start flex-wrap hidden m-auto"></div>
-	<div id="address-card-wrapper" class="flex container hidden mx-auto my-auto justify-content-center">
-		<form>
-			<div class="form-group">
-				<p>Billing Name</p>
-				<input type="text" name="billing-name" class="form-control" />
-			</div>
-			<div class="form-group">
-				<p>Address</p>
-				<input type="text" name="address" placeholder="Address" class="form-control" />
-			</div>
-			<div class="form-group">
-				<p>Country</p>
-				<select id="country" class="custom-select" name="country" class="form-control">
-					<option disabled selected>Select Country</option>
-					{%- for country in frappe.db.get_all('Country') -%}
-					<option>{{ country.name }}</option>
-					{%- endfor -%}
-				</select>
-			</div>
-			<div class="form-group">
-				<p>City</p>
-				<input type="text" name="city" class="form-control" />
-			</div>
-			<div class="form-group">
-				<p>State/Province/Region</p>
-				<input type="text" name="state" class="form-control" />
-			</div>
-			<div class="form-group">
-				<p>Postal Code</p>
-				<input type="text" name="postal-code" class="form-control" />
-			</div>
-			<div>
-				<button type="button" class="btn btn-primary" onclick="updateBillingInfo()">
-					Save
-				</button>
-			</div>
-		</form>
-	</div>
+	{{ subs_wrapper() }}
+	{{ plans_wrapper() }}
+	{{ address_wrapper() }}
+	{{ checkout_wrapper() }}
+	{{ stripe_wrapper() }}
 
-	<div id="checkout-wrapper" class="flex flex-col w-2/3 hidden mx-20 text-sm">
-		<div class="flex justify-content-between my-2">
-			<span>Plan</span>
-			<span class="new-plan"></span>
-		</div>
-		<div class="flex justify-content-between my-2">
-			<span>Amount / mo.</span>
-			<span class="new-plan-price"></span>
-		</div>
-		<div class="flex justify-content-between my-2">
-			<span>Billing:</span>
-			<select class="rounded px-2 pr-8" onchange="setTotal(this.value)">
-				<option class="pr-4" value="monthly">Monthly</option>
-				<option class="pr-4" value="annual">Annual</option>
-			</select>
-		</div>
-		<hr class="my-4">
-		<div class="flex justify-content-between my-2">
-			<span>GST (if applicable)</span>
-			<span class="gst text-red-600">-</span>
-		</div>
-		<div class="flex justify-content-between my-2">
-			<span>Discount</span>
-			<span class="discount text-green-500">-</span>
-		</div>
-		<div class="flex justify-content-between my-2">
-			<span>Total</span>
-			<span class="total font-semibold"></span>
-		</div>
-		<hr class="my-4">
-		<form class="flex justify-content-between my-2">
-			<span></span>
-			<button type="button" class="btn btn-primary w-32" onclick="setupStripe()">PAY</span>
-		</form>
-	</div>
+	{{ success_card() }}
+	{{ success_card() }}
+	{{ load_stripe() }}
+	{{ load_subs() }}
+</div>
+{%- endblock -%} 
 
-	<div id="stripe-wrapper" class="hidden">
-		<div id="card" class="hidden" ref="card-element">Card</div>
-	</div>
 
-	<div id="loading-stripe" class="mx-auto my-auto hidden">
-		<span class="spinner-border spinner-border-sm mr-3" role="status"></span><span>Processing payment request</span>
-	</div>
-	<div id="loading" class="mx-auto my-auto">
-		<span class="spinner-border spinner-border-sm mr-3" role="status"></span><span>Loading Susbcriptions </span>
-	</div>
-	<div>
-		{%- endblock -%} {%- block script -%}
+{%- block script -%}
 		<script src="https://js.stripe.com/v3/"></script>
 		<script>
 			const url_args = frappe.utils.get_query_params();
 			let secret_key = url_args.secret_key
 			let address = null;
+			let elements = null;
+			let stripe = null;
 			let response = {}
 
 			if (secret_key.length >= 0 && secret_key != null) {
@@ -208,21 +139,50 @@
 
 						r = r.message;
 						$("#stripe-wrapper").toggleClass("hidden");
-						const stripe = Stripe(r.publishable_key)
+						stripe = Stripe(r.publishable_key)
 						const options = {
 							clientSecret: r.client_secret,
 							appearance: {
 								theme: 'flat',
 							},
 						};
-						let elements = stripe.elements(options);
+						elements = stripe.elements(options);
 						const paymentElement = elements.create('payment');
 						paymentElement.mount('#card');
 
 						$('#card').toggleClass('hidden')
-						card.mount('#card')
 					}
 				});
+			}
+
+			async function handlePayment(e) {
+
+				try {
+					$('#pay-btn').attr('disabled','disabled');
+					$("#pay-btn-spinner").toggleClass("hidden");
+					$("#pay-btn-text").text("Processing...");
+
+					const payload = await stripe.confirmPayment({
+						elements,
+							redirect: 'if_required',
+					});
+
+					if (payload.error && payload.error === "card_error") {
+							$("#stripe-wrapper").toggleClass("hidden");
+							$("#success-wrapper").toggleClass("hidden");
+					} else {
+						if (payload.paymentIntent.status === "succeeded") {
+							$("#stripe-wrapper").toggleClass("hidden");
+							$("#success-wrapper").toggleClass("hidden");
+						}
+					}
+				} catch (err) {
+					console.log(err)
+					$('#pay-btn').removeAttr('disabled');
+					$("#pay-btn-spinner").toggleClass("hidden");
+					$("#pay-btn-text").text("Pay Now");
+				}
+
 			}
 
 			function selectPlan(new_plan, sub) {
@@ -231,7 +191,7 @@
 				$('#plans-wrapper').toggleClass('hidden');
 				if (address) {
 					$('#checkout-wrapper').toggleClass('hidden');
-					setTotal()
+					setTotal('monthly')
 				}
 				else {
 					$('#address-card-wrapper').toggleClass('hidden');
@@ -272,6 +232,4 @@
 					});
 			}
 		</script>
-		{% endblock %}
-	</div>
-</div>
+{% endblock %}

--- a/press/www/saas/billing.html
+++ b/press/www/saas/billing.html
@@ -67,7 +67,12 @@
 		</form>
 	</div>
 
-	<div class="stripe-wrapper">
+	<div id="stripe-wrapper" class="hidden">
+		<div
+			id="card"
+			class="hidden"
+			ref="card-element"
+		>Card</div>
 	</div>
 
 	<div id="loading" class="mx-auto my-auto">
@@ -75,7 +80,7 @@
 	</div>
 	<div>
 		{%- endblock -%} {%- block script -%}
-		<!--<script src="https://js.stripe.com/v3/"></script>-->
+		<script src="https://js.stripe.com/v3/"></script>
 		<script>
 
 			const url_args = frappe.utils.get_query_params();
@@ -166,11 +171,40 @@
 					$('gst').text("-")
 				}
 				
+				response.total = total
+				response.billing = billing
 				$('.total').text(`${response.currency === 'INR' ? '₹' : '$'} ${total}`)
 			}
 
 			function setupStripe() {
-				console.log("Setting up stripe")
+				$("#checkout-wrapper").toggleClass("hidden");
+
+				call('press.api.developer.marketplace.saas_payment', {
+					secret_key: secret_key,
+					data: response,
+				}).then((r) => {
+					if (r.message) {
+
+						r = r.message;
+						stripeVars = r.message
+						$("#stripe-wrapper").toggleClass("hidden");
+
+						const stripe = Stripe(r.publishable_key)
+						const options = {
+							clientSecret: r.client_secret,
+							appearance: {
+								theme: 'flat',
+							},
+						};
+						let elements = stripe.elements(options);
+
+						const paymentElement = elements.create('payment');
+						paymentElement.mount('#card');
+
+						$('#card').toggleClass('hidden')
+						card.mount('#card')
+					}
+				});
 			}
 
 			function selectPlan(new_plan, sub) {

--- a/press/www/saas/billing.html
+++ b/press/www/saas/billing.html
@@ -207,7 +207,11 @@ address_wrapper -%} {% block content %}
 			secret_key: secret_key,
 			data: billing_info,
 		}).then((r) => {
-			console.log(r);
+			if (r.message == 'success') {
+				$('#checkout-wrapper').toggleClass('hidden');
+				$('#address-card-wrapper').toggleClass('hidden');
+				setTotal('monthly');
+			}
 		});
 	}
 

--- a/press/www/saas/billing.html
+++ b/press/www/saas/billing.html
@@ -1,75 +1,67 @@
-{%- extends "templates/saas/billing_layout.html" -%} 
-{%- from "templates/saas/macros.html" import subs_wrapper, plans_wrapper, success_card, load_stripe, load_subs, checkout_wrapper, address_wrapper -%}
-
-{% block content %}
+{%- extends "templates/saas/billing_layout.html" -%} {%- from
+"templates/saas/macros.html" import subs_wrapper, plans_wrapper, success_card,
+error_card, load_stripe, load_subs, checkout_wrapper, stripe_wrapper,
+address_wrapper -%} {% block content %}
 <div class="flex justify-content-center mx-auto my-auto h-100 w-100">
-	{{ subs_wrapper() }}
-	{{ plans_wrapper() }}
-	{{ address_wrapper() }}
-	{{ checkout_wrapper() }}
-	{{ stripe_wrapper() }}
-
-	{{ success_card() }}
-	{{ success_card() }}
-	{{ load_stripe() }}
-	{{ load_subs() }}
+	{{ subs_wrapper() }} {{ plans_wrapper() }} {{ address_wrapper() }} {{
+	checkout_wrapper() }} {{ stripe_wrapper() }} {{ success_card() }} {{
+	success_card() }} {{ load_stripe() }} {{ load_subs() }}
 </div>
-{%- endblock -%} 
+{%- endblock -%} {%- block script -%}
+<script src="https://js.stripe.com/v3/"></script>
+<script>
+	const url_args = frappe.utils.get_query_params();
+	let secret_key = url_args.secret_key;
+	let address = null;
+	let elements = null;
+	let stripe = null;
+	let response = {};
 
+	if (secret_key.length >= 0 && secret_key != null) {
+		setup();
+	}
 
-{%- block script -%}
-		<script src="https://js.stripe.com/v3/"></script>
-		<script>
-			const url_args = frappe.utils.get_query_params();
-			let secret_key = url_args.secret_key
-			let address = null;
-			let elements = null;
-			let stripe = null;
-			let response = {}
+	function setup() {
+		return call('press.api.developer.marketplace.get_subscriptions', {
+			secret_key: secret_key,
+		}).then((r) => {
+			let data = r.message;
+			address = data.address;
+			let subscriptions = data.subscriptions;
+			response.currency = data.currency;
 
-			if (secret_key.length >= 0 && secret_key != null) {
-				setup();
-			}
+			if (subscriptions.length >= 0) {
+				$('#loading').toggleClass('hidden');
+				$('#subs-wrapper').toggleClass('hidden');
 
-			function setup() {
-				return call('press.api.developer.marketplace.get_subscriptions', {
-					secret_key: secret_key,
-				}).then((r) => {
-					let data = r.message;
-					address = data.address;
-					let subscriptions = data.subscriptions;
-					response.currency = data.currency
-
-					if (subscriptions.length >= 0) {
-						$('#loading').toggleClass('hidden');
-						$('#subs-wrapper').toggleClass('hidden');
-
-						for (let i in subscriptions) {
-							$('#subs-wrapper').append(`
+				for (let i in subscriptions) {
+					$('#subs-wrapper').append(`
 						<div class="flex flex-row items-center m-2 p-4 w-2/7 border border-gray-100 rounded cursor-pointer transition-all hover:shadow-lg" onclick='showPlans(${JSON.stringify(
-								subscriptions[i]
-							)})'>
-							<img src="${subscriptions[i].image}" alt="Logo" style="height: 38px;" class="rounded mr-2">
+							subscriptions[i]
+						)})'>
+							<img src="${
+								subscriptions[i].image
+							}" alt="Logo" style="height: 38px;" class="rounded mr-2">
 							<span class="text-base">${subscriptions[i].title}</span>
 						</div>
 						`);
-						}
-					}
-				});
+				}
 			}
+		});
+	}
 
-			function showPlans(sub) {
-				$('#subs-wrapper').toggleClass('hidden');
-				$('#plans-wrapper').toggleClass('hidden');
+	function showPlans(sub) {
+		$('#subs-wrapper').toggleClass('hidden');
+		$('#plans-wrapper').toggleClass('hidden');
 
-				let plans = sub.available_plans;
-				let style =
-					'flex flex-col flex-1 justify-content-between m-2 border rounded col-md-auto shadow-sm';
+		let plans = sub.available_plans;
+		let style =
+			'flex flex-col flex-1 justify-content-between m-2 border rounded col-md-auto shadow-sm';
 
-				for (let i in plans) {
-					let features = "";
-					plans[i].features.map((f) => {
-						features += `<div class="flex my-1">
+		for (let i in plans) {
+			let features = '';
+			plans[i].features.map((f) => {
+				features += `<div class="flex my-1">
 								<div class="mr-2 grid h-4 w-4 shrink-0 place-items-center rounded-full border border-green-500 bg-green-50">
 									<svg width="10" height="8" viewBox="0 0 10 8" fill="none" xmlns="http://www.w3.org/2000/svg">
 										<path d="M1.26562 3.86686L3.93229 6.53353L9.26562 1.2002" stroke="#38A160" stroke-miterlimit="10"
@@ -78,158 +70,161 @@
 								</div>
 								<p>${f}</p>
 							</div>`;
-					});
-					$('#plans-wrapper').append(`
-					<div class="${style} ${sub.marketplace_app_plan === plans[i].name ? 'border-primary' : ''
-						}" style="width: 220px;" >
+			});
+			$('#plans-wrapper').append(`
+					<div class="${style} ${
+				sub.marketplace_app_plan === plans[i].name ? 'border-primary' : ''
+			}" style="width: 220px;" >
 						<div>
 							<p class="mt-4 font-semibold text-sm">${plans[i].plan}</p>
-							<h3 class="my-4 font-bold text-xl">${response.currency === 'INR' ? '₹' : '$'}${plans[i][`price_${response.currency.toLowerCase()}`]}</h3>
+							<h3 class="my-4 font-bold text-xl">${response.currency === 'INR' ? '₹' : '$'}${
+				plans[i][`price_${response.currency.toLowerCase()}`]
+			}</h3>
 						<div class="flex flex-col">
 							${features}
 						</div>
 						</div>
-						<button class='rounded my-4 w-full bg-gray-100 btn ${sub.marketplace_app_plan === plans[i].name
-							? 'btn-primary disabled'
-							: 'active-btn'
+						<button class='rounded my-4 w-full bg-gray-100 btn ${
+							sub.marketplace_app_plan === plans[i].name
+								? 'btn-primary disabled'
+								: 'active-btn'
 						}' onclick='selectPlan(${JSON.stringify(plans[i])}, "${sub.name}")'>
 						${sub.marketplace_app_plan === plans[i].name ? 'Current Plan' : 'BUY NOW'}
 					</button>
 				</div>
 				`);
-				}
-			}
+		}
+	}
 
-			function setTotal(billing) {
-				let total = 0;
-				const plan_price = response.new_plan[`price_${response.currency.toLowerCase()}`]
-				total = billing === 'annual' ? plan_price * 12 : plan_price
-				$('.new-plan').text(response.new_plan.plan)
-				$('.new-plan-price').text(`${response.currency === 'INR' ? '₹' : '$'} ${plan_price}`)
+	function setTotal(billing) {
+		let total = 0;
+		const plan_price =
+			response.new_plan[`price_${response.currency.toLowerCase()}`];
+		total = billing === 'annual' ? plan_price * 12 : plan_price;
+		$('.new-plan').text(response.new_plan.plan);
+		$('.new-plan-price').text(
+			`${response.currency === 'INR' ? '₹' : '$'} ${plan_price}`
+		);
 
-				if (response.new_plan.discounted && billing === 'annual') {
-					let discount_percent = response.new_plan.discount_percent
-					$('.discount').text(`${discount_percent}%`)
-					total -= total * (discount_percent / 100)
-				} else {
-					$('.discount').text("-")
-				}
-				if (response.currency === "INR" && response.new_plan.gst === 1) {
-					$('.gst').text('18%')
-					total += total * .18
-				} else {
-					$('gst').text("-")
-				}
+		if (response.new_plan.discounted && billing === 'annual') {
+			let discount_percent = response.new_plan.discount_percent;
+			$('.discount').text(`${discount_percent}%`);
+			total -= total * (discount_percent / 100);
+		} else {
+			$('.discount').text('-');
+		}
+		if (response.currency === 'INR' && response.new_plan.gst === 1) {
+			$('.gst').text('18%');
+			total += total * 0.18;
+		} else {
+			$('gst').text('-');
+		}
 
-				response.total = total
-				response.billing = billing
-				$('.total').text(`${response.currency === 'INR' ? '₹' : '$'} ${total}`)
-			}
+		response.total = total;
+		response.billing = billing;
+		$('.total').text(`${response.currency === 'INR' ? '₹' : '$'} ${total}`);
+	}
 
-			function setupStripe() {
-				$("#checkout-wrapper").toggleClass("hidden");
+	function setupStripe() {
+		$('#checkout-wrapper').toggleClass('hidden');
 
-				$("#loading-stripe").toggleClass("hidden");
-				call('press.api.developer.marketplace.saas_payment', {
-					secret_key: secret_key,
-					data: response,
-				}).then((r) => {
-					$("#loading-stripe").toggleClass("hidden");
-					if (r.message) {
-
-						r = r.message;
-						$("#stripe-wrapper").toggleClass("hidden");
-						stripe = Stripe(r.publishable_key)
-						const options = {
-							clientSecret: r.client_secret,
-							appearance: {
-								theme: 'flat',
-							},
-						};
-						elements = stripe.elements(options);
-						const paymentElement = elements.create('payment');
-						paymentElement.mount('#card');
-
-						$('#card').toggleClass('hidden')
-					}
-				});
-			}
-
-			async function handlePayment(e) {
-
-				try {
-					$('#pay-btn').attr('disabled','disabled');
-					$("#pay-btn-spinner").toggleClass("hidden");
-					$("#pay-btn-text").text("Processing...");
-
-					const payload = await stripe.confirmPayment({
-						elements,
-							redirect: 'if_required',
-					});
-
-					if (payload.error && payload.error === "card_error") {
-							$("#stripe-wrapper").toggleClass("hidden");
-							$("#success-wrapper").toggleClass("hidden");
-					} else {
-						if (payload.paymentIntent.status === "succeeded") {
-							$("#stripe-wrapper").toggleClass("hidden");
-							$("#success-wrapper").toggleClass("hidden");
-						}
-					}
-				} catch (err) {
-					console.log(err)
-					$('#pay-btn').removeAttr('disabled');
-					$("#pay-btn-spinner").toggleClass("hidden");
-					$("#pay-btn-text").text("Pay Now");
-				}
-
-			}
-
-			function selectPlan(new_plan, sub) {
-				response.new_plan = new_plan
-				response.sub = sub
-				$('#plans-wrapper').toggleClass('hidden');
-				if (address) {
-					$('#checkout-wrapper').toggleClass('hidden');
-					setTotal('monthly')
-				}
-				else {
-					$('#address-card-wrapper').toggleClass('hidden');
-				}
-			}
-
-			function updateBillingInfo() {
-				let billing_info = {
-					billing_name: $('input[name="billing-name"]').val(),
-					address: $('input[name="address"]').val(),
-					country: $('select[name="country"]').val(),
-					city: $('input[name="city"]').val(),
-					state: $('input[name="state"]').val(),
-					postal_code: $('input[name="postal-code"]').val(),
+		$('#loading-stripe').toggleClass('hidden');
+		call('press.api.developer.marketplace.saas_payment', {
+			secret_key: secret_key,
+			data: response,
+		}).then((r) => {
+			$('#loading-stripe').toggleClass('hidden');
+			if (r.message) {
+				r = r.message;
+				$('#stripe-wrapper').toggleClass('hidden');
+				stripe = Stripe(r.publishable_key);
+				const options = {
+					clientSecret: r.client_secret,
+					appearance: {
+						theme: 'flat',
+					},
 				};
+				elements = stripe.elements(options);
+				const paymentElement = elements.create('payment');
+				paymentElement.mount('#card');
 
-				call('press.api.developer.marketplace.update_billing_info', {
-					secret_key: secret_key,
-					data: billing_info,
-				}).then((r) => {
-					console.log(r);
-				});
+				$('#card').toggleClass('hidden');
 			}
+		});
+	}
 
-			function call(method, args) {
-				return frappe
-					.call({
-						method: method,
-						args: args,
-						type: 'POST',
-					})
-					.then((r) => {
-						if (r.exc) {
-							console.error('An error occurred', r.exc);
-							return;
-						}
-						return r;
-					});
+	async function handlePayment(e) {
+		try {
+			$('#pay-btn').attr('disabled', 'disabled');
+			$('#pay-btn-spinner').toggleClass('hidden');
+			$('#pay-btn-text').text('Processing...');
+
+			const payload = await stripe.confirmPayment({
+				elements,
+				redirect: 'if_required',
+			});
+
+			if (payload.error && payload.error === 'card_error') {
+				$('#stripe-wrapper').toggleClass('hidden');
+				$('#success-wrapper').toggleClass('hidden');
+			} else {
+				if (payload.paymentIntent.status === 'succeeded') {
+					$('#stripe-wrapper').toggleClass('hidden');
+					$('#success-wrapper').toggleClass('hidden');
+				}
 			}
-		</script>
+		} catch (err) {
+			console.log(err);
+			$('#pay-btn').removeAttr('disabled');
+			$('#pay-btn-spinner').toggleClass('hidden');
+			$('#pay-btn-text').text('Pay Now');
+		}
+	}
+
+	function selectPlan(new_plan, sub) {
+		response.new_plan = new_plan;
+		response.sub = sub;
+		$('#plans-wrapper').toggleClass('hidden');
+		if (address) {
+			$('#checkout-wrapper').toggleClass('hidden');
+			setTotal('monthly');
+		} else {
+			$('#address-card-wrapper').toggleClass('hidden');
+		}
+	}
+
+	function updateBillingInfo() {
+		let billing_info = {
+			billing_name: $('input[name="billing-name"]').val(),
+			address: $('input[name="address"]').val(),
+			country: $('select[name="country"]').val(),
+			city: $('input[name="city"]').val(),
+			state: $('input[name="state"]').val(),
+			postal_code: $('input[name="postal-code"]').val(),
+		};
+
+		call('press.api.developer.marketplace.update_billing_info', {
+			secret_key: secret_key,
+			data: billing_info,
+		}).then((r) => {
+			console.log(r);
+		});
+	}
+
+	function call(method, args) {
+		return frappe
+			.call({
+				method: method,
+				args: args,
+				type: 'POST',
+			})
+			.then((r) => {
+				if (r.exc) {
+					console.error('An error occurred', r.exc);
+					return;
+				}
+				return r;
+			});
+	}
+</script>
 {% endblock %}

--- a/press/www/saas/billing.js
+++ b/press/www/saas/billing.js
@@ -47,7 +47,7 @@ $('#show-dialog').on('click', function () {
 $(d.body).html(`
 	<div id="wrapper" style="position:relative">
 		<iframe 
-			src="https://frappecloud.com/saas/billing.html?secret_key=${frappe.boot.subscription_key}" 
+			src="https://frappecloud.com/saas/billing.html?secret_key=${frappe.boot.subscription_conf.secret_key}"
 			style="position: relative; top: 0px; width: 100%; height: 60vh;" 
 			frameborder="0"
 		>

--- a/press/www/saas/billing.js
+++ b/press/www/saas/billing.js
@@ -1,0 +1,65 @@
+let subscription_string = __('Your subscription will end in x days');
+let $floatingBar = $(`
+    <div 
+			class="shadow sm:rounded-lg py-2" 
+			style="
+				position:fixed; 
+				left: 245px; 
+				bottom:20px; 
+				width:70%; 
+				margin: auto; 
+				border-radius: 10px; 
+				background-color: #F7FAFC; 
+				z-index: 1">
+    <div 
+			style="display: flex; align-items: center; justify-content: space-between"
+			class="text-muted">
+    <p style="margin-left: 20px; margin-top:5px; font-size: 17px">
+			${subscription_string}
+		</p>
+    <button id="show-dialog" type="button" 
+			class="
+				button-renew 
+				px-4 
+				py-2 
+				border 
+				border-transparent
+				text-white
+				hover:bg-indigo-700 
+				focus:outline-none 
+				focus:ring-offset-2 
+				focus:ring-indigo-500
+			" 
+			style="
+				background-color: #007bff; 
+				border-radius: 5px; 
+				margin-left:650px; 
+				margin-right: 10px
+			"
+		>
+		Subscribe
+		</button>
+    </div>
+    </div>
+`);
+$('footer').append($floatingBar);
+
+const d = new frappe.ui.Dialog({
+	title: __('Manage your subscriptions'),
+	size: 'large',
+});
+
+$('#show-dialog').on('click', function () {
+	d.show();
+});
+
+$(d.body).html(`
+	<div id="wrapper" style="position:relative">
+		<iframe 
+			src="https://frappecloud.com/saas/billing.html?secret_key=${frappe.boot.subscription_key}" 
+			style="position: relative; top: 0px; width: 100%; height: 60vh;" 
+			frameborder="0"
+		>
+	</div>
+`);
+

--- a/press/www/saas/billing.js
+++ b/press/www/saas/billing.js
@@ -1,20 +1,14 @@
-let subscription_string = __('Your subscription will end in x days');
+let subscription_string = __('Your subscription will end soon and the site will be suspended. Please subscribe before that for uninterrupted services');
 let $floatingBar = $(`
-    <div 
-			class="shadow sm:rounded-lg py-2" 
+    <div class="flex justify-content-center" style="width: 100%;">
+    <div class="flex justify-content-center flex-col shadow rounded p-2"
 			style="
-				position:fixed; 
-				left: 245px; 
-				bottom:20px; 
-				width:70%; 
-				margin: auto; 
-				border-radius: 10px; 
-				background-color: #F7FAFC; 
-				z-index: 1">
-    <div 
-			style="display: flex; align-items: center; justify-content: space-between"
-			class="text-muted">
-    <p style="margin-left: 20px; margin-top:5px; font-size: 17px">
+				width: 80%;
+				background-color: #e0f2fe;
+				position: fixed; 
+				bottom: 20px; 
+				z-index: 1;">
+    <p style="margin: auto 0; margin-right: 20px; padding-left: 10px; font-size: 15px;">
 			${subscription_string}
 		</p>
     <button id="show-dialog" type="button" 
@@ -25,15 +19,12 @@ let $floatingBar = $(`
 				border 
 				border-transparent
 				text-white
-				hover:bg-indigo-700 
-				focus:outline-none 
-				focus:ring-offset-2 
-				focus:ring-indigo-500
 			" 
 			style="
+				margin: auto;
+				height: fit-content;
 				background-color: #007bff; 
 				border-radius: 5px; 
-				margin-left:650px; 
 				margin-right: 10px
 			"
 		>


### PR DESCRIPTION
- [x] Load floating banner through a cdn (add to site config https://github.com/frappe/frappe/pull/18841)
- [x] Load susbcriptions and plans through an iframe
- [x] Update address if not added 
- [x] Handle payments

![saas](https://user-images.githubusercontent.com/50401596/216531120-13550c0c-07a0-44cf-9160-830cd3453199.gif)
