### PR TITLE
feat(DatabaseServer): Limit swap space for mariadb

### DIFF
--- a/press/playbooks/roles/mariadb_systemd_limits/templates/memory-custom.conf
+++ b/press/playbooks/roles/mariadb_systemd_limits/templates/memory-custom.conf
@@ -1,3 +1,4 @@
 [Service]
 MemoryHigh={{ memory_high }}G
 MemoryMax={{ memory_max }}G
+MemorySwapMax={{ memory_swap_max }}G

--- a/press/playbooks/roles/mariadb_systemd_limits/templates/memory.conf
+++ b/press/playbooks/roles/mariadb_systemd_limits/templates/memory.conf
@@ -1,3 +1,4 @@
 [Service]
 MemoryHigh={{ max(ansible_memtotal_mb // 1024 - 2, 1) }}G
 MemoryMax={{ max(ansible_memtotal_mb // 1024 - 1, 2) }}G
+MemorySwapMax=100M

--- a/press/press/doctype/database_server/database_server.json
+++ b/press/press/doctype/database_server/database_server.json
@@ -55,6 +55,8 @@
   "memory_high",
   "column_break_eiyu",
   "memory_max",
+  "column_break_wbbi",
+  "memory_swap_max",
   "section_break_ladc",
   "is_performance_schema_enabled",
   "mariadb_system_variables"
@@ -380,11 +382,21 @@
   {
    "fieldname": "column_break_apox",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_wbbi",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "memory_swap_max",
+   "fieldtype": "Float",
+   "label": "Memory Swap Max (GB)",
+   "non_negative": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-11-13 17:27:30.718828",
+ "modified": "2023-11-13 23:53:16.197071",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Database Server",

--- a/press/press/doctype/database_server/database_server.json
+++ b/press/press/doctype/database_server/database_server.json
@@ -388,6 +388,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "default": "0.1",
    "fieldname": "memory_swap_max",
    "fieldtype": "Float",
    "label": "Memory Swap Max (GB)",
@@ -396,7 +397,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-11-13 23:53:16.197071",
+ "modified": "2023-11-14 11:15:20.783328",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Database Server",

--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -37,7 +37,11 @@ class DatabaseServer(BaseServer):
 		if self.flags.in_insert or self.is_new():
 			return
 		self.update_mariadb_system_variables()
-		if self.has_value_changed("memory_high") or self.has_value_changed("memory_max"):
+		if (
+			self.has_value_changed("memory_high")
+			or self.has_value_changed("memory_max")
+			or self.has_value_changed("memory_swap_max")
+		):
 			self.update_memory_limits()
 
 		if (
@@ -80,6 +84,7 @@ class DatabaseServer(BaseServer):
 		)
 
 	def _update_memory_limits(self):
+		self.memory_swap_max = self.memory_swap_max or 0.1
 		if not self.memory_high or not self.memory_max:
 			return
 		ansible = Ansible(
@@ -91,6 +96,7 @@ class DatabaseServer(BaseServer):
 				"server": self.name,
 				"memory_high": self.memory_high,
 				"memory_max": self.memory_max,
+				"memory_swap_max": self.memory_swap_max,
 			},
 		)
 		play = ansible.run()

--- a/press/press/doctype/database_server/test_database_server.py
+++ b/press/press/doctype/database_server/test_database_server.py
@@ -94,6 +94,7 @@ class TestDatabaseServer(FrappeTestCase):
 				"server": server.name,
 				"memory_high": server.memory_high,
 				"memory_max": server.memory_max,
+				"memory_swap_max": 0.1,
 			},
 		)
 


### PR DESCRIPTION
- feat: Add MemorySwapMax setting to mariadb memory.conf
- feat(DatabaseServer): Add memory_swap_max field
- feat(DatabaseServer): Set memory_swap_max to 100M by default
