### PR TITLE
fix: set `payment_mode` as card if `default_payment_method` is set

### DIFF
--- a/press/press/doctype/stripe_payment_method/stripe_payment_method.py
+++ b/press/press/doctype/stripe_payment_method/stripe_payment_method.py
@@ -31,6 +31,7 @@ class StripePaymentMethod(Document):
 		self.is_default = 1
 		self.save()
 		frappe.db.set_value("Team", self.team, "default_payment_method", self.name)
+		frappe.db.set_value("Team", self.team, "payment_mode", "Card")
 
 	def on_trash(self):
 		self.remove_address_links()

--- a/press/press/doctype/stripe_payment_method/stripe_payment_method.py
+++ b/press/press/doctype/stripe_payment_method/stripe_payment_method.py
@@ -31,7 +31,8 @@ class StripePaymentMethod(Document):
 		self.is_default = 1
 		self.save()
 		frappe.db.set_value("Team", self.team, "default_payment_method", self.name)
-		frappe.db.set_value("Team", self.team, "payment_mode", "Card")
+		if not frappe.db.get_value("Team", self.team, "payment_mode"):
+			frappe.db.set_value("Team", self.team, "payment_mode", "Card")
 
 	def on_trash(self):
 		self.remove_address_links()


### PR DESCRIPTION
Some teams had payment mode empty while their default payment method was set
So this is a potential fix