### PR TITLE
fix: fetch server type for server path

### DIFF
--- a/dashboard/src/views/server/Server.vue
+++ b/dashboard/src/views/server/Server.vue
@@ -199,7 +199,7 @@ export default {
 					icon: 'external-link',
 					onClick: () => {
 						window.open(
-							`${window.location.protocol}//${window.location.host}/app/server/${this.server.name}`,
+							`${window.location.protocol}//${window.location.host}/app/${this.server.type}/${this.server.name}`,
 							'_blank'
 						);
 					}

--- a/press/api/server.py
+++ b/press/api/server.py
@@ -127,6 +127,7 @@ def get(name):
 		"tags": frappe.get_all(
 			"Press Tag", {"team": server.team, "doctype_name": "Server"}, ["name", "tag"]
 		),
+		"type": "database-server" if server.meta.name == "Database Server" else "server",
 	}
 
 

--- a/press/press/doctype/account_request/account_request.py
+++ b/press/press/doctype/account_request/account_request.py
@@ -102,7 +102,9 @@ class AccountRequest(Document):
 				f"/api/method/press.api.saas.validate_account_request?key={self.request_key}"
 			)
 
-		return get_url(f"/dashboard{'2' if dashboard2 else ''}/setup-account/{self.request_key}")
+		return get_url(
+			f"/dashboard{'2' if dashboard2 else ''}/setup-account/{self.request_key}"
+		)
 
 	@property
 	def full_name(self):

--- a/press/press/doctype/stripe_webhook_log/stripe_webhook_log.py
+++ b/press/press/doctype/stripe_webhook_log/stripe_webhook_log.py
@@ -27,7 +27,9 @@ class StripeWebhookLog(Document):
 
 		if invoice_id:
 			self.invoice_id = invoice_id
-			self.invoice = frappe.db.get_value("Invoice", {"stripe_invoice_id": invoice_id}, "name")
+			self.invoice = frappe.db.get_value(
+				"Invoice", {"stripe_invoice_id": invoice_id}, "name"
+			)
 
 
 @frappe.whitelist(allow_guest=True)


### PR DESCRIPTION
### Bug:
"Visit in desk" button redirects to server doctype for database servers as well since it was hardcoded. 

![image](https://github.com/frappe/press/assets/30501401/3fe0a31a-6d9c-4257-8d39-25f70d8135b9)


### Fix:
Fetch server type to redirect to correct server doctype in desk