### PR TITLE
chore: Create subscriptions such that invoicing conventions are maitained

### DIFF
--- a/press/marketplace/doctype/marketplace_app_subscription/marketplace_app_subscription.py
+++ b/press/marketplace/doctype/marketplace_app_subscription/marketplace_app_subscription.py
@@ -6,7 +6,6 @@ import json
 import requests
 
 from frappe.model.document import Document
-from frappe.utils import get_datetime
 from press.press.doctype.site.site import Site
 
 
@@ -161,42 +160,6 @@ class MarketplaceAppSubscription(Document):
 				pass
 		else:
 			return
-
-	def can_charge_for_subscription(self):
-		# check whatever marketplace related stuff
-		return (
-			self.status == "Active"
-			and self.team
-			and self.team != "Administrator"
-			and self.should_create_usage_record()
-		)
-
-	def should_create_usage_record(self):
-		# Don't create for free plans
-		is_free = frappe.db.get_value(
-			"Marketplace App Plan", self.marketplace_app_plan, "is_free"
-		)
-
-		if is_free:
-			return False
-
-		# For annual prepaid plans
-		plan_interval = frappe.db.get_value("Plan", self.plan, "interval")
-
-		if plan_interval == "Annually":
-			return False
-
-		# For non-active sites
-		site_status, trial_site = frappe.db.get_value(
-			"Site", self.site, ["status", "trial_end_date"]
-		)
-		if site_status not in ("Active", "Inactive"):
-			return False
-
-		if trial_site and frappe.utils.getdate() > get_datetime(trial_site).date():
-			return False
-
-		return True
 
 
 def process_prepaid_marketplace_payment(event):

--- a/press/marketplace/doctype/marketplace_app_subscription/marketplace_app_subscription.py
+++ b/press/marketplace/doctype/marketplace_app_subscription/marketplace_app_subscription.py
@@ -64,6 +64,9 @@ class MarketplaceAppSubscription(Document):
 			)
 			frappe.db.set_value("Subscription", self.subscription, "plan", self.plan)
 
+		if self.has_value_changed("team"):
+			frappe.db.set_value("Subscription", self.subscription, "team", self.team)
+
 		if self.has_value_changed("status"):
 			frappe.db.set_value(
 				"Subscription", self.subscription, "enabled", 1 if self.status == "Active" else 0

--- a/press/marketplace/doctype/marketplace_app_subscription/marketplace_app_subscription.py
+++ b/press/marketplace/doctype/marketplace_app_subscription/marketplace_app_subscription.py
@@ -80,8 +80,9 @@ class MarketplaceAppSubscription(Document):
 			{
 				"doctype": "Subscription",
 				"team": self.team,
-				"document_type": "Marketplace App Subscription",
-				"document_name": self.name,
+				"document_type": "Marketplace App",
+				"document_name": self.app,
+				"marketplace_app_subscription": self.name,
 				"plan": frappe.get_value("Marketplace App Plan", self.marketplace_app_plan, "plan"),
 			}
 		).insert(ignore_permissions=True)

--- a/press/marketplace/doctype/marketplace_app_subscription/test_marketplace_app_subscription.py
+++ b/press/marketplace/doctype/marketplace_app_subscription/test_marketplace_app_subscription.py
@@ -39,7 +39,13 @@ class TestMarketplaceAppSubscription(unittest.TestCase):
 	def setUp(self) -> None:
 		self.marketplace_subscription = create_test_marketplace_app_subscription()
 		self.subscription = frappe.get_doc(
-			"Subscription", self.marketplace_subscription.subscription
+			"Subscription",
+			{
+				"marketplace_app_subscription": self.marketplace_subscription.name,
+				"document_type": "Marketplace App",
+				"site": self.marketplace_subscription.site,
+				"enabled": 1,
+			},
 		)
 		self.plan = frappe.get_doc("Plan", self.subscription.plan)
 

--- a/press/press/doctype/marketplace_app/marketplace_app.py
+++ b/press/press/doctype/marketplace_app/marketplace_app.py
@@ -17,6 +17,7 @@ from press.marketplace.doctype.marketplace_app_plan.marketplace_app_plan import 
 )
 from press.press.doctype.marketplace_app.utils import get_rating_percentage_distribution
 from frappe.utils.safe_exec import safe_exec
+from frappe.utils import get_datetime
 
 
 class MarketplaceApp(WebsiteGenerator):
@@ -366,6 +367,48 @@ class MarketplaceApp(WebsiteGenerator):
 
 	def get_plans(self, frappe_version: str = None) -> List:
 		return get_plans_for_app(self.name, frappe_version)
+
+	def can_charge_for_subscription(self, subscription):
+		marketplace_app_plan, plan, site, team, status = frappe.get_value(
+			"Marketplace App Subscription",
+			subscription.marketplace_app_subscription,
+			["marketplace_app_plan", "plan", "site", "team", "status"],
+		)
+
+		return (
+			status == "Active"
+			and team
+			and team != "Administrator"
+			and self.should_create_usage_record(marketplace_app_plan, plan, site)
+		)
+
+	def should_create_usage_record(self, marketplace_app_plan, plan, site):
+		"""Check if the user can create a usage record for this app"""
+		is_free = frappe.db.get_value("Marketplace App Plan", marketplace_app_plan, "is_free")
+
+		if is_free:
+			return False
+
+		# For annual prepaid plans
+		plan_interval = frappe.db.get_value("Plan", plan, "interval")
+
+		if plan_interval == "Annually":
+			return False
+
+		# For non-active sites
+		site_status, trial_site, free = frappe.db.get_value(
+			"Site", site, ["status", "trial_end_date", "free"]
+		)
+		if site_status not in ("Active", "Inactive"):
+			return False
+
+		if free:
+			return False
+
+		if trial_site and frappe.utils.getdate() < get_datetime(trial_site).date():
+			return False
+
+		return True
 
 
 def get_plans_for_app(

--- a/press/press/doctype/self_hosted_server/self_hosted_server.py
+++ b/press/press/doctype/self_hosted_server/self_hosted_server.py
@@ -522,7 +522,7 @@ class SelfHostedServer(Document):
 		)
 		return frappe.get_doc("Subscription", name) if name else None
 
-	def can_charge_for_subscription(self):
+	def can_charge_for_subscription(self, subscription=None):
 		return (
 			self.status not in ["Archived", "Unreachable", "Pending"]
 			and self.team

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1118,7 +1118,7 @@ class Site(Document):
 		)
 		return frappe.get_doc("Subscription", name) if name else None
 
-	def can_charge_for_subscription(self):
+	def can_charge_for_subscription(self, subscription=None):
 		today = frappe.utils.getdate()
 		return (
 			self.status not in ["Archived", "Suspended"]

--- a/press/press/doctype/subscription/subscription.json
+++ b/press/press/doctype/subscription/subscription.json
@@ -11,7 +11,8 @@
   "document_type",
   "document_name",
   "plan",
-  "interval"
+  "interval",
+  "marketplace_app_subscription"
  ],
  "fields": [
   {
@@ -59,6 +60,12 @@
    "label": "Plan",
    "options": "Plan",
    "reqd": 1
+  },
+  {
+   "fieldname": "marketplace_app_subscription",
+   "fieldtype": "Link",
+   "label": "Marketplace App Subscription",
+   "options": "Marketplace App Subscription"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -68,10 +75,11 @@
    "link_fieldname": "subscription"
   }
  ],
- "modified": "2021-02-15 20:37:05.851885",
+ "modified": "2023-06-27 21:57:40.400786",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Subscription",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -102,6 +110,7 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "team",
  "track_changes": 1
 }

--- a/press/press/doctype/subscription/subscription.py
+++ b/press/press/doctype/subscription/subscription.py
@@ -88,7 +88,7 @@ class Subscription(Document):
 			return False
 
 		if hasattr(doc, "can_charge_for_subscription"):
-			return doc.can_charge_for_subscription()
+			return doc.can_charge_for_subscription(self)
 
 		return True
 

--- a/press/press/doctype/subscription/subscription.py
+++ b/press/press/doctype/subscription/subscription.py
@@ -72,6 +72,11 @@ class Subscription(Document):
 			amount=amount,
 			subscription=self.name,
 			interval=self.interval,
+			site=frappe.get_value(
+				"Marketplace App Subscription", self.marketplace_app_subscription, "site"
+			)
+			if self.document_type == "Marketplace App"
+			else None,
 		)
 		usage_record.insert()
 		usage_record.submit()


### PR DESCRIPTION
Some subscription and invoicing conventions were messed up my this https://github.com/frappe/press/pull/894

This PR follows the same line item convention as the previous usage records and invoices so that we don't have to rewrite every single piece of logic or server script that we have written for "Marketplace App" and not "Marketplace App Subscription"