### PR TITLE
feat: Binary log browser using timespan instead of files

### DIFF
--- a/press/press/report/binary_log_browser/binary_log_browser.js
+++ b/press/press/report/binary_log_browser/binary_log_browser.js
@@ -12,23 +12,6 @@ frappe.query_reports["Binary Log Browser"] = {
 			reqd: 1
 		},
 		{
-			fieldname: "file",
-			label: __("Binary Log File"),
-			fieldtype: "Link",
-			options: "File",
-			reqd: 1,
-			ignore_link_validation: true,
-			get_query: function () {
-				let site = frappe.query_report.get_filter_value('site');
-				if (site) {
-					return {
-						query: "press.press.report.binary_log_browser.binary_log_browser.get_files",
-						filters: {'site': frappe.query_report.get_filter_value('site')}
-					}
-				}
-			}
-		},
-		{
 			fieldname: "start_datetime",
 			label: __("Start From"),
 			fieldtype: "Datetime",

--- a/press/press/report/binary_log_browser/binary_log_browser.py
+++ b/press/press/report/binary_log_browser/binary_log_browser.py
@@ -47,39 +47,10 @@ def execute(filters=None):
 	return columns, data
 
 
-@frappe.whitelist()
-def get_files(*args, **kwargs):
-	def get_size(size):
-		if size > 1048576:
-			return "{0:.1f} MB".format(float(size) / 1048576)
-		else:
-			return "{0:.1f} KB".format(float(size) / 1024)
-
-	frappe.only_for(["System Manager", "Site Manager"])
-
-	site = args[-1]["site"]
-
-	server = frappe.db.get_value("Site", site, "server")
-	database_server = frappe.db.get_value("Server", server, "database_server")
-	agent = Agent(database_server, "Database Server")
-
-	files = []
-	for file in agent.get("database/binary/logs"):
-		size = file["size"]
-		modified = convert_utc_to_user_timezone(get_datetime(file["modified"]))
-		files.append([file["name"], modified, get_size(size)])
-	return sorted(files)
-
-
 def get_data(filters):
 	server = frappe.db.get_value("Site", filters.site, "server")
 	database_server = frappe.db.get_value("Server", server, "database_server")
 	agent = Agent(database_server, "Database Server")
-
-	def convert_user_timezone_to_utc(datetime):
-		timezone = pytz.timezone(get_time_zone())
-		datetime = get_datetime(datetime)
-		return get_datetime_str(timezone.localize(datetime).astimezone(pytz.utc))
 
 	data = {
 		"database": filters.database,
@@ -88,13 +59,54 @@ def get_data(filters):
 		"search_pattern": filters.pattern,
 		"max_lines": filters.max_lines or 4000,
 	}
-	rows = agent.post(f"database/binary/logs/{filters.file}", data=data)
-	for row in rows:
-		if filters.format_queries:
-			row["query"] = sqlparse.format(
-				row["query"].strip(), keyword_case="upper", reindent=True
+
+	files = agent.get("database/binary/logs")
+
+	files_in_timespan = get_files_in_timespan(files, data["start_datetime"], data["stop_datetime"])
+
+	results = []
+	for file in files_in_timespan:
+		rows = agent.post(f"database/binary/logs/{file}", data=data)
+		for row in rows:
+			if filters.format_queries:
+				row["query"] = sqlparse.format(
+					row["query"].strip(), keyword_case="upper", reindent=True
+				)
+			row["timestamp"] = get_datetime_str(
+				convert_utc_to_user_timezone(get_datetime(row["timestamp"]))
 			)
-		row["timestamp"] = get_datetime_str(
-			convert_utc_to_user_timezone(get_datetime(row["timestamp"]))
-		)
-	return rows
+			results.append(row)
+
+			if len(results) > data["max_lines"]:
+				return results
+
+	return results
+
+def get_files_in_timespan(files: list[dict[str, str]], start: str, stop: str) -> list[str]:
+	files.sort(key=lambda f: f["modified"])
+
+	start = convert_user_timezone_to_utc(start)
+	stop = convert_user_timezone_to_utc(stop)
+
+	files_in_timespan = []
+
+	for file in files:
+		if start > file["modified"]:
+			# Modified timestamp is *usually* last time when log file was touched,
+			# i.e. last query logged on file
+			continue
+
+		if file["modified"] > stop:
+			# This is last file that captures timespan
+			# Include it and dont process any further.
+			files_in_timespan.append(file["name"])
+			break
+
+		files_in_timespan.append(file["name"])
+
+	return files_in_timespan
+
+def convert_user_timezone_to_utc(datetime):
+	timezone = pytz.timezone(get_time_zone())
+	datetime = get_datetime(datetime)
+	return get_datetime_str(timezone.localize(datetime).astimezone(pytz.utc))


### PR DESCRIPTION
Instead of asking user to pick and read one bin log file at a time just use timespan to read data from all files.
