### PR TITLE
fix: format agent created timestamps separately

### DIFF
--- a/dashboard/src/utils.js
+++ b/dashboard/src/utils.js
@@ -9,9 +9,9 @@ let utils = {
 			}
 			return plural;
 		},
-		$date(date) {
+		$date(date, serverDatesTimezone = 'Asia/Kolkata') {
 			// assuming all dates on the server are stored in our timezone
-			let serverDatesTimezone = 'Asia/Kolkata';
+
 			let localZone = DateTime.local().zoneName;
 			return DateTime.fromSQL(date, { zone: serverDatesTimezone }).setZone(
 				localZone
@@ -21,8 +21,8 @@ let utils = {
 			let multiplier = Math.pow(10, precision || 0);
 			return Math.round(number * multiplier) / multiplier;
 		},
-		formatDate(value, type = 'DATETIME_FULL') {
-			let datetime = this.$date(value);
+		formatDate(value, type = 'DATETIME_FULL', isUTC = false) {
+			let datetime = isUTC ? this.$date(value, 'UTC') : this.$date(value);
 			let format = value;
 			if (type === 'relative') {
 				format = datetime.toRelative();

--- a/dashboard/src/views/bench/BenchVersions.vue
+++ b/dashboard/src/views/bench/BenchVersions.vue
@@ -21,7 +21,7 @@
 					:title="v.name"
 					:subtitle="
 						v.deployed_on
-							? `Deployed on ${formatDate(v.deployed_on, 'DATETIME_SHORT')}`
+							? `Deployed on ${formatDate(v.deployed_on, 'DATETIME_SHORT', true)}`
 							: ''
 					"
 				>
@@ -64,7 +64,8 @@
 									selectedVersion.deployed_on
 										? `Deployed on ${formatDate(
 												selectedVersion.deployed_on,
-												'DATETIME_SHORT'
+												'DATETIME_SHORT',
+												true
 										  )}`
 										: ''
 								}}

--- a/dashboard/src/views/site/SiteLogs.vue
+++ b/dashboard/src/views/site/SiteLogs.vue
@@ -14,7 +14,7 @@
 			>
 				<ListItem
 					:title="log.name"
-					:description="`${formatDate(log.modified) + '\n' + log.size} kB`"
+					:description="`${formatDate(log.modified, isUTC=true) + '\n' + log.size} kB`"
 				/>
 				<div class="border-b"></div>
 			</router-link>


### PR DESCRIPTION
fix #776 

## Context

Timestamps from Agent Job are always in UTC meanwhile timestamps created from desk are localized. So adding an option to `formatDate` to format these timestamps.

### Relevant Deploy

This was deployed around 5 mins after 6:59

<img src="https://github.com/frappe/press/assets/63963181/e72a8f55-73f7-41ea-b358-7cc9829e0b46" />

### Before

<img src="https://github.com/frappe/press/assets/63963181/0c2b9f7e-3c47-4822-9f66-78df9c75d462" width="512" />

### After

<img src="https://github.com/frappe/press/assets/63963181/e8df54d9-8619-453e-907c-dd7ad582ab68" width="512" />
