### PR TITLE
chore: free up CI space

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -74,6 +74,11 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
 
     steps:
+      - name: Remove unnecessary files
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
       - name: Clone
         uses: actions/checkout@v3
 


### PR DESCRIPTION
This PR adds a CI step to delete some unused files to prevent out of space errors. The app cache test has a disk utilization of ~6GB, this often caused space to run out.

Disk Utilization during app cache tests:
```
Total space: 72.5 GB

## Before PR:
- before app cache test: 64.95 GB
- after app cache test:  71.22 GB

## After PR:
- before app cache test: 55.99 GB
- after app cache test:  62.26 GB
```