### PR TITLE
fix(AppSource): remove `.git` from repo url

### DIFF
--- a/press/press/doctype/app_source/app_source.py
+++ b/press/press/doctype/app_source/app_source.py
@@ -61,6 +61,8 @@ class AppSource(Document):
 
 	def before_save(self):
 		# Assumes repository_url looks like https://github.com/frappe/erpnext
+		self.repository_url = self.repository_url.removesuffix(".git")
+
 		_, self.repository_owner, self.repository = self.repository_url.rsplit("/", 2)
 		# self.create_release()
 


### PR DESCRIPTION
If `repository_url` ends with `".git"` then `repository` is set as `"[REPO_NAME].git"`.

This causes:
- GitHub API call to fail with a `"Not Found"`.
- `last_github_poll_failed` to be set to `False`.
  - Renders the App Source broken unless `fetchLatestAppUpdate` is called from the dashboard
- App Release to silently not be created (`AppSource#create_release` is called on insert, silently fails).
- `ReleaseGroup#create_deploy_candidate` to fail with an `apps` mandatory error.
- Frustration.
