### PR TITLE
feat: Single click bench and site update

### DIFF
--- a/dashboard/src/components/AlertUpdate.vue
+++ b/dashboard/src/components/AlertUpdate.vue
@@ -126,6 +126,14 @@ export default {
 						return 'You must select atleast 1 app to proceed with update.';
 					}
 				},
+				onSuccess() {
+					this.showDeployDialog = false;
+					this.$notify({
+						title: 'Updates scheduled successfully',
+						icon: 'check',
+						color: 'green'
+					});
+				}
 			};
 		}
 	},

--- a/dashboard/src/components/AlertUpdate.vue
+++ b/dashboard/src/components/AlertUpdate.vue
@@ -1,0 +1,160 @@
+<template>
+	<Alert :title="alertTitle" v-if="show">
+		<span v-if="deployInformation.deploy_in_progress"
+			>A deploy for this bench is in progress</span
+		>
+		<span v-else-if="bench.status == 'Active'">
+			A new update is available for your bench. Would you like to deploy the
+			update now?
+		</span>
+		<span v-else>
+			Your bench is not deployed yet. You can add more apps to your bench before
+			deploying. If you want to deploy now, click on Deploy.
+		</span>
+		<template #actions>
+			<Button
+				v-if="deployInformation.deploy_in_progress"
+				appearance="primary"
+				:route="`/benches/${bench.name}/deploys/${deployInformation.last_deploy.name}`"
+				>View Progress</Button
+			>
+			<Button v-else appearance="primary" @click="() => {
+					showDeployDialog = true
+					step = 'Apps'
+				}">
+				Show updates
+			</Button>
+		</template>
+
+		<Dialog
+			:options="{ title: step == 'Apps'? 'Select the apps you want to update': 'Select the sites you want to update' }"
+			v-model="showDeployDialog"
+		>
+			<template v-slot:body-content>
+				<BenchAppUpdates
+					v-if="step == 'Apps'"
+					:apps="deployInformation.apps"
+					v-model:selectedApps="selectedApps"
+					:removedApps="deployInformation.removed_apps"
+				/>
+				<BenchSiteUpdates
+					v-if="step == 'Sites'"
+					:sites="deployInformation.sites"
+					v-model:selectedSites="selectedSites"
+				/>
+				<ErrorMessage class="mt-2" :message="errorMessage" />
+			</template>
+			<template v-slot:actions>
+				<Button
+					v-if="step == 'Sites'"
+					appearance="primary"
+					@click="$resources.deploy.submit()"
+					:loading="$resources.deploy.loading"
+				>
+					Update
+				</Button>
+				<Button
+					v-if="step == 'Sites'"
+					@click="step = 'Apps'"
+				>
+					Back
+				</Button>
+				<Button
+					v-else
+					appearance="primary"
+					@click="step = 'Sites'"
+				>
+					Next
+				</Button>
+			</template>
+		</Dialog>
+	</Alert>
+</template>
+<script>
+import BenchAppUpdates from './BenchAppUpdates.vue';
+import BenchSiteUpdates from './BenchSiteUpdates.vue';
+import SwitchTeamDialog from './SwitchTeamDialog.vue';
+export default {
+	name: 'AlertBenchUpdate',
+	props: ['bench'],
+	components: {
+		BenchAppUpdates,
+		BenchSiteUpdates,
+		SwitchTeamDialog
+	},
+	data() {
+		return {
+			showDeployDialog: false,
+			showTeamSwitcher: false,
+			selectedApps: [],
+			selectedSites: [],
+			step: "Apps"
+		};
+	},
+	resources: {
+		deployInformation() {
+			return {
+				method: 'press.api.bench.deploy_information',
+				params: {
+					name: this.bench?.name
+				},
+				auto: true
+			};
+		},
+		deploy() {
+			let appsToIgnore = [];
+			if (this.deployInformation) {
+				appsToIgnore = Array.from(
+					this.deployInformation.apps.filter(
+						app => app.update_available && !this.selectedApps.includes(app.app)
+					)
+				);
+			}
+
+			return {
+				method: 'press.api.bench.deploy_and_update',
+				params: {
+					name: this.bench?.name,
+					apps_to_ignore: appsToIgnore,
+					sites: this.selectedSites
+				},
+				validate() {
+					if (
+						this.selectedApps.length === 0 &&
+						this.deployInformation.removed_apps.length === 0
+					) {
+						return 'You must select atleast 1 app to proceed with update.';
+					}
+				},
+			};
+		}
+	},
+	computed: {
+		show() {
+			if (this.deployInformation) {
+				return (
+					this.deployInformation.update_available &&
+					['Awaiting Deploy', 'Active'].includes(this.bench.status)
+				);
+			}
+		},
+		errorMessage() {
+			return (
+				this.$resources.deploy.error ||
+				(this.bench.team !== $account.team.name
+					? "Current Team doesn't have enough permissions"
+					: '')
+			);
+		},
+		deployInformation() {
+			return this.$resources.deployInformation.data;
+		},
+		alertTitle() {
+			if (this.deployInformation && this.deployInformation.deploy_in_progress) {
+				return 'Deploy in Progress';
+			}
+			return this.bench.status == 'Active' ? 'Update Available' : 'Deploy';
+		}
+	}
+};
+</script>

--- a/dashboard/src/components/AlertUpdate.vue
+++ b/dashboard/src/components/AlertUpdate.vue
@@ -18,16 +18,27 @@
 				:route="`/benches/${bench.name}/deploys/${deployInformation.last_deploy.name}`"
 				>View Progress</Button
 			>
-			<Button v-else appearance="primary" @click="() => {
-					showDeployDialog = true
-					step = 'Apps'
-				}">
+			<Button
+				v-else
+				appearance="primary"
+				@click="
+					() => {
+						showDeployDialog = true;
+						step = 'Apps';
+					}
+				"
+			>
 				Show updates
 			</Button>
 		</template>
 
 		<Dialog
-			:options="{ title: step == 'Apps'? 'Select the apps you want to update': 'Select the sites you want to update' }"
+			:options="{
+				title:
+					step == 'Apps'
+						? 'Select the apps you want to update'
+						: 'Select the sites you want to update'
+			}"
 			v-model="showDeployDialog"
 		>
 			<template v-slot:body-content>
@@ -51,19 +62,10 @@
 					@click="$resources.deploy.submit()"
 					:loading="$resources.deploy.loading"
 				>
-					Update
+					{{ selectedSites.length > 0 ? 'Update' : 'Deploy Bench' }}
 				</Button>
-				<Button
-					v-if="step == 'Sites'"
-					@click="step = 'Apps'"
-				>
-					Back
-				</Button>
-				<Button
-					v-else
-					appearance="primary"
-					@click="step = 'Sites'"
-				>
+				<Button v-if="step == 'Sites'" @click="step = 'Apps'"> Back </Button>
+				<Button v-else appearance="primary" @click="step = 'Sites'">
 					Next
 				</Button>
 			</template>
@@ -88,7 +90,7 @@ export default {
 			showTeamSwitcher: false,
 			selectedApps: [],
 			selectedSites: [],
-			step: "Apps"
+			step: 'Apps'
 		};
 	},
 	resources: {

--- a/dashboard/src/components/BenchSiteUpdates.vue
+++ b/dashboard/src/components/BenchSiteUpdates.vue
@@ -2,11 +2,12 @@
 	<div class="mt-2 space-y-2 divide-y">
 		<SiteUpdateCard
 			v-for="site in sites"
-			:key="site"
+			:key="site.name"
 			@click.native.self="toggleSite(site)"
-			:site="site"
-			:selected="selectedSites.includes(site)"
+			:site="site.name"
+			:selected="selectedSites.map((s) => s.name).includes(site.name)"
 			:selectable="true"
+			v-model:selectedSites="selectedSites"
 		/>
 	</div>
 </template>
@@ -26,8 +27,7 @@ export default {
 	},
 	mounted() {
 		// Select all sites by default
-		this.selectedSites = this.sites;
-		this.$emit('update:selectedSites', this.selectedSites);
+		this.$emit('update:selectedSites', []);
 	},
 	methods: {
 		toggleSite(site) {
@@ -40,28 +40,5 @@ export default {
 			}
 		}
 	},
-	watch: {
-		selectedSites: {
-			handler(sites) {
-				// Hardcoded for now, need a better way
-				// to manage such dependencies (#TODO)
-				// If updating ERPNext, must update Frappe with it
-
-				let frappeUpdateAvailable =
-					this.sites.filter(app => app.update_available && app.app == 'frappe')
-						.length !== 0;
-
-				if (
-					sites.includes('erpnext') &&
-					!sites.includes('frappe') &&
-					frappeUpdateAvailable
-				) {
-					sites.push('frappe');
-				}
-			},
-			deep: true,
-			immediate: true
-		}
-	}
 };
 </script>

--- a/dashboard/src/components/BenchSiteUpdates.vue
+++ b/dashboard/src/components/BenchSiteUpdates.vue
@@ -1,0 +1,67 @@
+<template>
+	<div class="mt-2 space-y-2 divide-y">
+		<SiteUpdateCard
+			v-for="site in sites"
+			:key="site"
+			@click.native.self="toggleSite(site)"
+			:site="site"
+			:selected="selectedSites.includes(site)"
+			:selectable="true"
+		/>
+	</div>
+</template>
+<script>
+import SiteUpdateCard from './SiteUpdateCard.vue';
+
+export default {
+	name: 'BenchSiteUpdates',
+	props: ['sites'],
+	components: {
+		SiteUpdateCard
+	},
+	data() {
+		return {
+			selectedSites: []
+		};
+	},
+	mounted() {
+		// Select all sites by default
+		this.selectedSites = this.sites;
+		this.$emit('update:selectedSites', this.selectedSites);
+	},
+	methods: {
+		toggleSite(site) {
+			if (!this.selectedSites.includes(site)) {
+				this.selectedSites.push(site);
+				this.$emit('update:selectedSites', this.selectedSites);
+			} else {
+				this.selectedSites = this.selectedSites.filter(a => a !== site);
+				this.$emit('update:selectedSites', this.selectedSites);
+			}
+		}
+	},
+	watch: {
+		selectedSites: {
+			handler(sites) {
+				// Hardcoded for now, need a better way
+				// to manage such dependencies (#TODO)
+				// If updating ERPNext, must update Frappe with it
+
+				let frappeUpdateAvailable =
+					this.sites.filter(app => app.update_available && app.app == 'frappe')
+						.length !== 0;
+
+				if (
+					sites.includes('erpnext') &&
+					!sites.includes('frappe') &&
+					frappeUpdateAvailable
+				) {
+					sites.push('frappe');
+				}
+			},
+			deep: true,
+			immediate: true
+		}
+	}
+};
+</script>

--- a/dashboard/src/components/SiteUpdateCard.vue
+++ b/dashboard/src/components/SiteUpdateCard.vue
@@ -7,36 +7,34 @@
 		]"
 		ref="card"
 	>
-	<div class="flex flex-col">
-		<div class="flex flex-row items-center gap-2">
-			<input
-				v-if="selectable"
-				@click.self="$refs['card'].click()"
-				:checked="selected"
-				type="checkbox"
-				class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-transparent"
-			/>
-			<h3 class="text-lg font-medium text-gray-900 group-select">
-				{{ site }}
-			</h3>
+		<div class="flex flex-col">
+			<div class="flex flex-row items-center gap-2">
+				<input
+					v-if="selectable"
+					@click.self="$refs['card'].click()"
+					:checked="selected"
+					type="checkbox"
+					class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-transparent"
+				/>
+				<h3 class="text-lg font-medium text-gray-900 group-select">
+					{{ site }}
+				</h3>
+			</div>
+			<div v-if="selected" class="flex flex-row mt-2">
+				<Input
+					@change="toggleProperty($event, 'skip_failing_patches', site)"
+					type="checkbox"
+					label="Skip failing patches"
+					class="h-4 mr-2 rounded border-gray-300 text-gray-600 focus:ring-transparent"
+				/>
+				<Input
+					@change="toggleProperty($event, 'skip_backups', site)"
+					type="checkbox"
+					label="Skip backup"
+					class="h-4 rounded border-gray-300 text-gray-600 focus:ring-transparent"
+				/>
+			</div>
 		</div>
-		<div class="flex flex-row mt-2">
-			<Input
-				v-if="selectable"
-				@change="toggleProperty($event, 'skipped_failing_patches', site)"
-				type="checkbox"
-				label="Skip failing patches"
-				class="h-4 mr-2 rounded border-gray-300 text-gray-600 focus:ring-transparent"
-			 />
-			<Input
-				v-if="selectable"
-				@change="toggleProperty($event, 'skipped_backups', site)"
-				type="checkbox"
-				label="Skip backup"
-				class="h-4 rounded border-gray-300 text-gray-600 focus:ring-transparent"
-			 />
-		</div>
-	</div>
 	</button>
 </template>
 
@@ -47,10 +45,10 @@ export default {
 	methods: {
 		toggleProperty(value, prop, site) {
 			this.selectedSites.map(selectedSite => {
-				if (site == selectedSite.name){
-					selectedSite[prop] = value
+				if (site == selectedSite.name) {
+					selectedSite[prop] = value;
 				}
-			})
+			});
 			this.$emit('update:selectedSites', this.selectedSites);
 		}
 	}

--- a/dashboard/src/components/SiteUpdateCard.vue
+++ b/dashboard/src/components/SiteUpdateCard.vue
@@ -8,10 +8,13 @@
 		ref="card"
 	>
 		<div class="flex flex-col">
-			<div class="flex flex-row items-center gap-2">
+			<div
+				@click.self="$refs['card'].click()"
+				class="flex flex-row items-center gap-2"
+			>
 				<input
-					v-if="selectable"
 					@click.self="$refs['card'].click()"
+					v-if="selectable"
 					:checked="selected"
 					type="checkbox"
 					class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-transparent"

--- a/dashboard/src/components/SiteUpdateCard.vue
+++ b/dashboard/src/components/SiteUpdateCard.vue
@@ -25,13 +25,14 @@
 					@change="toggleProperty($event, 'skip_failing_patches', site)"
 					type="checkbox"
 					label="Skip failing patches"
-					class="h-4 mr-2 rounded border-gray-300 text-gray-600 focus:ring-transparent"
+					class="h-4 rounded border-gray-300 text-gray-600 focus:ring-transparent"
 				/>
 				<Input
+					v-if="$account.team?.skip_backups"
 					@change="toggleProperty($event, 'skip_backups', site)"
 					type="checkbox"
 					label="Skip backup"
-					class="h-4 rounded border-gray-300 text-gray-600 focus:ring-transparent"
+					class="h-4 ml-2 rounded border-gray-300 text-gray-600 focus:ring-transparent"
 				/>
 			</div>
 		</div>

--- a/dashboard/src/components/SiteUpdateCard.vue
+++ b/dashboard/src/components/SiteUpdateCard.vue
@@ -1,0 +1,30 @@
+<template>
+	<button
+		class="flex w-full flex-row items-center justify-between rounded-lg border border-gray-100 px-4 py-2 shadow focus:outline-none"
+		:class="[
+			selected ? 'ring-2 ring-inset ring-blue-500' : '',
+			selectable ? 'hover:border-gray-300' : 'cursor-default'
+		]"
+		ref="card"
+	>
+		<div class="flex flex-row items-center gap-2">
+			<input
+				v-if="selectable"
+				@click.self="$refs['card'].click()"
+				:checked="selected"
+				type="checkbox"
+				class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-transparent"
+			/>
+			<h3 class="text-lg font-medium text-gray-900">
+				{{ site }}
+			</h3>
+		</div>
+	</button>
+</template>
+
+<script>
+export default {
+	name: 'SiteUpdateCard',
+	props: ['site', 'selectable', 'selected'],
+};
+</script>

--- a/dashboard/src/components/SiteUpdateCard.vue
+++ b/dashboard/src/components/SiteUpdateCard.vue
@@ -7,6 +7,7 @@
 		]"
 		ref="card"
 	>
+	<div class="flex flex-col">
 		<div class="flex flex-row items-center gap-2">
 			<input
 				v-if="selectable"
@@ -15,16 +16,43 @@
 				type="checkbox"
 				class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-transparent"
 			/>
-			<h3 class="text-lg font-medium text-gray-900">
+			<h3 class="text-lg font-medium text-gray-900 group-select">
 				{{ site }}
 			</h3>
 		</div>
+		<div class="flex flex-row mt-2">
+			<Input
+				v-if="selectable"
+				@change="toggleProperty($event, 'skipped_failing_patches', site)"
+				type="checkbox"
+				label="Skip failing patches"
+				class="h-4 mr-2 rounded border-gray-300 text-gray-600 focus:ring-transparent"
+			 />
+			<Input
+				v-if="selectable"
+				@change="toggleProperty($event, 'skipped_backups', site)"
+				type="checkbox"
+				label="Skip backup"
+				class="h-4 rounded border-gray-300 text-gray-600 focus:ring-transparent"
+			 />
+		</div>
+	</div>
 	</button>
 </template>
 
 <script>
 export default {
 	name: 'SiteUpdateCard',
-	props: ['site', 'selectable', 'selected'],
+	props: ['site', 'selectable', 'selected', 'selectedSites'],
+	methods: {
+		toggleProperty(value, prop, site) {
+			this.selectedSites.map(selectedSite => {
+				if (site == selectedSite.name){
+					selectedSite[prop] = value
+				}
+			})
+			this.$emit('update:selectedSites', this.selectedSites);
+		}
+	}
 };
 </script>

--- a/dashboard/src/views/bench/BenchApps.vue
+++ b/dashboard/src/views/bench/BenchApps.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="space-y-5">
-		<AlertBenchUpdate :bench="bench" />
+		<AlertUpdate :bench="bench" />
 		<Card
 			title="Apps"
 			subtitle="Apps available on your bench"
@@ -130,7 +130,7 @@
 	</div>
 </template>
 <script>
-import AlertBenchUpdate from '@/components/AlertBenchUpdate.vue';
+import AlertUpdate from '@/components/AlertUpdate.vue';
 import AppSourceSelector from '@/components/AppSourceSelector.vue';
 import ChangeAppBranchDialog from '@/components/ChangeAppBranchDialog.vue';
 import Fuse from 'fuse.js/dist/fuse.basic.esm';
@@ -138,7 +138,7 @@ import Fuse from 'fuse.js/dist/fuse.basic.esm';
 export default {
 	name: 'BenchApps',
 	components: {
-		AlertBenchUpdate,
+		AlertUpdate,
 		AppSourceSelector,
 		ChangeAppBranchDialog
 	},

--- a/dashboard/src/views/bench/BenchOverview.vue
+++ b/dashboard/src/views/bench/BenchOverview.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="space-y-5" v-if="bench">
-		<AlertBenchUpdate :bench="bench" />
+		<AlertUpdate :bench="bench" />
 		<div class="grid grid-cols-1 gap-5 sm:grid-cols-2">
 			<BenchOverviewInfo :bench="bench" />
 			<BenchOverviewVersions :bench="bench" />
@@ -11,7 +11,7 @@
 </template>
 
 <script>
-import AlertBenchUpdate from '@/components/AlertBenchUpdate.vue';
+import AlertUpdate from '@/components/AlertUpdate.vue';
 import BenchOverviewInfo from './BenchOverviewInfo.vue';
 import BenchOverviewRecentDeploys from './BenchOverviewRecentDeploys.vue';
 import BenchOverviewVersions from './BenchOverviewVersions.vue';
@@ -21,7 +21,7 @@ export default {
 	name: 'BenchGeneral',
 	props: ['bench'],
 	components: {
-		AlertBenchUpdate,
+		AlertUpdate,
 		BenchOverviewInfo,
 		BenchOverviewRecentDeploys,
 		BenchOverviewVersions,

--- a/dashboard/src/views/site/SiteOverview.vue
+++ b/dashboard/src/views/site/SiteOverview.vue
@@ -7,13 +7,14 @@ import SiteOverviewInfo from './SiteOverviewInfo.vue';
 import SiteOverviewDomains from './SiteOverviewDomains.vue';
 import SiteOverviewCPUUsage from './SiteOverviewCPUUsage.vue';
 import AlertSiteUpdate from '@/components/AlertSiteUpdate.vue';
+import AlertUpdate from '@/components/AlertUpdate.vue';
 import AlertSiteActivation from '@/components/AlertSiteActivation.vue';
 import SiteActivity from './SiteActivity.vue';
-import SiteOverviewAppsAndSubscriptions from './SiteOverviewAppsAndSubscriptions.vue';
 
 const props = defineProps({ site: Object });
 const showPromotionalDialog = ref(false);
 const clickedPromotion = ref(null);
+const bench = {"name": props.site.group, "status": "Active", "team": props.site.team}
 
 const overview = useResource({
 	method: 'press.api.site.overview',
@@ -55,6 +56,7 @@ const marketplacePromotionalBanners = useResource({
 	<div class="space-y-5" v-if="site">
 		<AlertSiteActivation :site="site" />
 		<AlertSiteUpdate :site="site" />
+		<AlertUpdate :bench="bench"/>
 
 		<div
 			v-if="

--- a/dashboard/src/views/site/SiteOverview.vue
+++ b/dashboard/src/views/site/SiteOverview.vue
@@ -7,14 +7,12 @@ import SiteOverviewInfo from './SiteOverviewInfo.vue';
 import SiteOverviewDomains from './SiteOverviewDomains.vue';
 import SiteOverviewCPUUsage from './SiteOverviewCPUUsage.vue';
 import AlertSiteUpdate from '@/components/AlertSiteUpdate.vue';
-import AlertUpdate from '@/components/AlertUpdate.vue';
 import AlertSiteActivation from '@/components/AlertSiteActivation.vue';
 import SiteActivity from './SiteActivity.vue';
 
 const props = defineProps({ site: Object });
 const showPromotionalDialog = ref(false);
 const clickedPromotion = ref(null);
-const bench = {"name": props.site.group, "status": "Active", "team": props.site.team}
 
 const overview = useResource({
 	method: 'press.api.site.overview',
@@ -56,7 +54,6 @@ const marketplacePromotionalBanners = useResource({
 	<div class="space-y-5" v-if="site">
 		<AlertSiteActivation :site="site" />
 		<AlertSiteUpdate :site="site" />
-		<AlertUpdate :bench="bench"/>
 
 		<div
 			v-if="

--- a/press/api/bench.py
+++ b/press/api/bench.py
@@ -456,12 +456,19 @@ def deploy_and_update(name, apps_to_ignore=[], sites=[]):
 		frappe.throw(
 			"Bench can only be deployed by the bench owner", exc=frappe.PermissionError
 		)
-
 	frappe.get_doc(
 		{
 			"doctype": "Bench Update",
 			"group": name,
-			"sites": [{"name": site} for site in sites],
+			"sites": [
+				{
+					"site": site["name"],
+					"server": site["server"],
+					"skip_failing_patches": site["skip_failing_patches"],
+					"skip_backups": site["skip_backups"],
+				}
+				for site in sites
+			],
 			"status": "Pending",
 			"apps_to_ignore": str(apps_to_ignore),
 		}

--- a/press/api/bench.py
+++ b/press/api/bench.py
@@ -445,6 +445,31 @@ def deploy(name, apps_to_ignore=[]):
 
 @frappe.whitelist()
 @protected("Release Group")
+def deploy_and_update(name, apps_to_ignore=[], sites=[]):
+	if isinstance(apps_to_ignore, str):
+		apps_to_ignore = json.loads(apps_to_ignore)
+
+	team = get_current_team(True)
+	rg_team = frappe.db.get_value("Release Group", name, "team")
+
+	if rg_team != team.name:
+		frappe.throw(
+			"Bench can only be deployed by the bench owner", exc=frappe.PermissionError
+		)
+
+	frappe.get_doc(
+		{
+			"doctype": "Bench Update",
+			"group": name,
+			"sites": [{"name": site} for site in sites],
+			"status": "Pending",
+			"apps_to_ignore": str(apps_to_ignore),
+		}
+	).insert(ignore_permissions=True)
+
+
+@frappe.whitelist()
+@protected("Release Group")
 def create_deploy_candidate(name, apps_to_ignore=[]):
 	rg: ReleaseGroup = frappe.get_doc("Release Group", name)
 	candidate = rg.create_deploy_candidate(apps_to_ignore)

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -393,7 +393,16 @@ def process_new_bench_job_update(job):
 				"press.press.doctype.bench.bench.archive_obsolete_benches",
 				enqueue_after_commit=True,
 			)
-			frappe.get_doc("Bench", job.bench).add_ssh_user()
+			bench = frappe.get_doc("Bench", job.bench)
+			bench.add_ssh_user()
+
+			bench_update = frappe.get_all(
+				"Bench Update",
+				{"candidate": bench.candidate, "status": "Build Successful"},
+				pluck="name",
+			)
+			if bench_update:
+				frappe.get_doc("Bench Update", bench_update[0]).update_sites_on_server(bench.server)
 
 
 def process_archive_bench_job_update(job):

--- a/press/press/doctype/bench_site_update/bench_site_update.js
+++ b/press/press/doctype/bench_site_update/bench_site_update.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2023, Frappe and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Bench Site Update", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/press/press/doctype/bench_site_update/bench_site_update.json
+++ b/press/press/doctype/bench_site_update/bench_site_update.json
@@ -33,13 +33,13 @@
    "options": "Site Update"
   },
   {
-   "default": "Pending",
+   "fetch_from": "site_update.status",
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
    "in_preview": 1,
    "label": "Status",
-   "options": "Pending\nRunning\nFailure\nRecovered\nSuccess"
+   "options": "Pending\nRunning\nFailure\nRecovered\nSuccess\nFatal"
   },
   {
    "fieldname": "server",
@@ -63,7 +63,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-06-21 11:36:19.278665",
+ "modified": "2023-06-21 19:07:48.436786",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Bench Site Update",

--- a/press/press/doctype/bench_site_update/bench_site_update.json
+++ b/press/press/doctype/bench_site_update/bench_site_update.json
@@ -1,0 +1,52 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2023-06-16 18:26:31.546918",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "site",
+  "site_update",
+  "status"
+ ],
+ "fields": [
+  {
+   "fieldname": "site",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_preview": 1,
+   "label": "Site",
+   "options": "Site",
+   "reqd": 1
+  },
+  {
+   "fieldname": "site_update",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_preview": 1,
+   "label": "Site Update",
+   "options": "Site Update"
+  },
+  {
+   "default": "Pending",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "Pending\nRunning\nFailure\nRecovered\nSuccess"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2023-06-16 18:44:18.105399",
+ "modified_by": "Administrator",
+ "module": "Press",
+ "name": "Bench Site Update",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/press/press/doctype/bench_site_update/bench_site_update.json
+++ b/press/press/doctype/bench_site_update/bench_site_update.json
@@ -9,7 +9,10 @@
  "field_order": [
   "site",
   "site_update",
-  "status"
+  "status",
+  "server",
+  "skip_failing_patches",
+  "skip_backups"
  ],
  "fields": [
   {
@@ -33,14 +36,34 @@
    "default": "Pending",
    "fieldname": "status",
    "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_preview": 1,
    "label": "Status",
    "options": "Pending\nRunning\nFailure\nRecovered\nSuccess"
+  },
+  {
+   "fieldname": "server",
+   "fieldtype": "Link",
+   "label": "Server",
+   "options": "Server"
+  },
+  {
+   "default": "0",
+   "fieldname": "skip_failing_patches",
+   "fieldtype": "Check",
+   "label": "Skip failing patches"
+  },
+  {
+   "default": "0",
+   "fieldname": "skip_backups",
+   "fieldtype": "Check",
+   "label": "Skip backups"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-06-16 18:44:18.105399",
+ "modified": "2023-06-21 11:36:19.278665",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Bench Site Update",

--- a/press/press/doctype/bench_site_update/bench_site_update.py
+++ b/press/press/doctype/bench_site_update/bench_site_update.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Frappe and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class BenchSiteUpdate(Document):
+	pass

--- a/press/press/doctype/bench_site_update/test_bench_site_update.py
+++ b/press/press/doctype/bench_site_update/test_bench_site_update.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Frappe and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestBenchSiteUpdate(FrappeTestCase):
+	pass

--- a/press/press/doctype/bench_update/bench_update.js
+++ b/press/press/doctype/bench_update/bench_update.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2023, Frappe and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Bench Update", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/press/press/doctype/bench_update/bench_update.json
+++ b/press/press/doctype/bench_update/bench_update.json
@@ -8,8 +8,11 @@
  "engine": "InnoDB",
  "field_order": [
   "group",
-  "status",
   "apps_to_ignore",
+  "column_break_wff5",
+  "status",
+  "candidate",
+  "section_break_nfd1",
   "sites"
  ],
  "fields": [
@@ -31,17 +34,32 @@
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "Pending\nRunning\nPartial Failure\nFailure\nSuccess"
+   "options": "Pending\nRunning\nBuild Successful\nFailure\nSuccess"
   },
   {
    "fieldname": "apps_to_ignore",
    "fieldtype": "Data",
    "label": "Apps to Ignore"
+  },
+  {
+   "fieldname": "column_break_wff5",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "candidate",
+   "fieldtype": "Link",
+   "label": "Candidate",
+   "options": "Deploy Candidate",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_nfd1",
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-06-16 19:13:10.400177",
+ "modified": "2023-06-19 21:43:27.227631",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Bench Update",

--- a/press/press/doctype/bench_update/bench_update.json
+++ b/press/press/doctype/bench_update/bench_update.json
@@ -1,0 +1,66 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2023-06-16 18:29:22.245007",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "group",
+  "status",
+  "apps_to_ignore",
+  "sites"
+ ],
+ "fields": [
+  {
+   "fieldname": "group",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Group",
+   "options": "Release Group",
+   "reqd": 1
+  },
+  {
+   "fieldname": "sites",
+   "fieldtype": "Table",
+   "label": "Sites",
+   "options": "Bench Site Update"
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "Pending\nRunning\nPartial Failure\nFailure\nSuccess"
+  },
+  {
+   "fieldname": "apps_to_ignore",
+   "fieldtype": "Data",
+   "label": "Apps to Ignore"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2023-06-16 19:13:10.400177",
+ "modified_by": "Administrator",
+ "module": "Press",
+ "name": "Bench Update",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/press/press/doctype/bench_update/bench_update.json
+++ b/press/press/doctype/bench_update/bench_update.json
@@ -33,6 +33,7 @@
   {
    "fieldname": "status",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Status",
    "options": "Pending\nRunning\nBuild Successful\nFailure\nSuccess"
   },
@@ -59,7 +60,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-06-19 21:43:27.227631",
+ "modified": "2023-06-21 19:11:56.737713",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Bench Update",

--- a/press/press/doctype/bench_update/bench_update.py
+++ b/press/press/doctype/bench_update/bench_update.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2023, Frappe and contributors
 # For license information, please see license.txt
+import json
 
 import frappe
 from frappe.model.document import Document
 
 from press.press.doctype.release_group.release_group import ReleaseGroup
+from press.utils import log_error
 
 
 class BenchUpdate(Document):
@@ -15,10 +17,8 @@ class BenchUpdate(Document):
 		self.validate_pending_updates()
 		self.validate_pending_site_updates()
 
-	def validate_ongoing_updates(self):
-		if frappe.db.exists(
-			"Bench Update", {"status": ("in", ("Pending", "Running", "Failure"))}
-		):
+	def validate_pending_updates(self):
+		if frappe.db.exists("Bench Update", {"status": ("in", ("Pending", "Running"))}):
 			frappe.throw("An update is already pending for this bench", frappe.ValidationError)
 
 		if frappe.get_doc("Release Group", self.group).deploy_in_progress:
@@ -28,13 +28,31 @@ class BenchUpdate(Document):
 		for site in self.sites:
 			if frappe.db.exists(
 				"Site Update",
-				{"site": site.site, "status": ("in", ("Pending", "Running", "Failure"))},
+				{"site": site.site, "status": ("in", ("Pending", "Running"))},
 			):
 				frappe.throw("An update is already pending for this site", frappe.ValidationError)
 
 	def after_insert(self):
+		if isinstance(self.apps_to_ignore, str):
+			apps_to_ignore = json.loads(self.apps_to_ignore)
+
 		rg: ReleaseGroup = frappe.get_doc("Release Group", self.group)
-		candidate = rg.create_deploy_candidate(self.apps_to_ignore, bench_update=self.name)
+		candidate = rg.create_deploy_candidate(apps_to_ignore)
 		candidate.build_and_deploy()
 
 		self.status = "Running"
+		self.candidate = candidate.name
+		self.save()
+
+	def update_sites_on_server(self, server):
+		for site in self.sites:
+			if site.server == server and site.status == "Pending" and not site.site_update:
+				try:
+					site_update = frappe.get_doc("Site", site.site).schedule_update(
+						skip_failing_patches=site.skip_failing_patches, skip_backups=site.skip_backups
+					)
+					site.site_update = site_update
+					self.save(ignore_permissions=True)
+					frappe.db.commit()
+				except Exception as e:
+					log_error("Bench Update: Failed to create Site Update", e)

--- a/press/press/doctype/bench_update/bench_update.py
+++ b/press/press/doctype/bench_update/bench_update.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2023, Frappe and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+from press.press.doctype.release_group.release_group import ReleaseGroup
+
+
+class BenchUpdate(Document):
+	def validate(self):
+		if not self.is_new():
+			return
+
+		self.validate_pending_updates()
+		self.validate_pending_site_updates()
+
+	def validate_ongoing_updates(self):
+		if frappe.db.exists(
+			"Bench Update", {"status": ("in", ("Pending", "Running", "Failure"))}
+		):
+			frappe.throw("An update is already pending for this bench", frappe.ValidationError)
+
+		if frappe.get_doc("Release Group", self.group).deploy_in_progress:
+			frappe.throw("A deploy for this bench is already in progress")
+
+	def validate_pending_site_updates(self):
+		for site in self.sites:
+			if frappe.db.exists(
+				"Site Update",
+				{"site": site.site, "status": ("in", ("Pending", "Running", "Failure"))},
+			):
+				frappe.throw("An update is already pending for this site", frappe.ValidationError)
+
+	def after_insert(self):
+		rg: ReleaseGroup = frappe.get_doc("Release Group", self.group)
+		candidate = rg.create_deploy_candidate(self.apps_to_ignore, bench_update=self.name)
+		candidate.build_and_deploy()
+
+		self.status = "Running"

--- a/press/press/doctype/bench_update/test_bench_update.py
+++ b/press/press/doctype/bench_update/test_bench_update.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Frappe and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestBenchUpdate(FrappeTestCase):
+	pass

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -126,9 +126,20 @@ class DeployCandidate(Document):
 		except Exception:
 			log_error("Deploy Candidate Build Exception", name=self.name)
 			self.status = "Failure"
+			bench_update = frappe.get_all(
+				"Bench Update", {"status": "Running", "candidate": self.name}, pluck="name"
+			)
+			if bench_update:
+				frappe.db.set_value("Bench Update", bench_update[0], "status", "Failure")
 			raise
 		else:
 			self.status = "Success"
+			bench_update = frappe.get_all(
+				"Bench Update", {"status": "Running", "candidate": self.name}, pluck="name"
+			)
+			if bench_update:
+				frappe.db.set_value("Bench Update", bench_update[0], "status", "Build Successful")
+
 		finally:
 			self.build_end = now()
 			self.build_duration = self.build_end - self.build_start

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -218,6 +218,9 @@ class ReleaseGroup(Document):
 		last_dc_info = self.get_last_deploy_candidate_info()
 		out.last_deploy = last_dc_info
 		out.deploy_in_progress = last_dc_info and last_dc_info.status == "Running"
+		out.sites = frappe.get_all(
+			"Site", {"group": self.name, "status": "Active"}, pluck="name"
+		)
 
 		return out
 

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -218,9 +218,12 @@ class ReleaseGroup(Document):
 		last_dc_info = self.get_last_deploy_candidate_info()
 		out.last_deploy = last_dc_info
 		out.deploy_in_progress = last_dc_info and last_dc_info.status == "Running"
-		out.sites = frappe.get_all(
-			"Site", {"group": self.name, "status": "Active"}, pluck="name"
-		)
+		out.sites = [
+			site.update({"skip_failing_patches": False, "skip_backups": False})
+			for site in frappe.get_all(
+				"Site", {"group": self.name, "status": "Active"}, ["name", "server"]
+			)
+		]
 
 		return out
 

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -424,7 +424,7 @@ class Site(Document):
 		self.status_before_update = self.status
 		self.status = "Pending"
 		self.save()
-		frappe.get_doc(
+		doc = frappe.get_doc(
 			{
 				"doctype": "Site Update",
 				"site": self.name,
@@ -432,6 +432,7 @@ class Site(Document):
 				"skipped_backups": skip_backups,
 			}
 		).insert()
+		return doc.name
 
 	@frappe.whitelist()
 	def move_to_group(self, group, skip_failing_patches=False):


### PR DESCRIPTION
No need to wait after deploying a bench.
Bench > Update Available > Select apps to update > Select Sites to update.

- [x] Update benches and site's in a single flow
- [x] Use single update component for updating benches and sites together
- [x] Ignore sites to update bench only
- [x] Select random set of apps and sites to update
- [x] Handle only site update separately

Fixes: https://github.com/frappe/press/issues/720
![Screenshot from 2023-06-21 22-07-43](https://github.com/frappe/press/assets/50401596/4d02de83-ad73-4a4a-bbbd-3e31b8f8d37a)

![Screenshot from 2023-06-21 22-07-52](https://github.com/frappe/press/assets/50401596/c12836a0-0bf5-4325-a81a-b7ae9e7b0d16)

