### PR TITLE
fix: don't check billing info for paid by partner

### DIFF
--- a/dashboard/src/controllers/account.js
+++ b/dashboard/src/controllers/account.js
@@ -85,9 +85,10 @@ export default class Account {
 			return true;
 		}
 		if (
-			this.team.erpnext_partner ||
+			this.team.payment_mode === 'Paid By Partner' ||
 			this.team.payment_mode === 'Partner Credits'
 		) {
+			// partner credits shall be deprecated in few months
 			return true;
 		}
 		if (this.team.payment_mode == 'Card') {


### PR DESCRIPTION
Since most partners now use Prepaid Credits or Card for Billing we can safely remove the validation unless their payment mode is **Partner Credits** or **Paid By Partner**.

PS: Partner Credits will be dropped eventually in coming months.