### PR TITLE
perf: drop modified index to reduce contention

### DIFF
--- a/press/agent.py
+++ b/press/agent.py
@@ -796,7 +796,7 @@ class Agent:
 	):
 		"""Deduplicate jobs in execution state"""
 
-		filteres = {
+		filters = {
 			"server_type": self.server_type,
 			"server": self.server,
 			"job_type": job_type,
@@ -806,21 +806,21 @@ class Agent:
 		}
 
 		if bench:
-			filteres["bench"] = bench
+			filters["bench"] = bench
 
 		if site:
-			filteres["site"] = site
+			filters["site"] = site
 
 		if code_server:
-			filteres["code_server"] = code_server
+			filters["code_server"] = code_server
 
 		if upstream:
-			filteres["upstream"] = upstream
+			filters["upstream"] = upstream
 
 		if host:
-			filteres["host"] = host
+			filters["host"] = host
 
-		job = frappe.db.get_value("Agent Job", filteres, "name")
+		job = frappe.db.get_value("Agent Job", filters, "name")
 
 		return frappe.get_doc("Agent Job", job) if job else False
 

--- a/press/press/doctype/agent_job/agent_job.json
+++ b/press/press/doctype/agent_job/agent_job.json
@@ -211,7 +211,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2023-12-04 17:31:38.094742",
+ "modified": "2024-03-23 17:31:38.094742",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Agent Job",
@@ -247,7 +247,7 @@
   }
  ],
  "quick_entry": 1,
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],
  "title_field": "job_type",

--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -470,7 +470,7 @@ def fail_old_jobs():
 		{
 			"status": ("in", ["Pending", "Running"]),
 			"job_id": ("!=", 0),
-			"modified": ("<", add_days(None, -2)),
+			"creation": ("<", add_days(None, -2)),
 		},
 		"name",
 		pluck=True,
@@ -481,7 +481,7 @@ def fail_old_jobs():
 		"Agent Job",
 		{
 			"job_id": 0,
-			"modified": ("<", add_days(None, -2)),
+			"creation": ("<", add_days(None, -2)),
 			"status": ("!=", "Undelivered"),
 		},
 		"name",
@@ -938,3 +938,6 @@ def update_job_step_status():
 
 def on_doctype_update():
 	frappe.db.add_index("Agent Job", ["status", "server"])
+	# We don't need modified index, it's harmful on constantly updating tables
+	frappe.db.sql_ddl("drop index if exists modified on `tabAgent Job`")
+	frappe.db.add_index("Agent Job", ["creation"])

--- a/press/press/doctype/agent_job_step/agent_job_step.py
+++ b/press/press/doctype/agent_job_step/agent_job_step.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
@@ -28,4 +28,8 @@ class AgentJobStep(Document):
 		traceback: DF.Code | None
 	# end: auto-generated types
 
-	pass
+
+def on_doctype_update():
+	# We don't need modified index, it's harmful on constantly updating tables
+	frappe.db.sql_ddl("drop index if exists modified on `tabAgent Job Step`")
+	frappe.db.add_index("Agent Job Step", ["creation"])


### PR DESCRIPTION
Dropped modified index from `Agent Job` and `Agent Job Step`, we don't need these indexes and since these are two most busy tables the index causes unnecessary lock contention. 


TODO:
- [x] mark these as ignored
- [x] Observe and drop (merging this PR should be enough)