### PR TITLE
feat(DBOptimizer): p2 - Query analysis

### DIFF
--- a/press/press/report/mariadb_slow_queries/mariadb_slow_queries.py
+++ b/press/press/report/mariadb_slow_queries/mariadb_slow_queries.py
@@ -68,6 +68,14 @@ def execute(filters=None):
 		)
 		columns.append(
 			{
+				"fieldname": "potential_indexes",
+				"label": frappe._("Potential Indexes"),
+				"fieldtype": "Data",
+				"width": 400,
+			},
+		)
+		columns.append(
+			{
 				"fieldname": "example",
 				"label": frappe._("Example Query"),
 				"fieldtype": "Data",
@@ -163,6 +171,8 @@ def format_query(q, strip_comments=False):
 
 
 def summarize_by_query(data):
+	from press.utils.db_optimizer import DBOptimizer
+
 	queries = defaultdict(lambda: defaultdict(float))
 	for row in data:
 		query = row["query"]
@@ -179,4 +189,12 @@ def summarize_by_query(data):
 		entry["rows_sent"] += row["rows_sent"]
 		entry["example"] = query
 
-	return list(queries.values())
+	result = list(queries.values())
+	for row in result:
+		row["potential_indexes"] = ", ".join(
+			DBOptimizer(query=row["example"]).potential_indexes
+		)
+
+	result.sort(key=lambda r: r["duration"], reverse=True)
+
+	return result

--- a/press/press/report/mariadb_slow_queries/mariadb_slow_queries.py
+++ b/press/press/report/mariadb_slow_queries/mariadb_slow_queries.py
@@ -68,14 +68,6 @@ def execute(filters=None):
 		)
 		columns.append(
 			{
-				"fieldname": "potential_indexes",
-				"label": frappe._("Potential Indexes"),
-				"fieldtype": "Data",
-				"width": 400,
-			},
-		)
-		columns.append(
-			{
 				"fieldname": "example",
 				"label": frappe._("Example Query"),
 				"fieldtype": "Data",
@@ -171,8 +163,6 @@ def format_query(q, strip_comments=False):
 
 
 def summarize_by_query(data):
-	from press.utils.db_optimizer import DBOptimizer
-
 	queries = defaultdict(lambda: defaultdict(float))
 	for row in data:
 		query = row["query"]
@@ -190,11 +180,6 @@ def summarize_by_query(data):
 		entry["example"] = query
 
 	result = list(queries.values())
-	for row in result:
-		row["potential_indexes"] = ", ".join(
-			DBOptimizer(query=row["example"]).potential_indexes
-		)
-
-	result.sort(key=lambda r: r["duration"], reverse=True)
+	result.sort(key=lambda r: r["duration"] * r["count"], reverse=True)
 
 	return result

--- a/press/utils/db_optimizer.py
+++ b/press/utils/db_optimizer.py
@@ -1,0 +1,81 @@
+""" Basic DB optimizer for Frappe Framework based app.
+
+This is largely based on heuristics and known good practices for indexing.
+"""
+
+from dataclasses import dataclass
+from typing import Literal
+
+from sql_metadata import Parser
+
+
+@dataclass
+class DBExplain:
+	# refer: https://mariadb.com/kb/en/explain/
+	# Anything not explicitly encoded here is likely not supported.
+	select_type: Literal["SIMPLE", "PRIMARY", "SUBQUERY", "UNION", "DERIVED"]
+	table: str
+	scan_type: Literal[  # What type of scan will be performed
+		"ALL",  # Full table scan
+		"CONST",  # Single row will be read
+		"EQ_REF",  # A single row is found from *unique* index
+		"REF",  # Index is used, but MIGHT hit more than 1 rows as it's non-unique
+		"RANGE",  # The table will be accessed with a key over one or more value ranges.
+		"INDEX_MERGE",  # multiple indexes are used and merged smartly. Equivalent to RANGE
+		"INDEX_SUBQUERY",
+		"INDEX",  # Full index scan is performed. Similar to full table scan in case of large number of rows.
+		"REF_OR_NULL",
+		"UNIQUE_SUBQUERY",
+		"FULLTEXT",  # Full text index is used,
+	]
+	possible_keys: list[str] | None = None  # possible indexes that can be used
+	key: str | None = None  # This index is being used
+	key_len: int | None = None  # How many prefix bytes from index are being used
+	ref: str | None = None  # is reference constant or some other column
+	rows: int = 0  # roughly how many rows will be examined
+	extra: str | None = None
+	parsed_query: Parser = None
+
+
+@dataclass
+class DBOptimizer:
+	query: str  # raw query in string format
+	explain_plan: list[DBExplain] = None
+
+	def __post_init__(self):
+		if not self.explain_plan:
+			self.explain_plan = []
+		for explain_entry in self.explain_plan:
+			explain_entry.select_type = explain_entry.select_type.upper()
+			explain_entry.scan_type = explain_entry.scan_type.upper()
+		self.parsed_query = Parser(self.query)
+
+	def tables_examined(self):
+		return self.parsed_query.tables
+
+	@property
+	def potential_indexes(self) -> list[str]:
+		"""Get all columns that can potentially be indexed to speed up this query."""
+
+		possible_indexes = []
+
+		# Where claus columns using these operators benefit from index
+		#  1. = (equality)
+		#  2. >, <, >=, <=
+		#  3. LIKE 'xyz%' (Prefix search)
+		#  4. BETWEEN (for date[time] fields)
+		#  5. IN (similar to equality)
+		if where_columns := self.parsed_query.columns_dict.get("where"):
+			# TODO: Apply some heuristics here, not all columns in where clause are actually useful
+			possible_indexes.extend(where_columns)
+
+		# Join clauses - Both sides of join should ideally be indexed. One will *usually* be primary key.
+		if join_columns := self.parsed_query.columns_dict.get("join"):
+			possible_indexes.extend(join_columns)
+
+		# Top N query variant - Order by column can possibly speed up the query
+		if order_by_columns := self.parsed_query.columns_dict.get("order_by"):
+			if self.parsed_query.limit_and_offset:
+				possible_indexes.extend(order_by_columns)
+
+		return possible_indexes

--- a/press/utils/tests/test_db_optimizer.py
+++ b/press/utils/tests/test_db_optimizer.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+from frappe.tests.utils import FrappeTestCase
+
+from press.utils.db_optimizer import DBOptimizer
+
+
+class TestDBOptimizer(FrappeTestCase):
+	def test_basic_index_existence_analysis(self):
+		def possible_indexes(q):
+			return DBOptimizer(query=q).potential_indexes
+
+		self.assertEqual(
+			["modified"],
+			possible_indexes("select `name` from `tabUser` order by `modified` desc limit 1"),
+		)
+
+		self.assertEqual(
+			["full_name"],
+			possible_indexes("select `name` from `tabUser` where full_name = 'xyz'"),
+		)
+
+		self.assertIn(
+			"tabHasRole.parent",
+			possible_indexes(
+				"select `name` from `tabUser` u join tabHasRole h on h.parent = u.name"
+			),
+		)

--- a/press/utils/tests/test_db_optimizer.py
+++ b/press/utils/tests/test_db_optimizer.py
@@ -68,6 +68,26 @@ class TestDBOptimizer(FrappeTestCase):
 		self.assertEqual(index.column, "role")
 		self.assertEqual(index.table, "tabHas Role")
 
+	def test_complex_sub_query_aliases(self):
+		"""Check if table identification is correct for subqueries."""
+
+		q = """SELECT *,
+					(SELECT COUNT(*) FROM `tabHD Ticket Comment` WHERE `tabHD Ticket Comment`.`reference_ticket`=`tabHD Ticket`.`name`) `count_comment`,
+					(SELECT COUNT(*) FROM `tabCommunication` WHERE `tabCommunication`.`reference_doctype`='HD Ticket' AND `tabCommunication`.`reference_name`=`tabHD Ticket`.`name`) `count_msg`,
+				FROM `tabHD Ticket`
+				WHERE `agent_group`='L2'
+				ORDER BY `modified` DESC
+				LIMIT 20
+			"""
+		optimizer = DBOptimizer(query=q)
+		optimizer.update_table_data(DBTable.from_frappe_ouput(HD_TICKET_TABLE))
+		optimizer.update_table_data(DBTable.from_frappe_ouput(HD_TICKET_COMMENT_TABLE))
+		optimizer.update_table_data(DBTable.from_frappe_ouput(COMMUNICATION_TABLE))
+
+		index = optimizer.suggest_index()
+		self.assertEqual(index.table, "HD Ticket Comment")
+		self.assertEqual(index.column, "reference_ticket")
+
 
 # Table stats extracted using describe-database-table for testing.
 
@@ -242,6 +262,345 @@ HAS_ROLE_TABLE = {
 			"sequence": 1,
 			"nullable": "YES",
 			"column": "parent",
+			"type": "BTREE",
+		},
+	],
+}
+
+
+HD_TICKET_TABLE = {
+	"table_name": "tabHD Ticket",
+	"total_rows": 3820,
+	"schema": [
+		{
+			"column": "name",
+			"type": "bigint(20)",
+			"is_nullable": False,
+			"default": None,
+			"cardinality": 3529,
+		},
+		{"column": "creation", "type": "datetime(6)", "is_nullable": True, "default": None},
+		{
+			"column": "modified",
+			"type": "datetime(6)",
+			"is_nullable": True,
+			"default": None,
+			"cardinality": 3529,
+		},
+		{
+			"column": "modified_by",
+			"type": "varchar(140)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{"column": "owner", "type": "varchar(140)", "is_nullable": True, "default": None},
+		{"column": "docstatus", "type": "int(1)", "is_nullable": False, "default": "0"},
+		{"column": "idx", "type": "int(8)", "is_nullable": False, "default": "0"},
+		{"column": "subject", "type": "varchar(140)", "is_nullable": True, "default": None},
+		{"column": "raised_by", "type": "varchar(140)", "is_nullable": True, "default": None},
+		{
+			"column": "status",
+			"type": "varchar(140)",
+			"is_nullable": True,
+			"default": "Open",
+			"cardinality": 8,
+		},
+		{"column": "priority", "type": "varchar(140)", "is_nullable": True, "default": None},
+		{
+			"column": "ticket_type",
+			"type": "varchar(140)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{
+			"column": "agent_group",
+			"type": "varchar(140)",
+			"is_nullable": True,
+			"default": "L1",
+			"cardinality": 9,
+		},
+		{
+			"column": "ticket_split_from",
+			"type": "varchar(140)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{"column": "description", "type": "longtext", "is_nullable": True, "default": None},
+		{"column": "template", "type": "varchar(140)", "is_nullable": True, "default": None},
+		{"column": "sla", "type": "varchar(140)", "is_nullable": True, "default": None},
+		{
+			"column": "response_by",
+			"type": "datetime(6)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{
+			"column": "response_by_variance",
+			"type": "decimal(21,9)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{
+			"column": "agreement_status",
+			"type": "varchar(140)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{
+			"column": "resolution_by",
+			"type": "datetime(6)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{
+			"column": "resolution_by_variance",
+			"type": "decimal(21,9)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{
+			"column": "service_level_agreement_creation",
+			"type": "datetime(6)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{
+			"column": "on_hold_since",
+			"type": "datetime(6)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{
+			"column": "total_hold_time",
+			"type": "decimal(21,9)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{
+			"column": "first_response_time",
+			"type": "decimal(21,9)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{
+			"column": "first_responded_on",
+			"type": "datetime(6)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{
+			"column": "avg_response_time",
+			"type": "decimal(21,9)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{
+			"column": "resolution_details",
+			"type": "longtext",
+			"is_nullable": True,
+			"default": None,
+		},
+		{"column": "opening_date", "type": "date", "is_nullable": True, "default": None},
+		{"column": "opening_time", "type": "time(6)", "is_nullable": True, "default": None},
+		{
+			"column": "resolution_date",
+			"type": "datetime(6)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{
+			"column": "resolution_time",
+			"type": "decimal(21,9)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{
+			"column": "user_resolution_time",
+			"type": "decimal(21,9)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{"column": "contact", "type": "varchar(140)", "is_nullable": True, "default": None},
+		{"column": "customer", "type": "varchar(140)", "is_nullable": True, "default": None},
+		{
+			"column": "email_account",
+			"type": "varchar(140)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{"column": "attachment", "type": "text", "is_nullable": True, "default": None},
+		{"column": "_user_tags", "type": "text", "is_nullable": True, "default": None},
+		{"column": "_comments", "type": "text", "is_nullable": True, "default": None},
+		{"column": "_assign", "type": "text", "is_nullable": True, "default": None},
+		{"column": "_liked_by", "type": "text", "is_nullable": True, "default": None},
+		{"column": "_seen", "type": "text", "is_nullable": True, "default": None},
+	],
+	"indexes": [
+		{
+			"unique": True,
+			"cardinality": 3529,
+			"name": "PRIMARY",
+			"sequence": 1,
+			"nullable": False,
+			"column": "name",
+			"type": "BTREE",
+		},
+		{
+			"unique": False,
+			"cardinality": 8,
+			"name": "status",
+			"sequence": 1,
+			"nullable": True,
+			"column": "status",
+			"type": "BTREE",
+		},
+		{
+			"unique": False,
+			"cardinality": 3529,
+			"name": "modified",
+			"sequence": 1,
+			"nullable": True,
+			"column": "modified",
+			"type": "BTREE",
+		},
+	],
+}
+
+
+HD_TICKET_COMMENT_TABLE = {
+	"table_name": "tabHD Ticket Comment",
+	"total_rows": 2683,
+	"schema": [
+		{
+			"column": "name",
+			"type": "varchar(140)",
+			"is_nullable": False,
+			"default": None,
+			"cardinality": 2683,
+		},
+		{"column": "creation", "type": "datetime(6)", "is_nullable": True, "default": None},
+		{
+			"column": "modified",
+			"type": "datetime(6)",
+			"is_nullable": True,
+			"default": None,
+			"cardinality": 2345,
+		},
+		{
+			"column": "reference_ticket",
+			"type": "varchar(140)",
+			"is_nullable": True,
+			"default": None,
+			"cardinality": 1379,
+		},
+		{
+			"column": "commented_by",
+			"type": "varchar(140)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{"column": "content", "type": "longtext", "is_nullable": True, "default": None},
+		{"column": "is_pinned", "type": "int(1)", "is_nullable": False, "default": "0"},
+	],
+	"indexes": [
+		{
+			"unique": True,
+			"cardinality": 2345,
+			"name": "PRIMARY",
+			"sequence": 1,
+			"nullable": False,
+			"column": "name",
+			"type": "BTREE",
+		},
+		{
+			"unique": False,
+			"cardinality": 2345,
+			"name": "modified",
+			"sequence": 1,
+			"nullable": True,
+			"column": "modified",
+			"type": "BTREE",
+		},
+	],
+}
+
+
+COMMUNICATION_TABLE = {
+	"table_name": "tabCommunication",
+	"total_rows": 20727,
+	"schema": [
+		{
+			"column": "name",
+			"type": "varchar(140)",
+			"is_nullable": False,
+			"default": None,
+			"cardinality": 19713,
+		},
+		{"column": "creation", "type": "datetime(6)", "is_nullable": True, "default": None},
+		{
+			"column": "modified",
+			"type": "datetime(6)",
+			"is_nullable": True,
+			"default": None,
+			"cardinality": 19713,
+		},
+		{
+			"column": "reference_doctype",
+			"type": "varchar(140)",
+			"is_nullable": True,
+			"default": None,
+			"cardinality": 1,
+		},
+		{
+			"column": "reference_name",
+			"type": "varchar(140)",
+			"is_nullable": True,
+			"default": None,
+			"cardinality": 3798,
+		},
+		{
+			"column": "reference_owner",
+			"type": "varchar(140)",
+			"is_nullable": True,
+			"default": None,
+			"cardinality": 1314,
+		},
+	],
+	"indexes": [
+		{
+			"unique": True,
+			"cardinality": 19713,
+			"name": "PRIMARY",
+			"sequence": 1,
+			"nullable": False,
+			"column": "name",
+			"type": "BTREE",
+		},
+		{
+			"unique": False,
+			"cardinality": 19713,
+			"name": "modified",
+			"sequence": 1,
+			"nullable": True,
+			"column": "modified",
+			"type": "BTREE",
+		},
+		{
+			"unique": False,
+			"cardinality": 2,
+			"name": "reference_doctype_reference_name_index",
+			"sequence": 1,
+			"nullable": True,
+			"column": "reference_doctype",
+			"type": "BTREE",
+		},
+		{
+			"unique": False,
+			"cardinality": 9856,
+			"name": "reference_doctype_reference_name_index",
+			"sequence": 2,
+			"nullable": True,
+			"column": "reference_name",
 			"type": "BTREE",
 		},
 	],

--- a/press/utils/tests/test_db_optimizer.py
+++ b/press/utils/tests/test_db_optimizer.py
@@ -3,13 +3,21 @@
 
 from frappe.tests.utils import FrappeTestCase
 
-from press.utils.db_optimizer import DBOptimizer
+from press.utils.db_optimizer import DBOptimizer, DBTable
 
 
 class TestDBOptimizer(FrappeTestCase):
 	def test_basic_index_existence_analysis(self):
 		def possible_indexes(q):
-			return DBOptimizer(query=q).potential_indexes
+			user = DBTable.from_frappe_ouput(USER_TABLE)
+			has_role = DBTable.from_frappe_ouput(HAS_ROLE_TABLE)
+			return [
+				i.column
+				for i in DBOptimizer(
+					query=q,
+					tables={"tabUser": user, "tabHas Role": has_role},
+				).potential_indexes()
+			]
 
 		self.assertEqual(
 			["modified"],
@@ -22,8 +30,219 @@ class TestDBOptimizer(FrappeTestCase):
 		)
 
 		self.assertIn(
-			"tabHasRole.parent",
+			"parent",
 			possible_indexes(
-				"select `name` from `tabUser` u join tabHasRole h on h.parent = u.name"
+				"select `name` from `tabUser` u join `tabHas Role` h on h.parent = u.name"
 			),
 		)
+
+	def test_suggestion_using_table_stats(self):
+		user = DBTable.from_frappe_ouput(USER_TABLE)
+		has_role = DBTable.from_frappe_ouput(HAS_ROLE_TABLE)
+
+		tables = {"tabUser": user, "tabHas Role": has_role}
+		self.assertEqual(user.total_rows, 92)
+
+		# This should suggest adding api_key as it definitely has highest cardinality.
+		optimizer = DBOptimizer(
+			query="select name from tabUser where enabled = 1 and api_key = 'xyz'", tables=tables
+		)
+		self.assertIn("api_key", [i.column for i in optimizer.potential_indexes()])
+
+		index = optimizer.suggest_index()
+		self.assertEqual(index.column, "api_key")
+
+		# This should suggest nothing as modified is already indexed
+		optimizer = DBOptimizer(
+			query="select name from tabUser order by modified asc",
+			tables=tables,
+		)
+		self.assertIsNone(optimizer.suggest_index())
+
+		# This should suggest nothing as modified is already indexed
+		optimizer = DBOptimizer(
+			query="select name from tabUser u join `tabHas Role` r on r.parent = u.name where r.role='System Manager'",
+			tables=tables,
+		)
+		index = optimizer.suggest_index()
+		self.assertEqual(index.column, "role")
+		self.assertEqual(index.table, "tabHas Role")
+
+
+# Table stats extracted using describe-database-table for testing.
+
+USER_TABLE = {
+	"table_name": "tabUser",
+	"total_rows": 92,
+	"schema": [
+		{
+			"column": "name",
+			"type": "varchar(140)",
+			"is_nullable": False,
+			"default": None,
+			"cardinality": 91,
+		},
+		{"column": "creation", "type": "datetime(6)", "is_nullable": True, "default": None},
+		{
+			"column": "modified",
+			"type": "datetime(6)",
+			"is_nullable": True,
+			"default": None,
+			"cardinality": 91,
+		},
+		{
+			"column": "modified_by",
+			"type": "varchar(140)",
+			"is_nullable": True,
+			"default": None,
+		},
+		{"column": "owner", "type": "varchar(140)", "is_nullable": True, "default": None},
+		{"column": "docstatus", "type": "int(1)", "is_nullable": False, "default": "0"},
+		{"column": "idx", "type": "int(8)", "is_nullable": False, "default": "0"},
+		{"column": "enabled", "type": "int(1)", "is_nullable": False, "default": "1"},
+		{"column": "email", "type": "varchar(140)", "is_nullable": False, "default": ""},
+		{
+			"column": "first_name",
+			"type": "varchar(140)",
+			"is_nullable": True,
+			"default": None,
+			"cardinality": 88,
+		},
+		{
+			"column": "reset_password_key",
+			"type": "varchar(140)",
+			"is_nullable": True,
+			"default": None,
+			"cardinality": 84,
+		},
+		{
+			"column": "user_type",
+			"type": "varchar(140)",
+			"is_nullable": True,
+			"default": "System User",
+			"cardinality": 2,
+		},
+		{
+			"column": "api_key",
+			"type": "varchar(140)",
+			"is_nullable": True,
+			"default": None,
+			"cardinality": 70,
+		},
+		{"column": "api_secret", "type": "text", "is_nullable": True, "default": None},
+		{"column": "_user_tags", "type": "text", "is_nullable": True, "default": None},
+		{"column": "_comments", "type": "text", "is_nullable": True, "default": None},
+		{"column": "_assign", "type": "text", "is_nullable": True, "default": None},
+		{"column": "_liked_by", "type": "text", "is_nullable": True, "default": None},
+	],
+	"indexes": [
+		{
+			"unique": True,
+			"cardinality": 91,
+			"name": "PRIMARY",
+			"sequence": 1,
+			"nullable": False,
+			"column": "name",
+			"type": "BTREE",
+		},
+		{
+			"unique": True,
+			"cardinality": 91,
+			"name": "username",
+			"sequence": 1,
+			"nullable": True,
+			"column": "username",
+			"type": "BTREE",
+		},
+		{
+			"unique": False,
+			"cardinality": 91,
+			"name": "modified",
+			"sequence": 1,
+			"nullable": True,
+			"column": "modified",
+			"type": "BTREE",
+		},
+		{
+			"unique": False,
+			"cardinality": 91,
+			"name": "reset_password_key_index",
+			"sequence": 1,
+			"nullable": True,
+			"column": "reset_password_key",
+			"type": "BTREE",
+		},
+	],
+}
+
+
+HAS_ROLE_TABLE = {
+	"table_name": "tabHas Role",
+	"total_rows": 96,
+	"schema": [
+		{
+			"column": "name",
+			"type": "varchar(140)",
+			"is_nullable": "NO",
+			"default": None,
+			"cardinality": 92,
+		},
+		{"column": "creation", "type": "datetime(6)", "is_nullable": "YES", "default": None},
+		{"column": "modified", "type": "datetime(6)", "is_nullable": "YES", "default": None},
+		{
+			"column": "modified_by",
+			"type": "varchar(140)",
+			"is_nullable": "YES",
+			"default": None,
+		},
+		{"column": "owner", "type": "varchar(140)", "is_nullable": "YES", "default": None},
+		{"column": "docstatus", "type": "int(1)", "is_nullable": "NO", "default": "0"},
+		{"column": "idx", "type": "int(8)", "is_nullable": "NO", "default": "0"},
+		{
+			"column": "role",
+			"type": "varchar(140)",
+			"is_nullable": "YES",
+			"default": None,
+			"cardinality": 78,
+		},
+		{
+			"column": "parent",
+			"type": "varchar(140)",
+			"is_nullable": "YES",
+			"default": None,
+			"cardinality": 92,
+		},
+		{
+			"column": "parentfield",
+			"type": "varchar(140)",
+			"is_nullable": "YES",
+			"default": None,
+		},
+		{
+			"column": "parenttype",
+			"type": "varchar(140)",
+			"is_nullable": "YES",
+			"default": None,
+		},
+	],
+	"indexes": [
+		{
+			"unique": True,
+			"cardinality": 92,
+			"name": "PRIMARY",
+			"sequence": 1,
+			"nullable": "",
+			"column": "name",
+			"type": "BTREE",
+		},
+		{
+			"unique": False,
+			"cardinality": 92,
+			"name": "parent",
+			"sequence": 1,
+			"nullable": "YES",
+			"column": "parent",
+			"type": "BTREE",
+		},
+	],
+}

--- a/press/utils/tests/test_db_optimizer.py
+++ b/press/utils/tests/test_db_optimizer.py
@@ -85,7 +85,7 @@ class TestDBOptimizer(FrappeTestCase):
 		optimizer.update_table_data(DBTable.from_frappe_ouput(COMMUNICATION_TABLE))
 
 		index = optimizer.suggest_index()
-		self.assertEqual(index.table, "HD Ticket Comment")
+		self.assertEqual(index.table, "tabHD Ticket Comment")
 		self.assertEqual(index.column, "reference_ticket")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ tldextract==3.4.4
 responses==0.23.1
 paramiko==3.3.1
 oci==2.116.0
+sql_metadata==2.10.0


### PR DESCRIPTION
This PR adds a dumb SQL analyzer to find all potential indexes that can benefit a slow query.

As of this PR the table stats need to be manually fed into the optimizer, subsequent PRs will use agent to automatically fetch this data. WIP: https://github.com/frappe/agent/pull/71




Towards https://github.com/frappe/press/issues/1265
