### PR TITLE
fix: show paid by partner mode after partner linked

### DIFF
--- a/dashboard/src/components/ChangePaymentModeDialog.vue
+++ b/dashboard/src/components/ChangePaymentModeDialog.vue
@@ -122,7 +122,10 @@ export default {
 			}[this.paymentMode];
 		},
 		paymentModeOptions() {
-			if (this.$account.team.erpnext_partner) {
+			if (
+				this.$account.team.erpnext_partner ||
+				!this.$account.team.partner_email
+			) {
 				return ['Card', 'Prepaid Credits'];
 			}
 			return ['Card', 'Prepaid Credits', 'Paid By Partner'];

--- a/press/press/audit.py
+++ b/press/press/audit.py
@@ -401,12 +401,14 @@ class BillingAudit(Audit):
 		)
 
 	def prepaid_unpaid_invoices_with_stripe_invoice_id_set(self):
+		active_teams = frappe.get_all("Team", {"enabled": 1, "free_account": 0}, pluck="name")
 		return frappe.get_all(
 			"Invoice",
 			{
 				"status": "Unpaid",
 				"payment_mode": "Prepaid Credits",
 				"type": "Subscription",
+				"team": ("in", active_teams),
 				"stripe_invoice_id": ("is", "set"),
 			},
 			pluck="name",


### PR DESCRIPTION
Teams were able to select Paid by Partner mode even though their account was not linked to any partner