### PR TITLE
refactor(BenchDependencies): similar edit flow of Bench Config

### DIFF
--- a/dashboard/src/views/bench/BenchDependencies.vue
+++ b/dashboard/src/views/bench/BenchDependencies.vue
@@ -6,51 +6,20 @@
 	>
 		<template #actions>
 			<Button
-				v-if="editMode"
+				v-if="isDirty"
 				label="Update"
 				@click="$resources.updateDependencies.submit()"
+				:loading="$resources.updateDependencies.loading"
 			/>
-			<Button v-else label="Edit" @click="editMode = true" />
 		</template>
-		<table class="min-w-full divide-y divide-gray-300">
-			<thead>
-				<tr class="divide-x divide-gray-200">
-					<th
-						scope="col"
-						class="py-3.5 pl-4 pr-4 text-left text-base font-semibold text-gray-900 sm:pl-0"
-					>
-						Dependency
-					</th>
-					<th
-						scope="col"
-						class="px-4 py-3.5 text-left text-base font-semibold text-gray-900"
-					>
-						Version
-					</th>
-				</tr>
-			</thead>
-			<tbody class="divide-y divide-gray-200 bg-white">
-				<tr
-					v-for="dependency in $resources.dependencies.data"
-					:key="dependency.key"
-					class="divide-x divide-gray-200"
-				>
-					<td
-						class="whitespace-nowrap py-4 pl-4 pr-4 text-sm font-medium text-gray-900 sm:pl-0"
-					>
-						{{ dependency.key.split('_').join(' ') }}
-					</td>
-					<td class="whitespace-nowrap text-sm text-gray-500">
-						<input
-							class="border-none focus:text-gray-800 focus:ring-0"
-							v-model="dependency.value"
-							@input="isDirty = true"
-							:disabled="!editMode"
-						/>
-					</td>
-				</tr>
-			</tbody>
-		</table>
+		<FormControl
+			v-for="dependency in $resources.dependencies.data"
+			:key="dependency.key"
+			v-model="dependency.value"
+			:label="dependency.key.split('_').join(' ')"
+			class="my-2"
+			@input="isDirty = true"
+		/>
 	</Card>
 </template>
 
@@ -62,7 +31,6 @@ export default {
 	props: ['benchName'],
 	data() {
 		return {
-			editMode: false,
 			isDirty: false
 		};
 	},
@@ -89,7 +57,6 @@ export default {
 				},
 				onSuccess() {
 					this.isDirty = false;
-					this.editMode = false;
 				},
 				onError(err) {
 					notify({

--- a/dashboard/src/views/bench/BenchDependencies.vue
+++ b/dashboard/src/views/bench/BenchDependencies.vue
@@ -17,7 +17,7 @@
 			:key="dependency.key"
 			v-model="dependency.value"
 			:label="dependency.key.split('_').join(' ')"
-			class="my-2"
+			class="mx-0.5 my-2"
 			@input="isDirty = true"
 		/>
 	</Card>


### PR DESCRIPTION
related #1053 

The table looked out of place with what we had so re-using the design from bench config

## Before

![image](https://github.com/frappe/press/assets/63963181/2ea4652f-76e1-4cc1-bde3-290298590274)

## After

![image](https://github.com/frappe/press/assets/63963181/4e53877f-1255-451b-b5c7-48aae5704737)

