### PR TITLE
feat: show all private apps from the bench if bench is under user ownership

### DIFF
--- a/press/api/tests/test_site.py
+++ b/press/api/tests/test_site.py
@@ -66,6 +66,30 @@ class TestAPISite(FrappeTestCase):
 				self.assertEqual(version["group"]["name"], group14.name)
 
 	@patch.object(AgentJob, "enqueue_http_request", new=Mock())
+	def test_all_private_apps_from_bench_if_app_source_team_is_different(self):
+		from press.api.site import get_new_site_options
+
+		apps = []
+		new_team = create_test_press_admin_team("testteam1@frappe.cloud")
+
+		for app_to_mock in [
+			("frappe", "Frappe Framework", self.team.name),
+			("erpnext", "ERPNext", self.team.name),
+			("test app", "Test App", new_team.name),
+		]:
+			apps.append(create_test_app(app_to_mock[0], app_to_mock[1], app_to_mock[2]))
+
+		server = create_test_server()
+		group15 = create_test_release_group(
+			apps, user=self.team.user, frappe_version="Version 15"
+		)
+
+		create_test_bench(group=group15, server=server.name)
+		frappe.set_user(self.team.user)
+
+		get_new_site_options(group15.name)
+
+	@patch.object(AgentJob, "enqueue_http_request", new=Mock())
 	def test_new_fn_creates_site_and_subscription(self):
 		from press.api.site import new
 

--- a/press/press/doctype/app/test_app.py
+++ b/press/press/doctype/app/test_app.py
@@ -13,10 +13,12 @@ if TYPE_CHECKING:
 	from press.press.doctype.app.app import App
 
 
-def create_test_app(name: str = "frappe", title: str = "Frappe Framework") -> "App":
-	return frappe.get_doc({"doctype": "App", "name": name, "title": title}).insert(
-		ignore_if_duplicate=True
-	)
+def create_test_app(
+	name: str = "frappe", title: str = "Frappe Framework", team: str = None
+) -> "App":
+	return frappe.get_doc(
+		{"doctype": "App", "name": name, "title": title, "team": team}
+	).insert(ignore_if_duplicate=True)
 
 
 class TestApp(unittest.TestCase):

--- a/press/press/doctype/release_group/test_release_group.py
+++ b/press/press/doctype/release_group/test_release_group.py
@@ -39,7 +39,9 @@ def create_test_release_group(
 		}
 	)
 	for app in apps:
-		app_source = create_test_app_source(release_group.version, app)
+		app_source = create_test_app_source(
+			release_group.version, app, team=app.get("team", None)
+		)
 		release_group.append("apps", {"app": app.name, "source": app_source.name})
 
 	release_group.insert(ignore_if_duplicate=True)

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -306,7 +306,7 @@ class Team(Document):
 			self.save(ignore_permissions=True)
 
 	def get_partnership_start_date(self):
-		if frappe.flags.in_test:
+		if frappe.flags.in_test or frappe.flags.in_install:
 			return frappe.utils.getdate()
 
 		client = get_frappe_io_connection()


### PR DESCRIPTION
## Issue:

If bench team and app source team is different then the system is not showing those apps while creating new site though the apps are installed on the bench.

## Fix:
Validate bench ownership while pulling apps