### PR TITLE
fix: restrict fields based on doctype-fields allow list

### DIFF
--- a/dashboard/src2/components/ObjectList.vue
+++ b/dashboard/src2/components/ObjectList.vue
@@ -85,6 +85,9 @@
 				>
 					Loading...
 				</div>
+				<div v-else-if="$list.list.error" class="py-4 text-center">
+					<ErrorMessage :message="$list.list.error" />
+				</div>
 				<div v-else class="text-center text-sm leading-10 text-gray-500">
 					No results found
 				</div>
@@ -115,7 +118,8 @@ import {
 	ListSelectBanner,
 	TextInput,
 	FeatherIcon,
-	Tooltip
+	Tooltip,
+	ErrorMessage
 } from 'frappe-ui';
 
 let subscribed = {};
@@ -136,7 +140,8 @@ export default {
 		ListSelectBanner,
 		TextInput,
 		FeatherIcon,
-		Tooltip
+		Tooltip,
+		ErrorMessage
 	},
 	data() {
 		return {

--- a/dashboard/src2/components/SiteActionCell.vue
+++ b/dashboard/src2/components/SiteActionCell.vue
@@ -66,7 +66,8 @@ function getSiteActionHandler(action) {
 		'Drop site': onDropSite,
 		'Migrate site': onMigrateSite,
 		'Transfer site': onTransferSite,
-		'Reset site': onSiteReset
+		'Reset site': onSiteReset,
+		'Clear cache': onClearCache
 	};
 	if (actionHandlers[action]) {
 		actionHandlers[action].call(this);
@@ -158,6 +159,10 @@ function onMigrateSite() {
 				label: 'Skip patches if they fail during migration (Not recommended)',
 				fieldname: 'skipFailingPatches',
 				type: 'checkbox'
+			},
+			{
+				label: 'Please type the site name to confirm.',
+				fieldname: 'confirmSiteName'
 			}
 		],
 		primaryAction: {
@@ -165,6 +170,9 @@ function onMigrateSite() {
 			variant: 'solid',
 			theme: 'red',
 			onClick: ({ hide, values }) => {
+				if (values.confirmSiteName !== site.doc.name) {
+					throw new Error('Site name does not match');
+				}
 				return site.migrate
 					.submit({ skip_failing_patches: values.skipFailingPatches })
 					.then(hide);
@@ -225,6 +233,22 @@ function onTransferSite() {
 							`Transfer request sent to ${values.email} successfully.`
 						);
 					});
+			}
+		}
+	});
+}
+
+function onClearCache() {
+	return confirmDialog({
+		title: 'Clear Cache',
+		message: `<span class="rounded-sm bg-gray-100 p-0.5 font-mono text-sm font-semibold">bench clear-cache</span> and
+            <span class="rounded-sm bg-gray-100 p-0.5 font-mono text-sm font-semibold">bench clear-website-cache</span> commands
+            will be executed on your site. Are you sure you want to run these commands?`,
+		primaryAction: {
+			label: 'Clear Cache',
+			variant: 'solid',
+			onClick: ({ hide }) => {
+				return site.clearSiteCache.submit().then(hide);
 			}
 		}
 	});

--- a/dashboard/src2/components/SiteDailyUsage.vue
+++ b/dashboard/src2/components/SiteDailyUsage.vue
@@ -4,7 +4,7 @@
 			<h2 class="text-lg font-medium text-gray-900">Daily Usage</h2>
 			<router-link
 				class="text-base text-gray-600 hover:text-gray-700"
-				:to="`/sites/${site.name}/analytics`"
+				:to="{ name: 'Site Detail Analytics', params: { name: site } }"
 			>
 				All analytics →
 			</router-link>
@@ -24,7 +24,7 @@
 	</div>
 </template>
 <script>
-import { DateTime } from 'luxon';
+import dayjs from '../utils/dayjs';
 import LineChart from '@/components/charts/LineChart.vue';
 
 export default {
@@ -33,10 +33,10 @@ export default {
 	components: { LineChart },
 	resources: {
 		requestCounter() {
-			let localTimezone = DateTime.local().zoneName;
+			let localTimezone = dayjs.tz.guess();
 			return {
 				url: 'press.api.analytics.daily_usage',
-				params: { name: this.site?.name, timezone: localTimezone },
+				params: { name: this.site, timezone: localTimezone },
 				auto: true
 			};
 		}

--- a/dashboard/src2/components/SiteDatabaseAccessDialog.vue
+++ b/dashboard/src2/components/SiteDatabaseAccessDialog.vue
@@ -1,16 +1,191 @@
 <template>
-	<DatabaseAccessDialog :site="site" v-model="show" />
+	<Dialog :options="{ title: 'Manage Database Access' }" v-model="show">
+		<template #body-content>
+			<!-- Not available on current plan, upsell higher plans -->
+			<div v-if="!sitePlan?.database_access">
+				<div>
+					<p class="text-base">
+						Database access is not available on your current plan. Please
+						upgrade to a higher plan to use this feature.
+					</p>
+
+					<Button
+						class="mt-4 w-full"
+						variant="solid"
+						@click="showChangePlanDialog = true"
+					>
+						Upgrade Site Plan
+					</Button>
+					<ManageSitePlansDialog :site="site" v-if="showChangePlanDialog" />
+				</div>
+			</div>
+
+			<!-- Available on the current plan -->
+			<div v-else>
+				<div v-if="$site.doc.is_database_access_enabled">
+					<div v-if="databaseCredentials">
+						<p class="mb-2 text-base font-semibold text-gray-700">
+							Using an Analytics or Business Intelligence Tool
+						</p>
+						<p class="mb-2 text-base">
+							Use following credentials with your analytics or business
+							intelligence tool
+						</p>
+						<p class="ml-1 font-mono text-sm">
+							Host: {{ databaseCredentials.host }}
+						</p>
+						<p class="ml-1 font-mono text-sm">
+							Port: {{ databaseCredentials.port }}
+						</p>
+						<p class="ml-1 font-mono text-sm">
+							Database Name: {{ databaseCredentials.database }}
+						</p>
+						<p class="ml-1 font-mono text-sm">
+							Username: {{ databaseCredentials.username }}
+						</p>
+						<p class="ml-1 font-mono text-sm">
+							Password: {{ databaseCredentials.password }}
+						</p>
+					</div>
+					<div class="pb-2 pt-5">
+						<p class="mb-2 text-base font-semibold text-gray-700">
+							Using MariaDB Client
+						</p>
+						<p class="mb-2 text-base">
+							Run this command in your terminal to access MariaDB console
+						</p>
+						<ClickToCopyField class="ml-1" :textContent="dbAccessCommand" />
+						<p class="mt-3 text-sm">
+							Note: You should have a
+							<span class="font-mono">mariadb</span> client installed on your
+							computer.
+						</p>
+					</div>
+				</div>
+				<div v-else>
+					<p class="mb-2 text-sm">Database access is disabled for this site.</p>
+				</div>
+
+				<div class="mt-4">
+					<div
+						v-if="planSupportsDatabaseAccess && !databaseAccessEnabled"
+						class="mb-2"
+					>
+						<FormControl
+							label="Access type"
+							type="select"
+							:options="[
+								{ label: 'Read only', value: 'read_only' },
+								{ label: 'Read & Write', value: 'read_write' }
+							]"
+							v-model="mode"
+						/>
+						<p v-if="mode === 'read_write'" class="mt-2 text-base text-red-600">
+							Your credentials can be used to modify or wipe your database
+						</p>
+					</div>
+					<ErrorMessage
+						class="mt-2"
+						:message="
+							$site.enableDatabaseAccess.error ||
+							$site.disableDatabaseAccess.error ||
+							error
+						"
+					/>
+					<Button
+						v-if="planSupportsDatabaseAccess && !databaseAccessEnabled"
+						@click="enableDatabaseAccess"
+						:loading="
+							$site.enableDatabaseAccess.loading || pollingAgentJob?.loading
+						"
+						variant="solid"
+						class="mt-2 w-full"
+					>
+						Enable Access
+					</Button>
+					<Button
+						v-if="planSupportsDatabaseAccess && databaseAccessEnabled"
+						@click="$site.disableDatabaseAccess.submit()"
+						:loading="$site.disableDatabaseAccess.loading"
+						class="w-full"
+					>
+						Disable Access
+					</Button>
+				</div>
+			</div>
+		</template>
+	</Dialog>
 </template>
 <script>
-import DatabaseAccessDialog from '../../src/views/site/DatabaseAccessDialog.vue';
+import { defineAsyncComponent } from 'vue';
+import { getCachedDocumentResource } from 'frappe-ui';
+import ClickToCopyField from '../../src/components/ClickToCopyField.vue';
+import { pollJobStatus } from '../utils/agentJob';
+import { getPlan } from '../data/plans';
+
 export default {
 	name: 'SiteDatabaseAccessDialog',
 	props: ['site'],
-	components: { DatabaseAccessDialog },
+	components: {
+		ManageSitePlansDialog: defineAsyncComponent(() =>
+			import('./ManageSitePlansDialog.vue')
+		),
+		ClickToCopyField
+	},
 	data() {
 		return {
-			show: true
+			mode: 'read_only',
+			show: true,
+			showChangePlanDialog: false,
+			error: null,
+			pollingAgentJob: null
 		};
+	},
+	mounted() {
+		this.fetchDatabaseCredentials();
+	},
+	methods: {
+		enableDatabaseAccess() {
+			return this.$site.enableDatabaseAccess.submit(
+				{ mode: this.mode },
+				{
+					onSuccess: result => {
+						let jobId = result.message;
+						this.pollingAgentJob = pollJobStatus(jobId, status => {
+							if (status === 'Success') {
+								this.fetchDatabaseCredentials();
+								return true;
+							} else if (status === 'Failure') {
+								this.error = 'Failed to enable database access';
+								return true;
+							}
+						});
+					}
+				}
+			);
+		},
+		fetchDatabaseCredentials() {
+			if (this.planSupportsDatabaseAccess && this.databaseAccessEnabled) {
+				this.$site.getDatabaseCredentials.fetch();
+			}
+		}
+	},
+	computed: {
+		databaseCredentials() {
+			return this.$site.getDatabaseCredentials.data;
+		},
+		databaseAccessEnabled() {
+			return this.$site.doc.is_database_access_enabled;
+		},
+		planSupportsDatabaseAccess() {
+			return this.sitePlan?.database_access;
+		},
+		sitePlan() {
+			return getPlan(this.$site.doc.plan);
+		},
+		$site() {
+			return getCachedDocumentResource('Site', this.site);
+		}
 	}
 };
 </script>

--- a/dashboard/src2/components/SiteOverview.vue
+++ b/dashboard/src2/components/SiteOverview.vue
@@ -3,7 +3,7 @@
 		v-if="$site?.doc"
 		class="grid grid-cols-1 items-start gap-5 sm:grid-cols-2"
 	>
-		<SiteDailyUsage :site="$site.doc" />
+		<SiteDailyUsage :site="site" />
 		<div class="rounded-md border">
 			<div class="h-12 border-b px-5 py-4">
 				<h2 class="text-lg font-medium text-gray-900">Site information</h2>

--- a/dashboard/src2/components/TabsWithRouter.vue
+++ b/dashboard/src2/components/TabsWithRouter.vue
@@ -9,6 +9,16 @@
 </template>
 <script>
 import { Tabs } from 'frappe-ui';
+import router from '../router';
+
+let current;
+router.beforeEach((to, from, next) => {
+	if (current) {
+		current.setTabToRoute(to);
+	}
+	next();
+});
+
 export default {
 	name: 'TabsWithRouter',
 	props: ['tabs'],
@@ -32,12 +42,12 @@ export default {
 			}
 		}
 	},
-	beforeRouteUpdate(to, from, next) {
-		this.setTabToRoute(to);
-		next();
-	},
-	mounted() {
+	beforeMount() {
 		this.setTabToRoute(this.$route);
+		current = this;
+	},
+	beforeUnmount() {
+		current = null;
 	},
 	methods: {
 		setTabToRoute(route) {

--- a/dashboard/src2/data/plans.js
+++ b/dashboard/src2/data/plans.js
@@ -4,5 +4,8 @@ export let plans = createResource({
 	url: 'press.api.site.get_plans',
 	cache: 'site.plans'
 });
-
 plans.fetch();
+
+export function getPlan(planName) {
+	return (plans.data || []).find(plan => plan.name === planName);
+}

--- a/dashboard/src2/main.js
+++ b/dashboard/src2/main.js
@@ -8,6 +8,7 @@ import {
 import App from './App.vue';
 import router from './router';
 import { initSocket } from './socket';
+import { subscribeToJobUpdates } from './utils/agentJob';
 
 let request = options => {
 	let _options = options || {};
@@ -38,6 +39,7 @@ getInitialData().then(() => {
 	socket = initSocket();
 	app.config.globalProperties.$socket = socket;
 	window.$socket = socket;
+	subscribeToJobUpdates(socket);
 
 	importGlobals().then(() => {
 		app.mount('#app');

--- a/dashboard/src2/objects/bench.js
+++ b/dashboard/src2/objects/bench.js
@@ -97,17 +97,11 @@ export default {
 				route: 'apps',
 				type: 'list',
 				list: {
-					resource({ documentResource: releaseGroup }) {
+					doctype: 'Release Group App',
+					filters: releaseGroup => {
 						return {
-							type: 'list',
-							doctype: 'Release Group App',
-							cache: ['ObjectList', 'Release Group App', releaseGroup.name],
-							parent: 'Release Group',
-							filters: {
-								parenttype: 'Release Group',
-								parent: releaseGroup.name
-							},
-							auto: true
+							parenttype: 'Release Group',
+							parent: releaseGroup.doc.name
 						};
 					},
 					columns: [
@@ -320,7 +314,6 @@ export default {
 						},
 						{
 							label: 'Apps',
-							fieldname: 'apps',
 							format(value, row) {
 								return (row.apps || []).map(d => d.app).join(', ');
 							},
@@ -406,7 +399,10 @@ export default {
 				list: {
 					doctype: 'Common Site Config',
 					filters: releaseGroup => {
-						return { group: releaseGroup.name };
+						return {
+							parenttype: 'Release Group',
+							parent: releaseGroup.name
+						};
 					},
 					orderBy: 'creation desc',
 					fields: ['name'],
@@ -540,7 +536,10 @@ export default {
 				list: {
 					doctype: 'Release Group Dependency',
 					filters: releaseGroup => {
-						return { group: releaseGroup.doc.name };
+						return {
+							parenttype: 'Release Group',
+							parent: releaseGroup.name
+						};
 					},
 					columns: [
 						{

--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -183,7 +183,7 @@ export default {
 				list: {
 					doctype: 'Site App',
 					filters: site => {
-						return { site: site.doc.name };
+						return { parenttype: 'Site', parent: site.doc.name };
 					},
 					columns: [
 						{
@@ -218,20 +218,6 @@ export default {
 							width: '34rem'
 						}
 					],
-					resource({ documentResource: site }) {
-						return {
-							type: 'list',
-							doctype: 'Site App',
-							cache: ['Site Apps', site.name],
-							fields: ['name', 'app'],
-							parent: 'Site',
-							filters: {
-								parenttype: 'Site',
-								parent: site.doc.name
-							},
-							auto: true
-						};
-					},
 					primaryAction({ listResource: apps, documentResource: site }) {
 						return {
 							label: 'Install App',
@@ -611,7 +597,7 @@ export default {
 				list: {
 					doctype: 'Site Config',
 					filters: site => {
-						return { site: site.doc.name };
+						return { parent: site.doc.name, parenttype: 'Site' };
 					},
 					fields: ['name'],
 					pageLength: 999,
@@ -771,7 +757,6 @@ export default {
 				type: 'list',
 				list: {
 					doctype: 'Agent Job',
-					userFilters: {},
 					filters: site => {
 						return { site: site.doc.name };
 					},

--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -1,4 +1,4 @@
-import { frappeRequest } from 'frappe-ui';
+import { frappeRequest, LoadingIndicator } from 'frappe-ui';
 import { defineAsyncComponent, h } from 'vue';
 import { toast } from 'vue-sonner';
 import AddDomainDialog from '../components/AddDomainDialog.vue';
@@ -10,6 +10,7 @@ import { confirmDialog, icon, renderDialog } from '../utils/components';
 import { bytes, duration, date } from '../utils/format';
 import SiteActionCell from '../components/SiteActionCell.vue';
 import { dayjsLocal } from '../utils/dayjs';
+import { getRunningJobs } from '../utils/agentJob';
 
 export default {
 	doctype: 'Site',
@@ -834,7 +835,28 @@ export default {
 		actions(context) {
 			let { documentResource: site } = context;
 			let $team = getTeam();
+			let runningJobs = getRunningJobs({ site: site.doc.name });
+
 			return [
+				{
+					label: 'Jobs in progress',
+					slots: {
+						prefix: () => h(LoadingIndicator, { class: 'w-4 h-4' })
+					},
+					condition() {
+						return (
+							runningJobs.filter(job =>
+								['Pending', 'Running'].includes(job.status)
+							).length > 0
+						);
+					},
+					onClick() {
+						router.push({
+							name: 'Site Detail Jobs',
+							params: { name: site.name }
+						});
+					}
+				},
 				{
 					label: 'Update Available',
 					variant: 'solid',

--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -20,11 +20,11 @@ export default {
 		backup: 'backup',
 		clearSiteCache: 'clear_site_cache',
 		deactivate: 'deactivate',
-		disableDatabaseAccess: 'disable_database_access',
-		disableReadWrite: 'disable_read_write',
 		enableDatabaseAccess: 'enable_database_access',
-		enableReadWrite: 'enable_read_write',
+		disableDatabaseAccess: 'disable_database_access',
 		getDatabaseCredentials: 'get_database_credentials',
+		disableReadWrite: 'disable_read_write',
+		enableReadWrite: 'enable_read_write',
 		installApp: 'install_app',
 		uninstallApp: 'uninstall_app',
 		migrate: 'migrate',
@@ -33,20 +33,11 @@ export default {
 		loginAsAdmin: 'login_as_admin',
 		reinstall: 'reinstall',
 		removeDomain: 'remove_domain',
-		resetSiteUsage: 'reset_site_usage',
 		restoreSite: 'restore_site',
-		restoreTables: 'restore_tables',
-		retryArchive: 'retry_archive',
-		retryRename: 'retry_rename',
 		scheduleUpdate: 'schedule_update',
 		setPlan: 'set_plan',
-		suspend: 'suspend',
-		sync_info: 'sync_info',
-		unsuspend: 'unsuspend',
-		updateSiteConfig: 'update_site_config',
 		updateConfig: 'update_config',
 		deleteConfig: 'delete_config',
-		updateWithoutBackup: 'update_without_backup',
 		sendTransferRequest: 'send_change_team_request'
 	},
 	list: {
@@ -566,20 +557,18 @@ export default {
 							slots: {
 								prefix: icon('upload-cloud')
 							},
-							loading: backups.insert.loading,
+							loading: site.backup.loading,
 							onClick() {
-								return backups.insert.submit(
+								return site.backup.submit(
 									{
-										site: site.doc.name
+										with_files: true
 									},
 									{
 										onError(e) {
-											let messages = e.messages || ['Something went wrong'];
-											for (let message of messages) {
-												toast.error(message);
-											}
+											showErrorToast(e);
 										},
 										onSuccess() {
+											backups.reload();
 											toast.success('Backup scheduled');
 										}
 									}
@@ -829,7 +818,8 @@ export default {
 						},
 						{
 							label: 'Reason',
-							fieldname: 'reason'
+							fieldname: 'reason',
+							class: 'text-gray-600'
 						},
 						{
 							label: '',

--- a/dashboard/src2/pages/JobPage.vue
+++ b/dashboard/src2/pages/JobPage.vue
@@ -17,10 +17,9 @@
 						@click="$resources.job.reload()"
 						:loading="$resources.job.loading"
 					>
-						<template #prefix>
+						<template #icon>
 							<i-lucide-refresh-ccw class="h-4 w-4" />
 						</template>
-						Refresh
 					</Button>
 				</div>
 				<div>

--- a/dashboard/src2/pages/NewAppSite.vue
+++ b/dashboard/src2/pages/NewAppSite.vue
@@ -252,7 +252,7 @@ export default {
 			return this.$resources.siteRequest;
 		},
 		saasProduct() {
-			return this.$resources.siteRequest.doc.saas_product;
+			return this.siteRequest?.doc.saas_product;
 		},
 		selectedPlanDescription() {
 			if (!this.plan) return;
@@ -267,7 +267,7 @@ export default {
 			return `${pricePerMonth} per month`;
 		},
 		progressError() {
-			if (!this.siteRequest.getProgress.data?.error) return;
+			if (!this.siteRequest?.getProgress.data?.error) return;
 			if (this.progressErrorCount > 9) {
 				return 'An error occurred. Please contact Frappe Cloud Support.';
 			}

--- a/dashboard/src2/pages/ReleaseGroupBenchSites.vue
+++ b/dashboard/src2/pages/ReleaseGroupBenchSites.vue
@@ -331,6 +331,9 @@ export default {
 						type: 'Badge',
 						format(value, row) {
 							return value.slice(0, 7);
+						},
+						link: (value, row) => {
+							return `https://github.com/${row.repository_owner}/${row.repository}/commit/${value}`;
 						}
 					},
 					{

--- a/dashboard/src2/utils/agentJob.js
+++ b/dashboard/src2/utils/agentJob.js
@@ -1,0 +1,30 @@
+import { frappeRequest } from 'frappe-ui';
+import { reactive } from 'vue';
+
+let states = {};
+
+export function pollJobStatus(jobId, stopFunction) {
+	if (!states[jobId]) {
+		states[jobId] = reactive({ status: null, loading: false });
+	}
+	let state = states[jobId];
+	state.loading = true;
+	fetchJobStatus(jobId).then(status => {
+		state.status = status;
+	});
+	if (stopFunction(state.status)) {
+		state.loading = false;
+		return;
+	}
+	setTimeout(() => {
+		pollJobStatus(jobId, stopFunction);
+	}, 1000);
+	return state;
+}
+
+function fetchJobStatus(jobId) {
+	return frappeRequest({
+		url: 'press.api.site.get_job_status',
+		params: { job_name: jobId }
+	}).then(result => result.status);
+}

--- a/dashboard/src2/utils/toast.js
+++ b/dashboard/src2/utils/toast.js
@@ -1,0 +1,6 @@
+import { toast } from 'vue-sonner';
+
+export function showErrorToast(error) {
+	let errorMessage = e.messages.length ? e.messages.join('\n') : e.message;
+	toast.error(errorMessage);
+}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,2 @@
 pre-commit
-moto[all]
+moto[all]==4.2.14

--- a/press/api/client.py
+++ b/press/api/client.py
@@ -4,11 +4,37 @@
 from __future__ import unicode_literals
 import frappe
 import inspect
+from frappe.utils import cstr
 from pypika.queries import QueryBuilder
 from frappe.model.base_document import get_controller
 from frappe.model import default_fields, child_table_fields
 from frappe import is_whitelisted
 from frappe.handler import get_attr, run_doc_method as _run_doc_method
+
+ALLOWED_DOCTYPES = [
+	"Site",
+	"Site App",
+	"Site Domain",
+	"Site Backup",
+	"Site Activity",
+	"Site Config",
+	"Site Config Key",
+	"Plan",
+	"Invoice",
+	"Balance Transaction",
+	"Stripe Payment Method",
+	"Bench Dependency Version",
+	"Release Group",
+	"Release Group App",
+	"Release Group Dependency",
+	"Cluster",
+	"Press Permission Group",
+	"Team",
+	"SaaS Product Site Request",
+	"Deploy Candidate",
+	"Agent Job",
+	"Common Site Config",
+]
 
 
 @frappe.whitelist()
@@ -26,7 +52,11 @@ def get_list(
 	valid_fields = validate_fields(doctype, fields)
 	valid_filters = validate_filters(doctype, filters)
 
-	if frappe.get_meta(doctype).has_field("team"):
+	meta = frappe.get_meta(doctype)
+	if meta.istable and not (filters.get("parenttype") and filters.get("parent")):
+		frappe.throw("parenttype and parent are required to get child records")
+
+	if meta.has_field("team"):
 		valid_filters = valid_filters or frappe._dict()
 		valid_filters.team = frappe.local.team().name
 
@@ -38,6 +68,18 @@ def get_list(
 		limit=limit,
 		order_by=order_by,
 	)
+
+	if meta.istable:
+		parentmeta = frappe.get_meta(filters.get("parenttype"))
+		if parentmeta.has_field("team"):
+			ParentDocType = frappe.qb.DocType(filters.get("parenttype"))
+			ChildDocType = frappe.qb.DocType(doctype)
+			query = (
+				query.join(ParentDocType)
+				.on(ParentDocType.name == ChildDocType.parent)
+				.where(ParentDocType.team == frappe.local.team().name)
+			)
+
 	filters = frappe._dict(filters or {})
 	list_args = dict(
 		fields=fields,
@@ -173,7 +215,7 @@ def validate_filters(doctype, filters):
 
 	out = frappe._dict()
 	for fieldname, value in filters.items():
-		if is_valid_field(doctype, fieldname):
+		if is_allowed_field(doctype, fieldname):
 			out[fieldname] = value
 
 	return out
@@ -186,32 +228,65 @@ def validate_fields(doctype, fields):
 
 	filtered_fields = []
 	for field in fields:
-		if is_valid_field(doctype, field):
+		if is_allowed_field(doctype, field):
 			filtered_fields.append(field)
 
 	return filtered_fields
 
 
-def is_valid_field(doctype, field):
+def is_allowed_field(doctype, field):
 	"""Check if field is valid"""
 	if not field:
 		return False
 
-	if field == "*" or "." in field:
+	controller = get_controller(doctype)
+	whitelisted_fields = getattr(controller, "whitelisted_fields", [])
+
+	if field in whitelisted_fields:
 		return True
-	elif isinstance(field, dict) or field in [*default_fields, *child_table_fields]:
+	elif "." in field and is_allowed_linked_field(doctype, field):
 		return True
-	elif df := frappe.get_meta(doctype).get_field(field):
-		if df.fieldtype not in frappe.model.table_fields:
-			return True
+	elif isinstance(field, dict) and is_allowed_table_field(doctype, field):
+		return True
+	elif field in [*default_fields, *child_table_fields]:
+		return True
 
 	return False
 
 
+def is_allowed_linked_field(doctype, field):
+	linked_field = linked_field_fieldname = None
+	if " as " in field:
+		linked_field, _ = field.split(" as ")
+	else:
+		linked_field = field
+
+	linked_field, linked_field_fieldname = linked_field.split(".")
+	if not is_allowed_field(doctype, linked_field):
+		return False
+
+	linked_field_doctype = frappe.get_meta(doctype).get_field(linked_field).options
+	if not is_allowed_field(linked_field_doctype, linked_field_fieldname):
+		return False
+
+	return True
+
+
+def is_allowed_table_field(doctype, field):
+	for table_fieldname, table_fields in field.items():
+		if not is_allowed_field(doctype, table_fieldname):
+			return False
+
+		table_doctype = frappe.get_meta(doctype).get_field(table_fieldname).options
+		for table_field in table_fields:
+			if not is_allowed_field(table_doctype, table_field):
+				return False
+	return True
+
+
 def check_permissions(doctype):
-	# TODO: remove this when we have proper permission checking
-	if not (frappe.conf.developer_mode or frappe.local.dev_server):
-		frappe.only_for("System Manager")
+	if doctype not in ALLOWED_DOCTYPES:
+		frappe.throw("Not permitted", frappe.PermissionError)
 
 	if not frappe.local.team():
 		frappe.throw(
@@ -229,3 +304,14 @@ def check_method_permissions(doctype, docname, method) -> None:
 	if not has_method_permission(doctype, docname, method):
 		frappe.throw(f"{method} is not permitted on {doctype} {docname}")
 	return True
+
+
+def is_owned_by_team(doctype, docname, raise_exception=True):
+	if not frappe.local.team():
+		return False
+
+	docname = cstr(docname)
+	owned = frappe.db.get_value(doctype, docname, "team") == frappe.local.team().name
+	if not owned and raise_exception:
+		frappe.throw("Not permitted", frappe.PermissionError)
+	return owned

--- a/press/api/site.py
+++ b/press/api/site.py
@@ -1214,25 +1214,6 @@ def last_migrate_failed(name):
 @frappe.whitelist()
 @protected("Site")
 def backup(name, with_files=False):
-	site_doc = frappe.get_doc("Site", name)
-	if site_doc.status == "Suspended":
-		activity = frappe.db.get_all(
-			"Site Activity",
-			filters={"site": name, "action": "Suspend Site"},
-			order_by="creation desc",
-			limit=1,
-		)
-		suspension_time = frappe.get_doc("Site Activity", activity[0]).creation
-
-		if (
-			frappe.db.count(
-				"Site Backup",
-				filters=dict(site=name, status="Success", creation=(">=", suspension_time)),
-			)
-			> 3
-		):
-			frappe.throw("You cannot take more than 3 backups after site suspension")
-
 	frappe.get_doc("Site", name).backup(with_files)
 
 

--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -7,8 +7,15 @@ import frappe
 import random
 
 from press.agent import Agent
+from press.api.client import is_owned_by_team
 from press.utils import log_error
-from frappe.utils import cint, convert_utc_to_system_timezone, create_batch, add_days
+from frappe.utils import (
+	cint,
+	convert_utc_to_system_timezone,
+	create_batch,
+	add_days,
+	cstr,
+)
 from frappe.core.utils import find
 from frappe.model.document import Document
 from press.press.doctype.site_migration.site_migration import (
@@ -36,7 +43,16 @@ class AgentJob(Document):
 
 	@staticmethod
 	def get_list_query(query, filters=None, **list_args):
-		if filters.group:
+		site = cstr(filters.get("site", ""))
+		group = cstr(filters.get("group", ""))
+		if not (site or group):
+			frappe.throw("Not permitted", frappe.PermissionError)
+
+		if site:
+			is_owned_by_team("Site", site, raise_exception=True)
+
+		if group:
+			is_owned_by_team("Release Group", group, raise_exception=True)
 			AgentJob = frappe.qb.DocType("Agent Job")
 			Bench = frappe.qb.DocType("Bench")
 			benches = (

--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -28,7 +28,7 @@ from press.press.doctype.press_notification.press_notification import (
 
 
 class AgentJob(Document):
-	whitelisted_fields = [
+	dashboard_fields = [
 		"name",
 		"job_type",
 		"creation",

--- a/press/press/doctype/cluster/cluster.py
+++ b/press/press/doctype/cluster/cluster.py
@@ -45,7 +45,7 @@ if typing.TYPE_CHECKING:
 
 
 class Cluster(Document):
-	whitelisted_fields = ["title", "image"]
+	dashboard_fields = ["title", "image"]
 
 	base_servers = {
 		"Proxy Server": "n",

--- a/press/press/doctype/cluster/cluster.py
+++ b/press/press/doctype/cluster/cluster.py
@@ -45,6 +45,8 @@ if typing.TYPE_CHECKING:
 
 
 class Cluster(Document):
+	whitelisted_fields = ["title", "image"]
+
 	base_servers = {
 		"Proxy Server": "n",
 		"Database Server": "m",

--- a/press/press/doctype/common_site_config/common_site_config.py
+++ b/press/press/doctype/common_site_config/common_site_config.py
@@ -6,7 +6,7 @@ from frappe.model.document import Document
 
 
 class CommonSiteConfig(Document):
-	whitelisted_fields = ["key", "type", "value"]
+	dashboard_fields = ["key", "type", "value"]
 
 	@staticmethod
 	def get_list_query(query, filters=None, **list_args):

--- a/press/press/doctype/common_site_config/common_site_config.py
+++ b/press/press/doctype/common_site_config/common_site_config.py
@@ -6,16 +6,12 @@ from frappe.model.document import Document
 
 
 class CommonSiteConfig(Document):
+	whitelisted_fields = ["key", "type", "value"]
+
 	@staticmethod
 	def get_list_query(query, filters=None, **list_args):
 		Config = frappe.qb.DocType("Common Site Config")
-		if filters and filters.get("group"):
-			query = (
-				query.where(Config.parent == filters.get("group"))
-				.where(Config.parenttype == "Release Group")
-				.where(Config.internal == 0)
-				.orderby(Config.key, order=frappe.qb.asc)
-			)
+		query = query.where(Config.internal == 0).orderby(Config.key, order=frappe.qb.asc)
 		configs = query.run(as_dict=True)
 		config_key_titles = frappe.db.get_all(
 			"Site Config Key",

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -33,7 +33,7 @@ from press.utils import get_current_team, log_error
 
 
 class DeployCandidate(Document):
-	whitelisted_fields = [
+	dashboard_fields = [
 		"name",
 		"status",
 		"creation",

--- a/press/press/doctype/deploy_candidate_app/deploy_candidate_app.py
+++ b/press/press/doctype/deploy_candidate_app/deploy_candidate_app.py
@@ -8,4 +8,4 @@ from frappe.model.document import Document
 
 
 class DeployCandidateApp(Document):
-	pass
+	whitelisted_fields = ["app"]

--- a/press/press/doctype/deploy_candidate_app/deploy_candidate_app.py
+++ b/press/press/doctype/deploy_candidate_app/deploy_candidate_app.py
@@ -8,4 +8,4 @@ from frappe.model.document import Document
 
 
 class DeployCandidateApp(Document):
-	whitelisted_fields = ["app"]
+	dashboard_fields = ["app"]

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -27,7 +27,7 @@ DISCOUNT_MAP = {"Entry": 0, "Bronze": 0.05, "Silver": 0.1, "Gold": 0.15}
 
 
 class Invoice(Document):
-	whitelisted_fields = [
+	dashboard_fields = [
 		"period_start",
 		"period_end",
 		"team",
@@ -44,6 +44,8 @@ class Invoice(Document):
 		"docstatus",
 		"gst",
 		"applied_credits",
+		"status",
+		"due_date",
 	]
 
 	def get_doc(self, doc):

--- a/press/press/doctype/plan/plan.py
+++ b/press/press/doctype/plan/plan.py
@@ -22,7 +22,7 @@ class Plan(Document):
 		"cpu_time_per_day",
 		"max_database_usage",
 		"max_storage_usage",
-		"database_access"
+		"database_access",
 	]
 
 	def get_doc(self, doc):

--- a/press/press/doctype/plan/plan.py
+++ b/press/press/doctype/plan/plan.py
@@ -11,7 +11,7 @@ from frappe.utils import rounded
 
 
 class Plan(Document):
-	whitelisted_fields = [
+	dashboard_fields = [
 		"name",
 		"plan_title",
 		"document_type",
@@ -22,6 +22,7 @@ class Plan(Document):
 		"cpu_time_per_day",
 		"max_database_usage",
 		"max_storage_usage",
+		"database_access"
 	]
 
 	def get_doc(self, doc):

--- a/press/press/doctype/press_permission_group/press_permission_group.py
+++ b/press/press/doctype/press_permission_group/press_permission_group.py
@@ -60,13 +60,11 @@ class PressPermissionGroup(Document):
 
 	@frappe.whitelist()
 	def get_users(self):
-		from press.api.client import get_list
-
 		user_names = [user.user for user in self.users]
 		if not user_names:
 			return []
 
-		return get_list(
+		return frappe.db.get_all(
 			"User",
 			filters={"name": ["in", user_names], "enabled": 1},
 			fields=[

--- a/press/press/doctype/press_permission_group/press_permission_group.py
+++ b/press/press/doctype/press_permission_group/press_permission_group.py
@@ -10,7 +10,8 @@ DEFAULT_PERMISSIONS = {
 
 
 class PressPermissionGroup(Document):
-	whitelisted_fields = ["title"]
+	dashboard_fields = ["title"]
+	dashboard_actions = ["get_users", "add_user", "remove_user", "update_permissions"]
 
 	def validate(self):
 		self.validate_permissions()

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -40,7 +40,7 @@ DEFAULT_DEPENDENCIES = [
 
 
 class ReleaseGroup(Document):
-	whitelisted_fields = ["title", "version"]
+	whitelisted_fields = ["title", "version", "apps"]
 
 	@staticmethod
 	def get_list_query(query):

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -40,7 +40,19 @@ DEFAULT_DEPENDENCIES = [
 
 
 class ReleaseGroup(Document):
-	whitelisted_fields = ["title", "version", "apps"]
+	dashboard_fields = ["title", "version", "apps"]
+	dashboard_actions = [
+		"remove_app",
+		"change_app_branch",
+		"fetch_latest_app_update",
+		"delete_config",
+		"update_config",
+		"update_dependency",
+		"add_region",
+		"deployed_versions",
+		"get_app_versions",
+		"archive",
+	]
 
 	@staticmethod
 	def get_list_query(query):

--- a/press/press/doctype/release_group_app/release_group_app.py
+++ b/press/press/doctype/release_group_app/release_group_app.py
@@ -11,7 +11,7 @@ from press.api.bench import apps
 
 
 class ReleaseGroupApp(Document):
-	whitelisted_fields = ["app"]
+	dashboard_fields = ["app"]
 
 	@staticmethod
 	def get_list_query(query, filters=None, **list_args):

--- a/press/press/doctype/release_group_app/release_group_app.py
+++ b/press/press/doctype/release_group_app/release_group_app.py
@@ -11,8 +11,9 @@ from press.api.bench import apps
 
 
 class ReleaseGroupApp(Document):
+	whitelisted_fields = ["app"]
+
 	@staticmethod
 	def get_list_query(query, filters=None, **list_args):
-		if filters and filters.get("parent"):
-			group_name = cstr(filters.get("parent"))
-			return apps(group_name)
+		group = cstr(filters.get("parent", "")) if filters else None
+		return apps(group)

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -69,6 +69,7 @@ class Site(Document):
 		"team",
 		"plan",
 		"archive_failed",
+		"cluster"
 	]
 
 	@staticmethod

--- a/press/press/doctype/site_activity/site_activity.py
+++ b/press/press/doctype/site_activity/site_activity.py
@@ -8,6 +8,8 @@ from frappe.model.document import Document
 
 
 class SiteActivity(Document):
+	whitelisted_fields = ["action", "reason"]
+
 	def after_insert(self):
 		if self.action == "Login as Administrator" and self.reason:
 			d = frappe.get_all("Site", {"name": self.site}, ["notify_email", "team"])[0]

--- a/press/press/doctype/site_activity/site_activity.py
+++ b/press/press/doctype/site_activity/site_activity.py
@@ -8,7 +8,7 @@ from frappe.model.document import Document
 
 
 class SiteActivity(Document):
-	whitelisted_fields = ["action", "reason"]
+	dashboard_fields = ["action", "reason"]
 
 	def after_insert(self):
 		if self.action == "Login as Administrator" and self.reason:

--- a/press/press/doctype/site_app/site_app.py
+++ b/press/press/doctype/site_app/site_app.py
@@ -12,7 +12,7 @@ from frappe.utils import cstr
 class SiteApp(Document):
 	@staticmethod
 	def get_list_query(query, filters=None, **list_args):
-		if filters and filters.get("parent"):
-			site_name = cstr(filters.get("parent"))
-			site = frappe.get_doc("Site", site_name)
-			return get_installed_apps(site)
+		site = cstr(filters.get("parent", "")) if filters else None
+		if site:
+			site_doc = frappe.get_doc("Site", site)
+			return get_installed_apps(site_doc)

--- a/press/press/doctype/site_backup/site_backup.py
+++ b/press/press/doctype/site_backup/site_backup.py
@@ -14,6 +14,21 @@ from press.agent import Agent
 
 
 class SiteBackup(Document):
+	whitelisted_fields = [
+		"status",
+		"database_url",
+		"public_url",
+		"private_url",
+		"config_file_url",
+		"site",
+		"database_size",
+		"public_size",
+		"private_size",
+		"with_files",
+		"offsite",
+		"files_availability",
+	]
+
 	def before_insert(self):
 		if getattr(self, "force", False):
 			return

--- a/press/press/doctype/site_backup/site_backup.py
+++ b/press/press/doctype/site_backup/site_backup.py
@@ -14,7 +14,7 @@ from press.agent import Agent
 
 
 class SiteBackup(Document):
-	whitelisted_fields = [
+	dashboard_fields = [
 		"status",
 		"database_url",
 		"public_url",

--- a/press/press/doctype/site_config/site_config.py
+++ b/press/press/doctype/site_config/site_config.py
@@ -8,7 +8,7 @@ from frappe.model.document import Document
 
 
 class SiteConfig(Document):
-	whitelisted_fields = ["key", "value", "type"]
+	dashboard_fields = ["key", "value", "type"]
 
 	@staticmethod
 	def get_list_query(query, filters=None, **list_args):

--- a/press/press/doctype/site_config/site_config.py
+++ b/press/press/doctype/site_config/site_config.py
@@ -8,15 +8,12 @@ from frappe.model.document import Document
 
 
 class SiteConfig(Document):
+	whitelisted_fields = ["key", "value", "type"]
+
 	@staticmethod
 	def get_list_query(query, filters=None, **list_args):
 		Config = frappe.qb.DocType("Site Config")
-		if filters and filters.get("site"):
-			query = (
-				query.where(Config.parent == filters.get("site"))
-				.where(Config.parenttype == "Site")
-				.where(Config.internal == 0)
-			)
+		query = query.where(Config.internal == 0)
 		configs = query.run(as_dict=True)
 		config_key_titles = frappe.db.get_all(
 			"Site Config Key",

--- a/press/press/doctype/site_config_key/site_config_key.py
+++ b/press/press/doctype/site_config_key/site_config_key.py
@@ -7,6 +7,8 @@ from frappe.model.document import Document
 
 
 class SiteConfigKey(Document):
+	whitelisted_fields = ["key", "title", "description", "type"]
+
 	def validate(self):
 		import frappe
 

--- a/press/press/doctype/site_config_key/site_config_key.py
+++ b/press/press/doctype/site_config_key/site_config_key.py
@@ -7,7 +7,7 @@ from frappe.model.document import Document
 
 
 class SiteConfigKey(Document):
-	whitelisted_fields = ["key", "title", "description", "type"]
+	dashboard_fields = ["key", "title", "description", "type"]
 
 	def validate(self):
 		import frappe

--- a/press/press/doctype/site_domain/site_domain.py
+++ b/press/press/doctype/site_domain/site_domain.py
@@ -12,7 +12,7 @@ from press.overrides import get_permission_query_conditions_for_doctype
 
 
 class SiteDomain(Document):
-	whitelisted_fields = ["domain", "status", "dns_type", "site"]
+	dashboard_fields = ["domain", "status", "dns_type", "site"]
 
 	@staticmethod
 	def get_list_query(query, filters=None, **list_args):

--- a/press/press/doctype/site_domain/site_domain.py
+++ b/press/press/doctype/site_domain/site_domain.py
@@ -12,6 +12,8 @@ from press.overrides import get_permission_query_conditions_for_doctype
 
 
 class SiteDomain(Document):
+	whitelisted_fields = ["domain", "status", "dns_type", "site"]
+
 	@staticmethod
 	def get_list_query(query, filters=None, **list_args):
 		domains = query.run(as_dict=1)

--- a/press/press/doctype/stripe_payment_method/stripe_payment_method.py
+++ b/press/press/doctype/stripe_payment_method/stripe_payment_method.py
@@ -12,6 +12,16 @@ from press.utils import log_error
 
 
 class StripePaymentMethod(Document):
+	dashboard_fields = [
+		"is_default",
+		"expiry_month",
+		"expiry_year",
+		"brand",
+		"name_on_card",
+		"last_4",
+	]
+	dashboard_actions = ["set_default"]
+
 	def onload(self):
 		load_address_and_contact(self)
 

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -27,7 +27,7 @@ from press.utils.telemetry import capture
 
 
 class Team(Document):
-	whitelisted_fields = [
+	dashboard_fields = [
 		"enabled",
 		"team_title",
 		"user",
@@ -45,6 +45,7 @@ class Team(Document):
 		"billing_name",
 		"referrer_id",
 	]
+	dashboard_actions = ["get_team_members", "remove_team_member"]
 
 	def get_doc(self, doc):
 		if (

--- a/press/saas/doctype/saas_product_site_request/saas_product_site_request.py
+++ b/press/saas/doctype/saas_product_site_request/saas_product_site_request.py
@@ -7,7 +7,8 @@ from press.saas.doctype.saas_product.pooling import SitePool
 
 
 class SaaSProductSiteRequest(Document):
-	whitelisted_fields = ["site", "status", "saas_product"]
+	dashboard_fields = ["site", "status", "saas_product"]
+	dashboard_actions = ["create_site", "get_progress", "get_login_sid"]
 
 	def get_doc(self, doc):
 		saas_product = frappe.db.get_value(

--- a/press/www/dashboard2.py
+++ b/press/www/dashboard2.py
@@ -11,5 +11,4 @@ no_cache = 1
 
 
 def get_context(context):
-	frappe.only_for("System Manager")
 	return _get_context()


### PR DESCRIPTION
This is my attempt at setting up a permission system for Frappe Cloud which uses Allow approach rather than Restrict.

Every doctype that needs to be fetched on the client must be added in the `ALLOWED_DOCTYPES` list and for each of them a `dashboard_fields` attribute must be added in the doctype controller.

Every doctype action that needs to be available from the client must be added in the `dashboard_actions` attribute in the doctype controller.

This config is used by `press.api.client.*` methods for restricting fields and actions.

Apart from this `press.api.client.get_list` automatically applies `team = $current_team` filter for all select queries if the doctype contains a team field. For doctypes that don't have this field, custom `get_list_query` function is written to add necessary filters.

Also, `press.api.client.insert` sets `team = $current_team` in the doc if the doctype has a team field.
