### PR TITLE
fix(Bench): Redo math for memory limit calc

### DIFF
--- a/press/press/doctype/bench/bench.json
+++ b/press/press/doctype/bench/bench.json
@@ -22,6 +22,7 @@
   "gunicorn_workers",
   "port_offset",
   "auto_scale_workers",
+  "skip_memory_limits",
   "is_single_container",
   "is_ssh_enabled",
   "memory_high",
@@ -284,10 +285,16 @@
    "fieldname": "memory_swap",
    "fieldtype": "Int",
    "label": "Memory Swap (MB)"
+  },
+  {
+   "default": "0",
+   "fieldname": "skip_memory_limits",
+   "fieldtype": "Check",
+   "label": "Skip Memory Limits"
   }
  ],
  "links": [],
- "modified": "2023-10-17 11:45:33.339042",
+ "modified": "2023-10-27 09:27:05.409734",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Bench",

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -390,20 +390,26 @@ class Bench(Document):
 		Allocates workers and memory if required
 		"""
 		try:
-			maximum = frappe.get_value("Release Group", self.group, "max_gunicorn_workers")
-			minimum = frappe.get_value("Release Group", self.group, "min_gunicorn_workers")
+			max_gn, min_gn, max_bg, min_bg = frappe.db.get_values(
+				"Release Group",
+				self.group,
+				(
+					"max_gunicorn_workers",
+					"min_gunicorn_workers",
+					"max_background_workers",
+					"min_background_workers",
+				),
+			)[0]
 			self.gunicorn_workers = min(
-				maximum or 24,
+				max_gn or 24,
 				max(
-					minimum or 2, round(self.workload / server_workload * max_gunicorn_workers)
+					min_gn or 2, round(self.workload / server_workload * max_gunicorn_workers)
 				),  # min 2 max 24
 			)
-			maximum = frappe.get_value("Release Group", self.group, "max_background_workers")
-			minimum = frappe.get_value("Release Group", self.group, "min_background_workers")
 			self.background_workers = min(
-				maximum or 8,
+				max_bg or 8,
 				max(
-					minimum or 1, round(self.workload / server_workload * max_bg_workers)
+					min_bg or 1, round(self.workload / server_workload * max_bg_workers)
 				),  # min 1 max 8
 			)
 		except ZeroDivisionError:  # when total_workload is 0

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -416,7 +416,7 @@ class Bench(Document):
 			self.gunicorn_workers = 2
 			self.background_workers = 1
 		if set_memory_limits:
-			self.memory_high = (
+			self.memory_high = 512 + (
 				self.gunicorn_workers * gunicorn_memory + self.background_workers * bg_memory
 			)
 			self.memory_max = self.memory_high + gunicorn_memory + bg_memory

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -416,10 +416,14 @@ class Bench(Document):
 			self.gunicorn_workers = 2
 			self.background_workers = 1
 		if set_memory_limits:
-			self.memory_high = 512 + (
-				self.gunicorn_workers * gunicorn_memory + self.background_workers * bg_memory
-			)
-			self.memory_max = self.memory_high + gunicorn_memory + bg_memory
+			if self.skip_memory_limits:
+				self.memory_max = frappe.db.get_value("Server", self.server, "ram")
+				self.memory_high = self.memory_max - 1024
+			else:
+				self.memory_high = 512 + (
+					self.gunicorn_workers * gunicorn_memory + self.background_workers * bg_memory
+				)
+				self.memory_max = self.memory_high + gunicorn_memory + bg_memory
 			self.memory_swap = self.memory_max * 2
 		self.save()
 		return self.gunicorn_workers, self.background_workers

--- a/press/press/doctype/bench/test_bench.py
+++ b/press/press/doctype/bench/test_bench.py
@@ -238,3 +238,30 @@ class TestBench(unittest.TestCase):
 		self.assertFalse(bench2.memory_high)
 		self.assertFalse(bench2.memory_max)
 		self.assertFalse(bench2.memory_swap)
+
+	def test_memory_limits_set_to_server_ram_when_skip_memory_limits_is_set(self):
+		bench1 = self._create_bench_with_n_sites_with_cpu_time(3, 5)
+		bench2 = self._create_bench_with_n_sites_with_cpu_time(3, 5)
+
+		bench1.reload()
+		bench2.reload()
+		self.assertEqual(bench1.memory_high, 0)
+		self.assertEqual(bench1.memory_max, 0)
+		self.assertEqual(bench2.memory_high, 0)
+		self.assertEqual(bench2.memory_max, 0)
+		frappe.db.set_value("Server", bench1.server, "set_bench_memory_limits", True)
+		frappe.db.set_value("Bench", bench1.name, "skip_memory_limits", True)
+		server = frappe.get_doc("Server", bench1.server)
+
+		scale_workers()
+
+		bench1.reload()
+		bench2.reload()
+		self.assertTrue(bench1.memory_high)
+		self.assertEqual(bench1.memory_high, server.ram - 1024)
+		self.assertEqual(bench1.memory_max, server.ram)
+		self.assertEqual(bench1.memory_swap, server.ram * 2)
+
+		self.assertFalse(bench2.memory_high)
+		self.assertFalse(bench2.memory_max)
+		self.assertFalse(bench2.memory_swap)

--- a/press/press/doctype/bench/test_bench.py
+++ b/press/press/doctype/bench/test_bench.py
@@ -221,12 +221,14 @@ class TestBench(unittest.TestCase):
 		self.assertTrue(bench1.memory_swap)
 		self.assertEqual(
 			bench1.memory_high,
-			bench1.gunicorn_workers * server.GUNICORN_MEMORY
+			512
+			+ bench1.gunicorn_workers * server.GUNICORN_MEMORY
 			+ bench1.background_workers * server.BACKGROUND_JOB_MEMORY,
 		)
 		self.assertEqual(
 			bench1.memory_max,
-			bench1.gunicorn_workers * server.GUNICORN_MEMORY
+			512
+			+ bench1.gunicorn_workers * server.GUNICORN_MEMORY
 			+ bench1.background_workers * server.BACKGROUND_JOB_MEMORY
 			+ server.GUNICORN_MEMORY
 			+ server.BACKGROUND_JOB_MEMORY,


### PR DESCRIPTION
- refactor(Bench): Use 1 query to get values instead of 4
- fix(Bench): Consider memory used by redis and others in memory allocation
- feat(Bench): Add checkbox to skip memory limits optionally
