### PR TITLE
refactor: set threads as bench config

### DIFF
--- a/press/docker/config/supervisor.conf
+++ b/press/docker/config/supervisor.conf
@@ -5,7 +5,7 @@ environment={% for v in doc.environment_variables %}{{v.key}}="{{v.value}}",{% e
 {% endif %}
 
 [program:frappe-bench-frappe-web]
-command=/home/frappe/frappe-bench/env/bin/gunicorn --bind 0.0.0.0:8000 --workers 2 --timeout 120 --graceful-timeout 30 --worker-tmp-dir /dev/shm frappe.app:application --preload --max-requests 5000 --max-requests-jitter 1000 {{ '--worker-class=' + doc.gunicorn_worker_type if doc.gunicorn_worker_type else '' }} {% if doc.gunicorn_threads_per_worker %} --threads={{ doc.gunicorn_threads_per_worker }}{% endif %}
+command=/home/frappe/frappe-bench/env/bin/gunicorn --bind 0.0.0.0:8000 --workers 2 --timeout 120 --graceful-timeout 30 --worker-tmp-dir /dev/shm frappe.app:application --preload --max-requests 5000 --max-requests-jitter 1000
 
 environment=FORWARDED_ALLOW_IPS="*"
 priority=4

--- a/press/press/doctype/bench/bench.json
+++ b/press/press/doctype/bench/bench.json
@@ -39,8 +39,6 @@
   "feature_flags_section",
   "merge_all_rq_queues",
   "merge_default_and_short_rq_queues",
-  "gunicorn_worker_type",
-  "gunicorn_threads_per_worker",
   "column_break_mtyb",
   "environment_variables"
  ],
@@ -294,26 +292,10 @@
    "fieldname": "skip_memory_limits",
    "fieldtype": "Check",
    "label": "Skip Memory Limits"
-  },
-  {
-   "fetch_from": "candidate.gunicorn_threads_per_worker",
-   "fieldname": "gunicorn_threads_per_worker",
-   "fieldtype": "Int",
-   "label": "Gunicorn Threads Per Worker",
-   "read_only": 1
-  },
-  {
-   "default": "sync",
-   "fetch_from": "candidate.gunicorn_worker_type",
-   "fieldname": "gunicorn_worker_type",
-   "fieldtype": "Select",
-   "label": "Gunicorn Worker Type",
-   "options": "\nsync\ngthread",
-   "read_only": 1
   }
  ],
  "links": [],
- "modified": "2023-12-12 11:57:24.929123",
+ "modified": "2023-12-12 16:35:27.484083",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Bench",

--- a/press/press/doctype/bench/bench.json
+++ b/press/press/doctype/bench/bench.json
@@ -20,6 +20,7 @@
   "configuration_section",
   "background_workers",
   "gunicorn_workers",
+  "gunicorn_threads_per_worker",
   "port_offset",
   "auto_scale_workers",
   "skip_memory_limits",
@@ -292,10 +293,18 @@
    "fieldname": "skip_memory_limits",
    "fieldtype": "Check",
    "label": "Skip Memory Limits"
+  },
+  {
+   "default": "0",
+   "description": "Setting this to non-zero value will set Gunicorn worker class to gthread.",
+   "fieldname": "gunicorn_threads_per_worker",
+   "fieldtype": "Int",
+   "label": "Gunicorn Threads Per Worker",
+   "non_negative": 1
   }
  ],
  "links": [],
- "modified": "2023-12-12 16:35:27.484083",
+ "modified": "2023-12-12 16:45:15.665032",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Bench",

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -2,16 +2,14 @@
 # Copyright (c) 2019, Frappe and contributors
 # For license information, please see license.txt
 
-from functools import cached_property
 import json
 from datetime import datetime, timedelta
+from functools import cached_property
 
 import frappe
 from frappe.exceptions import DoesNotExistError
-
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists, make_autoname
-
 from press.agent import Agent
 from press.overrides import get_permission_query_conditions_for_doctype
 from press.press.doctype.site.site import Site
@@ -139,8 +137,6 @@ class Bench(Document):
 			"merge_default_and_short_rq_queues": bool(self.merge_default_and_short_rq_queues),
 			"environment_variables": self.get_environment_variables(),
 			"single_container": bool(self.is_single_container),
-			"gunicorn_worker_type": self.gunicorn_worker_type,
-			"gunicorn_threads_per_worker": self.gunicorn_threads_per_worker,
 		}
 		self.add_limits(bench_config)
 		self.update_bench_config_with_rg_config(bench_config)

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -2,14 +2,16 @@
 # Copyright (c) 2019, Frappe and contributors
 # For license information, please see license.txt
 
+from functools import cached_property
 import json
 from datetime import datetime, timedelta
-from functools import cached_property
 
 import frappe
 from frappe.exceptions import DoesNotExistError
+
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists, make_autoname
+
 from press.agent import Agent
 from press.overrides import get_permission_query_conditions_for_doctype
 from press.press.doctype.site.site import Site
@@ -137,6 +139,7 @@ class Bench(Document):
 			"merge_default_and_short_rq_queues": bool(self.merge_default_and_short_rq_queues),
 			"environment_variables": self.get_environment_variables(),
 			"single_container": bool(self.is_single_container),
+			"gunicorn_threads_per_worker": self.gunicorn_threads_per_worker,
 		}
 		self.add_limits(bench_config)
 		self.update_bench_config_with_rg_config(bench_config)

--- a/press/press/doctype/deploy_candidate/deploy_candidate.json
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.json
@@ -42,9 +42,7 @@
   "is_redisearch_enabled",
   "column_break_tkdd",
   "merge_all_rq_queues",
-  "merge_default_and_short_rq_queues",
-  "gunicorn_worker_type",
-  "gunicorn_threads_per_worker"
+  "merge_default_and_short_rq_queues"
  ],
  "fields": [
   {
@@ -285,26 +283,10 @@
    "fieldtype": "Datetime",
    "label": "Scheduled Time",
    "read_only": 1
-  },
-  {
-   "default": "sync",
-   "fetch_from": "group.gunicorn_worker_type",
-   "fieldname": "gunicorn_worker_type",
-   "fieldtype": "Select",
-   "label": "Gunicorn Worker Type",
-   "options": "\nsync\ngthread",
-   "read_only": 1
-  },
-  {
-   "fetch_from": "group.gunicorn_threads_per_worker",
-   "fieldname": "gunicorn_threads_per_worker",
-   "fieldtype": "Int",
-   "label": "Gunicorn Threads Per Worker",
-   "read_only": 1
   }
  ],
  "links": [],
- "modified": "2023-12-12 11:57:03.360730",
+ "modified": "2023-12-12 16:34:35.392466",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Deploy Candidate",

--- a/press/press/doctype/release_group/release_group.json
+++ b/press/press/doctype/release_group/release_group.json
@@ -43,9 +43,6 @@
   "column_break_9efq",
   "merge_all_rq_queues",
   "merge_default_and_short_rq_queues",
-  "gunicorn_config_section",
-  "gunicorn_worker_type",
-  "gunicorn_threads_per_worker",
   "saas_tab",
   "saas_bench",
   "column_break_26",
@@ -302,28 +299,10 @@
   {
    "fieldname": "column_break_njfg",
    "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "gunicorn_config_section",
-   "fieldtype": "Section Break",
-   "label": "Gunicorn Config"
-  },
-  {
-   "default": "sync",
-   "fieldname": "gunicorn_worker_type",
-   "fieldtype": "Select",
-   "label": "Gunicorn Worker Type",
-   "options": "\nsync\ngthread"
-  },
-  {
-   "description": "Setting this to non-zero value will convert sync to gthread worker. This doesn't apply to gevent. ",
-   "fieldname": "gunicorn_threads_per_worker",
-   "fieldtype": "Int",
-   "label": "Gunicorn Threads Per Worker"
   }
  ],
  "links": [],
- "modified": "2023-12-12 11:56:17.384674",
+ "modified": "2023-12-12 16:32:30.908063",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Release Group",

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -79,7 +79,6 @@ class ReleaseGroup(Document):
 		self.validate_app_versions()
 		self.validate_servers()
 		self.validate_rq_queues()
-		self.validate_gunicorn_config()
 		self.validate_max_min_workers()
 
 	def before_insert(self):
@@ -298,17 +297,6 @@ class ReleaseGroup(Document):
 				"Can't set Merge All RQ Queues and Merge Short and Default RQ Queues at once",
 				frappe.ValidationError,
 			)
-
-	def validate_gunicorn_config(self):
-		if not self.gunicorn_worker_type:
-			self.gunicorn_worker_type = "sync"
-
-		if self.gunicorn_worker_type == "gthread":
-			if self.gunicorn_threads_per_worker < 2:
-				self.gunicorn_threads_per_worker = 4  # GThread with 1 thread is meaningless.
-		else:
-			# This only applies to gthread workers
-			self.gunicorn_threads_per_worker = 0
 
 	def validate_max_min_workers(self):
 		if self.max_gunicorn_workers and self.min_gunicorn_workers:


### PR DESCRIPTION
Threads was previously readonly on Bench. Changing it from the Release Group caused updates to supervisor.conf and subsequently the Docker image.

Since agent has its own supervisor.conf, it's better to just update worker count there since that's what's used in prod. This allows on the fly changing of thread count (similar to worker count) using an agent job.

In colab with https://github.com/frappe/agent/pull/69
