### PR TITLE
fix: Add no-copy to various site update fields

### DIFF
--- a/press/press/doctype/site_update/site_update.json
+++ b/press/press/doctype/site_update/site_update.json
@@ -60,6 +60,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
+   "no_copy": 1,
    "options": "Pending\nRunning\nSuccess\nFailure\nRecovered\nFatal"
   },
   {
@@ -84,6 +85,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Deploy Type",
+   "no_copy": 1,
    "options": "\nPull\nMigrate"
   },
   {
@@ -93,6 +95,7 @@
    "hide_days": 1,
    "hide_seconds": 1,
    "label": "Source Deploy Candidate",
+   "no_copy": 1,
    "options": "Deploy Candidate"
   },
   {
@@ -102,6 +105,7 @@
    "hide_days": 1,
    "hide_seconds": 1,
    "label": "Destination Deploy Candidate",
+   "no_copy": 1,
    "options": "Deploy Candidate"
   },
   {
@@ -119,6 +123,7 @@
    "hide_days": 1,
    "hide_seconds": 1,
    "label": "Source Group",
+   "no_copy": 1,
    "options": "Release Group"
   },
   {
@@ -138,6 +143,7 @@
    "hide_days": 1,
    "hide_seconds": 1,
    "label": "Update Job",
+   "no_copy": 1,
    "options": "Agent Job"
   },
   {
@@ -146,7 +152,8 @@
    "fieldtype": "Check",
    "hide_days": 1,
    "hide_seconds": 1,
-   "label": "Cause of Failure is Resolved"
+   "label": "Cause of Failure is Resolved",
+   "no_copy": 1
   },
   {
    "fieldname": "column_break_14",
@@ -160,6 +167,7 @@
    "hide_days": 1,
    "hide_seconds": 1,
    "label": "Recover Job",
+   "no_copy": 1,
    "options": "Agent Job"
   },
   {
@@ -174,6 +182,7 @@
    "fieldname": "skipped_failing_patches",
    "fieldtype": "Check",
    "label": "Skipped Failing Patches",
+   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -181,18 +190,20 @@
    "fieldname": "destination_group",
    "fieldtype": "Link",
    "label": "Destination Group",
+   "no_copy": 1,
    "options": "Release Group"
   },
   {
    "default": "0",
    "fieldname": "skipped_backups",
    "fieldtype": "Check",
-   "label": "Skipped Backups"
+   "label": "Skipped Backups",
+   "no_copy": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-03-21 14:31:40.445390",
+ "modified": "2024-02-12 14:47:21.156498",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site Update",


### PR DESCRIPTION
When duplicating site update, these details should be re-fetched. 

Especially job names are not valid for copied site update. 