### PR TITLE
feat: feature flag for RQ WorkerPool support

### DIFF
--- a/press/docker/config/supervisor.conf
+++ b/press/docker/config/supervisor.conf
@@ -28,7 +28,50 @@ stderr_logfile=/home/frappe/frappe-bench/logs/schedule.error.log
 user=frappe
 directory=/home/frappe/frappe-bench
 
-{% if doc.merge_all_rq_queues %}
+{% if doc.use_rq_workerpool and doc.merge_all_rq_queues %}
+
+[program:frappe-bench-frappe-worker]
+command=bench worker-pool --queue short,default,long
+priority=4
+autostart=true
+autorestart=true
+stdout_logfile=/home/frappe/frappe-bench/logs/worker.log
+stderr_logfile=/home/frappe/frappe-bench/logs/worker.error.log
+user=frappe
+stopwaitsecs=1560
+directory=/home/frappe/frappe-bench
+killasgroup=true
+process_name=%(program_name)s
+
+{% elif doc.use_rq_workerpool %}
+
+[program:frappe-bench-frappe-short-worker]
+command=bench worker-pool --queue short,default
+priority=4
+autostart=true
+autorestart=true
+stdout_logfile=/home/frappe/frappe-bench/logs/worker.log
+stderr_logfile=/home/frappe/frappe-bench/logs/worker.error.log
+user=frappe
+stopwaitsecs=360
+directory=/home/frappe/frappe-bench
+killasgroup=true
+process_name=%(program_name)s
+
+[program:frappe-bench-frappe-long-worker]
+command=bench worker-pool --queue long,default,short
+priority=4
+autostart=true
+autorestart=true
+stdout_logfile=/home/frappe/frappe-bench/logs/worker.log
+stderr_logfile=/home/frappe/frappe-bench/logs/worker.error.log
+user=frappe
+stopwaitsecs=1560
+directory=/home/frappe/frappe-bench
+killasgroup=true
+process_name=%(program_name)s
+
+{% elif doc.merge_all_rq_queues %}
 
 [program:frappe-bench-frappe-worker]
 command=bench worker --queue short,default,long
@@ -158,7 +201,7 @@ programs=frappe-bench-frappe-web,frappe-bench-node-socketio
 [group:frappe-bench-workers]
 programs=frappe-bench-frappe-schedule,frappe-bench-frappe-worker
 
-{% elif doc.merge_default_and_short_rq_queues %}
+{% elif doc.merge_default_and_short_rq_queues or doc.use_rq_workerpool %}
 
 [group:frappe-bench-workers]
 programs=frappe-bench-frappe-schedule,frappe-bench-frappe-short-worker,frappe-bench-frappe-long-worker

--- a/press/press/doctype/bench/bench.json
+++ b/press/press/doctype/bench/bench.json
@@ -40,6 +40,7 @@
   "feature_flags_section",
   "merge_all_rq_queues",
   "merge_default_and_short_rq_queues",
+  "use_rq_workerpool",
   "is_code_server_enabled",
   "column_break_mtyb",
   "environment_variables",
@@ -324,10 +325,17 @@
    "fieldname": "mounts",
    "fieldtype": "Table",
    "options": "Bench Mount"
+  },
+  {
+   "default": "0",
+   "fetch_from": "candidate.use_rq_workerpool",
+   "fieldname": "use_rq_workerpool",
+   "fieldtype": "Check",
+   "label": "Use RQ WorkerPool"
   }
  ],
  "links": [],
- "modified": "2023-12-14 13:07:36.811559",
+ "modified": "2024-01-18 14:52:55.486620",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Bench",

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -141,6 +141,7 @@ class Bench(Document):
 			"single_container": bool(self.is_single_container),
 			"gunicorn_threads_per_worker": self.gunicorn_threads_per_worker,
 			"is_code_server_enabled": self.is_code_server_enabled,
+			"use_rq_workerpool": self.use_rq_workerpool,
 		}
 		self.add_limits(bench_config)
 		self.update_bench_config_with_rg_config(bench_config)

--- a/press/press/doctype/deploy_candidate/deploy_candidate.json
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.json
@@ -43,7 +43,9 @@
   "is_redisearch_enabled",
   "column_break_tkdd",
   "merge_all_rq_queues",
-  "merge_default_and_short_rq_queues"
+  "merge_default_and_short_rq_queues",
+  "use_rq_workerpool",
+  "gunicorn_threads_per_worker"
  ],
  "fields": [
   {
@@ -297,10 +299,17 @@
    "fieldtype": "Text",
    "label": "Mounts",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fetch_from": "group.use_rq_workerpool",
+   "fieldname": "use_rq_workerpool",
+   "fieldtype": "Check",
+   "label": "Use RQ WorkerPool"
   }
  ],
  "links": [],
- "modified": "2023-12-19 14:26:02.786216",
+ "modified": "2024-01-18 14:52:17.666769",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Deploy Candidate",

--- a/press/press/doctype/release_group/release_group.json
+++ b/press/press/doctype/release_group/release_group.json
@@ -46,12 +46,14 @@
   "column_break_9efq",
   "merge_all_rq_queues",
   "merge_default_and_short_rq_queues",
+  "use_rq_workerpool",
   "saas_tab",
   "saas_bench",
   "column_break_26",
   "saas_app",
   "miscellaneous_tab",
-  "tags"
+  "tags",
+  "is_code_server_enabled"
  ],
  "fields": [
   {
@@ -331,10 +333,16 @@
    "fieldtype": "Table",
    "label": "Mounts",
    "options": "Release Group Mount"
+  },
+  {
+   "default": "0",
+   "fieldname": "use_rq_workerpool",
+   "fieldtype": "Check",
+   "label": "Use RQ WorkerPool"
   }
  ],
  "links": [],
- "modified": "2024-01-01 12:44:40.902468",
+ "modified": "2024-01-18 13:18:18.493796",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Release Group",


### PR DESCRIPTION
Worker pool consumes 70% less memory for maxed out config of 8 background workers. This is roughly **100GB** of reduced RAM usage across FC servers assuming current usage. (Assuming at least 20MB reduction per worker for each bench with >2 workers) 

This is experimental right now but I've not seen any problems with it so far. We can slowly roll this out in future, starting with internal sites.

Note:
- RQ WorkerPool is only a good idea if you need more than 2 workers. At 2 workers it just breaks even.
- This feature is only available in v15.0.0+



![image](https://github.com/frappe/press/assets/9079960/eceef878-c12e-4b2d-b208-dd71c9565c14)





Framework: https://github.com/frappe/frappe/pull/21482
Agent: https://github.com/frappe/agent/pull/78