### PR TITLE
refactor: refac create_release to suck less

### DIFF
--- a/press/press/doctype/app_source/app_source.json
+++ b/press/press/doctype/app_source/app_source.json
@@ -154,8 +154,13 @@
   }
  ],
  "index_web_pages_for_search": 1,
- "links": [],
- "modified": "2023-01-17 14:29:19.684075",
+ "links": [
+  {
+   "link_doctype": "Error Log",
+   "link_fieldname": "reference_name"
+  }
+ ],
+ "modified": "2024-04-01 13:12:36.600288",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "App Source",

--- a/press/utils/__init__.py
+++ b/press/utils/__init__.py
@@ -35,16 +35,30 @@ def log_error(title, **kwargs):
 		del kwargs["reference_doctype"]
 		del kwargs["reference_name"]
 
+	if doc := kwargs.get("doc"):
+		reference_doctype = doc.doctype
+		reference_name = doc.name
+		del kwargs["doc"]
+
+	try:
+		kwargs["user"] = frappe.session.user
+		kwargs["team"] = frappe.local.team()
+	except Exception:
+		pass
+
 	traceback = frappe.get_traceback(with_context=True)
 	serialized = json.dumps(kwargs, indent=4, sort_keys=True, default=str, skipkeys=True)
 	message = f"Data:\n{serialized}\nException:\n{traceback}"
 
-	frappe.log_error(
-		title=title,
-		message=message,
-		reference_doctype=reference_doctype,
-		reference_name=reference_name,
-	)
+	try:
+		frappe.log_error(
+			title=title,
+			message=message,
+			reference_doctype=reference_doctype,
+			reference_name=reference_name,
+		)
+	except Exception:
+		pass
 
 
 def get_current_team(get_doc=False):


### PR DESCRIPTION
Create release adds a comment on failing and doesn't handle non success error codes correctly. Also the function itself is a bit unwieldy.

This PR:
- mentions app source on the error log
- shows error logs on the app source
- factorizes `create_release` into sensible chunks
- removes creating a comment on errors
- handles non success GitHub API call
