### PR TITLE
feat: handle agent jobs callbacks for delivery failure status

### DIFF
--- a/press/press/doctype/proxy_server/proxy_server.py
+++ b/press/press/doctype/proxy_server/proxy_server.py
@@ -532,7 +532,7 @@ def process_update_nginx_job_update(job):
 	proxy_server = frappe.get_doc("Proxy Server", job.server)
 	if job.status == "Success":
 		proxy_server.status = "Active"
-	elif job.status in ["Failure", "Undelivered"]:
+	elif job.status in ["Failure", "Undelivered", "Delivery Failure"]:
 		proxy_server.status = "Broken"
 	elif job.status in ["Pending", "Running"]:
 		proxy_server.status = "Installing"

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -2213,6 +2213,8 @@ def process_new_site_job_update(job):
 		marketplace_app_hook(site=job.site, op="install")
 	elif "Failure" in (first, second):
 		updated_status = "Broken"
+	elif "Delivery Failure" in (first, second):
+		updated_status = "Broken"
 	elif "Running" in (first, second):
 		updated_status = "Installing"
 	else:
@@ -2277,6 +2279,10 @@ def process_archive_site_job_update(job):
 		updated_status = "Archived"
 	elif "Failure" in (first, second):
 		updated_status = "Broken"
+	elif "Delivery Failure" == first == second:
+		updated_status = "Active"
+	elif "Delivery Failure" in (first, second):
+		updated_status = "Broken"
 	else:
 		updated_status = "Pending"
 
@@ -2296,6 +2302,7 @@ def process_install_app_site_job_update(job):
 		"Running": "Installing",
 		"Success": "Active",
 		"Failure": "Active",
+		"Delivery Failure": "Active",
 	}[job.status]
 
 	site_status = frappe.get_value("Site", job.site, "status")
@@ -2316,6 +2323,7 @@ def process_uninstall_app_site_job_update(job):
 		"Running": "Installing",
 		"Success": "Active",
 		"Failure": "Active",
+		"Delivery Failure": "Active",
 	}[job.status]
 
 	site_status = frappe.get_value("Site", job.site, "status")
@@ -2339,6 +2347,7 @@ def process_restore_job_update(job, force=False):
 		"Running": "Installing",
 		"Success": "Active",
 		"Failure": "Broken",
+		"Delivery Failure": "Active",
 	}[job.status]
 
 	site_status = frappe.get_value("Site", job.site, "status")
@@ -2362,6 +2371,7 @@ def process_reinstall_site_job_update(job):
 		"Running": "Installing",
 		"Success": "Active",
 		"Failure": "Broken",
+		"Delivery Failure": "Active",
 	}[job.status]
 
 	site_status = frappe.get_value("Site", job.site, "status")
@@ -2377,6 +2387,7 @@ def process_migrate_site_job_update(job):
 		"Running": "Updating",
 		"Success": "Active",
 		"Failure": "Broken",
+		"Delivery Failure": "Active",
 	}[job.status]
 
 	if updated_status == "Active":
@@ -2435,6 +2446,10 @@ def process_rename_site_job_update(job):
 		create_pooled_sites()
 
 	elif "Failure" in (first, second):
+		updated_status = "Broken"
+	elif "Delivery Failure" == first == second:
+		updated_status = "Active"
+	elif "Delivery Failure" in (first, second):
 		updated_status = "Broken"
 	elif "Running" in (first, second):
 		updated_status = "Updating"

--- a/press/press/doctype/site_backup/site_backup.py
+++ b/press/press/doctype/site_backup/site_backup.py
@@ -158,7 +158,12 @@ def process_backup_site_job_update(job):
 		return
 	backup = backups[0]
 	if job.status != backup.status:
-		frappe.db.set_value("Site Backup", backup.name, "status", job.status)
+
+		status = job.status
+		if job.status == "Delivery Failure":
+			status = "Failure"
+
+		frappe.db.set_value("Site Backup", backup.name, "status", status)
 		if job.status == "Success":
 			job_data = json.loads(job.data)
 			backup_data, offsite_backup_data = job_data["backups"], job_data["offsite"]

--- a/press/press/doctype/site_domain/site_domain.py
+++ b/press/press/doctype/site_domain/site_domain.py
@@ -173,6 +173,7 @@ def process_new_host_job_update(job):
 		"Running": "In Progress",
 		"Success": "Active",
 		"Failure": "Broken",
+		"Delivery Failure": "Broken",
 	}[job.status]
 
 	if updated_status != domain_status:

--- a/press/press/doctype/site_update/site_update.py
+++ b/press/press/doctype/site_update/site_update.py
@@ -526,6 +526,7 @@ def process_update_site_recover_job_update(job):
 		"Running": "Running",
 		"Success": "Recovered",
 		"Failure": "Fatal",
+		"Delivery Failure": "Fatal",
 	}[job.status]
 	site_update = frappe.get_all(
 		"Site Update",


### PR DESCRIPTION

 1. `process_new_site_job_update`: if any dependent job or all jobs remain undelivered set status to broken
 2. `process_restore_job_update`: as job has not delivered set site status to Active
 3. `process_reinstall_site_job_update`: as job has not delivered set site status to Active
 4. `process_migrate_site_job_update`: as job has not delivered set site status to Active
 5. `process_install_app_site_job_update`: as job has not delivered set site status to Active
 6. `process_uninstall_app_site_job_update`: as job has not delivered set site status to Active
 7. `process_new_site_job_update`: if any dependent job or all jobs remain undelivered set status to broken
 8. `process_archive_site_job_update`: if any dependent job or all jobs remain undelivered set status to broken
 9. `process_new_host_job_update`: set Site Domain status as broken if job remains undeliver 
10. `process_update_site_recover_job_update`: set Site Migrate status and fatal and site status as broken
11. `process_rename_site_job_update`:  
        - if any dependent job remain undelivered set status to broken
        - if all jobs undelivered set status as active
