### PR TITLE
feat(SiteChangeServer): allow switching to different server without creating a new group

### DIFF
--- a/dashboard/src/views/site/Site.vue
+++ b/dashboard/src/views/site/Site.vue
@@ -430,7 +430,8 @@ export default {
 				{
 					label: 'Change Server',
 					icon: 'server',
-					condition: () => this.site?.status === 'Active',
+					condition: () =>
+						this.site?.status === 'Active' && !this.site?.is_public,
 					onClick: () => (this.showChangeServerDialog = true)
 				}
 			];

--- a/dashboard/src/views/site/SiteChangeServerDialog.vue
+++ b/dashboard/src/views/site/SiteChangeServerDialog.vue
@@ -48,10 +48,6 @@
 						})
 				"
 			/>
-			<p v-else class="text-sm text-gray-700">
-				The chosen server isn't added to the bench yet. Please add the server to
-				the bench first.
-			</p>
 			<FormControl
 				class="mt-4"
 				v-if="$resources.isServerAddedInGroup.data"
@@ -60,6 +56,9 @@
 				:min="new Date().toISOString().slice(0, 16)"
 				v-model="targetDateTime"
 			/>
+			<p class="mt-4 text-sm text-gray-700">
+				{{ message }}
+			</p>
 			<ErrorMessage
 				class="mt-4"
 				:message="
@@ -98,6 +97,16 @@ export default {
 			set(value) {
 				this.$emit('update:modelValue', value);
 			}
+		},
+		message() {
+			if (this.targetServer && !this.$resources.isServerAddedInGroup.data) {
+				return "The chosen server isn't added to the bench yet. Please add the server to the bench first.";
+			} else if (
+				this.targetServer &&
+				this.$resources.isServerAddedInGroup.data
+			) {
+				return 'The chosen server is already added to the bench. You can now migrate the site to the server.';
+			} else return '';
 		},
 		datetimeInIST() {
 			if (!this.targetDateTime) return null;

--- a/dashboard/src/views/site/SiteChangeServerDialog.vue
+++ b/dashboard/src/views/site/SiteChangeServerDialog.vue
@@ -22,6 +22,7 @@
 					onClick: () => {
 						$resources.changeServer.submit({
 							name: site?.name,
+							server: targetServer,
 							scheduled_datetime: datetimeInIST
 						});
 					}

--- a/press/api/site.py
+++ b/press/api/site.py
@@ -1813,10 +1813,10 @@ def is_server_added_in_group(name, server):
 
 @frappe.whitelist()
 @protected("Site")
-def change_server(name, scheduled_datetime=None):
-	group, server = frappe.db.get_value("Site", name, ["group", "server"])
+def change_server(name, server, scheduled_datetime=None):
+	group = frappe.db.get_value("Site", name, "group")
 	bench = frappe.db.get_value(
-		"Bench", {"group": group, "status": "Active", "server": ("not in", server)}, "name"
+		"Bench", {"group": group, "status": "Active", "server": server}, "name"
 	)
 
 	site_migration = frappe.get_doc(

--- a/press/api/site.py
+++ b/press/api/site.py
@@ -1622,8 +1622,9 @@ def change_team(team, name):
 
 @frappe.whitelist()
 @protected("Site")
-def add_server_to_release_group(name, group_name):
-	server = frappe.db.get_value("Site", name, "server")
+def add_server_to_release_group(name, group_name, server=None):
+	if not server:
+		server = frappe.db.get_value("Site", name, "server")
 	deploy = frappe.get_doc("Release Group", group_name).add_server(server, deploy=True)
 
 	bench = find(deploy.benches, lambda bench: bench.server == server).bench
@@ -1802,39 +1803,21 @@ def change_server_options(name):
 
 @frappe.whitelist()
 @protected("Site")
-def change_server_bench_options(name, server):
-	site_group, site_bench = frappe.db.get_value("Site", name, ["group", "bench"])
-	site_candidate = frappe.db.get_value("Bench", site_bench, "candidate")
-	site_version = frappe.db.get_value("Release Group", site_group, "version")
-	team = get_current_team()
-
-	Bench = frappe.qb.DocType("Bench")
-	ReleaseGroup = frappe.qb.DocType("Release Group")
-	rg = (
-		frappe.qb.from_(Bench)
-		.select(ReleaseGroup.name, ReleaseGroup.title)
-		.join(ReleaseGroup)
-		.on(ReleaseGroup.name == Bench.group)
-		.where(Bench.server == server)
-		.where(Bench.status == "Active")
-		.where(ReleaseGroup.team == team)
-		.where(Bench.candidate >= site_candidate)
-		.where(ReleaseGroup.version == site_version)
-		.distinct()
-	).run(as_dict=True)
-
-	if not rg:
-		frappe.throw(
-			f"There are no benches with <b>{site_version}</b> in server <b>{server}</b>."
-		)
-
-	return rg
+def is_server_added_in_group(name, server):
+	site_group = frappe.get_value("Site", name, "group")
+	rg = frappe.get_doc("Release Group", site_group)
+	if server not in [s.server for s in rg.servers]:
+		return False
+	return True
 
 
 @frappe.whitelist()
 @protected("Site")
-def change_server(name, group, scheduled_datetime=None):
-	bench = frappe.db.get_value("Bench", {"group": group, "status": "Active"}, "name")
+def change_server(name, scheduled_datetime=None):
+	group, server = frappe.db.get_value("Site", name, ["group", "server"])
+	bench = frappe.db.get_value(
+		"Bench", {"group": group, "status": "Active", "server": ("not in", server)}, "name"
+	)
 
 	site_migration = frappe.get_doc(
 		{

--- a/press/api/tests/test_site.py
+++ b/press/api/tests/test_site.py
@@ -580,18 +580,26 @@ erpnext 0.8.3	    HEAD
 		from press.api.site import (
 			change_server,
 			change_server_options,
-			change_server_bench_options,
+			is_server_added_in_group,
 		)
 		from press.utils import get_current_team
 
 		app = create_test_app()
 		team = get_current_team()
 		server = create_test_server(team=team)
+
 		group = create_test_release_group([app])
-		other_group = create_test_release_group([app])
+		group.append(
+			"servers",
+			{
+				"server": server,
+			},
+		)
+		group.save()
+
 		bench = create_test_bench(group=group, server=server.name)
 		other_server = create_test_server(team=team)
-		create_test_bench(group=other_group, server=other_server.name)
+		create_test_bench(group=group, server=other_server.name)
 
 		group.append(
 			"servers",
@@ -609,8 +617,8 @@ erpnext 0.8.3	    HEAD
 		)
 
 		self.assertEqual(
-			change_server_bench_options(site.name, other_server.name),
-			[{"name": other_group.name, "title": other_group.title}],
+			is_server_added_in_group(site.name, other_server.name),
+			True,
 		)
 
 		with fake_agent_job("Update Site Migrate"):
@@ -620,7 +628,7 @@ erpnext 0.8.3	    HEAD
 				status=200,
 			)
 
-			change_server(site.name, other_group.name)
+			change_server(site.name, other_server.name)
 			site_migration = frappe.get_last_doc("Site Migration")
 			site_migration.update_site_record_fields()
 


### PR DESCRIPTION
1. Select server they want to move to (user's team should own it)

![image](https://github.com/frappe/press/assets/63963181/4558082a-6271-4271-a6a7-c0bd10dcea7e)

2. Add server to the bench if it's not added

![image](https://github.com/frappe/press/assets/63963181/e81da89e-a8dd-4226-9d1d-e0eb0188f87d)

3. Migrate to the server if it's added

![image](https://github.com/frappe/press/assets/63963181/7d262852-3340-41e4-95fc-b7a3a695aced)
