### PR TITLE
fix: key error while restoring site_config_file

### DIFF
--- a/dashboard/src/views/site/SiteDatabaseBackups.vue
+++ b/dashboard/src/views/site/SiteDatabaseBackups.vue
@@ -215,7 +215,6 @@ export default {
 					database: backup.remote_database_file,
 					public: backup.remote_public_file,
 					private: backup.remote_private_file,
-					config_file: backup.remote_config_file
 				}
 			}).then(() => {
 				this.isRestorePending = false;

--- a/press/api/site.py
+++ b/press/api/site.py
@@ -1121,7 +1121,6 @@ def restore(name, files, skip_failing_patches=False):
 	site.remote_database_file = files["database"]
 	site.remote_public_file = files["public"]
 	site.remote_private_file = files["private"]
-	site.remote_config_file = files["config_file"]
 	site.save()
 	site.reload()
 	site.restore_site(skip_failing_patches=skip_failing_patches)


### PR DESCRIPTION
Fix a key error while doing upload and backup.
Reverting (from #861) those lines are safe since config isn't restored anyway (from offsite backups).