### PR TITLE
feat: MariaDB Physical Backups

### DIFF
--- a/press/agent.py
+++ b/press/agent.py
@@ -406,6 +406,21 @@ class Agent:
 			site=site.name,
 		)
 
+	def backup_schema(self, site, offsite=False):
+		database_server = frappe.db.get_value("Bench", site.bench, "database_server")
+		data = {
+			"mariadb_root_password": get_decrypted_password(
+				"Database Server", database_server, "mariadb_root_password"
+			),
+		}
+
+		return self.create_agent_job(
+			"Backup MariaDB Schema",
+			f"database/backup/{site.database_name}",
+			data=data,
+			site=site.name,
+		)
+
 	def add_domain(self, site, domain):
 		data = {
 			"domain": domain,

--- a/press/fixtures/agent_job_type.json
+++ b/press/fixtures/agent_job_type.json
@@ -1906,5 +1906,41 @@
     "step_name": "Optimize Tables"
    }
   ]
+ },
+ {
+  "disabled_auto_retry": 1,
+  "docstatus": 0,
+  "doctype": "Agent Job Type",
+  "max_retry_count": 3,
+  "modified": "2024-01-12 17:14:39.617257",
+  "name": "Backup MariaDB Schema",
+  "request_method": "POST",
+  "request_path": "database/{site.database_name}/backup",
+  "steps": [
+   {
+    "parent": "Backup MariaDB Schema",
+    "parentfield": "steps",
+    "parenttype": "Agent Job Type",
+    "step_name": "Backup with Mariabackup"
+   },
+   {
+    "parent": "Backup MariaDB Schema",
+    "parentfield": "steps",
+    "parenttype": "Agent Job Type",
+    "step_name": "Prepare with Mariabackup"
+   },
+   {
+    "parent": "Backup MariaDB Schema",
+    "parentfield": "steps",
+    "parenttype": "Agent Job Type",
+    "step_name": "Create Table List"
+   },
+   {
+    "parent": "Backup MariaDB Schema",
+    "parentfield": "steps",
+    "parenttype": "Agent Job Type",
+    "step_name": "Create DDL File"
+   }
+  ]
  }
 ]

--- a/press/playbooks/roles/mariadb/tasks/main.yml
+++ b/press/playbooks/roles/mariadb/tasks/main.yml
@@ -23,6 +23,7 @@
       - mariadb-server
       - mariadb-client
       - libmariadbclient18
+      - mariadb-backup
     state: present
 
 - name: Install MySQLdb Python Package

--- a/press/playbooks/roles/user/files/sudoers
+++ b/press/playbooks/roles/user/files/sudoers
@@ -7,3 +7,4 @@ frappe ALL = (root) NOPASSWD: /usr/bin/supervisorctl
 frappe ALL = (root) NOPASSWD: /usr/sbin/nginx
 frappe ALL = (root) NOPASSWD: /usr/local/bin/bench
 
+frappe ALL = (mysql) NOPASSWD: /usr/bin/mariabackup

--- a/press/press/doctype/site_backup/site_backup.json
+++ b/press/press/doctype/site_backup/site_backup.json
@@ -8,30 +8,36 @@
   "status",
   "files_availability",
   "site",
-  "job",
+  "column_break_zwsb",
   "with_files",
   "offsite",
+  "job",
+  "column_break_noav",
   "database",
   "size",
   "url",
   "data_7",
   "database_file",
   "database_url",
+  "column_break_wiuq",
   "remote_database_file",
   "database_size",
-  "column_break_wiuq",
+  "config_section",
   "config_file",
   "config_file_url",
+  "column_break_qnqz",
   "remote_config_file",
   "config_file_size",
   "data_12",
   "public_file",
   "public_url",
+  "column_break_16",
   "remote_public_file",
   "public_size",
-  "column_break_16",
+  "private_section",
   "private_file",
   "private_url",
+  "column_break_blkb",
   "remote_private_file",
   "private_size",
   "section_break_21",
@@ -148,12 +154,16 @@
    "read_only": 1
   },
   {
+   "collapsible": 1,
    "fieldname": "data_7",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Database"
   },
   {
+   "collapsible": 1,
    "fieldname": "data_12",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Public"
   },
   {
    "fieldname": "column_break_16",
@@ -169,6 +179,7 @@
    "set_only_once": 1
   },
   {
+   "collapsible": 1,
    "fieldname": "section_break_21",
    "fieldtype": "Section Break"
   },
@@ -237,10 +248,38 @@
    "label": "Remote File",
    "options": "Remote File",
    "read_only": 1
+  },
+  {
+   "fieldname": "column_break_zwsb",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_noav",
+   "fieldtype": "Column Break"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "config_section",
+   "fieldtype": "Section Break",
+   "label": "Config"
+  },
+  {
+   "fieldname": "column_break_qnqz",
+   "fieldtype": "Column Break"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "private_section",
+   "fieldtype": "Section Break",
+   "label": "Private"
+  },
+  {
+   "fieldname": "column_break_blkb",
+   "fieldtype": "Column Break"
   }
  ],
  "links": [],
- "modified": "2023-12-06 17:33:23.890696",
+ "modified": "2024-01-12 12:26:10.740889",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site Backup",

--- a/press/press/doctype/site_backup/site_backup.json
+++ b/press/press/doctype/site_backup/site_backup.json
@@ -12,10 +12,6 @@
   "with_files",
   "offsite",
   "job",
-  "column_break_noav",
-  "database",
-  "size",
-  "url",
   "data_7",
   "database_file",
   "database_url",
@@ -59,6 +55,7 @@
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Status",
    "options": "Pending\nRunning\nSuccess\nFailure",
    "read_only": 1,
@@ -71,24 +68,6 @@
    "options": "Agent Job",
    "read_only": 1,
    "search_index": 1
-  },
-  {
-   "fieldname": "database",
-   "fieldtype": "Data",
-   "label": "database",
-   "read_only": 1
-  },
-  {
-   "fieldname": "size",
-   "fieldtype": "Data",
-   "label": "size",
-   "read_only": 1
-  },
-  {
-   "fieldname": "url",
-   "fieldtype": "Data",
-   "label": "url",
-   "read_only": 1
   },
   {
    "default": "0",
@@ -254,10 +233,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "column_break_noav",
-   "fieldtype": "Column Break"
-  },
-  {
    "collapsible": 1,
    "fieldname": "config_section",
    "fieldtype": "Section Break",
@@ -279,7 +254,7 @@
   }
  ],
  "links": [],
- "modified": "2024-01-12 12:26:10.740889",
+ "modified": "2024-01-12 12:29:20.190615",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site Backup",

--- a/press/press/doctype/site_backup/site_backup.json
+++ b/press/press/doctype/site_backup/site_backup.json
@@ -11,6 +11,7 @@
   "column_break_zwsb",
   "with_files",
   "offsite",
+  "physical",
   "job",
   "data_7",
   "database_file",
@@ -251,10 +252,17 @@
   {
    "fieldname": "column_break_blkb",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "physical",
+   "fieldtype": "Check",
+   "label": "Physical",
+   "search_index": 1
   }
  ],
  "links": [],
- "modified": "2024-01-12 12:29:20.190615",
+ "modified": "2024-01-12 15:03:24.919731",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site Backup",

--- a/press/press/doctype/site_backup/site_backup.py
+++ b/press/press/doctype/site_backup/site_backup.py
@@ -159,3 +159,9 @@ def get_backup_bucket(cluster, region=False):
 		return bucket_for_cluster[0] if bucket_for_cluster else default_bucket
 	else:
 		return bucket_for_cluster[0]["name"] if bucket_for_cluster else default_bucket
+
+
+def on_doctype_update():
+	frappe.db.add_index("Site Backup", ["site", "status"])
+	frappe.db.add_index("Site Backup", ["site", "creation"])
+	frappe.db.add_index("Site Backup", ["site", "files_availability", "creation"])


### PR DESCRIPTION
Reference: [Partial Backup and Restore with Mariabackup](https://mariadb.com/kb/en/partial-backup-and-restore-with-mariabackup/).

Needs https://github.com/frappe/agent/pull/76.

Backup is easy. [Restore is tricky](https://mariadb.com/kb/en/innodb-file-per-table-tablespaces/#importing-transportable-tablespaces-for-non-partitioned-tables).