### PR TITLE
fix: add app patch indicators

### DIFF
--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -2,7 +2,7 @@ import {
 	createListResource,
 	LoadingIndicator,
 	frappeRequest,
-	Button
+	Tooltip
 } from 'frappe-ui';
 import { defineAsyncComponent, h } from 'vue';
 import { toast } from 'vue-sonner';
@@ -353,7 +353,22 @@ export default {
 						{
 							label: 'App',
 							fieldname: 'app',
-							width: 1
+							width: 1,
+							suffix(row) {
+								if (!row.is_app_patched) {
+									return;
+								}
+
+								return h(
+									Tooltip,
+									{
+										text: 'App has been patched',
+										placement: 'top',
+										class: 'rounded-full bg-gray-100 p-1'
+									},
+									() => h(icon('alert-circle', 'w-3 h-3'))
+								);
+							}
 						},
 						{
 							label: 'Branch',

--- a/dashboard/src2/pages/ReleaseGroupBenchSites.vue
+++ b/dashboard/src2/pages/ReleaseGroupBenchSites.vue
@@ -30,7 +30,7 @@
 </template>
 <script>
 import { h } from 'vue';
-import { getCachedDocumentResource } from 'frappe-ui';
+import { getCachedDocumentResource, Tooltip } from 'frappe-ui';
 import GenericList from '../components/GenericList.vue';
 import { confirmDialog, icon, renderDialog } from '../utils/components';
 import { toast } from 'vue-sonner';
@@ -56,6 +56,7 @@ export default {
 					status: version.status,
 					proxyServer: version.proxy_server,
 					hasSSHAcess: version.has_ssh_access,
+					hasAppPatchApplied: version.has_app_patch_applied,
 					isBench: true
 				});
 				for (let site of version.sites) {
@@ -81,6 +82,21 @@ export default {
 								: row.name == 'No sites'
 								? 'text-gray-600 pl-2'
 								: 'text-gray-900 pl-2';
+						},
+						suffix(row) {
+							if (!row.hasAppPatchApplied) {
+								return;
+							}
+
+							return h(
+								Tooltip,
+								{
+									text: 'Patches applied',
+									placement: 'top',
+									class: 'rounded-full bg-gray-100 p-1'
+								},
+								() => h(icon('alert-circle', 'w-3 h-3'))
+							);
 						}
 					},
 					{

--- a/dashboard/src2/pages/ReleaseGroupBenchSites.vue
+++ b/dashboard/src2/pages/ReleaseGroupBenchSites.vue
@@ -91,7 +91,7 @@ export default {
 							return h(
 								Tooltip,
 								{
-									text: 'Patches applied',
+									text: 'Apps in this deploy have been patched',
 									placement: 'top',
 									class: 'rounded-full bg-gray-100 p-1'
 								},

--- a/press/press/doctype/press_notification/test_press_notification.py
+++ b/press/press/doctype/press_notification/test_press_notification.py
@@ -8,10 +8,7 @@ from press.press.doctype.agent_job.agent_job import poll_pending_jobs
 from press.press.doctype.agent_job.test_agent_job import fake_agent_job
 from press.press.doctype.app.test_app import create_test_app
 from press.press.doctype.deploy.deploy import create_deploy_candidate_differences
-from press.api.notifications import get_unread_count, get_notifications
-from press.press.doctype.deploy_candidate.test_deploy_candidate import (
-	create_test_deploy_candidate,
-)
+from press.api.notifications import get_unread_count
 from press.press.doctype.release_group.test_release_group import (
 	create_test_release_group,
 )
@@ -50,18 +47,3 @@ class TestPressNotification(FrappeTestCase):
 		# api test is added here since it's trivial
 		# move to separate file if it gets more complex
 		self.assertEqual(get_unread_count(), 1)
-
-	def test_notification_is_created_when_deploy_fails(self):
-		group = create_test_release_group(self.apps)
-		dc = create_test_deploy_candidate(group)
-
-		self.assertEqual(frappe.db.count("Press Notification"), 0)
-
-		dc.status = "Failure"
-		dc.save()
-
-		notification = frappe.get_last_doc("Press Notification")
-		self.assertEqual(notification.type, "Bench Deploy")
-		# api test is added here since it's trivial
-		# move to separate file if it gets more complex
-		self.assertEqual(len(get_notifications()), 1)

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -605,7 +605,17 @@ class ReleaseGroup(Document, TagHelpers):
 		cur_user_ssh_key = frappe.get_all(
 			"User SSH Key", {"user": frappe.session.user, "is_default": 1}, limit=1
 		)
+
+		benches = [dn.name for dn in deployed_versions]
+		benches_with_patches = frappe.get_all(
+			"App Patch",
+			fields=["bench"],
+			filters={"bench": ["in", benches], "status": "Applied"},
+			pluck="bench",
+		)
+
 		for version in deployed_versions:
+			version.has_app_patch_applied = version.name in benches_with_patches
 			version.has_ssh_access = version.is_ssh_proxy_setup and cur_user_ssh_key
 			version.sites = find_all(sites_in_group_details, lambda x: x.bench == version.name)
 			for site in version.sites:

--- a/press/press/doctype/site_app/site_app.py
+++ b/press/press/doctype/site_app/site_app.py
@@ -5,14 +5,33 @@
 
 import frappe
 from frappe.model.document import Document
-from press.api.site import get_installed_apps
 from frappe.utils import cstr
+from press.api.site import get_installed_apps
 
 
 class SiteApp(Document):
 	@staticmethod
 	def get_list_query(query, filters=None, **list_args):
 		site = cstr(filters.get("parent", "")) if filters else None
-		if site:
-			site_doc = frappe.get_doc("Site", site)
-			return get_installed_apps(site_doc)
+		if not site:
+			return None
+
+		site_doc = frappe.get_doc("Site", site)
+		installed_apps = get_installed_apps(site_doc)
+
+		# Apply is_app_patched flag to installed_apps
+		app_names = [a.app for a in site_doc.apps]
+		patched_apps = frappe.get_all(
+			"App Patch",
+			fields=["app"],
+			filters={
+				"bench": site_doc.bench,
+				"app": ["in", app_names],
+			},
+			pluck="app",
+		)
+		for app in installed_apps:
+			if app.app in patched_apps:
+				app.is_app_patched = True
+
+		return installed_apps


### PR DESCRIPTION
Closes #1567 

- [x] Patch indicator in RG site list
- [x] Patch indicator in Site app list
- [ ] (won't be added) Patch indicator on tabs

### Screenshots
![Screenshot 2024-03-15 at 13 01 53](https://github.com/frappe/press/assets/29507195/82608ba3-a260-48c3-9ae2-80ab846fd75c)

![Screenshot 2024-03-15 at 13 01 31](https://github.com/frappe/press/assets/29507195/4d4328b8-3440-4a46-904e-082379a8f89d)
