### PR TITLE
perf: optimize agent job retry code

### DIFF
--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -552,6 +552,9 @@ def update_job_and_step_status(job):
 def get_server_wise_undelivered_jobs(job_types):
 	jobs = frappe._dict()
 
+	if not job_types:
+		return jobs
+
 	for job in frappe.get_all(
 		"Agent Job",
 		{
@@ -562,6 +565,7 @@ def get_server_wise_undelivered_jobs(job_types):
 			"job_type": ("in", job_types),
 		},
 		["name", "server", "server_type"],
+		ignore_ifnull=True,  # job type is mandatory and next_retry_at has to be set for retry
 	):
 		jobs.setdefault((job.server, job.server_type), []).append(job["name"])
 


### PR DESCRIPTION
Framework is oversmart and adds ifnull assuming these fields are nullable, they are not. 

This results in full table scan of agent job, if we just drop ifnull it uses index and doesn't scan anything. 

```sql
select `name`, `server`, `server_type`
                        from `tabAgent Job`
                        where `tabAgent Job`.`status` = 'Undelivered' and `tabAgent Job`.`job_id` = 0.0 and `tabAgent Job`.`retry_count` >= 1.0 and coalesce(`tabAgent Job`.`next_retry_at`, '0001-01-01 00:00:00.000000') <= '2023-12-06 17:53:30.404813' and coalesce(`tabAgent Job`.`job_type`, '') in ('')

                         order by `tabAgent Job`.`modified` DESC
```