### PR TITLE
perf: Make long worker consume short and default queue too

### DIFF
--- a/press/docker/config/supervisor.conf
+++ b/press/docker/config/supervisor.conf
@@ -58,7 +58,7 @@ numprocs=1
 process_name=%(program_name)s-%(process_num)d
 
 [program:frappe-bench-frappe-long-worker]
-command=bench worker --queue long
+command=bench worker --queue long,default,short
 priority=4
 autostart=true
 autorestart=true


### PR DESCRIPTION
After this feature of merging and consuming multiple queues w/ feature flag (https://github.com/frappe/press/commit/5016b3b4a98d4cd87836fb31ffb7e15b878a4ddf) now we can go a bit more further and make long worker useful entire day: 

This way now there are two types of workers:

- Dedicated short workers ensuring short-running jobs are quickly consumed. 
- Dedicated long workers for long running jobs which don't have huge expectation for responsiveness.

### Why this priority?
- Short workers should give higher priority to short and then default jobs.
- Long workers should give higher priority to long jobs as they are only ones to work on long jobs. But when they have free resources they can consume short and default queues too.
- This mix of config ensures that long-running jobs will not block short/default jobs, but a burst of short/default jobs will be handled by long workers too. Thus increasing the throughput of overall system. 


### How does priority and multi-queue consumption works

> The default worker considers the order of queues as their priority order. That’s to say if the supplied queues are rq worker high low, the worker will prioritize dequeueing jobs from high before low.

ref: https://python-rq.org/docs/workers/#strategies-for-dequeuing-jobs-from-queues

### Why do this?
Long workers sit idle 99% of the time on majority of sites. This change makes them do some useful work when long jobs are not present.

The concept of "long" and "short" worker is frappe invented, RQ just cares about queues to consume and priorities.

After staged rollout IMO this should become the default behaviour


dependent agent PR: https://github.com/frappe/agent/pull/57 