### PR TITLE
fix: negative balance in credit transfer cases

### DIFF
--- a/press/press/doctype/balance_transaction/balance_transaction.py
+++ b/press/press/doctype/balance_transaction/balance_transaction.py
@@ -21,6 +21,7 @@ class BalanceTransaction(Document):
 			group_by="team",
 			pluck="ending_balance",
 		)
+		last_balance = last_balance[0] if last_balance else 0
 		if last_balance:
 			last_balance = last_balance[0]
 			self.ending_balance = (last_balance or 0) + self.amount

--- a/press/press/doctype/balance_transaction/balance_transaction.py
+++ b/press/press/doctype/balance_transaction/balance_transaction.py
@@ -14,15 +14,16 @@ class BalanceTransaction(Document):
 			frappe.throw("Amount cannot be 0")
 
 	def before_submit(self):
-		res = frappe.db.get_all(
+		last_balance = frappe.db.get_all(
 			"Balance Transaction",
 			filters={"team": self.team, "docstatus": 1},
 			fields=["sum(amount) as ending_balance"],
 			group_by="team",
 			pluck="ending_balance",
 		)
-		if res:
-			self.ending_balance = (res[0] or 0) + self.amount
+		if last_balance:
+			last_balance = last_balance[0]
+			self.ending_balance = (last_balance or 0) + self.amount
 		else:
 			self.ending_balance = self.amount
 
@@ -30,8 +31,18 @@ class BalanceTransaction(Document):
 			self.unallocated_amount = self.amount
 			if self.unallocated_amount < 0:
 				# in case of credit transfer
-				self.allocate_to_previous_transaction()
+				self.consume_unallocated_amount()
 				self.unallocated_amount = 0
+			elif last_balance < 0 and abs(last_balance) <= self.amount:
+				# previously the balance was negative
+				# settle the negative balance
+				self.unallocated_amount = self.amount - abs(last_balance)
+			elif last_balance < 0 and abs(last_balance) > self.amount:
+				frappe.throw(
+					f"Your credit balance is negative. You need to add minimum {abs(last_balance)} prepaid credits."
+				)
+
+
 
 	def before_update_after_submit(self):
 		total_allocated = sum([d.amount for d in self.allocated_to])
@@ -40,8 +51,41 @@ class BalanceTransaction(Document):
 	def on_submit(self):
 		frappe.publish_realtime("balance_updated", user=self.team)
 
-	def allocate_to_previous_transaction(self):
-		previous_transaction = (
+	def consume_unallocated_amount(self):
+		self.validate_total_unallocated_amount()
+
+		allocation_map = {}
+		remaining_amount = abs(self.amount)
+		transactions = frappe.get_all(
+			"Balance Transaction",
+			filters={
+				"docstatus": 1,
+				"team": self.team,
+				"unallocated_amount": (">", 0)
+			},
+			fields=["name", "unallocated_amount"],
+			order_by="creation asc",
+		)
+		for transaction in transactions:
+			if remaining_amount <= 0:
+				break
+			allocated_amount = min(
+				remaining_amount, transaction.unallocated_amount
+			)
+			remaining_amount -= allocated_amount
+			allocation_map[transaction.name] = allocated_amount
+
+		for transaction, amount in allocation_map.items():
+			doc = frappe.get_doc("Balance Transaction", transaction)
+			doc.append("allocated_to", {
+				"amount": abs(amount),
+				"currency": self.currency,
+				"balance_transaction": self.name,
+			})
+			doc.save(ignore_permissions=True)
+
+	def validate_total_unallocated_amount(self):
+		total_unallocated_amount = (
 			frappe.get_all(
 				"Balance Transaction",
 				filters={
@@ -49,25 +93,19 @@ class BalanceTransaction(Document):
 					"team": self.team,
 					"unallocated_amount": (">", 0)
 				},
-				order_by="creation desc",
-				pluck="name",
-				limit=1,
+				fields=["sum(unallocated_amount) as total_unallocated_amount"],
+				pluck="total_unallocated_amount",
 			)
 			or []
 		)
-		if not previous_transaction:
+		if not total_unallocated_amount:
 			frappe.throw(
-				"Cannot reduce unallocated amount from previous transaction as no previous transaction found"
+				"Cannot create transaction as no unallocated amount found"
 			)
-		previous_transaction = frappe.get_doc(
-			"Balance Transaction", previous_transaction[0]
-		)
-		previous_transaction.append("allocated_to", {
-			"amount": -1 * self.amount,
-			"currency": self.currency,
-			"balance_transaction": self.name,
-		})
-		previous_transaction.save(ignore_permissions=True)
+		if total_unallocated_amount[0] < abs(self.amount):
+			frappe.throw(
+				f"Cannot create transaction as unallocated amount {total_unallocated_amount[0]} is less than {self.amount}"
+			)
 
 
 get_permission_query_conditions = get_permission_query_conditions_for_doctype(

--- a/press/press/doctype/balance_transaction/balance_transaction.py
+++ b/press/press/doctype/balance_transaction/balance_transaction.py
@@ -23,7 +23,6 @@ class BalanceTransaction(Document):
 		)
 		last_balance = last_balance[0] if last_balance else 0
 		if last_balance:
-			last_balance = last_balance[0]
 			self.ending_balance = (last_balance or 0) + self.amount
 		else:
 			self.ending_balance = self.amount

--- a/press/press/doctype/balance_transaction_allocation/balance_transaction_allocation.json
+++ b/press/press/doctype/balance_transaction_allocation/balance_transaction_allocation.json
@@ -6,6 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "invoice",
+  "balance_transaction",
   "amount",
   "currency"
  ],
@@ -29,12 +30,18 @@
    "in_list_view": 1,
    "label": "Currency",
    "options": "Currency"
+  },
+  {
+   "fieldname": "balance_transaction",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Balance Transaction"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-12-07 21:56:10.582664",
+ "modified": "2023-11-18 23:53:33.424419",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Balance Transaction Allocation",

--- a/press/press/doctype/invoice/test_invoice.py
+++ b/press/press/doctype/invoice/test_invoice.py
@@ -537,7 +537,7 @@ class TestInvoice(unittest.TestCase):
 					"team": team.name,
 					"docstatus": 1,
 					"unallocated_amount": (">=", 0),
-					"source": "Prepaid Credits"
+					"source": "Prepaid Credits",
 				},
 				fields=["name", "unallocated_amount"],
 				order_by="creation asc",


### PR DESCRIPTION
Problem:
- Purchase 10$ credit (+ve balance transaction)
- Transfer 5$ (-ve balance transaction)
- Create and finalize a 10$ invoice
- Invoice gets finalized even though the team had only 5$ credit left
- Also balance becomes -5$ after the invoice is finalized
