### PR TITLE
feat: configurable gunicorn worker types

### DIFF
--- a/press/docker/config/supervisor.conf
+++ b/press/docker/config/supervisor.conf
@@ -5,7 +5,8 @@ environment={% for v in doc.environment_variables %}{{v.key}}="{{v.value}}",{% e
 {% endif %}
 
 [program:frappe-bench-frappe-web]
-command=/home/frappe/frappe-bench/env/bin/gunicorn --bind 0.0.0.0:8000 --workers 2 --timeout 120 --graceful-timeout 30 --worker-tmp-dir /dev/shm frappe.app:application --preload --max-requests 5000 --max-requests-jitter 1000
+command=/home/frappe/frappe-bench/env/bin/gunicorn --bind 0.0.0.0:8000 --workers 2 --timeout 120 --graceful-timeout 30 --worker-tmp-dir /dev/shm frappe.app:application --preload --max-requests 5000 --max-requests-jitter 1000 {{ '--worker-class=' + doc.gunicorn_worker_type if doc.gunicorn_worker_type else '' }} {% if doc.gunicorn_threads_per_worker %} --threads={{ doc.gunicorn_threads_per_worker }}{% endif %}
+
 environment=FORWARDED_ALLOW_IPS="*"
 priority=4
 autostart=true

--- a/press/press/doctype/bench/bench.json
+++ b/press/press/doctype/bench/bench.json
@@ -39,6 +39,8 @@
   "feature_flags_section",
   "merge_all_rq_queues",
   "merge_default_and_short_rq_queues",
+  "gunicorn_worker_type",
+  "gunicorn_threads_per_worker",
   "column_break_mtyb",
   "environment_variables"
  ],
@@ -292,10 +294,26 @@
    "fieldname": "skip_memory_limits",
    "fieldtype": "Check",
    "label": "Skip Memory Limits"
+  },
+  {
+   "fetch_from": "candidate.gunicorn_threads_per_worker",
+   "fieldname": "gunicorn_threads_per_worker",
+   "fieldtype": "Int",
+   "label": "Gunicorn Threads Per Worker",
+   "read_only": 1
+  },
+  {
+   "default": "sync",
+   "fetch_from": "candidate.gunicorn_worker_type",
+   "fieldname": "gunicorn_worker_type",
+   "fieldtype": "Select",
+   "label": "Gunicorn Worker Type",
+   "options": "\nsync\ngthread\ngevent",
+   "read_only": 1
   }
  ],
  "links": [],
- "modified": "2023-12-04 16:40:32.814283",
+ "modified": "2023-12-04 16:44:19.425413",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Bench",

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -139,6 +139,8 @@ class Bench(Document):
 			"merge_default_and_short_rq_queues": bool(self.merge_default_and_short_rq_queues),
 			"environment_variables": self.get_environment_variables(),
 			"single_container": bool(self.is_single_container),
+			"gunicorn_worker_type": self.gunicorn_worker_type,
+			"gunicorn_threads_per_worker": self.gunicorn_threads_per_worker,
 		}
 		self.add_limits(bench_config)
 		self.update_bench_config_with_rg_config(bench_config)

--- a/press/press/doctype/deploy_candidate/deploy_candidate.json
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.json
@@ -42,7 +42,9 @@
   "is_redisearch_enabled",
   "column_break_tkdd",
   "merge_all_rq_queues",
-  "merge_default_and_short_rq_queues"
+  "merge_default_and_short_rq_queues",
+  "gunicorn_worker_type",
+  "gunicorn_threads_per_worker"
  ],
  "fields": [
   {
@@ -283,10 +285,26 @@
    "fieldtype": "Datetime",
    "label": "Scheduled Time",
    "read_only": 1
+  },
+  {
+   "default": "sync",
+   "fetch_from": "group.gunicorn_worker_type",
+   "fieldname": "gunicorn_worker_type",
+   "fieldtype": "Select",
+   "label": "Gunicorn Worker Type",
+   "options": "\nsync\ngthread\ngevent",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "group.gunicorn_threads_per_worker",
+   "fieldname": "gunicorn_threads_per_worker",
+   "fieldtype": "Int",
+   "label": "Gunicorn Threads Per Worker",
+   "read_only": 1
   }
  ],
  "links": [],
- "modified": "2023-12-04 16:08:20.194391",
+ "modified": "2023-12-04 16:09:20.194391",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Deploy Candidate",

--- a/press/press/doctype/release_group/release_group.json
+++ b/press/press/doctype/release_group/release_group.json
@@ -43,6 +43,9 @@
   "column_break_9efq",
   "merge_all_rq_queues",
   "merge_default_and_short_rq_queues",
+  "gunicorn_config_section",
+  "gunicorn_worker_type",
+  "gunicorn_threads_per_worker",
   "saas_tab",
   "saas_bench",
   "column_break_26",
@@ -222,7 +225,8 @@
   },
   {
    "fieldname": "column_break_9efq",
-   "fieldtype": "Column Break"
+   "fieldtype": "Column Break",
+   "label": "RQ Worker Config"
   },
   {
    "default": "0",
@@ -297,10 +301,28 @@
   {
    "fieldname": "column_break_njfg",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "gunicorn_config_section",
+   "fieldtype": "Section Break",
+   "label": "Gunicorn Config"
+  },
+  {
+   "default": "sync",
+   "fieldname": "gunicorn_worker_type",
+   "fieldtype": "Select",
+   "label": "Gunicorn Worker Type",
+   "options": "\nsync\ngthread\ngevent"
+  },
+  {
+   "description": "Setting this to non-zero value will convert sync to gthread worker. This doesn't apply to gevent. ",
+   "fieldname": "gunicorn_threads_per_worker",
+   "fieldtype": "Int",
+   "label": "Gunicorn Threads Per Worker"
   }
  ],
  "links": [],
- "modified": "2023-09-21 09:17:28.956768",
+ "modified": "2023-12-03 14:13:58.693402",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Release Group",


### PR DESCRIPTION
Allow configuring worker type on release group:
- Sync or unspecified - Synchronous workers handling 1 request per
  process at a time.
- gthread - Each process having specified numbers of threads. Each
  process can handle same number of requests as thread at same time.
  This worker type requires configuring thread count per worker. IMO 2-4
  threads per worker seem to give best outcome.
  Note: Python GIL limitation applies so concurrency is ONLY for I/O
  and non-python CPU work.
- gevent - Green threads which patches low level IO libraries to
  magically implement cooperative scheduling.

In general:
- Sync is safe and well tested.
- Gthread is largely safe but there can be some thread unsafe code which
  has possibility of breaking
- Gevent is completely untested and requires some modification before it
  can be used in prod safely.


agent: https://github.com/frappe/agent/pull/67

---

:warning: I don't have test setup that builds and runs images. I checked the generated configuration and visually it seems fine.

~~It would be great if our docker build is actually validated in CI. @balamurali27 :grimacing:~~ Added a test here https://github.com/frappe/press/pull/1219

Closes https://github.com/frappe/press/issues/1002