### PR TITLE
perf: Refactor new site creation flow

### DIFF
--- a/dashboard/src/views/site/NewSiteApps.vue
+++ b/dashboard/src/views/site/NewSiteApps.vue
@@ -1,105 +1,110 @@
 <template>
-	<div class="space-y-6">
-		<div v-if="!this.privateBench">
-			<h2 class="text-lg font-semibold">Select Frappe version</h2>
-			<p class="text-base text-gray-700">
-				Select the Frappe version for your site
-			</p>
-			<div class="mt-4">
+	<div>
+		<div v-if="$resources.versions.loading" class="flex justify-center">
+			<LoadingText />
+		</div>
+		<div class="space-y-6" v-if="$resources.versions.data">
+			<div v-if="!this.privateBench">
+				<h2 class="text-lg font-semibold">Select Frappe version</h2>
+				<p class="text-base text-gray-700">
+					Select the Frappe version for your site
+				</p>
+				<div class="mt-4">
+					<Input
+						type="select"
+						v-model="selectedVersion"
+						:options="versionOptions"
+					/>
+				</div>
+			</div>
+			<div v-if="regionOptions.length > 0">
+				<h2 class="text-lg font-semibold">Select Region</h2>
+				<p class="text-base text-gray-700">
+					Select the datacenter region where your site should be created
+				</p>
+				<div class="mt-4">
+					<RichSelect
+						:value="selectedRegion"
+						@change="$emit('update:selectedRegion', $event)"
+						:options="regionOptions"
+					/>
+				</div>
+			</div>
+			<div v-if="publicApps.length || privateApps.length">
+				<h2 class="text-lg font-semibold">Select apps to install</h2>
+				<p class="text-base text-gray-700">
+					Choose apps to install on your site. You can select apps published on
+					marketplace or your private apps.
+				</p>
+				<div class="mt-4 space-y-4">
+					<div v-if="publicApps.length">
+						<h3 class="sr-only">Marketplace Apps</h3>
+						<div
+							class="-mx-2 mt-4 grid max-h-56 grid-cols-2 gap-4 overflow-y-auto px-2 py-2"
+						>
+							<SelectableCard
+								v-for="publicApp in publicApps"
+								:key="publicApp.app"
+								@click.native="toggleApp(publicApp)"
+								:title="
+									publicApp.marketplace
+										? publicApp.marketplace.title
+										: publicApp.app_title
+								"
+								:image="
+									publicApp.marketplace ? publicApp.marketplace.image : null
+								"
+								:selected="selectedApps.includes(publicApp.app)"
+								v-show="!publicApp.frappe"
+								fullCircleImage
+							>
+								<template #secondary-content>
+									<a
+										v-if="publicApp.marketplace"
+										class="inline-block text-sm leading-snug text-blue-600"
+										:href="'/' + publicApp.marketplace.route"
+										target="_blank"
+										@click.stop
+									>
+										Details
+									</a>
+									<span class="text-sm leading-snug text-gray-700" v-else>
+										{{ publicApp.repository_owner }}/{{ publicApp.repository }}
+									</span>
+								</template>
+							</SelectableCard>
+							<div class="h-1 py-4" v-if="publicApps.length > 4"></div>
+						</div>
+					</div>
+					<div v-if="privateApps.length > 0">
+						<h3 class="text-sm font-medium">Your Private Apps</h3>
+						<div
+							class="mt- -mx-2 grid max-h-56 grid-cols-2 gap-4 overflow-y-auto px-2 py-2"
+						>
+							<SelectableCard
+								v-for="app in privateApps"
+								:key="app.app"
+								@click.native="toggleApp(app)"
+								:selected="selectedApps.includes(app.app)"
+								:title="app.app_title"
+								fullCircleImage
+							>
+								<div slot="secondary-content" class="text-base text-gray-700">
+									{{ app.repository_owner }}:{{ app.branch }}
+								</div>
+							</SelectableCard>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div v-if="selectedApps.includes('erpnext')">
 				<Input
-					type="select"
-					v-model="selectedVersion"
-					:options="versionOptions"
+					type="checkbox"
+					label="I am okay if my details are shared with local partner"
+					@change="val => $emit('update:shareDetailsConsent', val)"
+					:modelValue="shareDetailsConsent"
 				/>
 			</div>
-		</div>
-		<div v-if="regionOptions.length > 0">
-			<h2 class="text-lg font-semibold">Select Region</h2>
-			<p class="text-base text-gray-700">
-				Select the datacenter region where your site should be created
-			</p>
-			<div class="mt-4">
-				<RichSelect
-					:value="selectedRegion"
-					@change="$emit('update:selectedRegion', $event)"
-					:options="regionOptions"
-				/>
-			</div>
-		</div>
-		<div v-if="publicApps.length || privateApps.length">
-			<h2 class="text-lg font-semibold">Select apps to install</h2>
-			<p class="text-base text-gray-700">
-				Choose apps to install on your site. You can select apps published on
-				marketplace or your private apps.
-			</p>
-			<div class="mt-4 space-y-4">
-				<div v-if="publicApps.length">
-					<h3 class="sr-only">Marketplace Apps</h3>
-					<div
-						class="-mx-2 mt-4 grid max-h-56 grid-cols-2 gap-4 overflow-y-auto px-2 py-2"
-					>
-						<SelectableCard
-							v-for="publicApp in publicApps"
-							:key="publicApp.app"
-							@click.native="toggleApp(publicApp)"
-							:title="
-								publicApp.marketplace
-									? publicApp.marketplace.title
-									: publicApp.app_title
-							"
-							:image="
-								publicApp.marketplace ? publicApp.marketplace.image : null
-							"
-							:selected="selectedApps.includes(publicApp.app)"
-							v-show="!publicApp.frappe"
-							fullCircleImage
-						>
-							<template #secondary-content>
-								<a
-									v-if="publicApp.marketplace"
-									class="inline-block text-sm leading-snug text-blue-600"
-									:href="'/' + publicApp.marketplace.route"
-									target="_blank"
-									@click.stop
-								>
-									Details
-								</a>
-								<span class="text-sm leading-snug text-gray-700" v-else>
-									{{ publicApp.repository_owner }}/{{ publicApp.repository }}
-								</span>
-							</template>
-						</SelectableCard>
-						<div class="h-1 py-4" v-if="publicApps.length > 4"></div>
-					</div>
-				</div>
-				<div v-if="privateApps.length > 0">
-					<h3 class="text-sm font-medium">Your Private Apps</h3>
-					<div
-						class="mt- -mx-2 grid max-h-56 grid-cols-2 gap-4 overflow-y-auto px-2 py-2"
-					>
-						<SelectableCard
-							v-for="app in privateApps"
-							:key="app.app"
-							@click.native="toggleApp(app)"
-							:selected="selectedApps.includes(app.app)"
-							:title="app.app_title"
-							fullCircleImage
-						>
-							<div slot="secondary-content" class="text-base text-gray-700">
-								{{ app.repository_owner }}:{{ app.branch }}
-							</div>
-						</SelectableCard>
-					</div>
-				</div>
-			</div>
-		</div>
-		<div v-if="selectedApps.includes('erpnext')">
-			<Input
-				type="checkbox"
-				label="I am okay if my details are shared with local partner"
-				@change="val => $emit('update:shareDetailsConsent', val)"
-				:modelValue="shareDetailsConsent"
-			/>
 		</div>
 	</div>
 </template>
@@ -120,16 +125,16 @@ export default {
 		'update:shareDetailsConsent'
 	],
 	props: [
-		'options',
 		'selectedApps',
 		'selectedGroup',
 		'privateBench',
 		'selectedRegion',
 		'shareDetailsConsent'
 	],
-	data: function () {
+	data() {
 		return {
-			selectedVersion: null
+			selectedVersion: null,
+			version: null
 		};
 	},
 	computed: {
@@ -137,7 +142,7 @@ export default {
 			return this.apps
 				.filter(app => app.public)
 				.map(app => {
-					app.marketplace = this.options.marketplace_apps[app.app] || null;
+					app.marketplace = this.marketplaceApps[app.app] || null;
 					return app;
 				});
 		},
@@ -148,15 +153,8 @@ export default {
 			let group = this.getSelectedGroup();
 			return group ? group.apps : [];
 		},
-		groupOptions() {
-			if (!this.options || !this.selectedVersion) return [];
-			let selectedVersion = this.options.versions.find(
-				version => version.name == this.selectedVersion
-			);
-			return selectedVersion.groups.map(group => group.name);
-		},
 		versionOptions() {
-			return this.options.versions.map(group => group.name);
+			return this.versions.map(version => version.name);
 		},
 		regionOptions() {
 			let group = this.getSelectedGroup();
@@ -172,8 +170,8 @@ export default {
 	watch: {
 		selectedVersion(value) {
 			if (!this.privateBench) {
-				let selectedVersion = this.options.versions.find(v => v.name == value);
-				this.$emit('update:selectedGroup', selectedVersion.groups[0].name);
+				let selectedVersion = this.versions.find(v => v.name == value);
+				this.$emit('update:selectedGroup', selectedVersion.group.name);
 			}
 		},
 		selectedGroup() {
@@ -181,20 +179,6 @@ export default {
 			if (this.regionOptions.length > 0) {
 				this.$emit('update:selectedRegion', this.regionOptions[0].value);
 			}
-		}
-	},
-	async mounted() {
-		if (this.privateBench) {
-			this.selectedVersion = this.options.versions.find(v =>
-				v.groups.some(g => g.name == this.selectedGroup)
-			).name;
-			this.$emit('update:selectedApps', ['frappe']);
-		} else {
-			this.selectedVersion = this.options.versions[0].name;
-		}
-
-		if (this.regionOptions.length == 1) {
-			this.$emit('update:selectedRegion', this.regionOptions[0].value);
 		}
 	},
 	methods: {
@@ -210,16 +194,39 @@ export default {
 			}
 		},
 		getSelectedGroup() {
-			if (!this.options || !this.selectedVersion || !this.selectedGroup) {
+			if (!this.versions || !this.selectedVersion || !this.selectedGroup) {
 				return null;
 			}
-			let selectedVersion = this.options.versions.find(
+			let selectedVersion = this.versions.find(
 				v => v.name == this.selectedVersion
 			);
-			let group = selectedVersion.groups.find(
-				g => g.name == this.selectedGroup
-			);
-			return group;
+			return selectedVersion.group;
+		}
+	},
+	resources: {
+		versions() {
+			return {
+				method: 'press.api.site.get_new_site_options',
+				auto: true,
+				onSuccess(r) {
+					this.versions = r.versions.filter(v => {
+						return v.group;
+					});
+					this.marketplaceApps = r.marketplace_apps;
+
+					// from mounted
+					if (this.privateBench) {
+						this.selectedVersion = this.versions[0].name;
+						this.$emit('update:selectedApps', ['frappe']);
+					} else {
+						this.selectedVersion = this.versions[0].name;
+					}
+
+					if (this.regionOptions.length == 1) {
+						this.$emit('update:selectedRegion', this.regionOptions[0].value);
+					}
+				}
+			};
 		}
 	}
 };

--- a/dashboard/src/views/site/NewSiteHostname.vue
+++ b/dashboard/src/views/site/NewSiteHostname.vue
@@ -14,7 +14,7 @@
 				@change="subdomainChange"
 			/>
 			<div class="flex items-center rounded-r bg-gray-100 px-4 text-base">
-				.{{ options.domain }}
+				.{{ domain }}
 			</div>
 		</div>
 		<div class="mt-1">
@@ -23,7 +23,7 @@
 				class="text-sm text-green-600"
 				role="alert"
 			>
-				{{ modelValue }}.{{ options.domain }} is available
+				{{ modelValue }}.{{ domain }} is available
 			</div>
 			<ErrorMessage :message="errorMessage" />
 		</div>
@@ -32,13 +32,26 @@
 <script>
 export default {
 	name: 'Hostname',
-	props: ['options', 'modelValue'],
+	props: ['modelValue'],
 	emits: ['update:modelValue', 'error'],
 	data() {
 		return {
 			subdomainAvailable: false,
 			errorMessage: null
 		};
+	},
+	resources: {
+		domain() {
+			return {
+				method: 'press.api.site.get_domain',
+				auto: true
+			};
+		}
+	},
+	computed: {
+		domain() {
+			return this.$resources.domain.data;
+		}
 	},
 	methods: {
 		async subdomainChange(e) {
@@ -50,10 +63,10 @@ export default {
 			if (!error) {
 				let subdomainTaken = await this.$call('press.api.site.exists', {
 					subdomain,
-					domain: this.options.domain
+					domain: this.domain
 				});
 				if (subdomainTaken) {
-					error = `${subdomain}.${this.options.domain} already exists.`;
+					error = `${subdomain}.${this.domain} already exists.`;
 				} else {
 					this.subdomainAvailable = true;
 				}

--- a/dashboard/src/views/site/NewSitePlans.vue
+++ b/dashboard/src/views/site/NewSitePlans.vue
@@ -7,7 +7,7 @@
 		<AlertBillingInformation class="mt-4" />
 		<div class="mt-4">
 			<SitePlansTable
-				:plans="options.plans"
+				:plans="plans"
 				:selectedPlan="selectedPlan"
 				@update:selectedPlan="plan => $emit('update:selectedPlan', plan)"
 			/>
@@ -15,16 +15,58 @@
 	</div>
 </template>
 <script>
+import { DateTime } from 'luxon';
 import SitePlansTable from '@/components/SitePlansTable.vue';
 import AlertBillingInformation from '@/components/AlertBillingInformation.vue';
 
 export default {
 	name: 'Plans',
 	emits: ['update:selectedPlan'],
-	props: ['options', 'selectedPlan'],
+	props: ['selectedPlan', 'benchCreation', 'benchTeam'],
 	components: {
 		SitePlansTable,
 		AlertBillingInformation
+	},
+	data() {
+		return {
+			plans: null
+		};
+	},
+	resources: {
+		plans() {
+			return {
+				method: 'press.api.site.get_plans',
+				auto: true,
+				onSuccess(r) {
+					this.plans = r.map(plan => {
+						plan.disabled = !this.$account.hasBillingInfo;
+						return plan;
+					});
+
+					if (this.benchTeam == this.$account.team.name) {
+						// Select a zero cost plan and remove the plan selection step
+						this.selectedPlan = { name: 'Unlimited' };
+						let plan_step_index = this.steps.findIndex(
+							step => step.name == 'Plan'
+						);
+						this.steps.splice(plan_step_index, 1);
+					} else {
+						// poor man's bench paywall
+						// this will disable creation of $10 sites on private benches
+						// wanted to avoid adding a new field, so doing this with a date check :)
+						let benchCreation = DateTime.fromSQL(this.benchCreation);
+						let paywalledBenchDate = DateTime.fromSQL('2021-09-21 00:00:00');
+						let isPaywalledBench = benchCreation > paywalledBenchDate;
+						if (
+							isPaywalledBench &&
+							this.$account.user.user_type != 'System User'
+						) {
+							this.plans = this.plans.filter(plan => plan.price_usd >= 25);
+						}
+					}
+				}
+			};
+		}
 	}
 };
 </script>

--- a/dashboard/src/views/site/NewSitePlans.vue
+++ b/dashboard/src/views/site/NewSitePlans.vue
@@ -6,7 +6,11 @@
 		</p>
 		<AlertBillingInformation class="mt-4" />
 		<div class="mt-4">
+			<div v-if="$resources.plans.loading" class="flex justify-center">
+				<LoadingText />
+			</div>
 			<SitePlansTable
+				v-if="plans"
 				:plans="plans"
 				:selectedPlan="selectedPlan"
 				@update:selectedPlan="plan => $emit('update:selectedPlan', plan)"

--- a/dashboard/src/views/site/NewSiteRestore.vue
+++ b/dashboard/src/views/site/NewSiteRestore.vue
@@ -144,7 +144,7 @@ import { DateTime } from 'luxon';
 export default {
 	name: 'Restore',
 	emits: ['update:selectedFiles', 'update:skipFailingPatches'],
-	props: ['options', 'selectedFiles', 'manualMigration', 'skipFailingPatches'],
+	props: ['selectedFiles', 'manualMigration', 'skipFailingPatches'],
 	components: {
 		FileUploader,
 		Form,

--- a/press/press/report/mariadb_deadlock_browser/mariadb_deadlock_browser.py
+++ b/press/press/report/mariadb_deadlock_browser/mariadb_deadlock_browser.py
@@ -64,7 +64,7 @@ def get_data(filters):
 		"max_lines": filters.max_lines or 1000,
 	}
 
-	results = agent.post(f"database/deadlocks", data=data)
+	results = agent.post("database/deadlocks", data=data)
 
 	return post_process(results)
 
@@ -74,7 +74,7 @@ def post_process(rows):
 
 	for idx, row in enumerate(rows):
 		row["timestamp"] = convert_utc_to_timezone(
-			frappe.utils.get_datetime(row["ts"]).replace(tzinfo=None), get_time_zone()
+			frappe.utils.get_datetime(row["ts"]).replace(tzinfo=None), get_system_timezone()
 		)
 		results.append(row)
 


### PR DESCRIPTION
Was very slow before because the api was fetching all the release groups owned by the team for filtering on private bench site creation(which was done on UI 😵‍💫). It was also doing pre-fetching of all the info needed for all the steps

Lot of mess in both UI and api in this flow.

Refactor
1. Fetches required info step-wise
2. Only fetches(versions, benches, clusters, apps..) what the UI and flow at the current step needs
3. Bit easier to read and edit
4. Keeping the old apis since they are use in site migration