### PR TITLE
fix: set pullable rel and hash on bench

### DIFF
--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -81,13 +81,20 @@ class Bench(Document):
 
 		if not self.apps:
 			for release in candidate.apps:
+				app_release = release.release
+				app_hash = release.hash
+
+				if release.pullable_release and release.pullable_hash:
+					app_release = release.pullable_release
+					app_hash = release.pullable_hash
+
 				self.append(
 					"apps",
 					{
-						"release": release.release,
+						"release": app_release,
 						"source": release.source,
 						"app": release.app,
-						"hash": release.hash,
+						"hash": app_hash,
 					},
 				)
 


### PR DESCRIPTION
`ReleaseGroup.deploy_information` checks last deployed Bench's app's release and hash, so if a Delta Build occurred Bench is not updated with the latest release and hash, this PR fixes that.