### PR TITLE
feat(SiteActivity): update notify mail action

### DIFF
--- a/dashboard/src2/dialogs/ConfirmDialog.vue
+++ b/dashboard/src2/dialogs/ConfirmDialog.vue
@@ -30,7 +30,12 @@ export default {
 			show: true,
 			error: null,
 			isLoading: false,
-			values: {}
+			values:
+				// set default values for fields
+				this.fields.reduce((acc, field) => {
+					acc[field.fieldname] = field.default || '';
+					return acc;
+				}, {})
 		};
 	},
 	components: { FormControl, ErrorMessage },

--- a/dashboard/src2/main.js
+++ b/dashboard/src2/main.js
@@ -25,7 +25,7 @@ setConfig('defaultListUrl', 'press.api.client.get_list');
 setConfig('defaultDocGetUrl', 'press.api.client.get');
 setConfig('defaultDocInsertUrl', 'press.api.client.insert');
 setConfig('defaultRunDocMethodUrl', 'press.api.client.run_doc_method');
-// setConfig('defaultDocUpdateUrl', 'press.api.list.set_value');
+setConfig('defaultDocUpdateUrl', 'press.api.client.set_value');
 setConfig('defaultDocDeleteUrl', 'press.api.client.delete');
 
 let app;

--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -1274,7 +1274,61 @@ export default {
 							type: 'Timestamp',
 							align: 'right'
 						}
-					]
+					],
+					primaryAction({ documentResource: site }) {
+						return {
+							label: 'Change Notification Email',
+							slots: {
+								prefix: icon('mail')
+							},
+							onClick: () => {
+								confirmDialog({
+									title: 'Change Notification Email',
+									fields: [
+										{
+											type: 'email',
+											label: 'Email',
+											fieldname: 'email',
+											default: site.doc.notify_email
+										}
+									],
+									onSuccess({ hide, values }) {
+										return site.setValue.submit(
+											{
+												notify_email: values.email
+											},
+											{
+												validate: doc => {
+													function validateEmail(email) {
+														const re = /\S+@\S+\.\S+/;
+														return re.test(email);
+													}
+
+													let email = doc?.fieldname?.notify_email;
+													if (!email) {
+														return 'Email is required';
+													} else if (!validateEmail(email)) {
+														return 'Enter a valid email address';
+													}
+												},
+												onSuccess() {
+													hide();
+													toast.success('Email updated successfully');
+												},
+												onError(e) {
+													throw new Error(
+														e.messages
+															? e.messages.join('\n')
+															: e.message || 'Error updating email'
+													);
+												}
+											}
+										);
+									}
+								});
+							}
+						};
+					}
 				}
 			},
 			logsTab(),

--- a/press/api/client.py
+++ b/press/api/client.py
@@ -7,7 +7,7 @@ import inspect
 
 import frappe
 from frappe import is_whitelisted
-from frappe.client import delete_doc
+from frappe.client import delete_doc, set_value as _set_value
 from frappe.handler import get_attr
 from frappe.handler import run_doc_method as _run_doc_method
 from frappe.model import child_table_fields, default_fields
@@ -203,7 +203,14 @@ def insert(doc=None):
 
 @frappe.whitelist(methods=["POST", "PUT"])
 def set_value(doctype, name, fieldname, value=None):
-	pass
+	check_permissions(doctype)
+	check_team_access(doctype, name)
+
+	for field in fieldname.keys():
+		# fields mentioned in whitelisted_actions are allowed to be set via set_value
+		check_dashboard_actions(doctype, field)
+
+	return _set_value(doctype, name, fieldname, value)
 
 
 @frappe.whitelist(methods=["DELETE", "POST"])

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -190,6 +190,7 @@ class Site(Document, TagHelpers):
 		"send_change_team_request",
 		"is_setup_wizard_complete",
 		"get_backup_download_link",
+		"notify_email",
 	]
 
 	@staticmethod


### PR DESCRIPTION

https://github.com/frappe/press/assets/63963181/a22fba98-b349-4c9e-bb27-0328ab02401b


### Other changes
- add `setValue` override in client.py
- assign default values if available in confirmDialog