### PR TITLE
fix: Handle stripe webhook timeout

### DIFF
--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -968,6 +968,12 @@ def process_stripe_webhook(doc, method):
 		process_micro_debit_test_charge(event)
 		return
 
+	if frappe.db.exists(
+		"Invoice", {"stripe_payment_intent_id": payment_intent["id"], "status": "Paid"}
+	):
+		# ignore creating if already allocated
+		return
+
 	team: Team = frappe.get_doc("Team", {"stripe_customer_id": payment_intent["customer"]})
 	amount = payment_intent["amount"] / 100
 	gst = float(metadata.get("gst", 0))


### PR DESCRIPTION
Problem:
The methods that handles invoice creation for prepaid credit times out. But we do create an invoice and allocate amount. 
https://github.com/frappe/press/blob/fd266750425d827f207e5563f3a2724b821ca7ed/press/press/doctype/team/team.py#L994
After a while stripe tries to resend webhook until it gets `200 success response`. This creates multiple allocations for the same payment attempt.

This change doesn't crate a duplicate invoice/allocation and simply returns if the amount has been allocated in previous timed out webhook for the same payment_intent/attempt