### PR TITLE
chore: change Attention Required URL

### DIFF
--- a/dashboard/src/views/bench/BenchApps.vue
+++ b/dashboard/src/views/bench/BenchApps.vue
@@ -43,7 +43,7 @@
 									placement="top"
 								>
 									<a
-										href="https://frappecloud.com/docs/faq/custom_apps#why-does-it-show-attention-required-next-to-my-custom-app"
+										href="https://frappecloud.com/docs/faq/app-installation-issue"
 										target="_blank"
 									>
 										<FeatherIcon

--- a/dashboard/src2/objects/bench.js
+++ b/dashboard/src2/objects/bench.js
@@ -203,7 +203,7 @@ export default {
 										h(
 											'a',
 											{
-												href: 'https://frappecloud.com/docs/faq/custom_apps#why-does-it-show-attention-required-next-to-my-custom-app',
+												href: 'https://frappecloud.com/docs/faq/app-installation-issue',
 												target: '_blank'
 											},
 											[h(icon('help-circle', 'w-3 h-3'), {})]


### PR DESCRIPTION
Changed from https://frappecloud.com/docs/faq/custom_apps#why-does-it-show-attention-required-next-to-my-custom-app- to https://frappecloud.com/docs/faq/app-installation-issue

The second page is updated with another potential cause and accounts for recent changes.