### PR TITLE
Update saas.py

### DIFF
--- a/press/api/saas.py
+++ b/press/api/saas.py
@@ -231,6 +231,13 @@ def validate_account_request(key):
 		frappe.throw("Request Key not provided")
 
 	app = frappe.db.get_value("Account Request", {"request_key": key}, "saas_app")
+
+	#saas generator uses app titla as its name
+	# so we need to get the app title
+   	
+	app_title = frappe.db.get_value("Saas App",app,"title")
+	app_title = "-".join(app_title.split(" ")).lower()
+	
 	headless, route = frappe.db.get_value(
 		"Saas Setup Account Generator", app, ["headless", "route"]
 	)


### PR DESCRIPTION
Use `app_title `in place of `app_name `when retrieving SaaS Account Generator

SaaS Account Generator uses the SaaS App Title for it's naming

Fixes Type Error when creating a validating a new saas account signup

```
headless, route = frappe.db.get_value(
                 "Saas Setup Account Generator", app, ["headless", "route"]
      )

TypeError: cannot unpack non-iterable NoneType object
```