### PR TITLE
fix: update billing details

### DIFF
--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -352,7 +352,7 @@ class Team(Document):
 		self.billing_name = billing_details.billing_name or self.billing_name
 		self.billing_address = address_doc.name
 		self.load_doc_before_save()
-		prev_billing_name= self.get_doc_before_save().billing_name
+		prev_billing_name = self.get_doc_before_save().billing_name
 		self.save()
 		self.reload()
 


### PR DESCRIPTION
for some weird reason `get_doc_before_save` was always giving out current doc and not previous one. Thus rename doc was always failing with this:

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 50, in application
    response = frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 48, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1591, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 33, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/client.py", line 239, in rename_doc
    new_name = frappe.rename_doc(doctype, old_name, new_name, merge=merge)
  File "apps/frappe/frappe/utils/typing_validations.py", line 33, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/__init__.py", line 1297, in rename_doc
    return rename_doc(
  File "apps/frappe/frappe/model/rename_doc.py", line 154, in rename_doc
    new = validate_rename(
  File "apps/frappe/frappe/model/rename_doc.py", line 357, in validate_rename
    frappe.throw(_("No changes made because old and new name are the same.").format(old, new))
  File "apps/frappe/frappe/__init__.py", line 523, in throw
    msgprint(
  File "apps/frappe/frappe/__init__.py", line 491, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 440, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError: No changes made because old and new name are the same.
```