### PR TITLE
fix: Release Group form rendering bug fix

### DIFF
--- a/press/press/doctype/release_group/release_group.json
+++ b/press/press/doctype/release_group/release_group.json
@@ -262,7 +262,6 @@
    "label": "Common Site Config"
   },
   {
-   "default": "{}",
    "fieldname": "common_site_config_table",
    "fieldtype": "Table",
    "label": "Configuration",


### PR DESCRIPTION
should not set "default" : {} for Table fieldtype
it will cause issue on form rendering, when it try to assign indexing for grid rows

Error Trace was:

grid.js:470 Uncaught (in promise) TypeError: Cannot create property 'idx' on string '{'
at Pt.render_result_rows (grid.js:470:7)
at Pt.refresh (grid.js:432:8)
at frappe.ui.form.ControlTable.refresh_input (table.js:125:13)
at frappe.ui.form.ControlTable.refresh (base_control.js:140:9)
at frappe.ui.form.Layout.attach_doc_and_docfields (layout.js:472:59)
at frappe.ui.form.Layout.refresh (layout.js:334:8)
at frappe.ui.form.Form.refresh_fields (form.js:666:15)
at form.js:610:16