### PR TITLE
feat: descriptive lables for child teams

### DIFF
--- a/dashboard/src/components/PrepaidCreditsDialog.vue
+++ b/dashboard/src/components/PrepaidCreditsDialog.vue
@@ -164,7 +164,7 @@ export default {
 				name: 'Frappe Cloud',
 				image: '/assets/press/images/frappe-cloud-logo.png',
 				prefill: {
-					email: this.$account.team.name
+					email: this.$account.team.user
 				},
 				theme: { color: '#2490EF' },
 				handler: this.handlePaymentSuccess

--- a/dashboard/src/views/settings/AccountTeam.vue
+++ b/dashboard/src/views/settings/AccountTeam.vue
@@ -12,13 +12,18 @@
 					Manage
 				</Button>
 			</template>
-			<ListItem v-for="team in teams" :title="team" :key="team">
+			<ListItem
+				v-for="team in teams"
+				:title="`${team.team_title}`"
+				:description="team.user"
+				:key="team"
+			>
 				<template #actions>
-					<div v-if="$account.team.name === team">
+					<div v-if="$account.team.name === team.name">
 						<Badge color="blue">Active</Badge>
 					</div>
 					<div v-else class="flex flex-row justify-end">
-						<Dropdown class="ml-2" :options="dropdownItems(team)" right>
+						<Dropdown class="ml-2" :options="dropdownItems(team.name)" right>
 							<template v-slot="{ open }">
 								<Button icon="more-horizontal" />
 							</template>
@@ -34,8 +39,8 @@
 				<template v-slot:body-content>
 					<ListItem
 						v-for="member in $account.child_team_members"
-						:title="`${member.name}`"
-						:description="member.name"
+						:title="`${member.user}`"
+						:description="member.team_title"
 						:key="member.name"
 					>
 						<template #actions>
@@ -52,10 +57,11 @@
 					<div v-if="showManageTeamForm">
 						<h5 class="mt-5 text-sm font-semibold"> Create child team</h5>
 						<Input
-							label="Enter the email address to create a new child team for shared access."
+							label="Enter name to create a new child team for shared access."
 							type="text"
 							class="mt-2"
-							v-model="childTeamEmail"
+							placeholder="e.g Accounts Team"
+							v-model="childTeamTitle"
 							required
 						/>
 						<ErrorMessage :message="$resourceErrors" />
@@ -66,7 +72,7 @@
 								class="ml-2"
 								appearance="primary"
 								:loading="$resources.addChildTeam.loading"
-								@click="$resources.addChildTeam.submit({ team: childTeamEmail })"
+								@click="$resources.addChildTeam.submit({ title: childTeamTitle })"
 							>
 								Add Child Team
 							</Button>
@@ -90,17 +96,13 @@ export default {
 		return {
 			showManageTeamDialog: false,
 			showManageTeamForm: false,
-			childTeamEmail: null,
+			childTeamTitle: null,
 			newChildTeamMessage: 'A new team is created',
 			newChildTeamTitle: 'Team Created!'
 		};
 	},
 	computed: {
 		teams() {
-			let current_team = this.$account.team.name;
-			if (!this.$account.teams.includes(current_team)) {
-				this.$account.teams.push(current_team);
-			}
 			return this.$account.teams;
 		},
 		showManageTeamButton() {
@@ -134,12 +136,8 @@ export default {
 			return {
 				method: 'press.api.account.create_child_team',
 				onSuccess(data) {
-					if (data == "new_team") {
-						this.newChildTeamMessage = "We have sent a verification email to " + this.childTeamEmail + ".";
-						this.newChildTeamTitle = "Email Sent"
-					}
 					this.showManageTeamDialog = false;
-					this.childTeamEmail = null;
+					this.childTeamTitle = null;
 					this.$account.fetchAccount();
 					this.$notify({
 						title: this.newChildTeamTitle,

--- a/dashboard/src/views/site/Site.vue
+++ b/dashboard/src/views/site/Site.vue
@@ -125,7 +125,7 @@
 		>
 			<template #body-content>
 				<Input
-					label="Enter email of the team"
+					label="Enter title of the child team"
 					type="text"
 					v-model="emailOfChildTeam"
 					required

--- a/press/api/saas.py
+++ b/press/api/saas.py
@@ -351,7 +351,7 @@ def create_team(account_request, get_stripe_id=False):
 			user_exists=frappe.db.exists("User", email),
 		)
 	else:
-		team_doc = frappe.get_doc("Team", email)
+		team_doc = frappe.get_doc("Team", {"user": email})
 
 	if get_stripe_id:
 		return team_doc.stripe_customer_id

--- a/press/api/site.py
+++ b/press/api/site.py
@@ -1426,19 +1426,21 @@ def change_notify_email(name, email):
 def change_team(team, name):
 
 	if not (
-		frappe.db.exists("Team", team) and frappe.db.get_value("Team", team, "enabled", 1)
+		frappe.db.exists("Team", {"team_title": team})
+		and frappe.db.get_value("Team", {"team_title": team}, "enabled", 1)
 	):
 		frappe.throw("No Active Team record found.")
 
 	from press.press.doctype.team.team import get_child_team_members
 
-	current_team = get_current_team()
-	child_teams = [team.name for team in get_child_team_members(current_team)]
-	teams = [current_team] + child_teams
+	current_team = get_current_team(True)
+	child_teams = [team.name for team in get_child_team_members(current_team.name)]
+	teams = [current_team.name] + child_teams
 
 	if team not in teams:
 		frappe.throw(f"{team} is not part of your organization.")
 
+	child_team = frappe.get_doc("Team", {"team_title": team})
 	site_doc = frappe.get_doc("Site", name)
-	site_doc.team = team
+	site_doc.team = child_team.name
 	site_doc.save(ignore_permissions=True)

--- a/press/patches.txt
+++ b/press/patches.txt
@@ -92,3 +92,4 @@ press.press.doctype.user_ssh_key.patches.set_existing_keys_as_default
 press.press.doctype.press_settings.patches.set_press_monitoring_password
 press.press.doctype.deploy_candidate_app.patches.set_app_name_to_app
 press.press.doctype.site.patches.set_database_access_credentials
+press.press.doctype.team.patches.set_team_title

--- a/press/press/doctype/team/patches/set_team_title.py
+++ b/press/press/doctype/team/patches/set_team_title.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
+# For license information, please see license.txt
+
+import frappe
+
+
+def execute():
+	frappe.reload_doctype("Team")
+	frappe.db.sql(
+		"""
+		UPDATE `tabTeam`
+		SET team_title = user
+		"""
+	)

--- a/press/press/doctype/team/team.json
+++ b/press/press/doctype/team/team.json
@@ -1,13 +1,14 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "Prompt",
+ "autoname": "hash",
  "creation": "2022-01-28 20:07:37.989538",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
   "enabled",
+  "team_title",
   "user",
   "is_developer",
   "free_account",
@@ -310,6 +311,11 @@
    "fieldtype": "Table",
    "label": "Child Team Members",
    "options": "Child Team Member"
+  },
+  {
+   "fieldname": "team_title",
+   "fieldtype": "Data",
+   "label": "Team Title"
   }
  ],
  "links": [
@@ -364,11 +370,11 @@
    "link_fieldname": "team"
   }
  ],
- "modified": "2023-04-28 10:34:44.264374",
+ "modified": "2023-05-12 10:48:45.920926",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Team",
- "naming_rule": "Set by user",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [
   {
@@ -391,8 +397,10 @@
   }
  ],
  "quick_entry": 1,
+ "show_title_field_in_link": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],
+ "title_field": "user",
  "track_changes": 1
 }

--- a/press/press/doctype/team/team.json
+++ b/press/press/doctype/team/team.json
@@ -58,8 +58,7 @@
    "fieldname": "user",
    "fieldtype": "Link",
    "label": "User",
-   "options": "User",
-   "unique": 1
+   "options": "User"
   },
   {
    "fieldname": "team_members",
@@ -370,7 +369,7 @@
    "link_fieldname": "team"
   }
  ],
- "modified": "2023-05-12 10:48:45.920926",
+ "modified": "2023-05-12 13:16:49.574435",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Team",

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -788,16 +788,15 @@ def get_child_team_members(team):
 	if frappe.get_value("Team", team, "parent_team"):
 		return []
 
-	children = frappe.db.get_all(
-		"Child Team Member", filters={"parent": team}, fields=["child_team"]
-	)
-	child_team_members = [d.child_team for d in children]
+	child_team_members = [
+		d.name for d in frappe.db.get_all("Team", {"parent_team": team}, ["name"])
+	]
 
 	child_teams = []
 	if child_team_members:
 		child_teams = frappe.db.sql(
 			"""
-				select t.name
+				select t.name, t.team_title, t.parent_team, t.user
 				from `tabTeam` t
 				where ifnull(t.name, '') in %s
 				and t.enabled = 1

--- a/press/utils/__init__.py
+++ b/press/utils/__init__.py
@@ -21,7 +21,11 @@ def log_error(title, **kwargs):
 def get_current_team(get_doc=False):
 	if not hasattr(frappe.local, "request"):
 		# if this is not a request, send the current user as default team
-		return frappe.get_doc("Team", frappe.session.user) if get_doc else frappe.session.user
+		return (
+			frappe.get_doc("Team", {"user": frappe.session.user})
+			if get_doc
+			else frappe.session.user
+		)
 
 	user_is_system_user = frappe.session.data.user_type == "System User"
 	# get team passed via request header
@@ -32,7 +36,11 @@ def get_current_team(get_doc=False):
 
 	if not team and user_is_press_admin and frappe.db.exists("Team", frappe.session.user):
 		# if user has_role of Press Admin then just return current user as default team
-		return frappe.get_doc("Team", frappe.session.user) if get_doc else frappe.session.user
+		return (
+			frappe.get_doc("Team", {"user": frappe.session.user})
+			if get_doc
+			else frappe.session.user
+		)
 
 	if not team:
 		# if team is not passed via header, get the first team that this user is part of
@@ -69,7 +77,7 @@ def get_app_tag(repository, repository_owner, hash):
 
 def get_default_team_for_user(user):
 	"""Returns the Team if user has one, or returns the Team to which they belong"""
-	if frappe.db.exists("Team", user):
+	if frappe.db.exists("Team", {"user": user}):
 		return user
 
 	team = frappe.db.get_value(


### PR DESCRIPTION
# Screenshots
1. Parent team's dashboard
<img width="1434" alt="Screenshot 2023-05-12 at 3 07 42 PM" src="https://github.com/frappe/press/assets/30501401/1545d903-46e1-4271-af4c-a6b14975e2a5">

2. Child team's dashboard
<img width="1425" alt="Screenshot 2023-05-12 at 3 07 58 PM" src="https://github.com/frappe/press/assets/30501401/d100641e-93a1-4cd7-be75-a028edfef981">

3.
<img width="632" alt="Screenshot 2023-05-12 at 3 51 30 PM" src="https://github.com/frappe/press/assets/30501401/160bdb72-e860-4817-922b-d1c7733136e9">