### PR TITLE
feat: DBOptimizer p1 - Normalized slow query report 

### DIFF
--- a/press/press/report/mariadb_slow_queries/mariadb_slow_queries.js
+++ b/press/press/report/mariadb_slow_queries/mariadb_slow_queries.js
@@ -36,6 +36,11 @@ frappe.query_reports['MariaDB Slow Queries'] = {
 			fieldtype: 'Check',
 		},
 		{
+			fieldname: 'normalize_queries',
+			label: __('Normalize Queries'),
+			fieldtype: 'Check',
+		},
+		{
 			fieldname: 'max_lines',
 			label: __('Max Lines'),
 			default: 100,


### PR DESCRIPTION
Slow query report has a lot of noise, what's really required is:

1. Which are the slowest queries in a given timeframe sorted by duration/count/rows read etc
2. Which fields are likely unindexed.

Because slow query log is just plain queries it's not that helpful for getting bigger picture of problems and focusing on most important slow queries.


This PR adds "normalize queries" checkbox in this report which instead of showing individual slow queries first normalizes them. Normalizing right now is very DUMB:
- We strip all literal/variables and replace them with `?`
- We format entire query so it's always same in string representation
- For variable length user input like `IN (x, y, z)` we just strip it manually to only put one placeholder there like `IN (?)`

This seems to get the job done in 90% of cases (just eyeballing the queries)


This is how it looks roughly. 
![image](https://github.com/frappe/press/assets/9079960/1bb998f3-2310-4c0f-b25b-c47225beca84)


Next - pick individual query and "suggest optimization"