### PR TITLE
chore: remove gevent from Worker Type

### DIFF
--- a/press/press/doctype/bench/bench.json
+++ b/press/press/doctype/bench/bench.json
@@ -308,12 +308,12 @@
    "fieldname": "gunicorn_worker_type",
    "fieldtype": "Select",
    "label": "Gunicorn Worker Type",
-   "options": "\nsync\ngthread\ngevent",
+   "options": "\nsync\ngthread",
    "read_only": 1
   }
  ],
  "links": [],
- "modified": "2023-12-04 16:44:19.425413",
+ "modified": "2023-12-12 11:57:24.929123",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Bench",

--- a/press/press/doctype/deploy_candidate/deploy_candidate.json
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.json
@@ -292,7 +292,7 @@
    "fieldname": "gunicorn_worker_type",
    "fieldtype": "Select",
    "label": "Gunicorn Worker Type",
-   "options": "\nsync\ngthread\ngevent",
+   "options": "\nsync\ngthread",
    "read_only": 1
   },
   {
@@ -304,7 +304,7 @@
   }
  ],
  "links": [],
- "modified": "2023-12-04 16:09:20.194391",
+ "modified": "2023-12-12 11:57:03.360730",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Deploy Candidate",

--- a/press/press/doctype/release_group/release_group.json
+++ b/press/press/doctype/release_group/release_group.json
@@ -313,7 +313,7 @@
    "fieldname": "gunicorn_worker_type",
    "fieldtype": "Select",
    "label": "Gunicorn Worker Type",
-   "options": "\nsync\ngthread\ngevent"
+   "options": "\nsync\ngthread"
   },
   {
    "description": "Setting this to non-zero value will convert sync to gthread worker. This doesn't apply to gevent. ",
@@ -323,7 +323,7 @@
   }
  ],
  "links": [],
- "modified": "2023-12-03 14:13:58.693402",
+ "modified": "2023-12-12 11:56:17.384674",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Release Group",


### PR DESCRIPTION
Gevent is not supported, enabling it would break FF (See #1218)

Gevent requires custom implementation of Locals using `gevent.ContextVars` (amongst other things), just replacing usage of ContextVards doesn't work either, probably due to werkzeug `LocalProxy` usage.
