### PR TITLE
fix: make pull update check more aggressive

### DIFF
--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -1018,26 +1018,35 @@ def can_pull_update(file_paths: list[str]) -> bool:
 
 
 def pull_update_file_filter(file_path: str) -> bool:
-	# Requires migrate but should not change image filesystem
-	if file_path.endswith(".json") and "/doctype/" in file_path:
-		return True
-
-	# Controller file
-	elif file_path.endswith(".py") and "/doctype/" in file_path:
-		return True
+	blacklist = [
+		# Requires pip install
+		"requirements.txt",
+		"pyproject.toml",
+		"setup.py",
+		# Requires yarn install, build
+		"package.json",
+		".vue",
+		".ts",
+		".jsx",
+		".tsx",
+		".scss",
+	]
+	if any(file_path.endswith(f) for f in blacklist):
+		return False
 
 	# Non build requiring frontend files
 	for ext in [".html", ".js", ".css"]:
 		if not file_path.endswith(ext):
 			continue
 
-		if "/public/" in file_path:
+		if "/public/" in file_path or "/www/" in file_path:
 			return True
 
-		elif "/www/" in file_path:
-			return True
+		# Probably requires build
+		else:
+			return False
 
-	return False
+	return True
 
 
 def cleanup_build_directories():


### PR DESCRIPTION
- Allows all python files through unless they're a `setup.py`.
- Disallows `js`, `html`, `css` files unless they're in `www` or `public`
- Flips default to `True` (aggressive 😤)
- Disallows few blacklisted files and types (they require dep install or build)