### PR TITLE
chore: skip sentry log on log_error

### DIFF
--- a/press/utils/__init__.py
+++ b/press/utils/__init__.py
@@ -50,6 +50,9 @@ def log_error(title, **kwargs):
 	serialized = json.dumps(kwargs, indent=4, sort_keys=True, default=str, skipkeys=True)
 	message = f"Data:\n{serialized}\nException:\n{traceback}"
 
+	enable_telemetry = frappe.get_system_settings("enable_telemetry")
+	frappe.local.system_settings.enable_telemetry = 0
+
 	try:
 		frappe.log_error(
 			title=title,
@@ -59,6 +62,8 @@ def log_error(title, **kwargs):
 		)
 	except Exception:
 		pass
+
+	frappe.local.system_settings.enable_telemetry = enable_telemetry
 
 
 def get_current_team(get_doc=False):


### PR DESCRIPTION
`press` uses internal _overload_ of `frappe.log_error`

A `log_error` call is mostly used to log errors that are expected and may have been handled.
If the error is to be thrown then a `raise` is called after the `log_error`

Due to this, sentry log of a log error is not really useful. This PR disables sentry logging when `log_error` is called.

[frappe reference](https://github.com/frappe/frappe/blob/9e8808f06cf1ca6e0c7014e7220a4e3029bd0dcf/frappe/utils/error.py#L71)