### PR TITLE
feat(config): password/secret support

### DIFF
--- a/dashboard/src/components/ConfigEditor.vue
+++ b/dashboard/src/components/ConfigEditor.vue
@@ -37,6 +37,10 @@
 						<FormControl
 							:label="getStandardConfigTitle(config.key)"
 							v-model="config.value"
+							@click="
+								config.type === 'Password' ? (config.value = '') : null;
+								config.type === 'Password' ? (isDirty = true) : null;
+							"
 							@input="isDirty = true"
 							class="flex-1"
 						/>
@@ -97,7 +101,7 @@
 							v-model="newConfig.type"
 							type="select"
 							:disabled="chosenStandardConfig && !showCustomKeyInput"
-							:options="['String', 'Number', 'JSON', 'Boolean']"
+							:options="['String', 'Password', 'Number', 'JSON', 'Boolean']"
 							@change="isDirty = true"
 						/>
 						<FormControl
@@ -162,6 +166,7 @@ export default {
 				const value = d.value;
 				if (!isNaN(value)) d.type = 'Number';
 				else if (isValidJSON(value)) d.type = 'JSON';
+				else if (d.type === 'Password') d.type = 'Password';
 				else d.type = 'String';
 
 				return {
@@ -203,6 +208,7 @@ export default {
 				},
 				onSuccess() {
 					this.isDirty = false;
+					this.$resources.configData.reload();
 				}
 			};
 		},
@@ -254,6 +260,7 @@ export default {
 		configInputProps() {
 			let type = {
 				String: 'text',
+				Password: 'text',
 				Number: 'number',
 				JSON: 'textarea',
 				Boolean: 'select'
@@ -294,11 +301,10 @@ export default {
 			this.newConfig.key = this.chosenStandardConfig?.value || '';
 		},
 		getStandardConfigType(key) {
-			const type =
+			return (
 				this.$resources.standardConfigKeys.data.find(d => d.key === key)
-					?.type || 'String';
-
-			return type === 'Password' ? 'String' : type;
+					?.type || 'String'
+			);
 		},
 		getStandardConfigKey(key) {
 			return (

--- a/dashboard/src/components/ConfigEditor.vue
+++ b/dashboard/src/components/ConfigEditor.vue
@@ -101,7 +101,13 @@
 							v-model="newConfig.type"
 							type="select"
 							:disabled="chosenStandardConfig && !showCustomKeyInput"
-							:options="['String', 'Password', 'Number', 'JSON', 'Boolean']"
+							:options="[
+								'String',
+								'Number',
+								'JSON',
+								'Boolean',
+								chosenStandardConfig?.value !== 'custom_key' ? 'Password' : null
+							]"
 							@change="isDirty = true"
 						/>
 						<FormControl

--- a/dashboard/src2/components/ConfigEditorDialog.vue
+++ b/dashboard/src2/components/ConfigEditorDialog.vue
@@ -42,7 +42,13 @@
 					label="Type"
 					:modelValue="selectedConfig?.type || type"
 					@update:modelValue="type = $event"
-					:options="['String', 'Password', 'Number', 'JSON', 'Boolean']"
+					:options="[
+						'String',
+						'Number',
+						'JSON',
+						'Boolean',
+						selectedConfig?.value !== '__custom_key' ? 'Password' : null
+					]"
 					:disabled="selectedConfig?.value !== '__custom_key'"
 					autocomplete="off"
 				/>

--- a/dashboard/src2/components/ConfigEditorDialog.vue
+++ b/dashboard/src2/components/ConfigEditorDialog.vue
@@ -42,7 +42,7 @@
 					label="Type"
 					:modelValue="selectedConfig?.type || type"
 					@update:modelValue="type = $event"
-					:options="['String', 'Number', 'JSON', 'Boolean']"
+					:options="['String', 'Password', 'Number', 'JSON', 'Boolean']"
 					:disabled="selectedConfig?.value !== '__custom_key'"
 					autocomplete="off"
 				/>
@@ -100,7 +100,7 @@ export default {
 				this.key = this.config.key;
 				this.type = this.config.type;
 			}
-			this.value = this.config.value;
+			this.value = this.config.type === 'Password' ? '' : this.config.value;
 		}
 	},
 	resources: {

--- a/dashboard/src2/objects/bench.js
+++ b/dashboard/src2/objects/bench.js
@@ -444,12 +444,16 @@ export default {
 							}
 						},
 						{
-							label: 'Type',
-							fieldname: 'type'
+							label: 'Config Value',
+							fieldname: 'value',
+							class: 'font-mono',
+							width: 2
 						},
 						{
-							label: 'Config Value',
-							fieldname: 'value'
+							label: 'Type',
+							fieldname: 'type',
+							type: 'Badge',
+							width: '100px'
 						}
 					],
 					primaryAction({

--- a/press/patches.txt
+++ b/press/patches.txt
@@ -111,3 +111,4 @@ press.press.doctype.virtual_machine_volume.patches.rename_aws_fields
 [post_model_sync]
 press.patches.v0_7_0.rename_plan_to_site_plan
 press.patches.v0_7_0.migrate_fields_from_plans_to_server_and_marketplace
+press.patches.v0_7_0.set_password_config_type

--- a/press/patches/v0_7_0/set_password_config_type.py
+++ b/press/patches/v0_7_0/set_password_config_type.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
+# For license information, please see license.txt
+
+
+import frappe
+
+
+def execute():
+	secret_keys = frappe.get_all(
+		"Site Config Key", filters={"type": "Password"}, pluck="key"
+	)
+
+	site_config_keys_that_should_be_secret = frappe.get_all(
+		"Site Config", filters={"key": ("in", secret_keys)}, pluck="name"
+	)
+
+	for key in site_config_keys_that_should_be_secret:
+		frappe.db.set_value("Site Config", key, "type", "Password")
+
+	common_site_config_keys_that_should_be_secret = frappe.get_all(
+		"Common Site Config", filters={"key": ("in", secret_keys)}, pluck="name"
+	)
+
+	for key in common_site_config_keys_that_should_be_secret:
+		frappe.db.set_value("Common Site Config", key, "type", "Password")

--- a/press/press/doctype/common_site_config/common_site_config.json
+++ b/press/press/doctype/common_site_config/common_site_config.json
@@ -30,7 +30,7 @@
    "fieldname": "type",
    "fieldtype": "Select",
    "label": "Type",
-   "options": "\nString\nNumber\nBoolean\nJSON"
+   "options": "\nString\nPassword\nNumber\nBoolean\nJSON"
   },
   {
    "allow_in_quick_entry": 1,
@@ -45,7 +45,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-07-02 11:23:36.999759",
+ "modified": "2024-02-23 10:04:24.528062",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Common Site Config",

--- a/press/press/doctype/common_site_config/common_site_config.py
+++ b/press/press/doctype/common_site_config/common_site_config.py
@@ -18,7 +18,12 @@ class CommonSiteConfig(Document):
 			fields=["key", "title"],
 			filters={"key": ["in", [c.key for c in configs]]},
 		)
+		secret_keys = frappe.get_all(
+			"Site Config Key", filters={"type": "Password"}, pluck="key"
+		)
 		for config in configs:
+			if config.key in secret_keys:
+				config.value = "*******"
 			config.title = next((c.title for c in config_key_titles if c.key == config.key), "")
 		return configs
 

--- a/press/press/doctype/common_site_config/common_site_config.py
+++ b/press/press/doctype/common_site_config/common_site_config.py
@@ -2,30 +2,14 @@
 # For license information, please see license.txt
 
 import frappe
-from frappe.model.document import Document
+
+from press.press.doctype.site_config.site_config import Config
 
 
-class CommonSiteConfig(Document):
-	dashboard_fields = ["key", "type", "value"]
-
+class CommonSiteConfig(Config):
 	@staticmethod
 	def get_list_query(query, filters=None, **list_args):
 		Config = frappe.qb.DocType("Common Site Config")
 		query = query.where(Config.internal == 0).orderby(Config.key, order=frappe.qb.asc)
 		configs = query.run(as_dict=True)
-		config_key_titles = frappe.db.get_all(
-			"Site Config Key",
-			fields=["key", "title"],
-			filters={"key": ["in", [c.key for c in configs]]},
-		)
-		secret_keys = frappe.get_all(
-			"Site Config Key", filters={"type": "Password"}, pluck="key"
-		)
-		for config in configs:
-			if config.key in secret_keys:
-				config.value = "*******"
-			config.title = next((c.title for c in config_key_titles if c.key == config.key), "")
-		return configs
-
-	def get_type(self):
-		return frappe.db.get_value("Site Config Key", self.key, "type")
+		return CommonSiteConfig.format_config_for_list(configs)

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -137,9 +137,6 @@ class ReleaseGroup(Document, TagHelpers):
 			# update internal flag from master
 			row.internal = frappe.db.get_value("Site Config Key", row.key, "internal")
 			key_type = row.type or row.get_type()
-			if key_type == "Password":
-				# we don't support password type yet!
-				key_type = "String"
 			row.type = key_type
 
 			if key_type == "Number":

--- a/press/press/doctype/site_config/site_config.json
+++ b/press/press/doctype/site_config/site_config.json
@@ -38,13 +38,13 @@
    "fieldname": "type",
    "fieldtype": "Select",
    "label": "Type",
-   "options": "\nString\nNumber\nBoolean\nJSON"
+   "options": "\nString\nPassword\nNumber\nBoolean\nJSON"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-09-21 17:03:07.326556",
+ "modified": "2024-02-23 09:28:25.746695",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site Config",
@@ -52,5 +52,6 @@
  "permissions": [],
  "quick_entry": 1,
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }

--- a/press/press/doctype/site_config/site_config.py
+++ b/press/press/doctype/site_config/site_config.py
@@ -20,7 +20,12 @@ class SiteConfig(Document):
 			fields=["key", "title"],
 			filters={"key": ["in", [c.key for c in configs]]},
 		)
+		secret_keys = frappe.get_all(
+			"Site Config Key", filters={"type": "Password"}, pluck="key"
+		)
 		for config in configs:
+			if config.key in secret_keys:
+				config.value = "*******"
 			config.title = next((c.title for c in config_key_titles if c.key == config.key), "")
 		return configs
 

--- a/press/press/doctype/site_config/site_config.py
+++ b/press/press/doctype/site_config/site_config.py
@@ -7,14 +7,13 @@ import frappe
 from frappe.model.document import Document
 
 
-class SiteConfig(Document):
-	dashboard_fields = ["key", "value", "type"]
+class Config(Document):
+	dashboard_fields = ["key", "type", "value"]
 
-	@staticmethod
-	def get_list_query(query, filters=None, **list_args):
-		Config = frappe.qb.DocType("Site Config")
-		query = query.where(Config.internal == 0)
-		configs = query.run(as_dict=True)
+	def get_type(self):
+		return frappe.db.get_value("Site Config Key", self.key, "type")
+
+	def format_config_for_list(configs):
 		config_key_titles = frappe.db.get_all(
 			"Site Config Key",
 			fields=["key", "title"],
@@ -29,5 +28,11 @@ class SiteConfig(Document):
 			config.title = next((c.title for c in config_key_titles if c.key == config.key), "")
 		return configs
 
-	def get_type(self):
-		return frappe.db.get_value("Site Config Key", self.key, "type")
+
+class SiteConfig(Config):
+	@staticmethod
+	def get_list_query(query, filters=None, **list_args):
+		Config = frappe.qb.DocType("Site Config")
+		query = query.where(Config.internal == 0)
+		configs = query.run(as_dict=True)
+		return SiteConfig.format_config_for_list(configs)


### PR DESCRIPTION
fix #1469

Introduces `Password` type to both Site Config and Common Site Config
Users will be able to set, edit (won't be able to see the value) and delete the key

![image](https://github.com/frappe/press/assets/63963181/d4cc45fc-4d50-4283-8437-e56ece729835)
![image](https://github.com/frappe/press/assets/63963181/962b7b34-08c4-4082-b343-b2292e7a7f2d)
![image](https://github.com/frappe/press/assets/63963181/0e4866c0-9cfa-4c6c-8e12-e27d36e3763a)

### Todo
- [ ] create a password field for storing passwords only
- [x] patch to store all keys of type password in password field