### PR TITLE
refactor: remote builder (continuation #1631)

### DIFF
--- a/dashboard/src2/components/BuildError.vue
+++ b/dashboard/src2/components/BuildError.vue
@@ -1,0 +1,127 @@
+<template>
+	<FoldStep
+		:open="open"
+		:title="title"
+		:body="body"
+		status="Failure"
+		@toggle="open = !open"
+	/>
+</template>
+<script lang="ts">
+import { defineComponent } from 'vue';
+import FoldStep from './FoldStep.vue';
+
+export default defineComponent({
+	name: 'BuildError',
+	data() {
+		return { open: true };
+	},
+	props: {
+		build_error: { type: String, required: true },
+		build_steps: { type: Array, required: false }
+	},
+	components: { FoldStep },
+	computed: {
+		title(): string {
+			if (!this.failedStepTitle) {
+				return 'Build Failed';
+			}
+
+			return `Build Step Failed - "${this.failedStepTitle}"`;
+		},
+		body(): string {
+			// @ts-ignore
+			window.d = this;
+			var splits = this.build_error
+				.trim()
+				.split('\n')
+				.map(s => s.trim());
+
+			// Remove first ERROR: line
+			if (splits.at(0)?.startsWith('ERROR:')) {
+				splits = splits.slice(1);
+			}
+
+			// Remove last ERROR: line
+			if (splits.at(-1)?.startsWith('ERROR:')) {
+				splits = splits.slice(0, -1);
+			}
+
+			// Remove error body start delimiter
+			if (splits.at(0).startsWith('------')) {
+				splits = splits.slice(1);
+			}
+
+			// Remove docker output from stage command line
+			if (splits.at(0).startsWith('> [stage-')) {
+				splits[0] = `# Build Step Command\n${parseStageLine(splits[0])}\n\n`;
+				splits[1] = `# Build Step Output\n${stripDurationStamp(splits[1])}`;
+			}
+
+			// Remove Dockerfile line end delimiter
+			if (splits.at(-1).startsWith('--------------------')) {
+				splits = splits.slice(0, -1);
+			}
+
+			// Remove error body end delimiter
+			const index = splits.findIndex(l => l.startsWith('Dockerfile:'));
+			if (index > 0) {
+				splits = splits.slice(0, index - 1);
+			}
+
+			return splits.map(s => stripDurationStamp(s)).join('\n');
+		},
+		failedStepTitle(): string {
+			for (const step of this.build_steps ?? []) {
+				if (step.status === 'Failure') return step.title;
+			}
+
+			return '';
+		}
+	}
+});
+
+function stripDurationStamp(line: string): string {
+	const match = line.match(/^\d+\.\d+\s/)?.[0];
+	if (!match) {
+		return line;
+	}
+
+	return line.split(match)[1].trim();
+}
+
+function parseStageLine(line: string): string {
+	var splits = line.split(/\[stage-[^]+\]/);
+	if (splits.length < 2) {
+		return line;
+	}
+
+	splits = splits[1]
+		.trim()
+		.split(' ')
+		.map(s => s.trim())
+		.filter(s => s.length);
+	if (splits.length < 2) {
+		return line;
+	}
+
+	// Remove Dockerfile command, eg: 'RUN'
+	splits = splits.slice(1);
+
+	// Remove Dockerfile command flags, eg: --mount
+	while (true) {
+		if (splits[0]?.startsWith('--')) {
+			splits = splits.slice(1);
+		} else break;
+	}
+
+	line = splits.join(' ');
+
+	// Remove trailing ':'
+	if (line.endsWith(':')) {
+		line = line.slice(0, -1);
+	}
+
+	return line.split('`#stage-')[0];
+}
+</script>

--- a/dashboard/src2/components/BuildError.vue
+++ b/dashboard/src2/components/BuildError.vue
@@ -30,8 +30,6 @@ export default defineComponent({
 			return `Build Step Failed - "${this.failedStepTitle}"`;
 		},
 		body(): string {
-			// @ts-ignore
-			window.d = this;
 			var splits = this.build_error
 				.trim()
 				.split('\n')

--- a/dashboard/src2/components/FoldStep.vue
+++ b/dashboard/src2/components/FoldStep.vue
@@ -1,0 +1,103 @@
+<template>
+	<div>
+		<button
+			class="flex w-full items-center justify-between rounded bg-gray-50 px-2.5 py-2 text-left text-base"
+			@click="$emit('toggle')"
+			:class="open ? 'rounded-b-none' : ''"
+		>
+			<div class="flex items-center space-x-2">
+				<FeatherIcon
+					:name="open ? 'chevron-down' : 'chevron-right'"
+					class="h-3 w-3"
+					:stroke-width="3"
+				/>
+				<Tooltip :text="status">
+					<div
+						class="grid h-4 w-4 place-items-center rounded-full"
+						:class="iconClass"
+					>
+						<LoadingIndicator
+							class="h-3.5 w-3.5 text-gray-900"
+							v-if="status === 'Running'"
+						/>
+						<FeatherIcon
+							v-else
+							:name="icon"
+							class="h-3 w-3 text-white"
+							:stroke-width="3"
+						/>
+					</div>
+				</Tooltip>
+				<span>
+					{{ title }}
+				</span>
+			</div>
+
+			<div class="text-gray-600" v-if="caption">
+				{{ caption }}
+			</div>
+		</button>
+		<div
+			class="overflow-auto rounded-b border border-gray-100 bg-gray-900 px-2.5 py-2 text-sm text-gray-200"
+			v-show="open || status == 'Running'"
+			ref="output"
+		>
+			<pre class="max-h-[50vh]">{{ body }}</pre>
+		</div>
+	</div>
+</template>
+<script lang="ts">
+import { LoadingIndicator } from 'frappe-ui';
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+	name: 'FoldStep',
+	props: {
+		open: { type: Boolean, required: true },
+		title: { type: String, required: true },
+		body: { type: String, required: true },
+		status: { type: String, required: false },
+		caption: { type: String, required: false }
+	},
+	emits: ['toggle'],
+	watch: {
+		body(val, oldVal) {
+			if (val === oldVal) {
+				return;
+			}
+
+			this.$nextTick(() => {
+				this.$refs.output.scrollTop = this.$refs.output.scrollHeight;
+			});
+		}
+	},
+	computed: {
+		icon(): string {
+			switch (this.status) {
+				case 'Success':
+					return 'check';
+				case 'Failure':
+					return 'x';
+				case 'Pending':
+					return 'clock';
+				case 'Skipped':
+					return 'minus';
+				default:
+					return 'circle';
+			}
+		},
+		iconClass(): string {
+			switch (this.status) {
+				case 'Success':
+					return 'bg-green-500';
+				case 'Failure':
+					return 'bg-red-500';
+				case 'Running':
+					return 'bg-transparent';
+				default:
+					return 'bg-gray-400';
+			}
+		}
+	}
+});
+</script>

--- a/dashboard/src2/components/JobStep.vue
+++ b/dashboard/src2/components/JobStep.vue
@@ -1,66 +1,15 @@
 <template>
-	<div>
-		<button
-			class="flex w-full items-center justify-between rounded bg-gray-50 px-2.5 py-2 text-left text-base"
-			@click="step.isOpen = !step.isOpen"
-			:class="step.isOpen ? 'rounded-b-none' : ''"
-		>
-			<div class="flex items-center space-x-2">
-				<FeatherIcon
-					:name="step.isOpen ? 'chevron-down' : 'chevron-right'"
-					class="h-3 w-3"
-					:stroke-width="3"
-				/>
-				<Tooltip :text="step.status">
-					<div
-						class="grid h-4 w-4 place-items-center rounded-full"
-						:class="{
-							'bg-green-500': step.status === 'Success',
-							'bg-red-500': step.status === 'Failure',
-							'bg-transparent': step.status === 'Running',
-							'bg-gray-400': ['Skipped', 'Pending'].includes(step.status)
-						}"
-					>
-						<LoadingIndicator
-							class="h-3.5 w-3.5 text-gray-900"
-							v-if="step.status === 'Running'"
-						/>
-						<FeatherIcon
-							v-else
-							:name="
-								{
-									Success: 'check',
-									Failure: 'x',
-									Skipped: 'minus',
-									Running: 'clock',
-									Pending: 'clock'
-								}[step.status]
-							"
-							class="h-3 w-3 text-white"
-							:stroke-width="3"
-						/>
-					</div>
-				</Tooltip>
-				<span>
-					{{ step.title }}
-				</span>
-			</div>
-
-			<div class="text-gray-600" v-if="step.duration">
-				{{ step.duration }}
-			</div>
-		</button>
-		<div
-			class="overflow-auto rounded-b border border-gray-100 bg-gray-900 px-2.5 py-2 text-sm text-gray-200"
-			v-show="step.isOpen || step.status == 'Running'"
-			ref="output"
-		>
-			<pre class="max-h-[50vh]">{{ step.output || 'No output' }}</pre>
-		</div>
-	</div>
+	<FoldStep
+		:open="Boolean(step.isOpen)"
+		:caption="step.duration"
+		:title="step.title"
+		:body="step.output || 'No Output'"
+		:status="step.status"
+		@toggle="step.isOpen = !step.isOpen"
+	/>
 </template>
 <script>
-import { LoadingIndicator } from 'frappe-ui';
+import FoldStep from './FoldStep.vue';
 
 export default {
 	name: 'JobStep',
@@ -70,14 +19,6 @@ export default {
 			required: true
 		}
 	},
-	watch: {
-		'step.output': function (val, oldVal) {
-			if (val !== oldVal) {
-				this.$nextTick(() => {
-					this.$refs.output.scrollTop = this.$refs.output.scrollHeight;
-				});
-			}
-		}
-	}
+	components: { FoldStep }
 };
 </script>

--- a/dashboard/src2/pages/BenchDeploy.vue
+++ b/dashboard/src2/pages/BenchDeploy.vue
@@ -69,7 +69,7 @@
 		</div>
 
 		<!-- Build Failure -->
-		<div class="mt-8" v-if="deploy.build_error">
+		<div class="mt-8" v-if="deploy.build_error && deploy.status === 'Failure'">
 			<BuildError
 				:build_error="deploy.build_error"
 				:build_steps="deploy.build_steps"

--- a/dashboard/src2/pages/BenchDeploy.vue
+++ b/dashboard/src2/pages/BenchDeploy.vue
@@ -68,7 +68,17 @@
 			</div>
 		</div>
 
-		<div class="mt-8 space-y-4">
+		<!-- Build Failure -->
+		<div class="mt-8" v-if="deploy.build_error">
+			<BuildError
+				:build_error="deploy.build_error"
+				:build_steps="deploy.build_steps"
+			/>
+			<hr class="mt-4" />
+		</div>
+
+		<!-- Build Steps -->
+		<div :class="deploy.build_error ? 'mt-4' : 'mt-8'" class="space-y-4">
 			<JobStep
 				v-for="step in deploy.build_steps"
 				:step="step"
@@ -82,12 +92,14 @@ import { getCachedDocumentResource } from 'frappe-ui';
 import { getObject } from '../objects';
 import JobStep from '../components/JobStep.vue';
 import AlertAddressableError from '../components/AlertAddressableError.vue';
+import BuildError from '../components/BuildError.vue';
 
 export default {
 	name: 'BenchDeploy',
 	props: ['id', 'objectType'],
 	components: {
 		JobStep,
+		BuildError,
 		AlertAddressableError
 	},
 	resources: {

--- a/press/agent.py
+++ b/press/agent.py
@@ -4,12 +4,11 @@
 import json
 import os
 from datetime import date
-from typing import List
+from typing import TYPE_CHECKING, List
 
 import _io
 import frappe
 import requests
-from typing import TYPE_CHECKING
 from frappe.utils.password import get_decrypted_password
 from press.utils import log_error, sanitize_config
 
@@ -22,8 +21,9 @@ if TYPE_CHECKING:
 
 class Agent:
 	if TYPE_CHECKING:
-		from requests import Response
 		from typing import Optional
+
+		from requests import Response
 
 		response: "Optional[Response]"
 
@@ -997,4 +997,28 @@ class Agent:
 			"Call Bench Supervisorctl",
 			f"/benches/{bench}/supervisorctl",
 			data={"command": action, "programs": programs},
+		)
+
+	def run_command_in_docker_cache(
+		self,
+		command: str = "ls -A",
+		cache_target: str = "/home/frappe/.cache",
+		remove_image: bool = True,
+	):
+		data = dict(
+			command=command,
+			cache_target=cache_target,
+			remove_image=remove_image,
+		)
+		return self.request(
+			"POST",
+			"docker_cache_utils/run_command_in_docker_cache",
+			data=data,
+		)
+
+	def get_cached_apps(self):
+		return self.request(
+			"POST",
+			"docker_cache_utils/get_cached_apps",
+			data={},
 		)

--- a/press/docker/Dockerfile
+++ b/press/docker/Dockerfile
@@ -8,7 +8,7 @@ ENV OPENBLAS_NUM_THREADS 1
 ENV MKL_NUM_THREADS 1
 
 # Install essential packages
-RUN --mount=type=cache,sharing=locked,target=/var/cache/apt apt-get update \
+RUN --mount=type=cache,target=/var/cache/apt apt-get update \
   && apt-get install --yes --no-install-suggests --no-install-recommends \
   # Essentials
   build-essential \
@@ -60,7 +60,7 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt apt-get update \
 COPY --chown=root:root supervisord.conf /etc/supervisor/supervisord.conf
 
 # Install Redis from PPA
-RUN --mount=type=cache,sharing=locked,target=/var/cache/apt curl -fsSL https://packages.redis.io/gpg | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg \
+RUN --mount=type=cache,target=/var/cache/apt curl -fsSL https://packages.redis.io/gpg | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg \
   && echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb focal main" | tee /etc/apt/sources.list.d/redis.list \
   && apt-get update \
   && apt-get install --yes --no-install-suggests --no-install-recommends \
@@ -69,7 +69,7 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt curl -fsSL https://p
 
 # Install Python from DeadSnakes PPA
 ENV {{ doc.get_dependency_version("PYTHON_VERSION") }}
-RUN --mount=type=cache,sharing=locked,target=/var/cache/apt add-apt-repository ppa:deadsnakes/ppa \
+RUN --mount=type=cache,target=/var/cache/apt add-apt-repository ppa:deadsnakes/ppa \
   && apt-get update \
   && apt-get install --yes --no-install-suggests --no-install-recommends \
   python${PYTHON_VERSION} \
@@ -124,7 +124,7 @@ RUN useradd -ms /bin/bash frappe
 
 # Run before install scripts
 {% if p.prerequisites %}
-RUN --mount=type=cache,sharing=locked,target=/var/cache/apt {{ p.prerequisites }} \
+RUN --mount=type=cache,target=/var/cache/apt {{ p.prerequisites }} \
   `#stage-pre_before-{{ p.package }}`
 {% endif %}
 
@@ -135,7 +135,7 @@ RUN {{ p.package_manager }} install {{ p.package }} \
 
 # Install Ubuntu packages
 {% else %}
-RUN --mount=type=cache,sharing=locked,target=/var/cache/apt apt-get update \
+RUN --mount=type=cache,target=/var/cache/apt apt-get update \
   && apt-get install --yes --no-install-suggests --no-install-recommends {{ p.package }} \
   && rm -rf /var/lib/apt/lists/* \
   `#stage-pre-{{ p.package }}`
@@ -143,7 +143,7 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt apt-get update \
 
 # Run after install scripts
 {% if p.after_install %}
-RUN  --mount=type=cache,sharing=locked,target=/var/cache/apt {{ p.after_install }} \
+RUN  --mount=type=cache,target=/var/cache/apt {{ p.after_install }} \
   && rm -rf /var/lib/apt/lists/* \
   `#stage-pre_after-{{ p.package }}`
 {% endif %}
@@ -177,7 +177,7 @@ RUN wget https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh
 ENV PATH "$PATH:/home/frappe/.nvm/versions/node/v${NODE_VERSION}/bin"
 
 # Install Yarn
-RUN --mount=type=cache,sharing=locked,target=/home/frappe/.cache,uid=1000,gid=1000 npm install -g yarn `#stage-pre-yarn`
+RUN --mount=type=cache,target=/home/frappe/.cache,uid=1000,gid=1000 npm install -g yarn `#stage-pre-yarn`
 
 
 # Install Bench
@@ -185,10 +185,10 @@ ENV PATH "$PATH:/home/frappe/.local/bin"
 
 RUN wget https://bootstrap.pypa.io/get-pip.py && python${PYTHON_VERSION} get-pip.py `#stage-pre-pip`
 ENV {{ doc.get_dependency_version("BENCH_VERSION") }}
-RUN --mount=type=cache,sharing=locked,target=/home/frappe/.cache,uid=1000,gid=1000 python${PYTHON_VERSION} -m pip install --upgrade frappe-bench==${BENCH_VERSION} `#stage-bench-bench`
+RUN --mount=type=cache,target=/home/frappe/.cache,uid=1000,gid=1000 python${PYTHON_VERSION} -m pip install --upgrade frappe-bench==${BENCH_VERSION} `#stage-bench-bench`
 
-RUN --mount=type=cache,sharing=locked,target=/home/frappe/.cache,uid=1000,gid=1000 python${PYTHON_VERSION} -m pip install Jinja2~=3.0.3
-RUN --mount=type=cache,sharing=locked,target=/home/frappe/.cache,uid=1000,gid=1000 python${PYTHON_VERSION} -m pip install --upgrade setuptools
+RUN --mount=type=cache,target=/home/frappe/.cache,uid=1000,gid=1000 python${PYTHON_VERSION} -m pip install Jinja2~=3.0.3
+RUN --mount=type=cache,target=/home/frappe/.cache,uid=1000,gid=1000 python${PYTHON_VERSION} -m pip install --upgrade setuptools
 
 RUN git config --global advice.detachedHead false
 
@@ -206,7 +206,7 @@ ENV {{v.key}} {{ v.value }}
 RUN --mount=type=cache,sharing=locked,target=/home/frappe/.cache,uid=1000,gid=1000 --mount=type=bind,source=apps/frappe,target=/home/frappe/context/apps/frappe bench init --python /usr/bin/python${PYTHON_VERSION} --no-backups --frappe-path file:///home/frappe/context/apps/frappe frappe-bench `#stage-apps-frappe`
 WORKDIR /home/frappe/frappe-bench
 
-RUN --mount=type=cache,sharing=locked,target=/home/frappe/.cache,uid=1000,gid=1000 /home/frappe/frappe-bench/env/bin/pip install pycups==2.0.1
+RUN --mount=type=cache,target=/home/frappe/.cache,uid=1000,gid=1000 /home/frappe/frappe-bench/env/bin/pip install pycups==2.0.1
 
 # Install Redisearch 2.0 from precompiled binaries
 COPY --chown=frappe:frappe redis /home/frappe/frappe-bench/redis

--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -629,6 +629,13 @@ def update_steps(job_name, job):
 
 def update_step(step_name, step):
 	step_data = json.dumps(step["data"], indent=4, sort_keys=True)
+
+	output = None
+	traceback = None
+	if isinstance(output, dict):
+		traceback = output.get("traceback")
+		output = output.get("output")
+
 	frappe.db.set_value(
 		"Agent Job Step",
 		step_name,
@@ -638,8 +645,8 @@ def update_step(step_name, step):
 			"duration": step["duration"],
 			"status": step["status"],
 			"data": step_data,
-			"output": step["data"].get("output"),
-			"traceback": step["data"].get("traceback"),
+			"output": output,
+			"traceback": traceback,
 		},
 	)
 

--- a/press/press/doctype/build_cache_shell/build_cache_shell.js
+++ b/press/press/doctype/build_cache_shell/build_cache_shell.js
@@ -1,0 +1,35 @@
+// Copyright (c) 2024, Frappe and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Build Cache Shell', {
+	onload(frm) {
+		frappe.ui.keys.add_shortcut({
+			shortcut: 'shift+enter',
+			action: () => frm.page.btn_primary.trigger('click'),
+			page: frm.page,
+			description: __('Run Build Cache Shell command'),
+			ignore_inputs: true,
+		});
+	},
+
+	refresh(frm) {
+		frm.disable_save();
+		frm.page.set_primary_action(__('Run'), async ($btn) => {
+			$btn.text(__('Running Command...'));
+			return frm.execute_action('Run').finally(() => $btn.text(__('Run')));
+		});
+
+		const command = localStorage.getItem('build_cache_shell_command');
+		if (!command) {
+			return;
+		}
+
+		frm.set_value('bench', bench);
+		frm.set_value('command', command);
+
+		['output', 'cwd', 'image_tag'].forEach((f) => frm.set_value(f, null));
+		frm.set_value('returncode', 0);
+
+		localStorage.removeItem('build_cache_shell_command');
+	},
+});

--- a/press/press/doctype/build_cache_shell/build_cache_shell.json
+++ b/press/press/doctype/build_cache_shell/build_cache_shell.json
@@ -1,0 +1,117 @@
+{
+ "actions": [
+  {
+   "action": "press.press.doctype.build_cache_shell.build_cache_shell.run_command",
+   "action_type": "Server Action",
+   "hidden": 1,
+   "label": "Run"
+  }
+ ],
+ "allow_rename": 1,
+ "creation": "2024-04-18 11:55:45.595311",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "command",
+  "cache_target",
+  "build_server",
+  "output_section",
+  "output",
+  "meta_section",
+  "cwd",
+  "image_tag",
+  "column_break_zdbf",
+  "returncode"
+ ],
+ "fields": [
+  {
+   "default": "ls -lAh",
+   "fieldname": "command",
+   "fieldtype": "Code",
+   "in_list_view": 1,
+   "label": "Command",
+   "reqd": 1
+  },
+  {
+   "default": "/home/frappe/.cache",
+   "description": "Sets the <code>mount=type=cache</code> target and the <code>WORKDIR</code> of where the command is run.",
+   "fieldname": "cache_target",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Cache Target",
+   "reqd": 1
+  },
+  {
+   "description": "If set, command will be run in a remote build server and not locally.",
+   "fieldname": "build_server",
+   "fieldtype": "Link",
+   "label": "Build Server",
+   "options": "Server"
+  },
+  {
+   "fieldname": "output_section",
+   "fieldtype": "Section Break",
+   "label": "Output"
+  },
+  {
+   "depends_on": "eval:doc.output",
+   "fieldname": "output",
+   "fieldtype": "Code",
+   "label": "Output",
+   "read_only": 1
+  },
+  {
+   "fieldname": "meta_section",
+   "fieldtype": "Section Break",
+   "label": "Meta"
+  },
+  {
+   "depends_on": "eval:doc.cwd",
+   "fieldname": "cwd",
+   "fieldtype": "Data",
+   "label": "CWD",
+   "read_only": 1
+  },
+  {
+   "fieldname": "image_tag",
+   "fieldtype": "Data",
+   "label": "Image Tag",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_zdbf",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:doc.output",
+   "fieldname": "returncode",
+   "fieldtype": "Int",
+   "label": "Return Code",
+   "read_only": 1
+  }
+ ],
+ "hide_toolbar": 1,
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2024-04-18 12:20:57.277931",
+ "modified_by": "Administrator",
+ "module": "Press",
+ "name": "Build Cache Shell",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/press/press/doctype/build_cache_shell/build_cache_shell.py
+++ b/press/press/doctype/build_cache_shell/build_cache_shell.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2024, Frappe and contributors
+# For license information, please see license.txt
+
+import json
+
+import frappe
+from frappe.model.document import Document
+from press.agent import Agent
+from press.press.doctype.deploy_candidate.cache_utils import (
+	CommandOutput,
+	run_command_in_docker_cache,
+)
+
+
+class BuildCacheShell(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		build_server: DF.Link | None
+		cache_target: DF.Data
+		command: DF.Code
+		cwd: DF.Data | None
+		image_tag: DF.Data | None
+		output: DF.Code | None
+		returncode: DF.Int
+	# end: auto-generated types
+
+	def run_command(self):
+		frappe.only_for("System Manager")
+		result = self._run_command()
+		self.output = result.get("output")
+		self.cwd = result.get("cwd")
+		self.image_tag = result.get("image_tag")
+		self.returncode = result.get("returncode")
+		frappe.db.commit()
+
+	def _run_command(self) -> CommandOutput:
+		if self.build_server:
+			return Agent(self.build_server).run_command_in_docker_cache(
+				self.command,
+				self.cache_target,
+			)
+
+		return run_command_in_docker_cache(
+			self.command,
+			self.cache_target,
+		)
+
+
+@frappe.whitelist()
+def run_command(doc):
+	bench_shell: "BuildCacheShell" = frappe.get_doc(json.loads(doc))
+	bench_shell.run_command()
+	return bench_shell.as_dict()

--- a/press/press/doctype/build_cache_shell/test_build_cache_shell.py
+++ b/press/press/doctype/build_cache_shell/test_build_cache_shell.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Frappe and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestBuildCacheShell(FrappeTestCase):
+	pass

--- a/press/press/doctype/deploy_candidate/cache_utils.py
+++ b/press/press/doctype/deploy_candidate/cache_utils.py
@@ -12,7 +12,7 @@ from typing import Tuple, TypedDict
 
 CommandOutput = TypedDict(
 	"CommandOutput",
-	cwd=Path,
+	cwd=str,
 	image_tag=str,
 	returncode=int,
 	output=str,
@@ -183,7 +183,7 @@ def run_build_command(df_path: Path, remove_image: bool) -> CommandOutput:
 	if remove_image:
 		run_image_rm(image_tag)
 	return dict(
-		cwd=df_path.parent,
+		cwd=df_path.parent.absolute().as_posix(),
 		image_tag=image_tag,
 		returncode=output.returncode,
 		output=strip_build_output(output.stdout),

--- a/press/press/doctype/deploy_candidate/deploy_candidate.js
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.js
@@ -15,12 +15,6 @@ frappe.ui.form.on('Deploy Candidate', {
 			};
 		};
 
-		if (window.dev_server) {
-			frm.add_custom_button('Check Status', () =>
-				frm.call('is_build_okay').then((r) => frm.refresh()),
-			);
-		}
-
 		const actions = [
 			[
 				__('Generate Build Context'),

--- a/press/press/doctype/deploy_candidate/deploy_candidate.json
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.json
@@ -45,6 +45,7 @@
   "environment_variables",
   "output_tab",
   "section_break_9",
+  "build_error",
   "build_steps",
   "build_output",
   "ssh_tab",
@@ -343,7 +344,7 @@
   {
    "fieldname": "parameters_tab",
    "fieldtype": "Tab Break",
-   "label": "Parameters"
+   "label": "Bench Params"
   },
   {
    "fieldname": "output_tab",
@@ -354,6 +355,13 @@
    "fieldname": "ssh_tab",
    "fieldtype": "Tab Break",
    "label": "SSH"
+  },
+  {
+   "depends_on": "eval:doc.build_error",
+   "fieldname": "build_error",
+   "fieldtype": "Code",
+   "label": "Build Error",
+   "read_only": 1
   }
  ],
  "links": [
@@ -366,7 +374,7 @@
    "link_fieldname": "reference_name"
   }
  ],
- "modified": "2024-04-02 10:17:58.386383",
+ "modified": "2024-04-16 11:27:12.314611",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Deploy Candidate",

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -579,27 +579,18 @@ class DeployCandidate(Document):
 		)
 
 	def _build_start(self):
-		if self.build_start or self.status == "Preparing":
-			pass
-
 		self.status = "Preparing"
 		self.build_start = now()
 		self.save()
 		frappe.db.commit()
 
 	def _build_run(self):
-		if self.status == "Running":
-			return
-
 		self.status = "Running"
 		self.save(ignore_version=True)
 		frappe.db.commit()
 
 	@reconnect_on_failure()
 	def _build_failed(self):
-		if self.status == "Failure":
-			return
-
 		self.status = "Failure"
 		bench_update = frappe.get_all(
 			"Bench Update", {"status": "Running", "candidate": self.name}, pluck="name"
@@ -613,9 +604,6 @@ class DeployCandidate(Document):
 		frappe.db.commit()
 
 	def _build_successful(self):
-		if self.status == "Success":
-			return
-
 		self.status = "Success"
 		bench_update = frappe.get_all(
 			"Bench Update", {"status": "Running", "candidate": self.name}, pluck="name"
@@ -627,9 +615,6 @@ class DeployCandidate(Document):
 		frappe.db.commit()
 
 	def _build_end(self):
-		if self.build_end and self.build_duration:
-			return
-
 		self.build_end = now()
 		self.build_duration = self.build_end - self.build_start
 

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -209,6 +209,7 @@ class DeployCandidate(Document):
 
 		self.status = "Pending"
 		self.set_remote_build_flags()
+		self.reset_build_state()
 		self.add_pre_build_steps()
 		self.save()
 		user, session_data, team, = (
@@ -628,6 +629,16 @@ class DeployCandidate(Document):
 				step.status = "Failure"
 				break
 
+	def reset_build_state(self):
+		self.build_steps.clear()
+		self.build_error = ""
+		self.build_output = ""
+		self.build_start = None
+		self.build_end = None
+		self.last_updated = None
+		self.build_duration = None
+		self.build_directory = None
+
 	def add_pre_build_steps(self):
 		"""
 		This function just adds build steps that occur before
@@ -636,10 +647,6 @@ class DeployCandidate(Document):
 		- `_update_build_steps`
 		- `_update_post_build_steps`
 		"""
-		if self.build_steps:
-			self.build_output = ""
-			self.build_steps.clear()
-
 		app_titles = {a.app: a.title for a in self.apps}
 		stage_slug = "clone"
 		for app in self.apps:

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -1069,22 +1069,11 @@ class DeployCandidate(Document):
 		return environment
 
 	def _get_build_command(self, no_cache: bool):
-		command = "docker build"
-		import platform
-
-		# check if it's running on apple silicon mac
-		is_apple_silicon = (
-			platform.machine() == "arm64"
-			and platform.system() == "Darwin"
-			and platform.processor() == "arm"
-		)
-		if is_apple_silicon:
-			command = f"{command}x build --platform linux/amd64"
-
+		command = "docker buildx build --platform linux/amd64"
 		if no_cache:
 			command += " --no-cache"
 
-		command += f" -t {self.docker_image}"
+		command += f" --tag {self.docker_image}"
 		command += " ."
 		return command
 

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -74,6 +74,7 @@ class DeployCandidate(Document):
 		build_directory: DF.Data | None
 		build_duration: DF.Time | None
 		build_end: DF.Datetime | None
+		build_error: DF.Code | None
 		build_output: DF.Code | None
 		build_start: DF.Datetime | None
 		build_steps: DF.Table[DeployCandidateBuildStep]

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -123,6 +123,7 @@ class DeployCandidate(Document):
 		"build_start",
 		"build_end",
 		"build_duration",
+		"build_error",
 		"apps",
 		"group",
 	]

--- a/press/press/doctype/deploy_candidate/docker_output_parsers.py
+++ b/press/press/doctype/deploy_candidate/docker_output_parsers.py
@@ -144,6 +144,7 @@ class DockerBuildOutputParser:
 		# Recorded errors not build failing errors
 		if not no_errors and re.match(done_check_rx, escaped_line):
 			self.error_lines = []
+			return
 
 		if no_errors and "ERROR:" not in escaped_line:
 			return

--- a/press/press/doctype/deploy_candidate/docker_output_parsers.py
+++ b/press/press/doctype/deploy_candidate/docker_output_parsers.py
@@ -271,19 +271,25 @@ class UploadStepUpdater:
 		self._upload_step = None
 
 	@property
-	def upload_step(self) -> "DeployCandidateBuildStep":
+	def upload_step(self) -> "DeployCandidateBuildStep | None":
 		if not self._upload_step:
 			self._upload_step = self.dc.get_step("upload", "image")
 		return self._upload_step
 
 	def start(self):
+		if not self.upload_step:
+			return
+
 		if self.upload_step.status == "Running":
-			pass
+			return
 
 		self.upload_step.status = "Running"
 		self.flush_output()
 
 	def process(self, output: "PushOutput"):
+		if not self.upload_step:
+			return
+
 		for line in output:
 			self._process_single_line(line)
 
@@ -302,6 +308,9 @@ class UploadStepUpdater:
 		self.flush_output()
 
 	def end(self, status: 'DF.Literal["Success", "Failure"]'):
+		if not self.upload_step:
+			return
+
 		# Used only if the build is running locally
 		self.upload_step.status = status
 		self.flush_output()

--- a/press/press/doctype/deploy_candidate/docker_output_parsers.py
+++ b/press/press/doctype/deploy_candidate/docker_output_parsers.py
@@ -237,10 +237,15 @@ def ansi_escape(text: str) -> str:
 def get_command(name: str) -> str:
 	# Strip docker flags and commands from the line
 	line = dockerfile.parse_string(name)[0]
-	name = " ".join(line.value).strip()
-	if not name:
-		name = line.original.split(maxsplit=1)[1]
-	return name.split("`#stage-", maxsplit=1)[0]
+	command = " ".join(line.value).strip()
+	if not command:
+		command: str = line.original.split(maxsplit=1)[1]
+	command = command.split("`#stage-", maxsplit=1)[0]
+
+	# Remove line fold slashes
+	splits = [p.strip() for p in command.split(" \\\n")]
+
+	return "\n".join([p for p in splits if len(p)])
 
 
 class UploadStepUpdater:

--- a/press/press/doctype/deploy_candidate/docker_output_parsers.py
+++ b/press/press/doctype/deploy_candidate/docker_output_parsers.py
@@ -10,6 +10,7 @@ from press.utils import log_error
 # Reference:
 # https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
 ansi_escape_rx = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+done_check_rx = re.compile(r"#\d+\sDONE\s\d+\.\d+")
 
 if typing.TYPE_CHECKING:
 	from typing import Any, Generator, Optional, TypedDict
@@ -139,6 +140,11 @@ class DockerBuildOutputParser:
 
 	def _append_error_line(self, escaped_line: str):
 		no_errors = len(self.error_lines) == 0
+
+		# Recorded errors not build failing errors
+		if not no_errors and re.match(done_check_rx, escaped_line):
+			self.error_lines = []
+
 		if no_errors and "ERROR:" not in escaped_line:
 			return
 

--- a/press/press/doctype/deploy_candidate/docker_output_parsers.py
+++ b/press/press/doctype/deploy_candidate/docker_output_parsers.py
@@ -245,6 +245,11 @@ def get_command(name: str) -> str:
 	# Remove line fold slashes
 	splits = [p.strip() for p in command.split(" \\\n")]
 
+	# Strip multiple internal whitespaces
+	for i in range(len(splits)):
+		s = splits[i]
+		splits[i] = " ".join([p.strip() for p in s.split() if len(p)])
+
 	return "\n".join([p for p in splits if len(p)])
 
 


### PR DESCRIPTION
**Changes**
- Improves error logging:
  - Agent Job doesn't fail on build fail
  - Build output reaches press, no need to go to check agent logs
- <details><summary>Displays error up top if parse-able</summary>
  
  ![Screenshot 2024-04-18 at 12 29 33](https://github.com/frappe/press/assets/29507195/96b6595c-8d38-45b6-a9c4-0f3474793c01)
  </details>
- <details><summary>Adds Build Cache Shell</summary>
  
   ![Screenshot 2024-04-18 at 12 43 15](https://github.com/frappe/press/assets/29507195/cc23ffa8-cc12-4f2f-8d4c-4f18ea61c901)
  </details>


_Note: This remote builder too is tentative, it's usable but will be separated out from press and agent and handled more elegantly._

Agent: https://github.com/frappe/agent/pull/98
Continuation: https://github.com/frappe/press/pull/1631