### PR TITLE
Retry undelivered jobs based on request status

### DIFF
--- a/dashboard/src/views/general/AgentJobs.vue
+++ b/dashboard/src/views/general/AgentJobs.vue
@@ -11,6 +11,7 @@
 				<ListItem :title="job.job_type" :description="formatDate(job.creation)">
 					<template v-slot:actions>
 						<Badge
+							class="whitespace-nowrap"
 							v-if="
 								runningJob &&
 								runningJob.id == job.name &&
@@ -18,7 +19,11 @@
 							"
 							:label="runningJob.status"
 						/>
-						<Badge v-else-if="job.status != 'Success'" :label="job.status" />
+						<Badge
+							class="whitespace-nowrap"
+							v-else-if="job.status != 'Success'"
+							:label="job.status"
+						/>
 					</template>
 				</ListItem>
 				<div class="border-b"></div>

--- a/press/agent.py
+++ b/press/agent.py
@@ -771,7 +771,7 @@ class Agent:
 		return status
 
 	def get_jobs_id(self, agent_job_ids):
-		return self.get(f"agent-job/{agent_job_ids}")
+		return self.get(f"agent-jobs/{agent_job_ids}")
 
 	def get_version(self):
 		return self.get("version")

--- a/press/agent.py
+++ b/press/agent.py
@@ -698,6 +698,7 @@ class Agent:
 			<br>
 		"""
 		self.log_failure_reason(agent_job, message)
+		agent_job.flags.status_code = result.status_code
 
 	def handle_exception(self, agent_job, exception):
 		message = f"""

--- a/press/agent.py
+++ b/press/agent.py
@@ -632,11 +632,13 @@ class Agent:
 	def post(self, path, data=None):
 		return self.request("POST", path, data)
 
-	def request(self, method, path, data=None, files=None):
+	def request(self, method, path, data=None, files=None, agent_job=None):
+		agent_job_id = agent_job.name if agent_job else None
+
 		try:
 			url = f"https://{self.server}:{self.port}/agent/{path}"
 			password = get_decrypted_password(self.server_type, self.server, "agent_password")
-			headers = {"Authorization": f"bearer {password}"}
+			headers = {"Authorization": f"bearer {password}", "X-Agent-Job-Id": agent_job_id}
 			intermediate_ca = frappe.db.get_value(
 				"Press Settings", "Press Settings", "backbone_intermediate_ca"
 			)
@@ -666,6 +668,7 @@ class Agent:
 				result.raise_for_status()
 				return json_response
 			except Exception:
+				self.handle_request_failure(agent_job, result)
 				log_error(
 					title="Agent Request Result Exception",
 					method=method,
@@ -675,7 +678,8 @@ class Agent:
 					headers=headers,
 					result=json_response or result.text,
 				)
-		except Exception:
+		except Exception as exce:
+			self.handle_exception(agent_job, exce)
 			log_error(
 				title="Agent Request Exception",
 				method=method,
@@ -684,6 +688,34 @@ class Agent:
 				files=files,
 				headers=headers,
 			)
+
+	def handle_request_failure(self, agent_job, result):
+		message = f"""
+			<br>
+			<p>Agent Job Failed</p>
+			<p>Status Code: {getattr(result, 'status_code', 'Unknown')}</p>
+			<p>Response: {getattr(result, 'text', 'Unknown')}</p>
+			<br>
+		"""
+		self.log_failure_reason(agent_job, message)
+
+	def handle_exception(self, agent_job, exception):
+		message = f"""
+			<br>
+			<p>Agent Job Failed</p>
+			<p>Exception: {exception}</p>
+			<br>
+		"""
+		self.log_failure_reason(agent_job, message)
+
+	def log_failure_reason(self, agent_job=None, message=None):
+		if not agent_job:
+			return
+
+		try:
+			agent_job.add_comment("Comment", message)
+		except Exception:
+			pass
 
 	def create_agent_job(
 		self,
@@ -747,6 +779,9 @@ class Agent:
 		if len(ids) == 1:
 			return [status]
 		return status
+
+	def get_jobs_id(self, agent_job_ids):
+		return self.get(f"agent-job/{agent_job_ids}")
 
 	def get_version(self):
 		return self.get("version")

--- a/press/agent.py
+++ b/press/agent.py
@@ -691,32 +691,21 @@ class Agent:
 
 	def handle_request_failure(self, agent_job, result):
 		message = f"""
-			<br>
-			<p>Agent Job Failed</p>
-			<p>Status Code: {getattr(result, 'status_code', 'Unknown')}</p>
-			<p>Response: {getattr(result, 'text', 'Unknown')}</p>
-			<br>
+			Status Code: {getattr(result, 'status_code', 'Unknown')} \n
+			Response: {getattr(result, 'text', 'Unknown')}
 		"""
 		self.log_failure_reason(agent_job, message)
 		agent_job.flags.status_code = result.status_code
 
 	def handle_exception(self, agent_job, exception):
-		message = f"""
-			<br>
-			<p>Agent Job Failed</p>
-			<p>Exception: {exception}</p>
-			<br>
-		"""
-		self.log_failure_reason(agent_job, message)
+		self.log_failure_reason(agent_job, exception)
 
 	def log_failure_reason(self, agent_job=None, message=None):
 		if not agent_job:
 			return
 
-		try:
-			agent_job.add_comment("Comment", message)
-		except Exception:
-			pass
+		agent_job.traceback = message
+		agent_job.output = message
 
 	def create_agent_job(
 		self,

--- a/press/fixtures/agent_job_type.json
+++ b/press/fixtures/agent_job_type.json
@@ -1,8 +1,10 @@
 [
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2021-06-16 20:39:50.568363",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.228754",
   "name": "Rename Upstream",
   "request_method": "POST",
   "request_path": "/proxy/upstreams/{ip}/rename",
@@ -28,9 +30,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2021-01-27 10:42:40.678534",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.057519",
   "name": "Rename Site",
   "request_method": "POST",
   "request_path": "benches/{site.bench}/sites/{site.name}/rename",
@@ -86,9 +90,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-02-21 12:34:39.569810",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.549528",
   "name": "Recover Failed Site Migration",
   "request_method": null,
   "request_path": null,
@@ -114,9 +120,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-08-11 12:17:23.658693",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.927111",
   "name": "Add Domain",
   "request_method": "POST",
   "request_path": "benches/{bench}/sites/{site}/domains",
@@ -142,9 +150,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-08-11 12:17:43.993040",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.946695",
   "name": "Remove Domain",
   "request_method": "DELETE",
   "request_path": "benches/{bench}/sites/{site}/domains/{domain}",
@@ -170,9 +180,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-07-27 19:18:17.532920",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.762138",
   "name": "Update Site Pull",
   "request_method": "POST",
   "request_path": "/benches/{bench}/sites/{site}/update/pull",
@@ -222,9 +234,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2023-05-04 14:15:26.755183",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.585210",
   "name": "Update Site Migrate",
   "request_method": "POST",
   "request_path": "/benches/{bench}/sites/{site}/update/migrate",
@@ -304,9 +318,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2023-08-14 16:44:10.920737",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.781844",
   "name": "New Site",
   "request_method": "POST",
   "request_path": "/benches/{bench}/sites",
@@ -350,9 +366,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-04-03 23:20:55.186989",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.646447",
   "name": "Add Host to Proxy",
   "request_method": "POST",
   "request_path": "/proxy/hosts",
@@ -378,9 +396,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-04-03 23:20:14.208716",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.626647",
   "name": "Add Site to Upstream",
   "request_method": "POST",
   "request_path": "/proxy/upstreams/{upstream}/sites",
@@ -406,9 +426,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2023-07-21 23:20:14.208716",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.671517",
   "name": "Add Code Server to Upstream",
   "request_method": "POST",
   "request_path": "/proxy/upstreams/{upstream}/sites",
@@ -434,9 +456,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2023-07-21 23:20:14.208716",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.651948",
   "name": "Remove Code Server from Upstream",
   "request_method": "POST",
   "request_path": "/proxy/upstreams/{upstream}/sites",
@@ -462,9 +486,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2023-07-21 23:20:14.208716",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.724970",
   "name": "Setup Code Server",
   "request_method": "POST",
   "request_path": "benches/{bench}/codeserver",
@@ -496,9 +522,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2023-07-21 23:20:14.208716",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.707766",
   "name": "Start Code Server",
   "request_method": "POST",
   "request_path": "benches/{bench}/codeserver/start",
@@ -512,9 +540,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2023-07-21 23:20:14.208716",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.743617",
   "name": "Stop Code Server",
   "request_method": "POST",
   "request_path": "benches/{bench}/codeserver/stop",
@@ -528,9 +558,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2023-07-21 23:20:14.208716",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.690936",
   "name": "Archive Code Server",
   "request_method": "POST",
   "request_path": "benches/{bench}/codeserver/archive",
@@ -556,9 +588,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-04-03 23:20:08.170631",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.607088",
   "name": "Add Upstream to Proxy",
   "request_method": "POST",
   "request_path": "/proxy/upstreams",
@@ -584,9 +618,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-04-08 15:02:15.559811",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.677444",
   "name": "Install App on Site",
   "request_method": "POST",
   "request_path": "/benches/{bench}/sites/{site}/apps",
@@ -600,9 +636,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-07-30 10:46:32.814468",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.839292",
   "name": "New Site from Backup",
   "request_method": "POST",
   "request_path": "/benches/{bench}/sites/restore",
@@ -676,9 +714,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-05-06 11:08:03.470650",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.690831",
   "name": "Reinstall Site",
   "request_method": "POST",
   "request_path": "benches/{bench}/sites/{site}/reinstall",
@@ -692,9 +732,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2022-05-14 09:39:59.938256",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.470276",
   "name": "Restore Site",
   "request_method": "POST",
   "request_path": "/benches/{bench}/sites/{site}/restore",
@@ -756,9 +798,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-05-21 14:43:42.827772",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.706871",
   "name": "Update Site Status",
   "request_method": "POST",
   "request_path": "/proxy/upstreams/{upstream}/sites/{site}/status",
@@ -784,9 +828,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-06-26 15:27:03.310761",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.740351",
   "name": "Uninstall App from Site",
   "request_method": "DELETE",
   "request_path": "/benches/{bench}/sites/{site}/apps",
@@ -800,9 +846,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-07-27 20:49:03.616821",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.805097",
   "name": "Recover Failed Site Pull",
   "request_method": "POST",
   "request_path": "/benches/{bench}/sites/{site}/update/pull/recover",
@@ -840,9 +888,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-07-27 20:48:53.225074",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.786058",
   "name": "Recover Failed Site Update",
   "request_method": "POST",
   "request_path": "/benches/{bench}/sites/{site}/update/recover",
@@ -856,9 +906,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2023-05-04 14:15:56.315104",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.625189",
   "name": "Recover Failed Site Migrate",
   "request_method": "POST",
   "request_path": "/benches/{bench}/sites/{site}/update/migrate/recover",
@@ -908,9 +960,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-08-05 17:32:00.556643",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.893005",
   "name": "Remove Host from Proxy",
   "request_method": "DELETE",
   "request_path": "/proxy/hosts/{host}",
@@ -936,9 +990,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-08-06 10:47:06.751838",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.911153",
   "name": "Migrate Site",
   "request_method": "POST",
   "request_path": "/benches/{bench}/sites/{site}/migrate",
@@ -952,9 +1008,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-10-02 15:34:23.594712",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.963183",
   "name": "Fetch Sites Info",
   "request_method": "POST",
   "request_path": "/benches/{bench}/info",
@@ -968,9 +1026,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-11-30 12:12:41.282921",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.000340",
   "name": "Setup Redirects on Hosts",
   "request_method": "POST",
   "request_path": "/proxy/hosts/redirects",
@@ -1002,9 +1062,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-11-30 12:12:21.595092",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.979580",
   "name": "Remove Redirects on Hosts",
   "request_method": "DELETE",
   "request_path": "/proxy/hosts/redirects",
@@ -1030,9 +1092,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2021-01-29 11:14:16.705614",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.100535",
   "name": "Rename Site on Upstream",
   "request_method": "POST",
   "request_path": "/proxy/upstreams/{upstream}/sites/{site}/rename",
@@ -1070,9 +1134,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2021-03-25 22:42:47.808999",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.131920",
   "name": "Add Wildcard Hosts to Proxy",
   "request_method": "POST",
   "request_path": "/proxy/wildcards",
@@ -1098,9 +1164,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2021-04-05 16:24:05.014172",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.180358",
   "name": "Setup ERPNext",
   "request_method": "POST",
   "request_path": "/benches/{site.bench}/sites/{site.name}/erpnext",
@@ -1120,9 +1188,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2021-04-04 12:27:30.772719",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.157390",
   "name": "Clear Cache",
   "request_method": "DELETE",
   "request_path": "/benches/{bench}/sites/{site}/cache",
@@ -1142,9 +1212,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2021-04-12 22:01:07.809393",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.203468",
   "name": "Restore Site Tables",
   "request_method": "POST",
   "request_path": "/benches/{bench}/sites/{site}/update/migrate/restore",
@@ -1164,9 +1236,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2022-01-16 13:37:05.759970",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.283667",
   "name": "Add User to Proxy",
   "request_method": "POST",
   "request_path": "/ssh/users",
@@ -1192,9 +1266,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2022-01-16 13:38:57.132558",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.308026",
   "name": "Remove User from Proxy",
   "request_method": "DELETE",
   "request_path": "/ssh/users/{user}",
@@ -1214,9 +1290,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2022-02-07 12:43:09.605095",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.327716",
   "name": "Add User to ProxySQL",
   "request_method": "POST",
   "request_path": "/proxysql/users",
@@ -1230,9 +1308,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2022-02-07 12:43:46.446468",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.345276",
   "name": "Remove User from ProxySQL",
   "request_method": "DELETE",
   "request_path": "/proxysql/users/{username}",
@@ -1246,9 +1326,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2022-02-13 14:26:09.458148",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.362722",
   "name": "Create Minio User",
   "request_method": "POST",
   "request_path": "/minio/create",
@@ -1274,9 +1356,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2022-02-13 14:26:41.239106",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.379874",
   "name": "Remove Minio User",
   "request_method": "POST",
   "request_path": "/minio/remove",
@@ -1290,9 +1374,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2022-02-15 14:21:09.184479",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.392780",
   "name": "Enable Minio User",
   "request_method": "POST",
   "request_path": "/minio/update",
@@ -1306,9 +1392,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2022-02-15 14:21:14.416719",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.405690",
   "name": "Disable Minio User",
   "request_method": "POST",
   "request_path": "/minio/update",
@@ -1322,9 +1410,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2021-10-14 09:27:02.587048",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.256524",
   "name": "Cleanup Unused Files",
   "request_method": "POST",
   "request_path": "server/cleanup",
@@ -1350,9 +1440,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2022-05-11 13:02:45.175768",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.446023",
   "name": "Add Backend to ProxySQL",
   "request_method": "POST",
   "request_path": "/proxysql/backends",
@@ -1366,9 +1458,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2022-02-15 14:21:14.416719",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.419313",
   "name": "Update Saas Plan",
   "request_method": "POST",
   "request_path": "/benches/{bench}/sites/{site}/update/saas",
@@ -1382,9 +1476,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2022-11-17 10:12:13.952175",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.502147",
   "name": "Run After Migrate Steps",
   "request_method": "POST",
   "request_path": "benches/{bench}/sites/{site}/run_after_migrate_steps",
@@ -1422,9 +1518,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2022-12-02 07:54:16.581300",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.531987",
   "name": "Move Site to Bench",
   "request_method": "POST",
   "request_path": "/benches/{bench}/sites/{site}/move_to_bench",
@@ -1480,9 +1578,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2023-03-14 12:29:53.005324",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.556954",
   "name": "Reset Site Usage",
   "request_method": "DELETE",
   "request_path": "benches/{bench}/sites/{site}/usage",
@@ -1496,9 +1596,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2023-07-25 15:25:39.121963",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.759939",
   "name": "Reload NGINX Job",
   "request_method": "POST",
   "request_path": "/proxy/reload",
@@ -1518,9 +1620,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-06-17 16:44:12.364275",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.725087",
   "name": "Backup Site",
   "request_method": null,
   "request_path": null,
@@ -1540,9 +1644,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2022-04-26 12:43:33.641886",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.432717",
   "name": "Bench Restart",
   "request_method": "POST",
   "request_path": "/benches/{bench}/restart",
@@ -1556,9 +1662,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-04-03 20:16:04.843363",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.568610",
   "name": "Archive Bench",
   "request_method": "POST",
   "request_path": "/benches/{bench}/archive",
@@ -1578,9 +1686,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-04-07 16:10:22.420615",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.663533",
   "name": "Update Site Configuration",
   "request_method": "POST",
   "request_path": "/benches/{bench}/sites/{site}/config",
@@ -1594,9 +1704,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-12-11 14:03:35.053168",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.023648",
   "name": "New Bench",
   "request_method": "POST",
   "request_path": "/benches",
@@ -1628,9 +1740,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-04-03 23:19:43.720292",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.587094",
   "name": "Remove Site from Upstream",
   "request_method": "DELETE",
   "request_path": "/proxy/upstreams/{upstream}/sites/{site}",
@@ -1656,9 +1770,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2020-02-20 10:19:17.561733",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:18.510770",
   "name": "Archive Site",
   "request_method": null,
   "request_path": null,
@@ -1684,9 +1800,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2023-10-17 16:59:09.138319",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.845251",
   "name": "Force Update Bench Limits",
   "request_method": "POST",
   "request_path": "benches/{bench}/limit",
@@ -1712,9 +1830,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2023-10-17 11:31:50.531377",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.822202",
   "name": "Update Bench Configuration",
   "request_method": "POST",
   "request_path": "/benches/{bench}/config",
@@ -1752,9 +1872,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2023-09-27 15:51:45.010890",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.803361",
   "name": "Rebuild Bench Assets",
   "request_method": "POST",
   "request_path": "benches/{bench}/rebuild",
@@ -1768,9 +1890,11 @@
   ]
  },
  {
+  "disabled_auto_retry": 1,
   "docstatus": 0,
   "doctype": "Agent Job Type",
-  "modified": "2023-10-19 14:54:11.470559",
+  "max_retry_count": 3,
+  "modified": "2023-11-06 07:28:19.861985",
   "name": "Optimize Tables",
   "request_method": "POST",
   "request_path": "benches/{bench}/sites/{site}/optimize",

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -212,7 +212,10 @@ scheduler_events = {
 		"0 3 * * *": [
 			"press.press.doctype.drip_email.drip_email.send_drip_emails",
 		],
-		"* * * * * 0/5": ["press.press.doctype.agent_job.agent_job.poll_pending_jobs"],
+		"* * * * * 0/5": [
+			"press.press.doctype.agent_job.agent_job.poll_pending_jobs",
+			"press.press.doctype.agent_job.agent_job.retry_undelivered_jobs",
+		],
 		"0 */6 * * *": [
 			"press.press.doctype.server.server.cleanup_unused_files",
 			"press.press.doctype.razorpay_payment_record.razorpay_payment_record.fetch_pending_payment_orders",

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -185,6 +185,7 @@ scheduler_events = {
 	],
 	"hourly": [
 		"press.press.doctype.site.backups.cleanup_local",
+		"press.press.doctype.agent_job.agent_job.update_job_step_status",
 	],
 	"hourly_long": [
 		"press.press.doctype.server.server.scale_workers",
@@ -202,7 +203,6 @@ scheduler_events = {
 	],
 	"all": [
 		"press.auth.flush",
-		"press.press.doctype.agent_jon.agent_job.update_job_step_status",
 	],
 	"cron": {
 		"0 4 * * *": [

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -202,6 +202,7 @@ scheduler_events = {
 	],
 	"all": [
 		"press.auth.flush",
+		"press.press.doctype.agent_jon.agent_job.update_job_step_status",
 	],
 	"cron": {
 		"0 4 * * *": [

--- a/press/press/doctype/agent_job/agent_job.json
+++ b/press/press/doctype/agent_job/agent_job.json
@@ -19,6 +19,8 @@
   "job_id",
   "request_path",
   "request_method",
+  "retry_count",
+  "next_retry_at",
   "column_break_10",
   "start",
   "end",
@@ -46,7 +48,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "Undelivered\nPending\nRunning\nSuccess\nFailure",
+   "options": "Undelivered\nPending\nRunning\nSuccess\nFailure\nDelivery Failure",
    "read_only": 1,
    "reqd": 1,
    "search_index": 1
@@ -192,11 +194,23 @@
    "label": "Code Server",
    "options": "Code Server",
    "read_only": 1
+  },
+  {
+   "fieldname": "retry_count",
+   "fieldtype": "Int",
+   "label": "Retry Count",
+   "read_only": 1
+  },
+  {
+   "fieldname": "next_retry_at",
+   "fieldtype": "Datetime",
+   "label": "Next Retry At",
+   "read_only": 1
   }
  ],
  "in_create": 1,
  "links": [],
- "modified": "2023-07-20 23:20:44.028057",
+ "modified": "2023-10-18 11:09:55.601701",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Agent Job",

--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -83,7 +83,9 @@ class AgentJob(Document):
 		except Exception:
 			self.status = "Failure"
 			self.save()
+
 			process_job_updates(self.name)
+
 			self.reload()
 			self.set_status_and_next_retry_at()
 

--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -8,6 +8,7 @@ import random
 
 from press.agent import Agent
 from press.utils import log_error
+from frappe.utils import cint
 from frappe.core.utils import find
 from frappe.model.document import Document
 from press.press.doctype.site_migration.site_migration import (
@@ -87,6 +88,9 @@ class AgentJob(Document):
 			self.set_status_and_next_retry_at()
 
 	def set_status_and_next_retry_at(self):
+		if 400 <= cint(self.flags.status_code) <= 499:
+			return
+
 		next_retry_at = get_next_retry_at(self.retry_count)
 
 		if not self.retry_count:

--- a/press/press/doctype/agent_job_step/agent_job_step.json
+++ b/press/press/doctype/agent_job_step/agent_job_step.json
@@ -41,7 +41,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "Pending\nRunning\nSuccess\nFailure\nSkipped",
+   "options": "Pending\nRunning\nSuccess\nFailure\nSkipped\nDelivery Failure",
    "read_only": 1,
    "reqd": 1,
    "search_index": 1
@@ -94,7 +94,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2021-02-15 19:45:04.313124",
+ "modified": "2023-10-20 11:27:22.573494",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Agent Job Step",
@@ -123,6 +123,7 @@
  ],
  "sort_field": "creation",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "step_name",
  "track_changes": 1
 }

--- a/press/press/doctype/agent_job_type/agent_job_type.json
+++ b/press/press/doctype/agent_job_type/agent_job_type.json
@@ -11,6 +11,7 @@
   "request_path",
   "request_method",
   "column_break_fijn",
+  "disabled_auto_retry",
   "max_retry_count"
  ],
  "fields": [
@@ -44,13 +45,20 @@
    "fieldtype": "Column Break"
   },
   {
+   "default": "3",
    "fieldname": "max_retry_count",
    "fieldtype": "Int",
    "label": "Max Retry Count"
+  },
+  {
+   "default": "1",
+   "fieldname": "disabled_auto_retry",
+   "fieldtype": "Check",
+   "label": "Disabled Auto Retry"
   }
  ],
  "links": [],
- "modified": "2023-10-16 16:31:00.984946",
+ "modified": "2023-11-06 05:00:29.705818",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Agent Job Type",

--- a/press/press/doctype/agent_job_type/agent_job_type.json
+++ b/press/press/doctype/agent_job_type/agent_job_type.json
@@ -9,7 +9,9 @@
   "steps",
   "agent_request_section",
   "request_path",
-  "request_method"
+  "request_method",
+  "column_break_fijn",
+  "max_retry_count"
  ],
  "fields": [
   {
@@ -36,10 +38,19 @@
    "in_list_view": 1,
    "label": "Request Method",
    "options": "POST\nDELETE"
+  },
+  {
+   "fieldname": "column_break_fijn",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "max_retry_count",
+   "fieldtype": "Int",
+   "label": "Max Retry Count"
   }
  ],
  "links": [],
- "modified": "2022-09-28 17:39:45.144111",
+ "modified": "2023-10-16 16:31:00.984946",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Agent Job Type",

--- a/press/press/doctype/agent_job_type/agent_job_type.json
+++ b/press/press/doctype/agent_job_type/agent_job_type.json
@@ -10,7 +10,7 @@
   "agent_request_section",
   "request_path",
   "request_method",
-  "column_break_fijn",
+  "job_retry_section",
   "disabled_auto_retry",
   "max_retry_count"
  ],
@@ -41,10 +41,6 @@
    "options": "POST\nDELETE"
   },
   {
-   "fieldname": "column_break_fijn",
-   "fieldtype": "Column Break"
-  },
-  {
    "default": "3",
    "fieldname": "max_retry_count",
    "fieldtype": "Int",
@@ -54,11 +50,16 @@
    "default": "1",
    "fieldname": "disabled_auto_retry",
    "fieldtype": "Check",
-   "label": "Disabled Auto Retry"
+   "label": "Disabled"
+  },
+  {
+   "fieldname": "job_retry_section",
+   "fieldtype": "Section Break",
+   "label": "Job Retry"
   }
  ],
  "links": [],
- "modified": "2023-11-06 05:00:29.705818",
+ "modified": "2023-11-16 12:19:35.365980",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Agent Job Type",

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -429,7 +429,8 @@ class DeployCandidate(Document):
 			and platform.system() == "Darwin"
 			and platform.processor() == "arm"
 		):
-			self.command = f"{self.command}x build --platform linux/amd64"
+			pass
+		self.command = f"{self.command}x build --platform linux/amd64"
 
 		environment = os.environ.copy()
 		environment.update(

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -429,8 +429,7 @@ class DeployCandidate(Document):
 			and platform.system() == "Darwin"
 			and platform.processor() == "arm"
 		):
-			pass
-		self.command = f"{self.command}x build --platform linux/amd64"
+			self.command = f"{self.command}x build --platform linux/amd64"
 
 		environment = os.environ.copy()
 		environment.update(


### PR DESCRIPTION
### Auto-Retry undelivered jobs

- In many cases, we have observed jobs remain in the Undelivered state, 
- Some identified reasons
   - The agent on the actual server is not reachable
   - The configurations are not proper
   - The site or bench does not exist on the actual path
 
To handle these cases, added a provision, where the system will retry the undelivered job.

While retrying it will check for
- If the job is already delivered to the agent but failed while processing the response
- If not it will retry the job with exponential backoff till it reaches to max retry count

### What after max retry count?
In the Agent Job,  have introduced a new status Delivery Failure. After reaching the max retry count the system will set the agent job status as  Delivery Failure, this will be the final state.


### Configure Agent Job Type for Auto Retry
<img width="1291" alt="Screenshot 2023-11-06 at 6 01 20 AM" src="https://github.com/frappe/press/assets/3784093/2d7df169-a3c0-4957-9898-fe996abd3bd6">

### Agent Job with Auto Retry

<img width="1295" alt="Screenshot 2023-11-06 at 6 01 52 AM" src="https://github.com/frappe/press/assets/3784093/cbba097f-a0e2-4301-9946-b26d4ebe02f1">



