### PR TITLE
feat: add log counter

### DIFF
--- a/press/api/tests/test_bench.py
+++ b/press/api/tests/test_bench.py
@@ -642,5 +642,11 @@ def set_press_settings_for_docker_build() -> None:
 
 
 def patch_dc_command_for_ci():
-	DeployCandidate.command = "docker buildx build"
-	DeployCandidate.command += " --cache-from type=gha --cache-to type=gha,mode=max --load"
+	DeployCandidate.base_build_command = " ".join(
+		[
+			DeployCandidate.base_build_command,
+			"--cache-from type=gha",
+			"--cache-to type=gha,mode=max",
+			"--load",
+		]
+	)

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -173,6 +173,7 @@ scheduler_events = {
 	"daily": [
 		"press.press.doctype.tls_certificate.tls_certificate.renew_tls_certificates",
 		"press.experimental.doctype.referral_bonus.referral_bonus.credit_referral_bonuses",
+		"press.press.doctype.log_counter.log_counter.record_counts",
 	],
 	"daily_long": [
 		"press.press.audit.check_bench_fields",

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -45,6 +45,9 @@ if typing.TYPE_CHECKING:
 
 
 class DeployCandidate(Document):
+	# This is altered in CI
+	base_build_command: str = "docker buildx build --platform linux/amd64"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 
@@ -1072,7 +1075,7 @@ class DeployCandidate(Document):
 		return environment
 
 	def _get_build_command(self, no_cache: bool):
-		command = "docker buildx build --platform linux/amd64"
+		command = self.base_build_command
 		if no_cache:
 			command += " --no-cache"
 

--- a/press/press/doctype/deploy_candidate/docker_output_parsers.py
+++ b/press/press/doctype/deploy_candidate/docker_output_parsers.py
@@ -223,12 +223,18 @@ class DockerBuildOutputParser:
 		if len(splits) != 2 and len(keys) == 0:
 			return None
 
+		index_str, line = splits
 		try:
-			index_str, line = splits
+			is_unusual = False
 			index = int(index_str[1:])
-			return dict(index=index, line=line, is_unusual=False)
 		except ValueError:
-			return dict(index=keys[-1], line=line, is_unusual=True)
+			is_unusual = True
+			index = keys[-1] if len(keys) else -1
+
+		if index == -1:
+			return None
+
+		return dict(index=index, line=line, is_unusual=is_unusual)
 
 
 def ansi_escape(text: str) -> str:

--- a/press/press/doctype/log_counter/log_counter.js
+++ b/press/press/doctype/log_counter/log_counter.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, Frappe and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Log Counter", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/press/press/doctype/log_counter/log_counter.json
+++ b/press/press/doctype/log_counter/log_counter.json
@@ -1,0 +1,94 @@
+{
+ "actions": [],
+ "creation": "2024-04-19 11:57:50.263215",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "logtype",
+  "groupby",
+  "column_break_nyqx",
+  "date",
+  "section_break_epfa",
+  "counts",
+  "total"
+ ],
+ "fields": [
+  {
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Collection Date",
+   "read_only": 1,
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "column_break_nyqx",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_epfa",
+   "fieldtype": "Section Break",
+   "label": "Counts"
+  },
+  {
+   "fieldname": "counts",
+   "fieldtype": "JSON",
+   "label": "Counts",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "total",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Total",
+   "non_negative": 1,
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "groupby",
+   "fieldtype": "Data",
+   "label": "Group By",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "logtype",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Log Type",
+   "options": "DocType",
+   "read_only": 1,
+   "reqd": 1,
+   "search_index": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-04-19 13:17:13.153028",
+ "modified_by": "Administrator",
+ "module": "Press",
+ "name": "Log Counter",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/press/press/doctype/log_counter/log_counter.py
+++ b/press/press/doctype/log_counter/log_counter.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2024, Frappe and contributors
+# For license information, please see license.txt
+
+import datetime
+from typing import Optional, TypedDict
+
+import frappe
+import frappe.utils
+import json
+from frappe.model.document import Document
+from frappe.query_builder import DocType
+from frappe.query_builder.functions import Count
+from pypika import Order
+
+# DocType: groupby
+RECORD_FOR: dict[str, str] = {
+	"Error Log": "method",
+}
+
+Counts = TypedDict(
+	"Counts",
+	{
+		"counts": dict[str, int],
+		"date": datetime.date,
+		"total": int,
+	},
+)
+
+
+class LogCounter(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		counts: DF.JSON
+		date: DF.Date
+		groupby: DF.Data
+		logtype: DF.Link
+		total: DF.Int
+	# end: auto-generated types
+
+	def autoname(self):
+		self.name = get_name(self.logtype, self.date)
+
+
+def record_counts():
+	date = frappe.utils.now_datetime().date() - datetime.timedelta(days=1)
+	for doctype, groupby in RECORD_FOR.items():
+		record_for_date(doctype, groupby, date)
+	frappe.db.commit()
+
+
+def record_for_date(
+	doctype: str = "Error Log",
+	groupby: str = "method",
+	date: Optional[datetime.date] = None,
+):
+	counts = get_counts(
+		doctype,
+		groupby,
+		date,
+	)
+	name = get_name(doctype, counts["date"])
+	counts_json = json.dumps(counts["counts"], indent=2)
+
+	# Update counts if name value exists
+	if frappe.db.exists("Log Counter", name):
+		frappe.db.set_value("Log Counter", name, "counts", counts_json)
+		frappe.db.set_value("Log Counter", name, "total", counts["total"])
+		return
+
+	lc = frappe.get_doc(
+		{
+			"doctype": "Log Counter",
+			"logtype": doctype,
+			"groupby": groupby,
+			"counts": counts_json,
+			"total": counts["total"],
+			"date": counts["date"],
+		}
+	)
+	lc.insert()
+
+
+def get_counts(
+	doctype: str = "Error Log",
+	groupby: str = "method",
+	date: Optional[datetime.date] = None,
+) -> Counts:
+	date_to = date if date else frappe.utils.now_datetime().date()
+	date_from = date_to - datetime.timedelta(days=1)
+
+	table = DocType(doctype)
+	column = table[groupby]
+
+	q = frappe.qb.from_(table)
+	q = q.select(column, Count("*", alias="count"))
+	q = q.where(table.creation[date_from:date_to])
+	q = q.groupby(column)
+	q = q.orderby("count", order=Order.desc)
+	r = q.run()
+
+	counts = {c[0]: c[1] for c in r}
+	total = sum(c[1] for c in r)
+	return dict(counts=counts, date=date_to, total=total)
+
+
+def get_name(doctype: str, date: datetime.date):
+	dt_stub = doctype.lower().replace(" ", "_")
+	date_iso = date.isoformat().replace("-", "_")
+	return f"{dt_stub}-{date_iso}"

--- a/press/press/doctype/log_counter/test_log_counter.py
+++ b/press/press/doctype/log_counter/test_log_counter.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Frappe and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestLogCounter(FrappeTestCase):
+	pass


### PR DESCRIPTION
A tentative DocType to track Error Log counts, will mostly be removed once Error Log counts are in control.

Can be extended to keep count of other values too by adding entries here:

```python
# DocType: groupby
RECORD_FOR: dict[str, str] = {
	"Error Log": "method",
}
```

This is required cause Error Logs are dumped every 10 days, hence counts can't be captured from before that.

There are probably better ways to go about this, but that isn't important for now.