### PR TITLE
chore: validate marketplace app image logo dimensions

### DIFF
--- a/dashboard/src/components/FileUploader.vue
+++ b/dashboard/src/components/FileUploader.vue
@@ -110,7 +110,7 @@ export default {
 							.slice(-2, -1)[0];
 					}
 					this.error = errorMessage;
-					this.$emit('failure', error);
+					this.$emit('failure', errorMessage);
 				});
 		}
 	}

--- a/dashboard/src/components/MarketplaceAppProfile.vue
+++ b/dashboard/src/components/MarketplaceAppProfile.vue
@@ -10,6 +10,7 @@
 				/>
 				<FileUploader
 					@success="onAppImageChange"
+					@failure="onAppImageUploadError"
 					fileTypes="image/*"
 					:upload-args="{
 						doctype: 'Marketplace App',
@@ -157,7 +158,7 @@ export default {
 				method: 'press.api.marketplace.update_app_title',
 				params: {
 					name,
-					title,
+					title
 				},
 				onSuccess() {
 					this.showAppProfileEditDialog = false;
@@ -194,6 +195,13 @@ export default {
 		onAppImageChange() {
 			this.$resources.profileImageUrl.submit();
 			this.notifySuccess();
+		},
+		onAppImageUploadError(errorMessage) {
+			this.$notify({
+				title: errorMessage,
+				color: 'red',
+				icon: 'x'
+			});
 		},
 		branchUri(source) {
 			return `${source.repository_owner}/${source.repository}:${source.branch}`;

--- a/press/api/marketplace.py
+++ b/press/api/marketplace.py
@@ -205,6 +205,10 @@ def profile_image_url(app: str) -> str:
 @frappe.whitelist()
 def update_app_image() -> str:
 	"""Handles App Image Upload"""
+	file_content = frappe.local.uploaded_file
+
+	validate_app_image_dimensions(file_content)
+
 	app_name = frappe.form_dict.docname
 	_file = frappe.get_doc(
 		{
@@ -215,7 +219,7 @@ def update_app_image() -> str:
 			"folder": "Home/Attachments",
 			"file_name": frappe.local.uploaded_filename,
 			"is_private": 0,
-			"content": frappe.local.uploaded_file,
+			"content": file_content,
 		}
 	)
 	_file.save(ignore_permissions=True)
@@ -224,6 +228,15 @@ def update_app_image() -> str:
 
 	return file_url
 
+def validate_app_image_dimensions(file_content):
+	"""Throws if image is not a square image, atleast 300x300px in size"""
+	from PIL import Image
+	from io import BytesIO
+
+	im = Image.open(BytesIO(file_content))
+	im_width, im_height = im.size
+	if im_width != im_height or im_height < 300:
+		frappe.throw("Logo must be a square image atleast 300x300px in size")
 
 @frappe.whitelist()
 def update_app_title(name: str, title: str) -> MarketplaceApp:

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
+import os
 import frappe
 
 from frappe import _
@@ -368,7 +369,7 @@ class Team(Document):
 		try:
 			frappeio_client = get_frappe_io_connection()
 		except FrappeioServerNotSet as e:
-			if frappe.conf.developer_mode:
+			if frappe.conf.developer_mode or os.environ.get("CI"):
 				return
 			else:
 				raise e


### PR DESCRIPTION
- fix(FileUploader): emits message (instead of object) as payload
- feat: add logo image dimensions validation
