### PR TITLE
fix: Serialize agent job callbacks without deadlock

### DIFF
--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -244,6 +244,7 @@ def poll_pending_jobs_server(server):
 			# Update Job Status
 			# If it is worthy of an update
 			if job.status != polled_job["status"]:
+				lock_doc_updated_by_job(job.name)
 				update_job(job.name, polled_job)
 
 			# Update Steps' Status
@@ -325,7 +326,6 @@ def lock_doc_updated_by_job(job_name):
 
 
 def update_job(job_name, job):
-	lock_doc_updated_by_job(job_name)
 	job_data = json.dumps(job["data"], indent=4, sort_keys=True)
 	frappe.db.set_value(
 		"Agent Job",

--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -380,6 +380,7 @@ def update_steps(job_name, job):
 	for polled_step in job["steps"]:
 		step = find(steps, lambda x: x.step_name == polled_step["name"])
 		if step and step.status != polled_step["status"]:
+			lock_doc_updated_by_job(job_name)
 			update_step(step.name, polled_step)
 
 

--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -302,7 +302,30 @@ def fail_old_jobs():
 	)
 
 
+def lock_doc_updated_by_job(job_name):
+	"""
+	Ensure serializability of callback of jobs associated with the same document
+
+	All select queries in this transaction should have for_update True for this to work correctly
+	"""
+	doc_names = frappe.db.get_values(
+		"Agent Job", job_name, ["site", "bench", "server", "server_type"], as_dict=True
+	)[
+		0
+	]  # relies on order of values to be site, bench..
+	for field, doc_name in doc_names.items():
+		doctype = field.capitalize()
+		if field == "server":
+			doctype = doc_names["server_type"]
+		elif field == "server_type":  # ideally will never happen, but sanity
+			return
+		if doc_name:
+			frappe.db.get_value(doctype, doc_name, "modified", for_update=True)
+			return doc_name
+
+
 def update_job(job_name, job):
+	lock_doc_updated_by_job(job_name)
 	job_data = json.dumps(job["data"], indent=4, sort_keys=True)
 	frappe.db.set_value(
 		"Agent Job",

--- a/press/press/doctype/code_server/code_server.py
+++ b/press/press/doctype/code_server/code_server.py
@@ -89,18 +89,17 @@ class CodeServer(Document):
 def process_new_code_server_job_update(job):
 	frappe.db.get_value("Code Server", job.code_server, "status", for_update=True)
 
-	other_job_type = {
-		"Add Code Server to Upstream": "Setup Code Server",
-		"Setup Code Server": "Add Code Server to Upstream",
+	other_job_types = {
+		"Add Code Server to Upstream": ("Setup Code Server"),
+		"Setup Code Server": ("Add Code Server to Upstream"),
 	}[job.job_type]
 
 	first = job.status
-	second = frappe.get_value(
+	second = frappe.get_all(
 		"Agent Job",
-		{"job_type": other_job_type, "code_server": job.code_server},
-		"status",
-		for_update=True,
-	)
+		fields=["status"],
+		filters={"job_type": ("in", other_job_types), "code_server": job.code_server},
+	)[0].status
 
 	if "Success" == first == second:
 		updated_status = "Running"
@@ -125,18 +124,17 @@ def process_stop_code_server_job_update(job):
 def process_archive_code_server_job_update(job):
 	frappe.db.get_value("Code Server", job.code_server, "status", for_update=True)
 
-	other_job_type = {
-		"Remove Code Server from Upstream": "Archive Code Server",
-		"Archive Code Server": "Remove Code Server from Upstream",
+	other_job_types = {
+		"Remove Code Server from Upstream": ("Archive Code Server"),
+		"Archive Code Server": ("Remove Code Server from Upstream"),
 	}[job.job_type]
 
 	first = job.status
-	second = frappe.get_value(
+	second = frappe.get_all(
 		"Agent Job",
-		{"job_type": other_job_type, "code_server": job.code_server},
-		"status",
-		for_update=True,
-	)
+		fields=["status"],
+		filters={"job_type": ("in", other_job_types), "code_server": job.code_server},
+	)[0].status
 
 	if "Success" == first == second:
 		updated_status = "Archived"

--- a/press/press/doctype/code_server/code_server.py
+++ b/press/press/doctype/code_server/code_server.py
@@ -87,7 +87,7 @@ class CodeServer(Document):
 
 
 def process_new_code_server_job_update(job):
-	frappe.db.get_value("Code Server", job.code_server, "status", for_update=True)
+	frappe.db.get_value("Code Server", job.code_server, "status")
 
 	other_job_types = {
 		"Add Code Server to Upstream": ("Setup Code Server"),
@@ -122,7 +122,7 @@ def process_stop_code_server_job_update(job):
 
 
 def process_archive_code_server_job_update(job):
-	frappe.db.get_value("Code Server", job.code_server, "status", for_update=True)
+	frappe.db.get_value("Code Server", job.code_server, "status")
 
 	other_job_types = {
 		"Remove Code Server from Upstream": ("Archive Code Server"),

--- a/press/press/doctype/code_server/code_server.py
+++ b/press/press/doctype/code_server/code_server.py
@@ -87,7 +87,6 @@ class CodeServer(Document):
 
 
 def process_new_code_server_job_update(job):
-	frappe.db.commit()
 	frappe.db.get_value("Code Server", job.code_server, "status", for_update=True)
 
 	other_job_type = {
@@ -124,7 +123,6 @@ def process_stop_code_server_job_update(job):
 
 
 def process_archive_code_server_job_update(job):
-	frappe.db.commit()
 	frappe.db.get_value("Code Server", job.code_server, "status", for_update=True)
 
 	other_job_type = {

--- a/press/press/doctype/code_server/code_server.py
+++ b/press/press/doctype/code_server/code_server.py
@@ -87,6 +87,7 @@ class CodeServer(Document):
 
 
 def process_new_code_server_job_update(job):
+	frappe.db.commit()
 	frappe.db.get_value("Code Server", job.code_server, "status", for_update=True)
 
 	other_job_type = {
@@ -123,6 +124,7 @@ def process_stop_code_server_job_update(job):
 
 
 def process_archive_code_server_job_update(job):
+	frappe.db.commit()
 	frappe.db.get_value("Code Server", job.code_server, "status", for_update=True)
 
 	other_job_type = {

--- a/press/press/doctype/code_server/code_server.py
+++ b/press/press/doctype/code_server/code_server.py
@@ -89,17 +89,18 @@ class CodeServer(Document):
 def process_new_code_server_job_update(job):
 	frappe.db.get_value("Code Server", job.code_server, "status", for_update=True)
 
-	other_job_types = {
-		"Add Code Server to Upstream": ("Setup Code Server"),
-		"Setup Code Server": ("Add Code Server to Upstream"),
+	other_job_type = {
+		"Add Code Server to Upstream": "Setup Code Server",
+		"Setup Code Server": "Add Code Server to Upstream",
 	}[job.job_type]
 
 	first = job.status
-	second = frappe.get_all(
+	second = frappe.get_value(
 		"Agent Job",
-		fields=["status"],
-		filters={"job_type": ("in", other_job_types), "code_server": job.code_server},
-	)[0].status
+		{"job_type": other_job_type, "code_server": job.code_server},
+		"status",
+		for_update=True,
+	)
 
 	if "Success" == first == second:
 		updated_status = "Running"
@@ -124,17 +125,18 @@ def process_stop_code_server_job_update(job):
 def process_archive_code_server_job_update(job):
 	frappe.db.get_value("Code Server", job.code_server, "status", for_update=True)
 
-	other_job_types = {
-		"Remove Code Server from Upstream": ("Archive Code Server"),
-		"Archive Code Server": ("Remove Code Server from Upstream"),
+	other_job_type = {
+		"Remove Code Server from Upstream": "Archive Code Server",
+		"Archive Code Server": "Remove Code Server from Upstream",
 	}[job.job_type]
 
 	first = job.status
-	second = frappe.get_all(
+	second = frappe.get_value(
 		"Agent Job",
-		fields=["status"],
-		filters={"job_type": ("in", other_job_types), "code_server": job.code_server},
-	)[0].status
+		{"job_type": other_job_type, "code_server": job.code_server},
+		"status",
+		for_update=True,
+	)
 
 	if "Success" == first == second:
 		updated_status = "Archived"

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1454,11 +1454,12 @@ def process_new_site_job_update(job):
 	}[job.job_type]
 
 	first = job.status
-	second = frappe.get_all(
+	second = frappe.get_value(
 		"Agent Job",
-		fields=["status"],
-		filters={"job_type": ("in", other_job_types), "site": job.site},
-	)[0].status
+		{"job_type": ("in", other_job_types), "site": job.site},
+		"status",
+		for_update=True,
+	)
 
 	backup_tests = frappe.get_all(
 		"Backup Restoration Test", dict(test_site=job.site, status="Running"), pluck="name"
@@ -1513,8 +1514,7 @@ def process_archive_site_job_update(job):
 	}[job.job_type]
 
 	other_job = frappe.get_last_doc(
-		"Agent Job",
-		filters={"job_type": other_job_type, "site": job.site},
+		"Agent Job", filters={"job_type": other_job_type, "site": job.site}, for_update=True
 	)
 
 	first = get_remove_step_status(job)
@@ -1656,6 +1656,7 @@ def process_rename_site_job_update(job):
 	other_job = frappe.get_last_doc(
 		"Agent Job",
 		filters={"job_type": other_job_type, "site": job.site},
+		for_update=True,
 	)
 	first = get_rename_step_status(job)
 	second = get_rename_step_status(other_job)

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1445,7 +1445,6 @@ def release_name(name):
 
 
 def process_new_site_job_update(job):
-	frappe.db.commit()
 	site_status = frappe.get_value("Site", job.site, "status", for_update=True)
 
 	other_job_types = {
@@ -1507,7 +1506,6 @@ def get_remove_step_status(job):
 
 
 def process_archive_site_job_update(job):
-	frappe.db.commit()
 	site_status = frappe.get_value("Site", job.site, "status", for_update=True)
 
 	other_job_type = {
@@ -1648,7 +1646,6 @@ def get_rename_step_status(job):
 
 
 def process_rename_site_job_update(job):
-	frappe.db.commit()
 	site_status = frappe.get_value("Site", job.site, "status", for_update=True)
 
 	other_job_type = {

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1445,7 +1445,7 @@ def release_name(name):
 
 
 def process_new_site_job_update(job):
-	site_status = frappe.get_value("Site", job.site, "status", for_update=True)
+	site_status = frappe.get_value("Site", job.site, "status")
 
 	other_job_types = {
 		"Add Site to Upstream": ("New Site", "New Site from Backup"),
@@ -1505,7 +1505,7 @@ def get_remove_step_status(job):
 
 
 def process_archive_site_job_update(job):
-	site_status = frappe.get_value("Site", job.site, "status", for_update=True)
+	site_status = frappe.get_value("Site", job.site, "status")
 
 	other_job_type = {
 		"Remove Site from Upstream": "Archive Site",
@@ -1646,7 +1646,7 @@ def get_rename_step_status(job):
 
 
 def process_rename_site_job_update(job):
-	site_status = frappe.get_value("Site", job.site, "status", for_update=True)
+	site_status = frappe.get_value("Site", job.site, "status")
 
 	other_job_type = {
 		"Rename Site": "Rename Site on Upstream",

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1454,12 +1454,11 @@ def process_new_site_job_update(job):
 	}[job.job_type]
 
 	first = job.status
-	second = frappe.get_value(
+	second = frappe.get_all(
 		"Agent Job",
-		{"job_type": ("in", other_job_types), "site": job.site},
-		"status",
-		for_update=True,
-	)
+		fields=["status"],
+		filters={"job_type": ("in", other_job_types), "site": job.site},
+	)[0].status
 
 	backup_tests = frappe.get_all(
 		"Backup Restoration Test", dict(test_site=job.site, status="Running"), pluck="name"
@@ -1514,7 +1513,8 @@ def process_archive_site_job_update(job):
 	}[job.job_type]
 
 	other_job = frappe.get_last_doc(
-		"Agent Job", filters={"job_type": other_job_type, "site": job.site}, for_update=True
+		"Agent Job",
+		filters={"job_type": other_job_type, "site": job.site},
 	)
 
 	first = get_remove_step_status(job)
@@ -1656,7 +1656,6 @@ def process_rename_site_job_update(job):
 	other_job = frappe.get_last_doc(
 		"Agent Job",
 		filters={"job_type": other_job_type, "site": job.site},
-		for_update=True,
 	)
 	first = get_rename_step_status(job)
 	second = get_rename_step_status(other_job)

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1445,6 +1445,7 @@ def release_name(name):
 
 
 def process_new_site_job_update(job):
+	frappe.db.commit()
 	site_status = frappe.get_value("Site", job.site, "status", for_update=True)
 
 	other_job_types = {
@@ -1506,6 +1507,7 @@ def get_remove_step_status(job):
 
 
 def process_archive_site_job_update(job):
+	frappe.db.commit()
 	site_status = frappe.get_value("Site", job.site, "status", for_update=True)
 
 	other_job_type = {
@@ -1646,6 +1648,7 @@ def get_rename_step_status(job):
 
 
 def process_rename_site_job_update(job):
+	frappe.db.commit()
 	site_status = frappe.get_value("Site", job.site, "status", for_update=True)
 
 	other_job_type = {


### PR DESCRIPTION
Problem:
For activities that have multiple agent jobs on different servers (Rename Site), when processing the respective callbacks parallelly can leave the doc in a pending state. This happens as the select isn't done with for_update.

Solution:
- ~~Use for_update for every select in the callback transaction.~~ (2nd point ensures serializability as callback will run only after commit of the other)
- Get lock on resource (common to both jobs) at the beginning of the transaction (before the first set_value actually) to avoid deadlock

Essentially simulate [this](https://mariadb.com/kb/en/set-transaction/#serializable)