### PR TITLE
fix: reconnect on build_failed error

### DIFF
--- a/press/press/doctype/ansible_console/ansible_console.py
+++ b/press/press/doctype/ansible_console/ansible_console.py
@@ -3,23 +3,19 @@
 
 import json
 import shutil
+
 import frappe
-from frappe.model.document import Document
-
-import wrapt
-from ansible import context
-from ansible import constants
-
+from ansible import constants, context
+from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.inventory.manager import InventoryManager
 from ansible.module_utils.common.collections import ImmutableDict
 from ansible.parsing.dataloader import DataLoader
-
+from ansible.playbook.play import Play
 from ansible.plugins.callback import CallbackBase
 from ansible.vars.manager import VariableManager
-from pymysql.err import InterfaceError
-from ansible.playbook.play import Play
-from ansible.executor.task_queue_manager import TaskQueueManager
+from frappe.model.document import Document
 from frappe.utils import get_timedelta
+from press.utils import reconnect_on_failure
 
 
 class AnsibleConsole(Document):
@@ -52,18 +48,6 @@ def _execute_command(doc):
 	console = frappe.get_doc(json.loads(doc))
 	console.run()
 	return console.as_dict()
-
-
-def reconnect_on_failure():
-	@wrapt.decorator
-	def wrapper(wrapped, instance, args, kwargs):
-		try:
-			return wrapped(*args, **kwargs)
-		except InterfaceError:
-			frappe.db.connect()
-			return wrapped(*args, **kwargs)
-
-	return wrapper
 
 
 class AnsibleCallback(CallbackBase):

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -34,7 +34,7 @@ from press.press.doctype.deploy_candidate.deploy_notifications import (
 )
 from press.press.doctype.release_group.release_group import ReleaseGroup
 from press.press.doctype.server.server import Server
-from press.utils import get_current_team, log_error
+from press.utils import get_current_team, log_error, reconnect_on_failure
 
 if typing.TYPE_CHECKING:
 	from press.press.doctype.app_release.app_release import AppRelease
@@ -410,6 +410,7 @@ class DeployCandidate(Document):
 		self.save()
 		frappe.db.commit()
 
+	@reconnect_on_failure()
 	def _build_failed(self):
 		self.status = "Failure"
 		bench_update = frappe.get_all(


### PR DESCRIPTION
Probably the lazy way to go about it. On checking mysql error logs, no particular pattern was found that would help debugging the `InterfaceError` that occurs when build status is set to _Failure_ after a long running build failing.

I'd previously suspected that the connection is killed off, but the wait time out is 8 hours, and so this seems implausible. 

Looking at the build in question, it was failed just cause it was long running (by the server script).