### PR TITLE
feat: Add GST for indian customers while finalizing invoices and buying prepaid credits

### DIFF
--- a/dashboard/src/components/BuyPrepaidCredits.vue
+++ b/dashboard/src/components/BuyPrepaidCredits.vue
@@ -2,7 +2,8 @@
 	<div>
 		<FormControl
 			v-if="step == 'Get Amount'"
-			:label="`Amount (Minimum Amount: ${minimumAmount})`"
+			class="mb-2"
+			label="Credits"
 			v-model.number="creditsToBuy"
 			name="amount"
 			autocomplete="off"
@@ -25,6 +26,17 @@
 			></div>
 			<ErrorMessage class="mt-1" :message="cardErrorMessage" />
 		</label>
+
+		<FormControl
+			v-if="step == 'Get Amount'"
+			label="Total Amount + GST(if applicable)"
+			disabled
+			v-model="total"
+			name="total"
+			autocomplete="off"
+			type="number"
+		/>
+
 		<div v-if="step == 'Setting up Stripe'" class="mt-8 flex justify-center">
 			<Spinner class="h-4 w-4 text-gray-600" />
 		</div>
@@ -71,11 +83,20 @@ export default {
 			default: 0
 		}
 	},
+	mounted() {
+		this.updateTotal();
+	},
+	watch: {
+		creditsToBuy() {
+			this.updateTotal();
+		}
+	},
 	data() {
 		return {
 			step: 'Get Amount', // Get Amount / Add Card Details
 			clientSecret: null,
 			creditsToBuy: this.minimumAmount || null,
+			total: this.minimumAmount,
 			cardErrorMessage: null,
 			errorMessage: null,
 			paymentInProgress: false
@@ -140,6 +161,18 @@ export default {
 		}
 	},
 	methods: {
+		updateTotal() {
+			if (this.$account.team.currency === 'INR') {
+				this.total = Number(
+					(
+						this.creditsToBuy +
+						this.creditsToBuy * this.$account.billing_info.gst_percentage
+					).toFixed(2)
+				);
+			} else {
+				this.total = this.creditsToBuy;
+			}
+		},
 		setupStripe() {
 			this.$resources.createPaymentIntent.submit();
 		},

--- a/press/press/doctype/invoice/fixtures/stripe_payment_intent_succeeded_webhook.json
+++ b/press/press/doctype/invoice/fixtures/stripe_payment_intent_succeeded_webhook.json
@@ -50,7 +50,10 @@
 						"id": "ch_1HtDyjGjnxV0XKmrM13MbJf2",
 						"invoice": null,
 						"livemode": false,
-						"metadata": {},
+					  "metadata": {
+						  "gst": "144.36",
+						  "payment_for": "prepaid_credits"
+					  },
 						"object": "charge",
 						"on_behalf_of": null,
 						"order": null,
@@ -123,7 +126,10 @@
 			"invoice": null,
 			"last_payment_error": null,
 			"livemode": false,
-			"metadata": {},
+			"metadata": {
+				"gst": "144.36",
+				"payment_for": "prepaid_credits"
+			},
 			"next_action": null,
 			"object": "payment_intent",
 			"on_behalf_of": null,

--- a/press/press/doctype/invoice/invoice.json
+++ b/press/press/doctype/invoice/invoice.json
@@ -34,6 +34,7 @@
   "total_discount_amount",
   "column_break_15",
   "total",
+  "gst",
   "applied_credits",
   "free_credits",
   "amount_due",
@@ -421,6 +422,12 @@
    "fieldtype": "Date",
    "label": "Frappe Partnership Date",
    "read_only": 1
+  },
+  {
+   "fieldname": "gst",
+   "fieldtype": "Currency",
+   "label": "GST",
+   "options": "currency"
   }
  ],
  "is_submittable": 1,
@@ -441,7 +448,7 @@
    "link_fieldname": "invoice"
   }
  ],
- "modified": "2023-09-25 12:38:40.289145",
+ "modified": "2023-11-08 17:14:00.102873",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Invoice",

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -33,7 +33,6 @@ class Invoice(Document):
 		self.validate_duplicate()
 		self.validate_items()
 		self.validate_amount()
-		self.validate_gst()
 		self.compute_free_credits()
 
 	def before_submit(self):
@@ -406,16 +405,6 @@ class Invoice(Document):
 
 		self.total_before_discount = total
 		self.set_total_and_discount()
-
-	def validate_gst(self):
-		if (
-			self.currency == "INR"
-			and self.type == "Subscription"
-			and self.payment_mode == "Card"
-		):
-			gst = self.total * frappe.db.get_single_value("Press Settings", "gst_percentage")
-			self.gst = gst
-			self.total += self.gst
 
 	def compute_free_credits(self):
 		self.free_credits = sum(

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -33,6 +33,7 @@ class Invoice(Document):
 		self.validate_duplicate()
 		self.validate_items()
 		self.validate_amount()
+		self.validate_gst()
 		self.compute_free_credits()
 
 	def before_submit(self):
@@ -405,6 +406,16 @@ class Invoice(Document):
 
 		self.total_before_discount = total
 		self.set_total_and_discount()
+
+	def validate_gst(self):
+		if (
+			self.currency == "INR"
+			and self.type == "Subscription"
+			and self.payment_mode == "Card"
+		):
+			gst = self.total * frappe.db.get_single_value("Press Settings", "gst_percentage")
+			self.gst = gst
+			self.total += self.gst
 
 	def compute_free_credits(self):
 		self.free_credits = sum(

--- a/press/press/doctype/invoice/test_invoice.py
+++ b/press/press/doctype/invoice/test_invoice.py
@@ -307,8 +307,8 @@ class TestInvoice(unittest.TestCase):
 		with patch.object(Invoice, "update_transaction_details", return_value=None):
 			process_stripe_webhook(doc, "")
 
-		# balance should 900 after buying prepaid credits
-		self.assertEqual(self.team.get_balance(), 900)
+		# balance should 755.64 after buying prepaid credits with gst applied
+		self.assertEqual(self.team.get_balance(), 755.64)
 
 	def test_single_x_percent_flat_on_total(self):
 

--- a/press/press/doctype/press_settings/press_settings.json
+++ b/press/press/doctype/press_settings/press_settings.json
@@ -11,6 +11,8 @@
   "column_break_2",
   "bench_configuration",
   "billing_tab",
+  "invoicing_column",
+  "gst_percentage",
   "stripe_settings_section",
   "stripe_inr_plan_id",
   "stripe_publishable_key",
@@ -70,7 +72,6 @@
   "column_break_66",
   "code_server",
   "code_server_password",
-  "docker_remote_builder",
   "auto_update_section",
   "auto_update_queue_size",
   "remote_files_section",
@@ -1026,14 +1027,19 @@
    "label": "AWS Secret Access Key"
   },
   {
-   "fieldname": "docker_remote_builder",
-   "fieldtype": "Data",
-   "label": "Docker Remote Builder"
+   "fieldname": "invoicing_column",
+   "fieldtype": "Column Break",
+   "label": "Invoicing"
+  },
+  {
+   "fieldname": "gst_percentage",
+   "fieldtype": "Float",
+   "label": "GST Percentage"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2023-10-25 13:37:18.168053",
+ "modified": "2023-11-08 17:03:04.819861",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Press Settings",


### PR DESCRIPTION
GST is added to total on validate. Not adding any separate fields for tracking amount before GST since we generate invoices on frappe.io where gst is added as inclusive of total amount.
- [x] Add GST when finalizing card payments
- [x] Add GST while purchasing prepaid credits