### PR TITLE
fix(PressJob): Set Mariadb config automatically on resize

### DIFF
--- a/press/fixtures/press_job_type.json
+++ b/press/fixtures/press_job_type.json
@@ -74,7 +74,7 @@
  {
   "docstatus": 0,
   "doctype": "Press Job Type",
-  "modified": "2022-11-01 14:38:02.723500",
+  "modified": "2023-09-27 15:52:54.416534",
   "name": "Resize Server",
   "steps": [
    {
@@ -116,6 +116,14 @@
     "script": "machine = frappe.get_doc(\"Virtual Machine\", doc.virtual_machine)\nmachine.sync()\nresult = (machine.status == \"Running\", False)",
     "step_name": "Wait for Virtual Machine to Start",
     "wait_until_true": 1
+   },
+   {
+    "parent": "Resize Server",
+    "parentfield": "steps",
+    "parenttype": "Press Job Type",
+    "script": "if doc.doctype == \"Database Server\":\n    server = frappe.get_doc(doc.doctype, doc.server)\n    server.adjust_memory_config()",
+    "step_name": "Set additional config",
+    "wait_until_true": 0
    }
   ]
  },

--- a/press/fixtures/press_job_type.json
+++ b/press/fixtures/press_job_type.json
@@ -74,7 +74,7 @@
  {
   "docstatus": 0,
   "doctype": "Press Job Type",
-  "modified": "2023-09-27 15:52:54.416534",
+  "modified": "2023-10-03 17:11:39.766483",
   "name": "Resize Server",
   "steps": [
    {
@@ -121,7 +121,7 @@
     "parent": "Resize Server",
     "parentfield": "steps",
     "parenttype": "Press Job Type",
-    "script": "if doc.doctype == \"Database Server\":\n    server = frappe.get_doc(doc.doctype, doc.server)\n    server.adjust_memory_config()",
+    "script": "if doc.server_type == \"Database Server\":\n    server = frappe.get_doc(doc.server_type, doc.server)\n    server.adjust_memory_config()",
     "step_name": "Set additional config",
     "wait_until_true": 0
    }

--- a/press/press/doctype/database_server/database_server.json
+++ b/press/press/doctype/database_server/database_server.json
@@ -45,6 +45,9 @@
   "ssh_user",
   "ssh_port",
   "root_public_key",
+  "section_break_cees",
+  "ram",
+  "column_break_apox",
   "tags_section",
   "tags",
   "mariadb_settings_tab",
@@ -364,11 +367,24 @@
    "fieldtype": "Table",
    "label": "Tags",
    "options": "Resource Tag"
+  },
+  {
+   "fieldname": "section_break_cees",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "ram",
+   "fieldtype": "Float",
+   "label": "RAM (MB)"
+  },
+  {
+   "fieldname": "column_break_apox",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-07-30 22:29:30.346012",
+ "modified": "2023-09-24 09:11:57.951188",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Database Server",

--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -572,6 +572,20 @@ class DatabaseServer(BaseServer):
 			log_error("Database Server Rename Exception", server=self.as_dict())
 		self.save()
 
+	def adjust_memory_config(self):
+		if not self.ram:
+			return
+
+		self.memory_high = max(self.ram // 1024 - 2, 1)
+		self.memory_max = max(self.ram // 1024 - 1, 2)
+		self.save()
+
+		self.add_mariadb_variable(
+			"innodb_buffer_pool_size",
+			"value_int",
+			int(self.ram * 0.685),  # will be rounded up based on chunk_size
+		)
+
 
 get_permission_query_conditions = get_permission_query_conditions_for_doctype(
 	"Database Server"


### PR DESCRIPTION
- feat(DatabaseServer): Add ram field like in server
- fix(APISite): Allow protected methods to be called non request contexts
- fix(PressJob): Autoset memory related variables on server resize
