### PR TITLE
feat: allow to skip backups

### DIFF
--- a/dashboard/src/components/AlertSiteUpdate.vue
+++ b/dashboard/src/components/AlertSiteUpdate.vue
@@ -27,6 +27,22 @@
 						Skip failing patches if any?
 					</label>
 				</div>
+
+				<div class="mt-2" v-if="skip_backups">
+					<!-- Skip Site Backup -->
+					<input
+						id="skip-backup"
+						type="checkbox"
+						class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+						v-model="wantToSkipBackups"
+					/>
+					<label for="skip-backup" class="ml-1 text-sm text-gray-900">
+						Update without site backup?
+					</label>
+					<div class="mt-1 text-red-600 text-sm" v-if="wantToSkipBackups">
+						In case of failure, you won't be able to restore the site.
+					</div>
+				</div>
 				<ErrorMessage class="mt-1" :error="$resources.scheduleUpdate.error" />
 			</template>
 			<template #actions>
@@ -52,7 +68,8 @@ export default {
 	data() {
 		return {
 			showUpdatesDialog: false,
-			wantToSkipFailingPatches: false
+			wantToSkipFailingPatches: false,
+			wantToSkipBackups: false
 		};
 	},
 	resources: {
@@ -79,7 +96,8 @@ export default {
 				method: 'press.api.site.update',
 				params: {
 					name: this.site?.name,
-					skip_failing_patches: this.wantToSkipFailingPatches
+					skip_failing_patches: this.wantToSkipFailingPatches,
+					skip_backups: this.wantToSkipBackups
 				},
 				onSuccess() {
 					this.showUpdatesDialog = false;
@@ -106,6 +124,9 @@ export default {
 		},
 		lastMigrateFailed() {
 			return this.$resources.lastMigrateFailed.data;
+		},
+		skip_backups() {
+			return this.$account.team?.skip_backups;
 		}
 	}
 };

--- a/press/agent.py
+++ b/press/agent.py
@@ -247,12 +247,15 @@ class Agent:
 			site=site.name,
 		)
 
-	def update_site(self, site, target, deploy_type, skip_failing_patches=False):
+	def update_site(
+		self, site, target, deploy_type, skip_failing_patches=False, skip_backups=False
+	):
 		activate = site.status_before_update in ("Active", "Broken")
 		data = {
 			"target": target,
 			"activate": activate,
 			"skip_failing_patches": skip_failing_patches,
+			"skip_backups": skip_backups,
 		}
 		return self.create_agent_job(
 			f"Update Site {deploy_type}",

--- a/press/api/site.py
+++ b/press/api/site.py
@@ -925,9 +925,9 @@ def login(name, reason=None):
 
 @frappe.whitelist()
 @protected("Site")
-def update(name, skip_failing_patches=False):
+def update(name, skip_failing_patches=False, skip_backups=False):
 	return frappe.get_doc("Site", name).schedule_update(
-		skip_failing_patches=skip_failing_patches
+		skip_failing_patches=skip_failing_patches, skip_backups=skip_backups
 	)
 
 

--- a/press/press/doctype/site/site.js
+++ b/press/press/doctype/site/site.js
@@ -106,6 +106,7 @@ frappe.ui.form.on('Site', {
 			[__('Run After Migrate Steps'), 'run_after_migrate_steps'],
 			[__('Retry Rename'), 'retry_rename'],
 			[__('Retry Archive'), 'retry_archive', frm.doc.name.includes('.archived')],
+			[__('Update without Backup'), 'update_without_backup'],
 		].forEach(([label, method, condition]) => {
 			if (typeof condition === "undefined" || condition){
 				frm.add_custom_button(

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -408,7 +408,7 @@ class Site(Document):
 		).insert()
 
 	@frappe.whitelist()
-	def schedule_update(self, skip_failing_patches=False):
+	def schedule_update(self, skip_failing_patches=False, skip_backups=False):
 		log_site_activity(self.name, "Update")
 		self.status_before_update = self.status
 		self.status = "Pending"
@@ -418,6 +418,7 @@ class Site(Document):
 				"doctype": "Site Update",
 				"site": self.name,
 				"skipped_failing_patches": skip_failing_patches,
+				"skipped_backups": skip_backups,
 			}
 		).insert()
 
@@ -456,6 +457,20 @@ class Site(Document):
 			except Exception:
 				log_error("Site Status Fetch Error", site=self.name)
 		self.save()
+
+	@frappe.whitelist()
+	def update_without_backup(self):
+		log_site_activity(self.name, "Update without Backup")
+		self.status_before_update = self.status
+		self.status = "Pending"
+		self.save()
+		frappe.get_doc(
+			{
+				"doctype": "Site Update",
+				"site": self.name,
+				"skipped_backups": 1,
+			}
+		).insert()
 
 	@frappe.whitelist()
 	def add_domain(self, domain):

--- a/press/press/doctype/site_update/site_update.json
+++ b/press/press/doctype/site_update/site_update.json
@@ -23,7 +23,8 @@
   "update_job",
   "recover_job",
   "cause_of_failure_is_resolved",
-  "skipped_failing_patches"
+  "skipped_failing_patches",
+  "skipped_backups"
  ],
  "fields": [
   {
@@ -181,11 +182,17 @@
    "fieldtype": "Link",
    "label": "Destination Group",
    "options": "Release Group"
+  },
+  {
+   "default": "0",
+   "fieldname": "skipped_backups",
+   "fieldtype": "Check",
+   "label": "Skipped Backups"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-02-26 19:47:20.358497",
+ "modified": "2023-03-21 14:31:40.445390",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site Update",

--- a/press/press/doctype/site_update/site_update.py
+++ b/press/press/doctype/site_update/site_update.py
@@ -116,6 +116,7 @@ class SiteUpdate(Document):
 			self.destination_bench,
 			self.deploy_type,
 			skip_failing_patches=self.skipped_failing_patches,
+			skip_backups=self.skipped_backups,
 		)
 		frappe.db.set_value("Site Update", self.name, "update_job", job.name)
 
@@ -353,7 +354,8 @@ def process_update_site_job_update(job):
 			frappe.get_doc("Site Update", site_update.name).reallocate_workers()
 		elif updated_status == "Failure":
 			frappe.db.set_value("Site", job.site, "status", "Broken")
-			trigger_recovery_job(site_update.name)
+			if not frappe.db.get_value("Site Update", site_update.name, "skipped_backups"):
+				trigger_recovery_job(site_update.name)
 
 
 def process_update_site_recover_job_update(job):

--- a/press/press/doctype/team/team.json
+++ b/press/press/doctype/team/team.json
@@ -38,6 +38,7 @@
   "feature_flags_section",
   "referrer_id",
   "ssh_access_enabled",
+  "skip_backups",
   "column_break_31",
   "database_access_enabled",
   "razorpay_enabled",
@@ -283,6 +284,13 @@
    "fieldtype": "Link",
    "label": "Last Used Team",
    "options": "Team"
+  },
+  {
+   "default": "0",
+   "description": "If checked, team can skip backups for site update",
+   "fieldname": "skip_backups",
+   "fieldtype": "Check",
+   "label": "Allow to skip Backups"
   }
  ],
  "links": [
@@ -337,7 +345,7 @@
    "link_fieldname": "team"
   }
  ],
- "modified": "2022-09-15 13:33:03.650725",
+ "modified": "2023-03-21 16:51:49.538848",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Team",


### PR DESCRIPTION
### Changes

- Check to skip backup from dashboard
- Skip backup from desk
- Dont trigger recover job if site update fails without backup