### PR TITLE
fix: allow single and double quotes for app_title

### DIFF
--- a/press/api/github.py
+++ b/press/api/github.py
@@ -234,7 +234,7 @@ def app(owner, repository, branch, installation=None):
 					headers=headers,
 				).json()
 				content = b64decode(hooks["content"]).decode()
-				match = re.search('app_title = "(.*)"', content)
+				match = re.search(r"""app_title = ["'](.*)["']""", content)
 				if match:
 					title = match.group(1)
 				else:


### PR DESCRIPTION
closes https://github.com/frappe/press/issues/1455


handles most cases I can think of:
`'title'`
`"title"`
`"title's"`
