### PR TITLE
fix(Site): Update apps table on new site from backup 100% of the time

### DIFF
--- a/press/api/tests/test_site.py
+++ b/press/api/tests/test_site.py
@@ -383,6 +383,7 @@ insights 0.8.3	    HEAD
 		group = create_test_release_group([app, app2])
 		plan = create_test_plan("Site")
 		create_test_bench(group=group)
+		subdomain = "testsite"
 
 		# frappe.set_user(self.team.user) # can't this due to weird perm error with ignore_perimssions in new site
 		database = create_test_remote_file().name
@@ -396,13 +397,16 @@ insights 0.8.3	    HEAD
 erpnext 0.8.3	    HEAD
 """
 			),
+		), fake_agent_job(
+			"Add Site to Upstream",
+			"Success",
 		):
 			new(
 				{
-					"name": "testsite",
+					"name": subdomain,
 					"group": group.name,
 					"plan": plan.name,
-					"apps": [app.name],
+					"apps": [app.name],  # giving 1 app only
 					"files": {
 						"database": database,
 						"public": public,
@@ -413,7 +417,7 @@ erpnext 0.8.3	    HEAD
 			)
 			poll_pending_jobs()
 
-		site = frappe.get_last_doc("Site")
+		site = frappe.get_last_doc("Site", {"subdomain": subdomain})
 		self.assertEqual(len(site.apps), 2)
 		self.assertEqual(site.apps[0].app, "frappe")
 		self.assertEqual(site.apps[1].app, "erpnext")

--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -727,7 +727,7 @@ def process_job_updates(job_name):
 			process_new_site_job_update(job)
 		elif job.job_type == "New Site from Backup":
 			process_new_site_job_update(job)
-			process_restore_job_update(job)
+			process_restore_job_update(job, force=True)
 		elif job.job_type == "Restore Site":
 			process_restore_job_update(job)
 		elif job.job_type == "Reinstall Site":

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -2074,7 +2074,10 @@ def process_uninstall_app_site_job_update(job):
 		frappe.db.set_value("Site", job.site, "status", updated_status)
 
 
-def process_restore_job_update(job):
+def process_restore_job_update(job, force=False):
+	"""
+	force: force updates apps table sync
+	"""
 	updated_status = {
 		"Pending": "Pending",
 		"Running": "Installing",
@@ -2083,7 +2086,7 @@ def process_restore_job_update(job):
 	}[job.status]
 
 	site_status = frappe.get_value("Site", job.site, "status")
-	if updated_status != site_status:
+	if force or updated_status != site_status:
 		if job.status == "Success":
 			apps = [line.split()[0] for line in job.output.splitlines()]
 			site = frappe.get_doc("Site", job.site)


### PR DESCRIPTION
Add a force check in process_restore_job_update so that apps table
always gets synced.

Required in case where Add Site to Upstream job gets processed first
(and site status is Active by the end of New Site from Backup callback)
leaving process_restore_job_update useless.

Also fixes test to simulate both jobs' success
