### PR TITLE
fix: Prevent Gunicorn child workers hangup

### DIFF
--- a/press/docker/config/supervisor.conf
+++ b/press/docker/config/supervisor.conf
@@ -5,11 +5,13 @@ environment={% for v in doc.environment_variables %}{{v.key}}="{{v.value}}",{% e
 {% endif %}
 
 [program:frappe-bench-frappe-web]
-command=/home/frappe/frappe-bench/env/bin/gunicorn --bind 0.0.0.0:8000 --workers 2 --timeout 120 --worker-tmp-dir /dev/shm frappe.app:application --preload --max-requests 5000 --max-requests-jitter 1000
+command=/home/frappe/frappe-bench/env/bin/gunicorn --bind 0.0.0.0:8000 --workers 2 --timeout 120 --graceful-timeout 30 --worker-tmp-dir /dev/shm frappe.app:application --preload --max-requests 5000 --max-requests-jitter 1000
 environment=FORWARDED_ALLOW_IPS="*"
 priority=4
 autostart=true
 autorestart=true
+stopwaitsecs=40
+killasgroup=true
 stdout_logfile=/home/frappe/frappe-bench/logs/web.log
 stderr_logfile=/home/frappe/frappe-bench/logs/web.error.log
 user=frappe


### PR DESCRIPTION
Problem:

- Prerequisite: long running reqeust is going on.
- `bench restart` is requested.
- supervisord sends sigterm to gunicorn master process.
- gunicorn passes it to all child workers and waits for graceful shutdown (30 seconds)
- supervisord has no chill, and sends sigkill to master process in 10 seconds
- gunicorn master proesss is dead, so now child workers will keep running until they complete request which can take a really long time.
- This entire time the sites will be down.

Fix:
- Explicitly encode default graceful_timeout in config - 30 seconds.
- Make supervisor wait 10 more seconds for gunicorn to do its thing, then only send sigkill.


Detailed analysis: https://gameplan.frappe.cloud/g/engineering/projects/152/discussion/2523