### PR TITLE
fix(Incident): Minor fixes to incident management

### DIFF
--- a/press/press/doctype/alertmanager_webhook_log/alertmanager_webhook_log.py
+++ b/press/press/doctype/alertmanager_webhook_log/alertmanager_webhook_log.py
@@ -58,7 +58,9 @@ class AlertmanagerWebhookLog(Document):
 		enqueue_doc(
 			self.doctype, self.name, "send_telegram_notification", enqueue_after_commit=True
 		)
-		enqueue_doc(self.doctype, self.name, "validate_and_create_incident")
+		enqueue_doc(
+			self.doctype, self.name, "validate_and_create_incident", enqueue_after_commit=True
+		)
 
 	def get_past_alert_instances(self):
 		past_alerts = frappe.get_all(

--- a/press/press/doctype/alertmanager_webhook_log/alertmanager_webhook_log.py
+++ b/press/press/doctype/alertmanager_webhook_log/alertmanager_webhook_log.py
@@ -99,7 +99,7 @@ class AlertmanagerWebhookLog(Document):
 			return
 
 		instances = self.get_past_alert_instances()
-		if len(instances) > min(0.4 * self.total_instances(), 25):
+		if len(instances) > min(0.4 * self.total_instances(), 15):
 			self.create_incident()
 
 	def get_repeat_interval(self):

--- a/press/press/doctype/alertmanager_webhook_log/alertmanager_webhook_log.py
+++ b/press/press/doctype/alertmanager_webhook_log/alertmanager_webhook_log.py
@@ -5,6 +5,7 @@ from functools import cached_property
 import frappe
 import json
 from frappe.model.document import Document
+from frappe.utils.background_jobs import enqueue_doc
 from press.telegram_utils import Telegram
 from press.utils import get_last_doc, log_error
 from frappe.utils import get_url_to_form
@@ -52,12 +53,12 @@ class AlertmanagerWebhookLog(Document):
 		self.common_labels = json.dumps(self.parsed["commonLabels"], indent=2, sort_keys=True)
 
 		self.payload = json.dumps(self.parsed, indent=2, sort_keys=True)
-		frappe.enqueue_doc(
-			self.doctype, self.name, "send_telegram_notification", enqueue_after_commit=True
-		)
 
 	def after_insert(self):
-		self.validate_and_create_incident()
+		enqueue_doc(
+			self.doctype, self.name, "send_telegram_notification", enqueue_after_commit=True
+		)
+		enqueue_doc(self.doctype, self.name, "validate_and_create_incident")
 
 	def get_past_alert_instances(self):
 		past_alerts = frappe.get_all(
@@ -192,5 +193,5 @@ class AlertmanagerWebhookLog(Document):
 				incident.server = self.server
 				incident.cluster = self.cluster
 				incident.save()
-		except Exception as e:
-			log_error("Failed to create incident", e)
+		except Exception:
+			log_error("Incident creation failed")

--- a/press/press/doctype/alertmanager_webhook_log/alertmanager_webhook_log.py
+++ b/press/press/doctype/alertmanager_webhook_log/alertmanager_webhook_log.py
@@ -6,7 +6,7 @@ import frappe
 import json
 from frappe.model.document import Document
 from press.telegram_utils import Telegram
-from press.utils import log_error
+from press.utils import get_last_doc, log_error
 from frappe.utils import get_url_to_form
 from frappe.utils.data import add_to_date
 
@@ -178,16 +178,15 @@ class AlertmanagerWebhookLog(Document):
 
 	def create_incident(self):
 		try:
-			if incident_exists := frappe.db.exists(
+			if not get_last_doc(
 				"Incident",
 				{
 					"alert": self.alert,
 					INCIDENT_SCOPE: self.server,
 					"status": "Validating",
 				},
+				for_update=True,
 			):
-				incident = frappe.get_doc("Incident", incident_exists)
-			else:
 				incident = frappe.new_doc("Incident")
 				incident.alert = self.alert
 				incident.server = self.server

--- a/press/press/doctype/incident/incident.py
+++ b/press/press/doctype/incident/incident.py
@@ -3,7 +3,6 @@
 
 import contextlib
 import frappe
-from twilio.rest import Client
 from frappe.website.website_generator import WebsiteGenerator
 from tenacity import RetryError, retry, stop_after_attempt, wait_fixed
 from tenacity.retry import retry_if_result
@@ -47,15 +46,11 @@ class Incident(WebsiteGenerator):
 	def twilio_client(self):
 		press_settings = frappe.get_cached_doc("Press Settings")
 		try:
-			account_sid = press_settings.twilio_account_sid
-			auth_token = press_settings.get_password("twilio_auth_token")
+			return press_settings.twilio_client
 		except Exception:
-			log_error(
-				"Twilio credentials are not entered in Press Settings.",
-			)
-			frappe.db.commit()  # don't interrupt alert creation
+			log_error("Twilio Client not configured in Press Settings")
+			frappe.db.commit()
 			raise
-		return Client(account_sid, auth_token)
 
 	@retry(
 		retry=retry_if_result(

--- a/press/press/doctype/incident/incident.py
+++ b/press/press/doctype/incident/incident.py
@@ -3,6 +3,7 @@
 
 import contextlib
 import frappe
+from frappe.utils.background_jobs import enqueue_doc
 from frappe.website.website_generator import WebsiteGenerator
 from tenacity import RetryError, retry, stop_after_attempt, wait_fixed
 from tenacity.retry import retry_if_result
@@ -28,7 +29,7 @@ class Incident(WebsiteGenerator):
 
 	def after_insert(self):
 		if self.phone_call:
-			frappe.enqueue_doc(self.doctype, self.name, "_call_humans", queue="long")
+			enqueue_doc(self.doctype, self.name, "_call_humans", queue="long")
 
 	def get_humans(self) -> list["IncidentSettingsUser"]:
 		"""

--- a/press/press/doctype/incident/incident.py
+++ b/press/press/doctype/incident/incident.py
@@ -29,7 +29,9 @@ class Incident(WebsiteGenerator):
 
 	def after_insert(self):
 		if self.phone_call:
-			enqueue_doc(self.doctype, self.name, "_call_humans", queue="long")
+			enqueue_doc(
+				self.doctype, self.name, "_call_humans", queue="long", enqueue_after_commit=True
+			)
 
 	def get_humans(self) -> list["IncidentSettingsUser"]:
 		"""

--- a/press/press/doctype/incident/incident.py
+++ b/press/press/doctype/incident/incident.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2023, Frappe and contributors
 # For license information, please see license.txt
 
+import contextlib
 import frappe
 from twilio.rest import Client
 from frappe.website.website_generator import WebsiteGenerator
-from tenacity import retry, stop_after_attempt, wait_fixed
+from tenacity import RetryError, retry, stop_after_attempt, wait_fixed
 from tenacity.retry import retry_if_result
 
 from press.utils import log_error
@@ -67,7 +68,8 @@ class Incident(WebsiteGenerator):
 				to=human.phone,
 				from_=self.twilio_phone_number,
 			)
-			self.wait_for_pickup(call)
+			with contextlib.suppress(RetryError):
+				self.wait_for_pickup(call)
 			if call.status in ["completed", "answered"]:  # at least one picked up
 				break
 

--- a/press/press/doctype/incident/test_incident.py
+++ b/press/press/doctype/incident/test_incident.py
@@ -39,6 +39,10 @@ class MockTwilioClient:
 
 
 @patch("press.press.doctype.incident.incident.frappe.db.commit", new=Mock())
+@patch(
+	"press.press.doctype.alertmanager_webhook_log.alertmanager_webhook_log.frappe.enqueue_doc",
+	new=foreground_enqueue_doc,
+)
 class TestIncident(FrappeTestCase):
 	def setUp(self):
 		frappe.db.set_value("Press Settings", None, "twilio_account_sid", "test")

--- a/press/press/doctype/incident_updates/incident_updates.json
+++ b/press/press/doctype/incident_updates/incident_updates.json
@@ -13,19 +13,21 @@
   {
    "fieldname": "update_note",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Update Note"
   },
   {
    "default": "now",
    "fieldname": "update_time",
    "fieldtype": "Datetime",
+   "in_list_view": 1,
    "label": "Update Time"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-10-17 18:40:16.203759",
+ "modified": "2023-12-20 00:46:20.068124",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Incident Updates",

--- a/press/press/doctype/press_settings/press_settings.json
+++ b/press/press/doctype/press_settings/press_settings.json
@@ -132,7 +132,8 @@
   "aws_secret_access_key",
   "twilio_section",
   "twilio_account_sid",
-  "twilio_auth_token",
+  "twilio_api_key_sid",
+  "twilio_api_key_secret",
   "column_break_kxuj",
   "twilio_phone_number",
   "marketplace_tab",
@@ -1049,11 +1050,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "twilio_auth_token",
-   "fieldtype": "Password",
-   "label": "Twilio Auth Token"
-  },
-  {
    "fieldname": "twilio_phone_number",
    "fieldtype": "Phone",
    "label": "Twilio Phone Number"
@@ -1080,11 +1076,21 @@
   {
    "fieldname": "column_break_edst",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "twilio_api_key_sid",
+   "fieldtype": "Data",
+   "label": "Twilio API Key SID"
+  },
+  {
+   "fieldname": "twilio_api_key_secret",
+   "fieldtype": "Password",
+   "label": "Twilio API Key Secret"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2023-12-14 13:58:16.779724",
+ "modified": "2023-12-20 08:59:12.583012",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Press Settings",

--- a/press/press/doctype/press_settings/press_settings.py
+++ b/press/press/doctype/press_settings/press_settings.py
@@ -99,7 +99,7 @@ class PressSettings(Document):
 		return Telegram
 
 	@property
-	def twilio_client(self):
+	def twilio_client(self) -> Client:
 		account_sid = self.twilio_account_sid
 		api_key_sid = self.twilio_api_key_sid
 		api_key_secret = self.get_password("twilio_api_key_secret")

--- a/press/press/doctype/press_settings/press_settings.py
+++ b/press/press/doctype/press_settings/press_settings.py
@@ -6,6 +6,7 @@
 import boto3
 import frappe
 from boto3.session import Session
+from twilio.rest import Client
 from frappe.model.document import Document
 from frappe.utils import get_url
 
@@ -96,3 +97,10 @@ class PressSettings(Document):
 	@property
 	def telegram(self):
 		return Telegram
+
+	@property
+	def twilio_client(self):
+		account_sid = self.twilio_account_sid
+		api_key_sid = self.twilio_api_key_sid
+		api_key_secret = self.get_password("twilio_api_key_secret")
+		return Client(api_key_sid, api_key_secret, account_sid)

--- a/press/press/doctype/press_settings/test_press_settings.py
+++ b/press/press/doctype/press_settings/test_press_settings.py
@@ -35,16 +35,13 @@ def create_test_press_settings():
 		}
 	).insert(ignore_if_duplicate=True)
 
-	settings = frappe.get_doc(
-		{
-			"doctype": "Press Settings",
-			"domain": "fc.dev",
-			"bench_configuration": "{}",
-			"rsa_key_size": "2048",
-			"certbot_directory": ".certbot",
-			"eff_registration_email": frappe.mock("email"),
-		}
-	).insert()
+	settings = frappe.get_single("Press Settings")
+	settings.domain = "fc.dev"
+	settings.bench_configuration = "{}"
+	settings.rsa_key_size = 2048
+	settings.certbot_directory = ".certbot"
+	settings.eff_registration_email = frappe.mock("email")
+	settings.save()
 	return settings
 
 


### PR DESCRIPTION
- Incident creation in bg job
- Handle RetryError correctly
- Disallow duplicate/parallel incident creation
- Reduce threshold for sites down to 15
- Make calls actually sequential
- API Key auth for twilio
- Send telegram msg in after insert of AlertmanagerWebhookLog
- Press Settings won't be reset by create_test_press_settings anymore
- Cleaner tests