### PR TITLE
feat: add simple vimrc to image

### DIFF
--- a/press/docker/.vimrc
+++ b/press/docker/.vimrc
@@ -1,0 +1,10 @@
+set noexpandtab
+set shiftwidth=4
+set tabstop=4
+set number
+set backspace=indent,eol,start
+set complete-=i
+set smarttab
+set incsearch
+set ruler
+filetype plugin indent on

--- a/press/docker/Dockerfile
+++ b/press/docker/Dockerfile
@@ -211,7 +211,7 @@ RUN --mount=type=cache,target=/home/frappe/.cache,uid=1000,gid=1000 /home/frappe
 
 # Install Redisearch 2.0 from precompiled binaries
 COPY --chown=frappe:frappe redis /home/frappe/frappe-bench/redis
-
+COPY --chown=frappe:frappe .vimrc /home/frappe/.vimrc
 COPY --chown=frappe:frappe common_site_config.json /home/frappe/frappe-bench/sites/common_site_config.json
 
 # Install other apps

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -465,7 +465,7 @@ class DeployCandidate(Document):
 			f.write(content)
 
 	def _copy_config_files(self):
-		for target in ["common_site_config.json", "supervisord.conf"]:
+		for target in ["common_site_config.json", "supervisord.conf", ".vimrc"]:
 			shutil.copy(
 				os.path.join(frappe.get_app_path("press", "docker"), target), self.build_directory
 			)


### PR DESCRIPTION
Adds a bare-bones `.vimrc`. This enables a few niceties. Some of them:
- sensible tab behavior and display
- line numbers, cursor position display
- syntax highlighting

Some it is from: https://github.com/tpope/vim-sensible/blob/master/plugin/sensible.vim
And some of it has been suggested by Ankush.