### PR TITLE
Validation to not skip Major Upgrades Sequentially

### DIFF
--- a/press/press/doctype/version_upgrade/version_upgrade.py
+++ b/press/press/doctype/version_upgrade/version_upgrade.py
@@ -13,6 +13,7 @@ class VersionUpgrade(Document):
 	def validate(self):
 		self.validate_same_server()
 		self.validate_apps()
+		self.validate_versions()
 
 	def validate_same_server(self):
 		site_server = frappe.get_doc("Site", self.site).server
@@ -35,6 +36,25 @@ class VersionUpgrade(Document):
 		if set(site_apps) - set(bench_apps):
 			frappe.throw(
 				f"Destination Release Group {self.destination_group} doesn't have some of the apps installed on {self.site}",
+				frappe.ValidationError,
+			)
+
+	def validate_versions(self):
+		source_version = frappe.get_value("Release Group", self.source_group, "version")
+		dest_version = frappe.get_value("Release Group", self.destination_group, "version")
+		if dest_version == "Nightly":
+			frappe.msgprint(
+				"You are upgrading the site to Nightly Branch. Please note that Nightly might not be stable"
+			)
+			return
+		elif source_version == "Nightly":
+			versions = frappe.get_all("Frappe Version", pluck="name")
+			source_version = max([opt for opt in versions if opt.startswith("Version")])
+		source = int(source_version.split()[1])
+		dest = int(dest_version.split()[1])
+		if dest - source > 1:
+			frappe.throw(
+				f"Upgrading Sites by skipping a major version is unsupported. Destination Release Group {self.destination_group} is {dest_version.title()}",
 				frappe.ValidationError,
 			)
 

--- a/press/scripts/migrate.py
+++ b/press/scripts/migrate.py
@@ -342,7 +342,7 @@ def select_site():
 
 	if get_all_sites_request.ok:
 		# the following lines have data with a lot of redundancy, but there's no real reason to bother cleaning them up
-		all_sites = get_all_sites_request.json()["message"]
+		all_sites = get_all_sites_request.json()["message"]["site_list"]
 		sites_info = {site["name"]: get_site_info(site["name"]) for site in all_sites}
 		sites_version = {x: get_version(y) for x, y in sites_info.items()}
 		available_sites = render_site_table(all_sites, sites_version)


### PR DESCRIPTION
Major Upgrades when skipped can make the whole DB corrupt. Example v12 -> v14 directly shouldn't be done.

- feat: Implement skip Major Upgrades Validation
- fix: Update migrate script to make use of new API

![Screenshot 2023-04-22 at 12 20 44 AM](https://user-images.githubusercontent.com/40897573/233718101-8738c2af-1958-42f1-b7e8-cfcf19f491a5.png)

![Screenshot 2023-04-22 at 12 21 18 AM](https://user-images.githubusercontent.com/40897573/233717989-73095989-7f43-4294-96e7-588a3f80f9ae.png)
