### PR TITLE
fix: drip email after payment

### DIFF
--- a/press/press/doctype/drip_email/drip_email.py
+++ b/press/press/doctype/drip_email/drip_email.py
@@ -21,7 +21,7 @@ class DripEmail(Document):
 		if self.email_type == "Drip" and site.status in ["Pending", "Broken"]:
 			return
 
-		if not self.send_after_payment and site.has_paid:
+		if site.has_paid and not self.send_after_payment:
 			return
 
 		account_request = frappe.get_doc("Account Request", site.account_request)


### PR DESCRIPTION
The condition was checked in the wrong order, if the `send_after_payment` was unchecked, the condition would become false and the email would never send.