### PR TITLE
refactor: fetch default dependencies from frappe version

### DIFF
--- a/press/fixtures/frappe_version.json
+++ b/press/fixtures/frappe_version.json
@@ -1,9 +1,93 @@
 [
  {
   "default": 0,
+  "dependencies": [
+   {
+    "dependency": "NVM_VERSION",
+    "parent": "Version 15",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "0.36.0"
+   },
+   {
+    "dependency": "NODE_VERSION",
+    "parent": "Version 15",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "18.16.0"
+   },
+   {
+    "dependency": "PYTHON_VERSION",
+    "parent": "Version 15",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "3.11"
+   },
+   {
+    "dependency": "WKHTMLTOPDF_VERSION",
+    "parent": "Version 15",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "0.12.5"
+   },
+   {
+    "dependency": "BENCH_VERSION",
+    "parent": "Version 15",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "5.16.0"
+   }
+  ],
   "docstatus": 0,
   "doctype": "Frappe Version",
-  "modified": "2020-11-12 17:31:04.114000",
+  "modified": "2023-07-19 17:31:05.044895",
+  "name": "Version 15",
+  "number": 15,
+  "public": 1,
+  "status": "Beta"
+ },
+ {
+  "default": 0,
+  "dependencies": [
+   {
+    "dependency": "NVM_VERSION",
+    "parent": "Version 12",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "0.36.0"
+   },
+   {
+    "dependency": "NODE_VERSION",
+    "parent": "Version 12",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "12.19.0"
+   },
+   {
+    "dependency": "PYTHON_VERSION",
+    "parent": "Version 12",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "3.7"
+   },
+   {
+    "dependency": "WKHTMLTOPDF_VERSION",
+    "parent": "Version 12",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "0.12.5"
+   },
+   {
+    "dependency": "BENCH_VERSION",
+    "parent": "Version 12",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "5.15.2"
+   }
+  ],
+  "docstatus": 0,
+  "doctype": "Frappe Version",
+  "modified": "2023-07-21 19:40:15.332088",
   "name": "Version 12",
   "number": 12,
   "public": 1,
@@ -11,9 +95,46 @@
  },
  {
   "default": 0,
+  "dependencies": [
+   {
+    "dependency": "NVM_VERSION",
+    "parent": "Version 13",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "0.36.0"
+   },
+   {
+    "dependency": "NODE_VERSION",
+    "parent": "Version 13",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "14.19.0"
+   },
+   {
+    "dependency": "PYTHON_VERSION",
+    "parent": "Version 13",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "3.7"
+   },
+   {
+    "dependency": "WKHTMLTOPDF_VERSION",
+    "parent": "Version 13",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "0.12.5"
+   },
+   {
+    "dependency": "BENCH_VERSION",
+    "parent": "Version 13",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "5.15.2"
+   }
+  ],
   "docstatus": 0,
   "doctype": "Frappe Version",
-  "modified": "2021-12-03 12:34:31.455781",
+  "modified": "2023-07-21 19:41:46.898316",
   "name": "Version 13",
   "number": 13,
   "public": 1,
@@ -21,19 +142,93 @@
  },
  {
   "default": 0,
+  "dependencies": [
+   {
+    "dependency": "NVM_VERSION",
+    "parent": "Nightly",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "0.36.0"
+   },
+   {
+    "dependency": "NODE_VERSION",
+    "parent": "Nightly",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "18.16.0"
+   },
+   {
+    "dependency": "PYTHON_VERSION",
+    "parent": "Nightly",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "3.11"
+   },
+   {
+    "dependency": "WKHTMLTOPDF_VERSION",
+    "parent": "Nightly",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "0.12.5"
+   },
+   {
+    "dependency": "BENCH_VERSION",
+    "parent": "Nightly",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "5.16.2"
+   }
+  ],
   "docstatus": 0,
   "doctype": "Frappe Version",
-  "modified": "2020-11-12 17:30:35.182746",
+  "modified": "2023-07-21 19:46:37.813960",
   "name": "Nightly",
-  "number": 14,
+  "number": 15,
   "public": 1,
   "status": "Develop"
  },
  {
   "default": 1,
+  "dependencies": [
+   {
+    "dependency": "NVM_VERSION",
+    "parent": "Version 14",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "0.36.0"
+   },
+   {
+    "dependency": "NODE_VERSION",
+    "parent": "Version 14",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "14.19.0"
+   },
+   {
+    "dependency": "PYTHON_VERSION",
+    "parent": "Version 14",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "3.10"
+   },
+   {
+    "dependency": "WKHTMLTOPDF_VERSION",
+    "parent": "Version 14",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "0.12.5"
+   },
+   {
+    "dependency": "BENCH_VERSION",
+    "parent": "Version 14",
+    "parentfield": "dependencies",
+    "parenttype": "Frappe Version",
+    "version": "5.15.2"
+   }
+  ],
   "docstatus": 0,
   "doctype": "Frappe Version",
-  "modified": "2022-01-13 16:32:57.334902",
+  "modified": "2023-07-21 19:44:34.122005",
   "name": "Version 14",
   "number": 14,
   "public": 1,

--- a/press/press/doctype/frappe_version/frappe_version.json
+++ b/press/press/doctype/frappe_version/frappe_version.json
@@ -9,8 +9,11 @@
  "field_order": [
   "public",
   "number",
+  "column_break_ramy",
   "default",
-  "status"
+  "status",
+  "dependency_table_section",
+  "dependencies"
  ],
  "fields": [
   {
@@ -45,6 +48,21 @@
    "label": "Status",
    "options": "Develop\nBeta\nStable\nEnd of Life",
    "reqd": 1
+  },
+  {
+   "fieldname": "column_break_ramy",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "dependency_table_section",
+   "fieldtype": "Section Break",
+   "label": "Dependency Table"
+  },
+  {
+   "fieldname": "dependencies",
+   "fieldtype": "Table",
+   "label": "Version Dependencies",
+   "options": "Frappe Version Dependency"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -54,10 +72,11 @@
    "link_fieldname": "version"
   }
  ],
- "modified": "2021-01-12 09:55:49.348217",
+ "modified": "2023-07-19 16:24:24.727292",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Frappe Version",
+ "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
   {
@@ -75,5 +94,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/press/press/doctype/frappe_version/frappe_version.py
+++ b/press/press/doctype/frappe_version/frappe_version.py
@@ -4,8 +4,24 @@
 
 
 # import frappe
+import copy
 from frappe.model.document import Document
 
 
+DEFAULT_DEPENDENCIES = [
+	{"dependency": "NVM_VERSION", "version": "0.36.0"},
+	{"dependency": "NODE_VERSION", "version": "18.16.0"},
+	{"dependency": "PYTHON_VERSION", "version": "3.11"},
+	{"dependency": "WKHTMLTOPDF_VERSION", "version": "0.12.5"},
+	{"dependency": "BENCH_VERSION", "version": "5.16.2"},
+]
+
+
 class FrappeVersion(Document):
-	pass
+	def validate(self):
+		self.validate_dependencies()
+
+	def validate_dependencies(self):
+		dependencies = copy.deepcopy(DEFAULT_DEPENDENCIES)
+		if not hasattr(self, "dependencies") or not self.dependencies:
+			self.extend("dependencies", dependencies)

--- a/press/press/doctype/frappe_version/test_frappe_version.py
+++ b/press/press/doctype/frappe_version/test_frappe_version.py
@@ -38,4 +38,6 @@ def create_test_frappe_version(
 
 
 class TestFrappeVersion(unittest.TestCase):
-	pass
+	def test_create_frappe_version_with_default_dependencies(self):
+		frappe_version = create_test_frappe_version(13)
+		self.assertEqual(len(frappe_version.dependencies), 5)

--- a/press/press/doctype/frappe_version/test_frappe_version.py
+++ b/press/press/doctype/frappe_version/test_frappe_version.py
@@ -7,10 +7,31 @@ import frappe
 import unittest
 
 
-def create_test_frappe_version():
+def create_test_frappe_version(
+	number: int = 13,
+	nvm: str = "0.36.0",
+	node: str = "14.19.0",
+	python: str = "3.7",
+	wkhtmltopdf: str = "0.12.5",
+	bench: str = "5.15.2",
+):
 	"""Create test Frappe Version doc"""
+
+	dependencies = [
+		{"dependency": "NVM_VERSION", "version": nvm},
+		{"dependency": "NODE_VERSION", "version": node},
+		{"dependency": "PYTHON_VERSION", "version": python},
+		{"dependency": "WKHTMLTOPDF_VERSION", "version": wkhtmltopdf},
+		{"dependency": "BENCH_VERSION", "version": bench},
+	]
 	frappe_version = frappe.get_doc(
-		{"doctype": "Frappe Version", "name": "Version 13", "number": 13, "status": "Stable"}
+		{
+			"doctype": "Frappe Version",
+			"name": f"Version {number}",
+			"number": number,
+			"status": "Stable",
+			"dependencies": dependencies,
+		}
 	).insert(ignore_if_duplicate=True)
 	frappe_version.reload()
 	return frappe_version

--- a/press/press/doctype/frappe_version/test_frappe_version.py
+++ b/press/press/doctype/frappe_version/test_frappe_version.py
@@ -5,6 +5,7 @@
 
 import frappe
 import unittest
+import random
 
 
 def create_test_frappe_version(
@@ -39,5 +40,6 @@ def create_test_frappe_version(
 
 class TestFrappeVersion(unittest.TestCase):
 	def test_create_frappe_version_with_default_dependencies(self):
-		frappe_version = create_test_frappe_version(13)
+		version_number = random.randint(1, 100)
+		frappe_version = create_test_frappe_version(version_number)
 		self.assertEqual(len(frappe_version.dependencies), 5)

--- a/press/press/doctype/frappe_version_dependency/frappe_version_dependency.json
+++ b/press/press/doctype/frappe_version_dependency/frappe_version_dependency.json
@@ -1,0 +1,41 @@
+{
+ "actions": [],
+ "creation": "2023-07-13 12:18:06.259601",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "dependency",
+  "version"
+ ],
+ "fields": [
+  {
+   "fieldname": "dependency",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Dependency",
+   "reqd": 1
+  },
+  {
+   "fieldname": "version",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Version",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2023-07-19 15:45:52.544440",
+ "modified_by": "Administrator",
+ "module": "Press",
+ "name": "Frappe Version Dependency",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/press/press/doctype/frappe_version_dependency/frappe_version_dependency.py
+++ b/press/press/doctype/frappe_version_dependency/frappe_version_dependency.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Frappe and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class FrappeVersionDependency(Document):
+	pass

--- a/press/press/doctype/release_group/release_group.js
+++ b/press/press/doctype/release_group/release_group.js
@@ -91,10 +91,4 @@ frappe.ui.form.on('Release Group', {
 
 		frm.set_df_property('dependencies', 'cannot_add_rows', 1);
 	},
-	version: function (frm) {
-		if (frm.is_new()) {
-			frm.clear_table('dependencies');
-			frm.call('validate_dependencies');
-		}
-	},
 });


### PR DESCRIPTION
fixes: https://github.com/frappe/press/issues/948