### PR TITLE
fix: conditional causing NoneType iterable error

### DIFF
--- a/press/api/github.py
+++ b/press/api/github.py
@@ -267,7 +267,7 @@ def _get_app_name_and_title_from_hooks(
 ) -> "tuple[str, str]":
 	reason_for_invalidation = ""
 	for directory, files in tree.items():
-		if files and "hooks.py" not in files or "patches.txt" not in files:
+		if files and ("hooks.py" not in files or "patches.txt" not in files):
 			reason_for_invalidation = (
 				f"Files {frappe.bold('hooks.py or patches.txt')} does not exist"
 				f" inside {directory}/{directory} directory."


### PR DESCRIPTION
Fixes this:

```
  File "apps/press/press/api/github.py", line 218, in app

    app_name, title = getapp_name_and_title_from_hooks(

  File "apps/press/press/api/github.py", line 270, in getapp_name_and_title_from_hooks

    if files and "hooks.py" not in files or "patches.txt" not in files:

TypeError: argument of type 'NoneType' is not iterable

```