### PR TITLE
fix(Bench): Don't archive bench if update is ongoing from it

### DIFF
--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -428,13 +428,17 @@ def archive_obsolete_benches():
 		if active_archival_jobs:
 			continue
 
-		active_site_updates = frappe.db.exists(
+		active_site_updates = frappe.db.get_all(
 			"Site Update",
 			{
-				"destination_bench": bench.name,
 				"status": ("in", ["Pending", "Running", "Failure"]),
 			},
+			or_filters={
+				"source_bench": bench.name,
+				"destination_bench": bench.name,
+			},
 		)
+
 		if active_site_updates:
 			continue
 


### PR DESCRIPTION
There is a chance that site update will fail and move back to old bench will happen. We didn't handle this case before.