### PR TITLE
Site Migration error quick fix

### DIFF
--- a/press/press/doctype/site/site.js
+++ b/press/press/doctype/site/site.js
@@ -117,7 +117,7 @@ frappe.ui.form.on('Site', {
 				'disable_database_access',
 				frm.doc.is_database_access_enabled,
 			],
-			[__('Create DNS Record'), 'create_dns_record'],
+			[__('Create DNS Record'), '_create_dns_record'],
 			[
 				__('Enable Database Write Access'),
 				'enable_read_write',

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -249,8 +249,13 @@ class Site(Document):
 		# log activity
 		log_site_activity(self.name, "Create")
 		self._create_default_site_domain()
-		create_dns_record(self, record_name=self._get_site_name(self.subdomain))
+		self._create_dns_record()
 		self.create_agent_request()
+
+	@frappe.whitelist()
+	def _create_dns_record(self):
+		"""Create dns record of site pointing to proxy."""
+		create_dns_record(doc=self, record_name=self._get_site_name(self.subdomain))
 
 	def remove_dns_record(self, domain: Document, proxy_server: str, site: str):
 		"""Remove dns record of site pointing to proxy."""

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -255,7 +255,9 @@ class Site(Document):
 	@frappe.whitelist()
 	def _create_dns_record(self):
 		"""Create dns record of site pointing to proxy."""
-		create_dns_record(doc=self, record_name=self._get_site_name(self.subdomain))
+		create_dns_record(
+			doc=self, record_name=self._get_site_name(self.subdomain)
+		)
 
 	def remove_dns_record(self, domain: Document, proxy_server: str, site: str):
 		"""Remove dns record of site pointing to proxy."""

--- a/press/press/doctype/site_migration/site_migration.py
+++ b/press/press/doctype/site_migration/site_migration.py
@@ -10,6 +10,7 @@ from frappe.model.document import Document
 from press.agent import Agent
 from press.press.doctype.site_backup.site_backup import process_backup_site_job_update
 from press.utils import log_error
+from press.utils.dns import create_dns_record
 
 
 def get_ongoing_migration(site: str, scheduled=False):
@@ -314,7 +315,7 @@ class SiteMigration(Document):
 		site.cluster = self.destination_cluster
 		site.server = self.destination_server
 		if self.migration_type == "Cluster":
-			site.create_dns_record()
+			site._create_dns_record()
 			domain = frappe.get_doc("Root Domain", site.domain)
 			if self.destination_cluster == domain.default_cluster:
 				source_proxy = frappe.db.get_value("Server", self.source_server, "proxy_server")

--- a/press/press/doctype/site_migration/site_migration.py
+++ b/press/press/doctype/site_migration/site_migration.py
@@ -10,7 +10,6 @@ from frappe.model.document import Document
 from press.agent import Agent
 from press.press.doctype.site_backup.site_backup import process_backup_site_job_update
 from press.utils import log_error
-from press.utils.dns import create_dns_record
 
 
 def get_ongoing_migration(site: str, scheduled=False):


### PR DESCRIPTION
Site Migration is failing due to DNS record error in which a method was removed from Site Class.

This adds the class with as a small abstraction layer.