### PR TITLE
feat: Some method to setting default mariadb variables on servers

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -41,3 +41,4 @@ bench start &> bench_start_logs.txt &
 CI=Yes bench build --app frappe &
 bench new-site --db-root-password root --admin-password admin test_site
 bench --site test_site install-app press
+bench set-config -g server_script_enabled 1

--- a/press/api/tests/test_site.py
+++ b/press/api/tests/test_site.py
@@ -398,6 +398,7 @@ erpnext 0.8.3	    HEAD
 						"public": public,
 						"private": private,
 					},
+					"cluster": "Default",
 				}
 			)
 			poll_pending_jobs()

--- a/press/fixtures/mariadb_variable.json
+++ b/press/fixtures/mariadb_variable.json
@@ -8,6 +8,7 @@
   "dynamic": 1,
   "modified": "2023-06-15 14:41:36.038646",
   "name": "innodb_buffer_pool_size",
+  "set_on_new_servers": 0,
   "skippable": 0
  },
  {
@@ -19,17 +20,19 @@
   "dynamic": 0,
   "modified": "2023-06-15 14:41:09.156699",
   "name": "log_bin",
+  "set_on_new_servers": 0,
   "skippable": 1
  },
  {
   "datatype": "Int",
-  "default_value": "16",
+  "default_value": "512",
   "doc_section": "server",
   "docstatus": 0,
   "doctype": "MariaDB Variable",
   "dynamic": 1,
-  "modified": "2023-06-15 14:41:28.376813",
+  "modified": "2023-09-22 08:38:25.704420",
   "name": "max_allowed_packet",
+  "set_on_new_servers": 1,
   "skippable": 0
  },
  {
@@ -39,8 +42,9 @@
   "docstatus": 0,
   "doctype": "MariaDB Variable",
   "dynamic": 1,
-  "modified": "2023-06-15 14:41:18.419011",
+  "modified": "2023-09-22 08:38:16.807229",
   "name": "tmp_disk_table_size",
+  "set_on_new_servers": 1,
   "skippable": 0
  },
  {
@@ -52,6 +56,7 @@
   "dynamic": 0,
   "modified": "2023-07-27 18:21:51.984252",
   "name": "performance_schema",
+  "set_on_new_servers": 0,
   "skippable": 0
  },
  {
@@ -63,6 +68,7 @@
   "dynamic": 0,
   "modified": "2023-07-27 17:55:19.751992",
   "name": "performance-schema-instrument",
+  "set_on_new_servers": 0,
   "skippable": 0
  },
  {
@@ -74,6 +80,7 @@
   "dynamic": 0,
   "modified": "2023-07-27 17:55:19.766945",
   "name": "performance-schema-consumer-events-stages-current",
+  "set_on_new_servers": 0,
   "skippable": 0
  },
  {
@@ -85,6 +92,7 @@
   "dynamic": 0,
   "modified": "2023-07-27 17:55:19.784028",
   "name": "performance-schema-consumer-events-stages-history",
+  "set_on_new_servers": 0,
   "skippable": 0
  },
  {
@@ -96,6 +104,7 @@
   "dynamic": 0,
   "modified": "2023-07-27 17:55:19.809367",
   "name": "performance-schema-consumer-events-stages-history-long",
+  "set_on_new_servers": 0,
   "skippable": 0
  },
  {
@@ -107,6 +116,7 @@
   "dynamic": 0,
   "modified": "2023-07-27 17:55:19.833060",
   "name": "performance-schema-consumer-events-statements-current",
+  "set_on_new_servers": 0,
   "skippable": 0
  },
  {
@@ -118,6 +128,7 @@
   "dynamic": 0,
   "modified": "2023-07-27 17:55:19.851892",
   "name": "performance-schema-consumer-events-statements-history",
+  "set_on_new_servers": 0,
   "skippable": 0
  },
  {
@@ -129,6 +140,7 @@
   "dynamic": 0,
   "modified": "2023-07-27 17:55:19.870716",
   "name": "performance-schema-consumer-events-statements-history-long",
+  "set_on_new_servers": 0,
   "skippable": 0
  },
  {
@@ -140,6 +152,7 @@
   "dynamic": 0,
   "modified": "2023-07-27 17:55:19.951921",
   "name": "performance-schema-consumer-events-waits-current",
+  "set_on_new_servers": 0,
   "skippable": 0
  },
  {
@@ -151,6 +164,7 @@
   "dynamic": 0,
   "modified": "2023-07-27 17:55:19.971205",
   "name": "performance-schema-consumer-events-waits-history",
+  "set_on_new_servers": 0,
   "skippable": 0
  },
  {
@@ -162,6 +176,7 @@
   "dynamic": 0,
   "modified": "2023-07-27 17:55:19.987419",
   "name": "performance-schema-consumer-events-waits-history-long",
+  "set_on_new_servers": 0,
   "skippable": 0
  },
  {
@@ -173,6 +188,7 @@
   "dynamic": 1,
   "modified": "2023-08-03 14:20:47.702196",
   "name": "expire_logs_days",
+  "set_on_new_servers": 0,
   "skippable": 0
  },
  {
@@ -184,6 +200,7 @@
   "dynamic": 1,
   "modified": "2023-09-15 15:15:31.563815",
   "name": "innodb_old_blocks_time",
+  "set_on_new_servers": 0,
   "skippable": 0
  },
  {
@@ -195,6 +212,7 @@
   "dynamic": 1,
   "modified": "2023-09-15 15:21:13.086214",
   "name": "innodb_old_blocks_pct",
+  "set_on_new_servers": 0,
   "skippable": 0
  }
 ]

--- a/press/fixtures/press_job_type.json
+++ b/press/fixtures/press_job_type.json
@@ -2,7 +2,7 @@
  {
   "docstatus": 0,
   "doctype": "Press Job Type",
-  "modified": "2023-08-14 15:59:21.127979",
+  "modified": "2023-09-22 08:37:36.852558",
   "name": "Create Server",
   "steps": [
    {
@@ -41,7 +41,7 @@
     "parent": "Create Server",
     "parentfield": "steps",
     "parenttype": "Press Job Type",
-    "script": "plays = frappe.get_all(\"Ansible Play\", {\"server\": doc.server, \"play\": \"Setup TLS Certificates\"}, [\"status\"], order_by=\"creation desc\", limit=1)\nresult = (plays and plays[0].status == \"Success\", False)",
+    "script": "plays = frappe.get_all(\"Ansible Play\", {\"server\": doc.server, \"play\": \"Setup TLS Certificates\"}, [\"status\"], order_by=\"creation desc\", limit=1)\nresult = (plays and plays[0].status in (\"Success\", \"Failure\"), False)",
     "step_name": "Wait for TLS Certificate to be updated",
     "wait_until_true": 1
    },
@@ -57,9 +57,17 @@
     "parent": "Create Server",
     "parentfield": "steps",
     "parenttype": "Press Job Type",
-    "script": "plays = frappe.get_all(\"Ansible Play\", {\"server\": doc.server, \"play\": \"Update Agent\"}, [\"status\"], order_by=\"creation desc\", limit=1)\nresult = (plays and plays[0].status == \"Success\", False)",
+    "script": "plays = frappe.get_all(\"Ansible Play\", {\"server\": doc.server, \"play\": \"Update Agent\"}, [\"status\"], order_by=\"creation desc\", limit=1)\nresult = (plays and plays[0].status in (\"Success\", \"Failure\"), False)",
     "step_name": "Wait for Agent to be updated",
     "wait_until_true": 1
+   },
+   {
+    "parent": "Create Server",
+    "parentfield": "steps",
+    "parenttype": "Press Job Type",
+    "script": "if doc.server_type == \"Database Server\":\n    default_variables = frappe.get_all(\"MariaDB Variable\", {\"set_on_new_servers\":1}, pluck=\"name\")\n    for var_name in default_variables:\n        var = frappe.get_doc(\"MariaDB Variable\", var_name)\n        var.set_on_server(doc.server)",
+    "step_name": "Set additional config",
+    "wait_until_true": 0
    }
   ]
  },

--- a/press/playbooks/roles/mariadb/templates/mariadb.cnf
+++ b/press/playbooks/roles/mariadb/templates/mariadb.cnf
@@ -34,6 +34,7 @@ thread-cache-size               = 50
 open-files-limit                = 65535
 table-definition-cache          = 4096
 table-open-cache                = 10240
+tmp-disk-table-size							= 5120M
 
 # INNODB #
 innodb-flush-method             = O_DIRECT

--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -162,7 +162,7 @@ class DatabaseServer(BaseServer):
 		if play.status == "Failure":
 			log_error("MariaDB Restart Error", server=self.name)
 
-	def add_variable(
+	def add_mariadb_variable(
 		self,
 		variable: str,
 		value_type: str,

--- a/press/press/doctype/database_server/test_database_server.py
+++ b/press/press/doctype/database_server/test_database_server.py
@@ -6,6 +6,7 @@
 from unittest.mock import MagicMock, Mock, patch
 
 import frappe
+from frappe.model.naming import make_autoname
 from frappe.tests.utils import FrappeTestCase
 
 from press.press.doctype.database_server.database_server import DatabaseServer
@@ -26,7 +27,7 @@ def create_test_database_server(ip=None, cluster="Default") -> DatabaseServer:
 			"ip": ip,
 			"private_ip": frappe.mock("ipv4_private"),
 			"agent_password": frappe.mock("password"),
-			"hostname": "m",
+			"hostname": f"m{make_autoname('.##')}",
 			"cluster": cluster,
 		}
 	).insert(ignore_if_duplicate=True)

--- a/press/press/doctype/database_server_mariadb_variable/test_database_server_mariadb_variable.py
+++ b/press/press/doctype/database_server_mariadb_variable/test_database_server_mariadb_variable.py
@@ -338,3 +338,39 @@ class TestDatabaseServerMariaDBVariable(FrappeTestCase):
 			server.save()
 		except Exception:
 			self.fail("Update of doc without variables failed")
+
+	@patch(
+		"press.press.doctype.database_server.database_server.frappe.enqueue_doc",
+		new=foreground_enqueue_doc,
+	)
+	def test_add_variable_method_adds_and_updates_variables(self):
+		server = create_test_database_server()
+
+		with patch(
+			"press.press.doctype.database_server_mariadb_variable.database_server_mariadb_variable.Ansible",
+			wraps=Ansible,
+		) as Mock_Ansible:
+			server.add_variable("tmp_disk_table_size", "value_int", 10241)
+
+		Mock_Ansible.assert_called_once()
+
+		server.reload()
+		self.assertEqual(1, len(server.mariadb_system_variables))
+		self.assertEqual(
+			"tmp_disk_table_size", server.mariadb_system_variables[0].mariadb_variable
+		)
+		self.assertEqual(10241, server.mariadb_system_variables[0].value_int)
+
+		with patch(
+			"press.press.doctype.database_server_mariadb_variable.database_server_mariadb_variable.Ansible",
+			wraps=Ansible,
+		) as Mock_Ansible:
+			server.add_variable("tmp_disk_table_size", "value_int", 10242)
+
+		Mock_Ansible.assert_called_once()
+
+		self.assertEqual(1, len(server.mariadb_system_variables))
+		self.assertEqual(
+			"tmp_disk_table_size", server.mariadb_system_variables[0].mariadb_variable
+		)
+		self.assertEqual(10242, server.mariadb_system_variables[0].value_int)

--- a/press/press/doctype/database_server_mariadb_variable/test_database_server_mariadb_variable.py
+++ b/press/press/doctype/database_server_mariadb_variable/test_database_server_mariadb_variable.py
@@ -374,3 +374,19 @@ class TestDatabaseServerMariaDBVariable(FrappeTestCase):
 			"tmp_disk_table_size", server.mariadb_system_variables[0].mariadb_variable
 		)
 		self.assertEqual(10242, server.mariadb_system_variables[0].value_int)
+
+		with patch(
+			"press.press.doctype.database_server_mariadb_variable.database_server_mariadb_variable.Ansible",
+			wraps=Ansible,
+		) as Mock_Ansible:
+			server.add_variable("tmp_disk_table_size", "value_int", 10242)  # no change
+		Mock_Ansible.assert_not_called()
+
+		with patch(
+			"press.press.doctype.database_server_mariadb_variable.database_server_mariadb_variable.Ansible",
+			wraps=Ansible,
+		) as Mock_Ansible:
+			server.add_variable(
+				"tmp_disk_table_size", "value_int", 10242, persist=False
+			)  # no change
+		Mock_Ansible.assert_called_once()

--- a/press/press/doctype/database_server_mariadb_variable/test_database_server_mariadb_variable.py
+++ b/press/press/doctype/database_server_mariadb_variable/test_database_server_mariadb_variable.py
@@ -350,7 +350,7 @@ class TestDatabaseServerMariaDBVariable(FrappeTestCase):
 			"press.press.doctype.database_server_mariadb_variable.database_server_mariadb_variable.Ansible",
 			wraps=Ansible,
 		) as Mock_Ansible:
-			server.add_variable("tmp_disk_table_size", "value_int", 10241)
+			server.add_mariadb_variable("tmp_disk_table_size", "value_int", 10241)
 
 		Mock_Ansible.assert_called_once()
 
@@ -365,7 +365,7 @@ class TestDatabaseServerMariaDBVariable(FrappeTestCase):
 			"press.press.doctype.database_server_mariadb_variable.database_server_mariadb_variable.Ansible",
 			wraps=Ansible,
 		) as Mock_Ansible:
-			server.add_variable("tmp_disk_table_size", "value_int", 10242)
+			server.add_mariadb_variable("tmp_disk_table_size", "value_int", 10242)
 
 		Mock_Ansible.assert_called_once()
 
@@ -379,14 +379,14 @@ class TestDatabaseServerMariaDBVariable(FrappeTestCase):
 			"press.press.doctype.database_server_mariadb_variable.database_server_mariadb_variable.Ansible",
 			wraps=Ansible,
 		) as Mock_Ansible:
-			server.add_variable("tmp_disk_table_size", "value_int", 10242)  # no change
+			server.add_mariadb_variable("tmp_disk_table_size", "value_int", 10242)  # no change
 		Mock_Ansible.assert_not_called()
 
 		with patch(
 			"press.press.doctype.database_server_mariadb_variable.database_server_mariadb_variable.Ansible",
 			wraps=Ansible,
 		) as Mock_Ansible:
-			server.add_variable(
+			server.add_mariadb_variable(
 				"tmp_disk_table_size", "value_int", 10242, persist=False
 			)  # no change
 		Mock_Ansible.assert_called_once()

--- a/press/press/doctype/mariadb_variable/mariadb_variable.js
+++ b/press/press/doctype/mariadb_variable/mariadb_variable.js
@@ -8,5 +8,19 @@ frappe.ui.form.on('MariaDB Variable', {
 			`${root}${frm.doc.doc_section}-system-variables/#${frm.doc.name}`,
 			__('Check MariaDB Documentation'),
 		);
+		frm.add_custom_button(__('Set on all servers'), () => {
+			frappe.confirm(
+				`Are you sure you want to set variable on all servers?
+								If variable is not dynamic, mariadb will be restarted`,
+				() =>
+					frm.call('set_on_all_servers').then((r) => {
+						if (r.message) {
+							frappe.msgprint(r.message);
+						} else {
+							frm.refresh();
+						}
+					}),
+			);
+		});
 	},
 });

--- a/press/press/doctype/mariadb_variable/mariadb_variable.json
+++ b/press/press/doctype/mariadb_variable/mariadb_variable.json
@@ -15,7 +15,7 @@
   "skippable",
   "column_break_yrfg",
   "default_value",
-  "set_default_value_in_new_servers"
+  "set_on_new_servers"
  ],
  "fields": [
   {
@@ -58,14 +58,14 @@
   },
   {
    "default": "0",
-   "fieldname": "set_default_value_in_new_servers",
+   "fieldname": "set_on_new_servers",
    "fieldtype": "Check",
-   "label": "Set in new servers"
+   "label": "Set on new servers"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-09-22 04:41:46.696434",
+ "modified": "2023-09-22 08:36:43.526135",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "MariaDB Variable",

--- a/press/press/doctype/mariadb_variable/mariadb_variable.json
+++ b/press/press/doctype/mariadb_variable/mariadb_variable.json
@@ -12,8 +12,10 @@
   "dynamic",
   "datatype",
   "doc_section",
+  "skippable",
+  "column_break_yrfg",
   "default_value",
-  "skippable"
+  "set_default_value_in_new_servers"
  ],
  "fields": [
   {
@@ -49,11 +51,21 @@
    "label": "Doc Section",
    "options": "server\nreplication-and-binary-log\ninnodb",
    "reqd": 1
+  },
+  {
+   "fieldname": "column_break_yrfg",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "set_default_value_in_new_servers",
+   "fieldtype": "Check",
+   "label": "Set in new servers"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-07-27 17:35:06.034806",
+ "modified": "2023-09-22 04:41:46.696434",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "MariaDB Variable",

--- a/press/press/doctype/mariadb_variable/mariadb_variable.py
+++ b/press/press/doctype/mariadb_variable/mariadb_variable.py
@@ -1,9 +1,28 @@
 # Copyright (c) 2023, Frappe and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+
+from press.press.doctype.database_server.database_server import DatabaseServer
 
 
 class MariaDBVariable(Document):
-	pass
+	@frappe.whitelist()
+	def set_on_all_servers(self):
+		if not (value := self.default_value):
+			frappe.throw("Default Value is required")
+		match self.datatype:
+			case "Int":
+				value = int(self.default_value)
+			case "Float":
+				value = float(self.default_value)
+			case "Bool":
+				value = bool(self.default_value)
+
+		servers = frappe.get_all(
+			"Database Server", {"status": "Active", "is_self_hosted": False}, pluck="name"
+		)
+		for server_name in servers:
+			server: DatabaseServer = frappe.get_doc("Database Server", server_name)
+			server.add_mariadb_variable(self.name, f"value_{self.datatype.lower()}", value)

--- a/press/press/doctype/mariadb_variable/test_mariadb_variable.py
+++ b/press/press/doctype/mariadb_variable/test_mariadb_variable.py
@@ -1,9 +1,41 @@
 # Copyright (c) 2023, Frappe and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from press.press.doctype.database_server.test_database_server import (
+	create_test_database_server,
+)
 
 
 class TestMariaDBVariable(FrappeTestCase):
-	pass
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_set_on_all_servers_sets_on_all_servers(self):
+
+		db_1 = create_test_database_server()
+		db_2 = create_test_database_server()
+		db_1.add_mariadb_variable("tmp_disk_table_size", "value_int", 1024)
+		db_1.add_mariadb_variable("innodb_old_blocks_time", "value_str", "1000")
+
+		variable = frappe.get_doc("MariaDB Variable", "tmp_disk_table_size")  # in fixture
+		variable.default_value = "5120"
+		variable.save()
+
+		variable.set_on_all_servers()
+		db_1.reload()
+		db_2.reload()
+		self.assertEqual(db_1.mariadb_system_variables[0].value, 5120 * 1024 * 1024)
+		self.assertEqual(db_2.mariadb_system_variables[0].value, 5120 * 1024 * 1024)
+
+		variable = frappe.get_doc("MariaDB Variable", "innodb_old_blocks_time")
+		variable.default_value = "5000"
+		variable.save()
+
+		variable.set_on_all_servers()
+		db_1.reload()
+		db_2.reload()
+		self.assertEqual(db_1.mariadb_system_variables[1].value, "5000")
+		self.assertEqual(db_2.mariadb_system_variables[1].value, "5000")

--- a/press/press/doctype/mariadb_variable/test_mariadb_variable.py
+++ b/press/press/doctype/mariadb_variable/test_mariadb_variable.py
@@ -39,3 +39,30 @@ class TestMariaDBVariable(FrappeTestCase):
 		db_2.reload()
 		self.assertEqual(db_1.mariadb_system_variables[1].value, "5000")
 		self.assertEqual(db_2.mariadb_system_variables[1].value, "5000")
+
+	def test_set_on_server_sets_on_one_server(self):
+		db_1 = create_test_database_server()
+		db_2 = create_test_database_server()
+		db_2.add_mariadb_variable("tmp_disk_table_size", "value_int", 1024)
+		db_1.add_mariadb_variable("tmp_disk_table_size", "value_int", 1024)
+		db_1.add_mariadb_variable("innodb_old_blocks_time", "value_str", "1000")
+
+		variable = frappe.get_doc("MariaDB Variable", "tmp_disk_table_size")
+		variable.default_value = "5120"
+		variable.save()
+
+		variable.set_on_server(db_1.name)
+		db_1.reload()
+		db_2.reload()
+		self.assertEqual(db_1.mariadb_system_variables[0].value, 5120 * 1024 * 1024)
+		self.assertEqual(db_2.mariadb_system_variables[0].value, 1024 * 1024 * 1024)
+
+		variable = frappe.get_doc("MariaDB Variable", "innodb_old_blocks_time")
+		variable.default_value = "5000"
+		variable.save()
+
+		variable.set_on_server(db_2.name)
+		db_1.reload()
+		db_2.reload()
+		self.assertEqual(db_1.mariadb_system_variables[1].value, "1000")
+		self.assertEqual(db_2.mariadb_system_variables[1].value, "5000")


### PR DESCRIPTION
![image](https://github.com/frappe/press/assets/25403045/7615b8db-fdbc-4ae5-bd94-fe3438f8d937)

Checkbox if variable has to be set with default value on new servers. And button to update on existing ones.

![image](https://github.com/frappe/press/assets/25403045/341523a7-3d1e-4077-95f0-ef9155b14a0c)

New step in create server job for the same

