### PR TITLE
refactor: AWS Instance Pricing Report

### DIFF
--- a/press/press/report/aws_instance_pricing/aws_instance_pricing.json
+++ b/press/press/report/aws_instance_pricing/aws_instance_pricing.json
@@ -2,6 +2,13 @@
  "add_total_row": 0,
  "columns": [
   {
+   "fieldname": "cluster",
+   "fieldtype": "Link",
+   "label": "Cluster",
+   "options": "Cluster",
+   "width": 0
+  },
+  {
    "fieldname": "instance",
    "fieldtype": "Data",
    "label": "Instance",
@@ -66,7 +73,7 @@
    "fieldname": "cluster",
    "fieldtype": "Link",
    "label": "Cluster",
-   "mandatory": 1,
+   "mandatory": 0,
    "options": "Cluster",
    "wildcard_filter": 0
   },

--- a/press/press/report/aws_instance_pricing/aws_instance_pricing.json
+++ b/press/press/report/aws_instance_pricing/aws_instance_pricing.json
@@ -121,11 +121,12 @@
    "wildcard_filter": 0
   },
   {
+   "default": "Intel",
    "fieldname": "processor",
    "fieldtype": "Select",
    "label": "Processor",
    "mandatory": 0,
-   "options": "\nIntel\nAMD\nGraviton",
+   "options": "Intel\nAMD\nGraviton\n",
    "wildcard_filter": 0
   },
   {
@@ -140,7 +141,7 @@
  "is_standard": "Yes",
  "json": "{}",
  "letterhead": null,
- "modified": "2023-11-06 18:47:01.743872",
+ "modified": "2023-11-06 19:08:45.728372",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "AWS Instance Pricing",

--- a/press/press/report/aws_instance_pricing/aws_instance_pricing.json
+++ b/press/press/report/aws_instance_pricing/aws_instance_pricing.json
@@ -51,6 +51,12 @@
    "width": 0
   },
   {
+   "fieldname": "is_latest_generation",
+   "fieldtype": "Check",
+   "label": "Is Latest Generation?",
+   "width": 0
+  },
+  {
    "fieldname": "size",
    "fieldtype": "Data",
    "label": "Size",
@@ -94,7 +100,6 @@
   }
  ],
  "creation": "2022-09-19 17:12:10.701432",
- "disable_prepared_report": 0,
  "disabled": 0,
  "docstatus": 0,
  "doctype": "Report",
@@ -112,7 +117,7 @@
    "fieldtype": "Select",
    "label": "Instance Family",
    "mandatory": 0,
-   "options": "General Purpose\nCompute Optimized\nMemory Optimized\n",
+   "options": "\nGeneral Purpose\nCompute Optimized\nMemory Optimized",
    "wildcard_filter": 0
   },
   {
@@ -120,20 +125,13 @@
    "fieldtype": "Select",
    "label": "Processor",
    "mandatory": 0,
-   "options": "Intel\nAMD\nGraviton\n",
+   "options": "\nIntel\nAMD\nGraviton",
    "wildcard_filter": 0
   },
   {
-   "fieldname": "enhanced_networking",
+   "fieldname": "latest_generation_only",
    "fieldtype": "Check",
-   "label": "Enhanced Networking",
-   "mandatory": 0,
-   "wildcard_filter": 0
-  },
-  {
-   "fieldname": "instance_store",
-   "fieldtype": "Check",
-   "label": "Instance Store",
+   "label": "Latest Generation Only",
    "mandatory": 0,
    "wildcard_filter": 0
   }
@@ -141,7 +139,8 @@
  "idx": 0,
  "is_standard": "Yes",
  "json": "{}",
- "modified": "2022-09-20 01:34:57.237617",
+ "letterhead": null,
+ "modified": "2023-11-06 18:47:01.743872",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "AWS Instance Pricing",

--- a/press/press/report/aws_instance_pricing/aws_instance_pricing.json
+++ b/press/press/report/aws_instance_pricing/aws_instance_pricing.json
@@ -33,6 +33,36 @@
    "width": 0
   },
   {
+   "fieldname": "processor",
+   "fieldtype": "Data",
+   "label": "Processor",
+   "width": 0
+  },
+  {
+   "fieldname": "family",
+   "fieldtype": "Data",
+   "label": "Family",
+   "width": 0
+  },
+  {
+   "fieldname": "generation",
+   "fieldtype": "Int",
+   "label": "Generation",
+   "width": 0
+  },
+  {
+   "fieldname": "size",
+   "fieldtype": "Data",
+   "label": "Size",
+   "width": 0
+  },
+  {
+   "fieldname": "size_multiplier",
+   "fieldtype": "Float",
+   "label": "Size Multiplier",
+   "width": 0
+  },
+  {
    "fieldname": "on_demand",
    "fieldtype": "Float",
    "label": "On-Demand",

--- a/press/press/report/aws_instance_pricing/aws_instance_pricing.py
+++ b/press/press/report/aws_instance_pricing/aws_instance_pricing.py
@@ -112,6 +112,14 @@ def get_cluster_data(filters, cluster_name):
 			)
 			rows.append(row)
 
+	latest_generation = max(row["generation"] for row in rows)
+	for row in rows:
+		if row["generation"] == latest_generation:
+			row["is_latest_generation"] = True
+
+	if filters.latest_generation_only:
+		rows = [row for row in rows if row.get("is_latest_generation")]
+
 	client = boto3.client(
 		"savingsplans",
 		aws_access_key_id=cluster.aws_access_key_id,

--- a/press/press/report/aws_instance_pricing/aws_instance_pricing.py
+++ b/press/press/report/aws_instance_pricing/aws_instance_pricing.py
@@ -57,11 +57,6 @@ def get_cluster_data(filters, cluster_name):
 			}
 		)
 
-	if not filters.instance_store:
-		product_filters.append(
-			{"Type": "TERM_MATCH", "Field": "storage", "Value": "EBS only"}
-		)
-
 	response_iterator = paginator.paginate(
 		ServiceCode="AmazonEC2", Filters=product_filters, PaginationConfig={"PageSize": 100}
 	)
@@ -69,17 +64,6 @@ def get_cluster_data(filters, cluster_name):
 	for response in response_iterator:
 		for item in response["PriceList"]:
 			product = json.loads(item)
-			if (
-				filters.enhanced_networking
-				and "n." not in product["product"]["attributes"]["instanceType"]
-			):
-				continue
-			if (
-				not filters.enhanced_networking
-				and "n." in product["product"]["attributes"]["instanceType"]
-			):
-				continue
-
 			if filters.processor:
 				if filters.processor not in product["product"]["attributes"]["physicalProcessor"]:
 					continue


### PR DESCRIPTION
- Only shows C (compute optimized), M (general purpose), and R (memory optimized) instance types
- Only shows machines that don't have any special capability e.g. d (instance store), n (enhanced networking, z (extra memory), e (extra storage)
- Shows instance types from all clusters if no cluster is selected
- Removed Enhanced Networking and Instance Store filter
- Added Generation and Latest Generation columns

Before
![image](https://github.com/frappe/press/assets/8528887/0f066c65-8064-4e9d-b89d-22ec5f700856)

After
![image](https://github.com/frappe/press/assets/8528887/c8b257f1-1ae8-4681-bc7e-d27db55e3580)
