### PR TITLE
feat: fetch deps from app pyproject

### DIFF
--- a/press/docker/Dockerfile
+++ b/press/docker/Dockerfile
@@ -119,38 +119,36 @@ RUN echo "[mysqldump]\nmax_allowed_packet              = 512M" > /etc/mysql/conf
 # Add frappe user
 RUN useradd -ms /bin/bash frappe
 
-# Install Additional APT Packages
-{% if doc.additional_packages %}
+# Install Additional Packages
 {% for p in doc.additional_packages %}
 
+# Run before install scripts
 {% if p.prerequisites %}
 RUN --mount=type=cache,target=/var/cache/apt {{ p.prerequisites }} \
-  `#stage-pre-{{ p.package }}`
+  `#stage-pre_before-{{ p.package }}`
 {% endif %}
 
+# Install non Ubuntu packages
 {% if p.package_manager not in ["apt-get", "apt"] %}
-
 RUN {{ p.package_manager }} install {{ p.package }} \
   `#stage-pre-{{ p.package }}`
 
+# Install Ubuntu packages
 {% else %}
-
 RUN --mount=type=cache,target=/var/cache/apt apt-get update \
-  && apt-get install --yes --no-install-suggests --no-install-recommends \
-  {{ p.package }} \
+  && apt-get install --yes --no-install-suggests --no-install-recommends {{ p.package }} \
   && rm -rf /var/lib/apt/lists/* \
   `#stage-pre-{{ p.package }}`
-
 {% endif %}
 
+# Run after install scripts
 {% if p.after_install %}
 RUN  --mount=type=cache,target=/var/cache/apt {{ p.after_install }} \
   && rm -rf /var/lib/apt/lists/* \
-  `#stage-pre-{{ p.package }}`
+  `#stage-pre_after-{{ p.package }}`
 {% endif %}
 
 {% endfor %}
-{% endif %}
 
 
 # symlink mysqldump to mariadb-dump
@@ -251,18 +249,12 @@ RUN ["/bin/bash", "-c", "if bench validate-dependencies --help 1> /dev/null 2> /
 COPY --chown=frappe:frappe config /home/frappe/frappe-bench/config
 COPY --chown=frappe:frappe apps.txt /home/frappe/frappe-bench/sites/apps.txt
 
-# create custom mounts
-{% if doc.mounts %}
+# Create custom mounts
 {% for m in doc.container_mounts %}
-
-{% if not m.is_absolute_path %}
-RUN mkdir -p {{ m.destination }} \
-  && chown -R frappe:frappe {{ m.destination }} \
+RUN mkdir -p {{ m.destination }} && \
+  chown -R frappe:frappe {{ m.destination }} \
   `#stage-mounts-create`
-{% endif %}
-
 {% endfor %}
-{% endif %}
 
 ENV FRAPPE_HARD_LINK_ASSETS True
 

--- a/press/press/doctype/deploy_candidate/deploy_candidate.json
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.json
@@ -17,7 +17,6 @@
   "apps",
   "dependencies",
   "packages",
-  "apt_packages",
   "environment_variables",
   "mounts",
   "section_break_6",
@@ -251,12 +250,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "apt_packages",
-   "fieldtype": "Text",
-   "label": "APT Packages",
-   "read_only": 1
-  },
-  {
    "fieldname": "column_break_tkdd",
    "fieldtype": "Column Break"
   },
@@ -325,7 +318,7 @@
   }
  ],
  "links": [],
- "modified": "2024-02-05 11:30:59.225112",
+ "modified": "2024-02-28 18:45:58.819771",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Deploy Candidate",

--- a/press/press/doctype/deploy_candidate/deploy_candidate.json
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.json
@@ -18,7 +18,6 @@
   "dependencies",
   "packages",
   "environment_variables",
-  "mounts",
   "section_break_6",
   "build_start",
   "build_end",
@@ -290,12 +289,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "mounts",
-   "fieldtype": "Text",
-   "label": "Mounts",
-   "read_only": 1
-  },
-  {
    "default": "0",
    "fetch_from": "group.use_rq_workerpool",
    "fieldname": "use_rq_workerpool",
@@ -318,7 +311,7 @@
   }
  ],
  "links": [],
- "modified": "2024-02-28 18:45:58.819771",
+ "modified": "2024-02-29 13:32:52.946943",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Deploy Candidate",

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -9,7 +9,7 @@ import shlex
 import shutil
 import subprocess
 from subprocess import Popen
-from typing import List
+from typing import List, Tuple
 
 import docker
 import dockerfile
@@ -104,7 +104,7 @@ class DeployCandidate(Document):
 		if not kwargs.get("no_cache"):
 			self._update_app_releases()
 		self.prepare_mounts()
-		self.add_build_steps()
+		self.add_pre_build_steps()
 		self.save()
 		user, session_data, team, = (
 			frappe.session.user,
@@ -203,88 +203,30 @@ class DeployCandidate(Document):
 			self.save()
 			frappe.db.commit()
 
-	def add_build_steps(self):
+	def add_pre_build_steps(self):
+		"""
+		This function just adds build steps that occur before
+		a docker build, rest of the steps are updated after the
+		Dockerfile is generated in:
+		- `_update_build_steps`
+		- `_update_post_build_steps`
+		"""
 		if self.build_steps:
-			return
+			self.build_steps.clear()
 
-		# stage_slug, step_slug, stage, step
-		preparation_steps = [
-			("pre", "essentials", "Setup Prerequisites", "Install Essential Packages"),
-			("pre", "redis", "Setup Prerequisites", "Install Redis"),
-			("pre", "python", "Setup Prerequisites", "Install Python"),
-			("pre", "wkhtmltopdf", "Setup Prerequisites", "Install wkhtmltopdf"),
-			("pre", "fonts", "Setup Prerequisites", "Install Fonts"),
-			# package steps added in: _update_build_steps_with_packages
-		]
-
-		if frappe.get_value("Team", self.team, "is_code_server_user"):
-			preparation_steps.extend(
-				[
-					("pre", "code-server", "Setup Prerequisites", "Install Code Server"),
-				]
-			)
-
-		preparation_steps.extend(
-			[
-				("pre", "node", "Setup Prerequisites", "Install Node.js"),
-				("pre", "yarn", "Setup Prerequisites", "Install Yarn"),
-				("pre", "pip", "Setup Prerequisites", "Install pip"),
-				("bench", "bench", "Setup Bench", "Install Bench"),
-				("bench", "env", "Setup Bench", "Setup Virtual Environment"),
-			]
-		)
-
-		clone_steps = []
-		app_install_steps = []
-		pull_update_steps = []
-
+		app_titles = {a.app: a.title for a in self.apps}
+		stage_slug = "clone"
 		for app in self.apps:
-			clone_steps.append(("clone", app.app, "Clone Repositories", app.title))
-			app_install_steps.append(("apps", app.app, "Install Apps", app.title))
-
-			if app.pullable_release:
-				pull_update_steps.append(("pull", app.app, "Pull Updates", app.title))
-
-		validation_steps = [
-			("validate", "dependencies", "Run Validations", "Validate Dependencies"),
-		]
-
-		mount_step = []
-		if self.mounts:
-			mount_step = [
-				("mounts", "create", "Setup Mounts", "Prepare Mounts"),
-			]
-
-		steps = [
-			*clone_steps,
-			*preparation_steps,
-			*app_install_steps,
-			*pull_update_steps,
-			*validation_steps,
-			*mount_step,
-		]
-
-		for stage_slug, step_slug, stage, step in steps:
-			self.append(
-				"build_steps",
-				{
-					"status": "Pending",
-					"stage_slug": stage_slug,
-					"step_slug": step_slug,
-					"stage": stage,
-					"step": step,
-				},
+			step_slug = app.app
+			stage, step = get_build_stage_and_step(stage_slug, step_slug, app_titles)
+			step = dict(
+				status="Pending",
+				stage_slug=stage_slug,
+				step_slug=step_slug,
+				stage=stage,
+				step=step,
 			)
-		self.append(
-			"build_steps",
-			{
-				"status": "Pending",
-				"stage_slug": "upload",
-				"step_slug": "upload",
-				"stage": "Upload",
-				"step": "Docker Image",
-			},
-		)
+			self.append("build_steps", step)
 		self.save()
 
 	def prepare_mounts(self):
@@ -411,12 +353,13 @@ class DeployCandidate(Document):
 		have been cloned.
 		"""
 		self._update_packages()
-		self._update_build_steps_with_packages()
 		self.save(ignore_version=True)
 		self._set_additional_packages()
 
 		self._load_mounts()
-		self._generate_dockerfile()
+		dockerfile = self._generate_dockerfile()
+		self._add_build_steps(dockerfile)
+		self._add_post_build_steps()
 		self._copy_config_files()
 		self._generate_redis_cache_config()
 		self._generate_supervisor_config()
@@ -463,13 +406,6 @@ class DeployCandidate(Document):
 			package = dict(package_manager="apt", package=" ".join(app_packages))
 			self.append("packages", package)
 
-	def _update_build_steps_with_packages(self):
-		package_steps = []
-		for p in self.packages:
-			step = ("pre", p.package, "Setup Prerequisite", f"Install package {p.package}")
-			package_steps.append(step)
-		# TODO: Splice into self.build_steps
-
 	def _set_additional_packages(self):
 		"""
 		additional_packages is used when rendering the Dockerfile template
@@ -506,6 +442,74 @@ class DeployCandidate(Document):
 
 			content = frappe.render_template(dockerfile_template, {"doc": self}, is_path=True)
 			f.write(content)
+			return content
+
+	def _add_build_steps(self, dockerfile: str):
+		"""
+		This function adds build steps that take place inside docker build.
+		These steps are added from the generated Dockerfile.
+
+		Build steps are updated when docker build runs and prints a string of
+		the following format `#stage-{ stage_slug }-{ step_slug }` to the output.
+
+		To add additional build steps:
+		- Update STAGE_SLUG_MAP
+		- Update STEP_SLUG_MAP
+		- Update get_build_stage_and_step
+		"""
+		app_titles = {a.app: a.title for a in self.apps}
+
+		checkpoints = self._get_dockerfile_checkpoints(dockerfile)
+		for checkpoint in checkpoints:
+			splits = checkpoint.split("-", 1)
+			if len(splits) != 2:
+				continue
+
+			stage_slug, step_slug = splits
+			stage, step = get_build_stage_and_step(
+				stage_slug,
+				step_slug,
+				app_titles,
+			)
+
+			step = dict(
+				status="Pending",
+				stage_slug=stage_slug,
+				step_slug=step_slug,
+				stage=stage,
+				step=step,
+			)
+			self.append("build_steps", step)
+
+	def _get_dockerfile_checkpoints(self, dockerfile: str) -> list[str]:
+		"""
+		Returns checkpoint slugs from a generated Dockerfile
+		"""
+
+		# Example: "`#stage-pre-essentials`", "`#stage-apps-print_designer`"
+		rx = re.compile(r"`#stage-([^` ]+)`")
+
+		# Example: "pre-essentials", "apps-print_designer"
+		checkpoints = []
+		for line in dockerfile.split("\n"):
+			matches = rx.findall(line)
+			checkpoints.extend(matches)
+
+		return checkpoints
+
+	def _add_post_build_steps(self):
+		slugs = [("upload", "image")]
+
+		for stage_slug, step_slug in slugs:
+			stage, step = get_build_stage_and_step(stage_slug, step_slug, {})
+			step = dict(
+				status="Pending",
+				stage_slug=stage_slug,
+				step_slug=step_slug,
+				stage=stage,
+				step=step,
+			)
+			self.append("build_steps", step)
 
 	def _copy_config_files(self):
 		for target in ["common_site_config.json", "supervisord.conf", ".vimrc"]:
@@ -1170,3 +1174,44 @@ def run_scheduled_builds():
 		except Exception:
 			frappe.db.rollback()
 			log_error(title="Scheduled Deploy Candidate Error", candidate=candidate)
+
+
+# Key: stage_slug
+STAGE_SLUG_MAP = {
+	"clone": "Clone Repositories",
+	"pre": "Setup Prerequisites",
+	"bench": "Setup Bench",
+	"apps": "Install Apps",
+	"validate": "Run Validations",
+	"pull": "Pull Updates",
+	"mounts": "Setup Mounts",
+	"upload": "Upload",
+}
+
+# Key: (stage_slug, step_slug)
+STEP_SLUG_MAP = {
+	("pre", "essentials"): "Install Essential Packages",
+	("pre", "redis"): "Install Redis",
+	("pre", "python"): "Install Python",
+	("pre", "wkhtmltopdf"): "Install wkhtmltopdf",
+	("pre", "fonts"): "Install Fonts",
+	("pre", "node"): "Install Node.js",
+	("pre", "yarn"): "Install Yarn",
+	("pre", "pip"): "Install pip",
+	("bench", "bench"): "Install Bench",
+	("bench", "env"): "Setup Virtual Environment",
+	("validate", "dependencies"): "Validate Dependencies",
+	("mounts", "create"): "Prepare Mounts",
+	("upload", "image"): "Docker Image",
+}
+
+
+def get_build_stage_and_step(
+	stage_slug: str, step_slug: str, app_titles: dict[str, str] = None
+) -> Tuple[str, str]:
+	stage = STAGE_SLUG_MAP.get(stage_slug, stage_slug)
+	if stage_slug == "clone" or stage_slug == "apps":
+		return (stage, app_titles[step_slug])
+
+	step = STEP_SLUG_MAP.get((stage_slug, step_slug), step_slug)
+	return (stage, step)


### PR DESCRIPTION
Individual apps can mention apt dependencies in their pyproject.toml.

[For Example](https://github.com/frappe/drive/commit/83254c0833211613fc4bbe6d50f8801b41c806fa):
```toml
[deploy.dependencies.apt]
packages = [
  "ffmpeg",
  "libsm6",
  "libxext6",
]
```

For each app, these are grouped together into a single package row.

Todo:
- [x] Populate build steps after generating Dockerfile
- [ ] Check if everything works
