### PR TITLE
fix: minor-ish improvements to deploy_candidate.py

### DIFF
--- a/press/api/bench.py
+++ b/press/api/bench.py
@@ -10,7 +10,6 @@ import frappe
 from frappe.core.utils import find, find_all
 from frappe.model.naming import append_number_if_name_exists
 from frappe.utils import flt, sbool
-
 from press.api.github import branches
 from press.api.site import protected
 from press.press.doctype.agent_job.agent_job import job_detail
@@ -685,7 +684,7 @@ def deploy(name, apps):
 		frappe.throw("A deploy for this bench is already in progress")
 
 	candidate = rg.create_deploy_candidate(apps)
-	candidate.deploy_to_production()
+	candidate.schedule_build_and_deploy()
 
 	return candidate.name
 

--- a/press/api/site.py
+++ b/press/api/site.py
@@ -3,37 +3,37 @@
 # For license information, please see license.txt
 
 import json
-from frappe.utils.user import is_system_user
-from press.press.doctype.server.server import is_dedicated_server
-from press.press.doctype.marketplace_app.marketplace_app import get_plans_for_app
-import wrapt
-import frappe
-from dns.resolver import Resolver
-import dns.exception
-
 from typing import Dict
+
+import dns.exception
+import frappe
+import wrapt
 from boto3 import client
-from frappe.core.utils import find
 from botocore.exceptions import ClientError
+from dns.resolver import Resolver
+from frappe.core.utils import find
 from frappe.desk.doctype.tag.tag import add_tag
-from frappe.utils import flt, time_diff_in_hours, sbool
+from frappe.utils import flt, sbool, time_diff_in_hours
 from frappe.utils.password import get_decrypted_password
+from frappe.utils.user import is_system_user
 from press.press.doctype.agent_job.agent_job import job_detail
+from press.press.doctype.marketplace_app.marketplace_app import (
+	get_plans_for_app,
+	get_total_installs_by_app,
+)
 from press.press.doctype.press_user_permission.press_user_permission import (
 	has_user_permission,
 )
 from press.press.doctype.remote_file.remote_file import get_remote_key
+from press.press.doctype.server.server import is_dedicated_server
 from press.press.doctype.site_plan.plan import Plan
 from press.press.doctype.site_update.site_update import benches_with_available_update
-from press.press.doctype.marketplace_app.marketplace_app import (
-	get_total_installs_by_app,
-)
 from press.utils import (
-	get_current_team,
-	log_error,
-	get_last_doc,
-	get_frappe_backups,
 	get_client_blacklisted_keys,
+	get_current_team,
+	get_frappe_backups,
+	get_last_doc,
+	log_error,
 	unique,
 )
 
@@ -1866,7 +1866,7 @@ def clone_group(name, new_group_title):
 	cloned_group.insert()
 
 	candidate = cloned_group.create_deploy_candidate()
-	candidate.deploy_to_production()
+	candidate.schedule_build_and_deploy()
 
 	return {
 		"bench_name": cloned_group.name,

--- a/press/api/tests/test_bench.py
+++ b/press/api/tests/test_bench.py
@@ -1,42 +1,40 @@
 import json
 import os
 import time
-import requests
 from unittest.mock import Mock, patch
 
+import docker
 import frappe
+import requests
 from frappe.core.utils import find
 from frappe.tests.utils import FrappeTestCase, timeout
-from press.press.doctype.agent_job.agent_job import AgentJob
-from press.press.doctype.app.test_app import create_test_app
-
-
 from press.api.bench import (
+	all,
+	bench_config,
 	dependencies,
 	deploy,
 	deploy_and_update,
 	deploy_information,
 	get,
 	new,
-	all,
 	update_config,
-	bench_config,
 	update_dependencies,
 )
+from press.press.doctype.agent_job.agent_job import AgentJob
+from press.press.doctype.app.test_app import create_test_app
 from press.press.doctype.app_release.test_app_release import create_test_app_release
+from press.press.doctype.bench.test_bench import create_test_bench
 from press.press.doctype.deploy_candidate.deploy_candidate import DeployCandidate
 from press.press.doctype.press_settings.test_press_settings import (
 	create_test_press_settings,
 )
-from press.press.doctype.bench.test_bench import create_test_bench
-from press.press.doctype.server.test_server import create_test_server
-from press.press.doctype.team.test_team import create_test_press_admin_team
 from press.press.doctype.release_group.test_release_group import (
 	create_test_release_group,
 )
+from press.press.doctype.server.test_server import create_test_server
+from press.press.doctype.team.test_team import create_test_press_admin_team
 from press.utils import get_current_team
 from press.utils.test import foreground_enqueue_doc
-import docker
 
 
 @patch.object(AgentJob, "enqueue_http_request", new=Mock())
@@ -122,7 +120,7 @@ class TestAPIBench(FrappeTestCase):
 		"press.press.doctype.deploy_candidate.deploy_candidate.frappe.enqueue_doc",
 		new=foreground_enqueue_doc,
 	)
-	@patch.object(DeployCandidate, "deploy_to_production", new=Mock())
+	@patch.object(DeployCandidate, "schedule_build_and_deploy", new=Mock())
 	@patch(
 		"press.press.doctype.deploy_candidate.deploy_candidate.frappe.db.commit", new=Mock()
 	)

--- a/press/docker/Dockerfile
+++ b/press/docker/Dockerfile
@@ -243,9 +243,6 @@ RUN --mount=type=bind,source=app_updates/{{ app.app }},target=/home/frappe/conte
 {% endfor %}
 
 
-# Validate dependencies
-RUN ["/bin/bash", "-c", "if bench validate-dependencies --help 1> /dev/null 2> /dev/null; then bench validate-dependencies; else echo skipped; fi;"] `#stage-validate-dependencies`
-
 COPY --chown=frappe:frappe config /home/frappe/frappe-bench/config
 COPY --chown=frappe:frappe apps.txt /home/frappe/frappe-bench/sites/apps.txt
 

--- a/press/docker/Dockerfile
+++ b/press/docker/Dockerfile
@@ -68,7 +68,7 @@ RUN --mount=type=cache,target=/var/cache/apt curl -fsSL https://packages.redis.i
   && rm -rf /var/lib/apt/lists/* `#stage-pre-redis`
 
 # Install Python from DeadSnakes PPA
-ENV {{ doc.get_dependency_version("PYTHON_VERSION") }}
+ENV {{ doc.get_dependency_version("python", True) }}
 RUN --mount=type=cache,target=/var/cache/apt add-apt-repository ppa:deadsnakes/ppa \
   && apt-get update \
   && apt-get install --yes --no-install-suggests --no-install-recommends \
@@ -81,18 +81,18 @@ RUN --mount=type=cache,target=/var/cache/apt add-apt-repository ppa:deadsnakes/p
 
 
 # Install wkhtmltopdf
-ENV {{ doc.get_dependency_version("WKHTMLTOPDF_VERSION") }}
-{% if doc.get_dependency_version("WKHTMLTOPDF_VERSION").split(" ")[1] == '0.12.6' %}
+ENV {{ doc.get_dependency_version("wkhtmltopdf", True) }}
+{% if doc.get_dependency_version("wkhtmltopdf") == '0.12.6' %}
 RUN wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb \
   && dpkg -i wkhtmltox_0.12.6-1.focal_amd64.deb \
   && rm wkhtmltox_0.12.6-1.focal_amd64.deb \
   `#stage-pre-wkhtmltopdf`
-{% elif doc.get_dependency_version("WKHTMLTOPDF_VERSION").split(" ")[1] == '0.12.5' %}
+{% elif doc.get_dependency_version("wkhtmltopdf") == '0.12.5' %}
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.focal_amd64.deb \
   && dpkg -i wkhtmltox_0.12.5-1.focal_amd64.deb \
   && rm wkhtmltox_0.12.5-1.focal_amd64.deb \
   `#stage-pre-wkhtmltopdf`
-{% elif doc.get_dependency_version("WKHTMLTOPDF_VERSION").split(" ")[1] == '0.12.4' %}
+{% elif doc.get_dependency_version("wkhtmltopdf") == '0.12.4' %}
 RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz \
   && tar -xvf wkhtmltox-0.12.4_linux-generic-amd64.tar.xz \
   && mv wkhtmltox/bin/wkhtmlto* /usr/local/bin/ \
@@ -161,8 +161,8 @@ WORKDIR /home/frappe
 
 # Install Node using NVM
 ENV NVM_DIR /home/frappe/.nvm
-ENV {{ doc.get_dependency_version("NVM_VERSION") }}
-ENV {{ doc.get_dependency_version("NODE_VERSION") }}
+ENV {{ doc.get_dependency_version("nvm", True) }}
+ENV {{ doc.get_dependency_version("node", True) }}
 
 RUN wget https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh \
   && bash install.sh \
@@ -184,7 +184,7 @@ RUN --mount=type=cache,target=/home/frappe/.cache,uid=1000,gid=1000 npm install 
 ENV PATH "$PATH:/home/frappe/.local/bin"
 
 RUN wget https://bootstrap.pypa.io/get-pip.py && python${PYTHON_VERSION} get-pip.py `#stage-pre-pip`
-ENV {{ doc.get_dependency_version("BENCH_VERSION") }}
+ENV {{ doc.get_dependency_version("bench", True) }}
 RUN --mount=type=cache,target=/home/frappe/.cache,uid=1000,gid=1000 python${PYTHON_VERSION} -m pip install --upgrade frappe-bench==${BENCH_VERSION} `#stage-bench-bench`
 
 RUN --mount=type=cache,target=/home/frappe/.cache,uid=1000,gid=1000 python${PYTHON_VERSION} -m pip install Jinja2~=3.0.3

--- a/press/press/doctype/app_release/app_release.py
+++ b/press/press/doctype/app_release/app_release.py
@@ -219,7 +219,7 @@ class AppRelease(Document):
 			apps = [app.as_dict() for app in group.apps if app.enable_auto_deploy]
 			candidate = group.create_deploy_candidate(apps)
 			if candidate:
-				candidate.deploy_to_production()
+				candidate.schedule_build_and_deploy()
 
 
 def cleanup_unused_releases():

--- a/press/press/doctype/bench_update/bench_update.py
+++ b/press/press/doctype/bench_update/bench_update.py
@@ -3,7 +3,6 @@
 
 import frappe
 from frappe.model.document import Document
-
 from press.press.doctype.release_group.release_group import ReleaseGroup
 from press.utils import log_error
 
@@ -50,7 +49,7 @@ class BenchUpdate(Document):
 	def deploy(self):
 		rg: ReleaseGroup = frappe.get_doc("Release Group", self.group)
 		candidate = rg.create_deploy_candidate(self.apps)
-		candidate.deploy_to_production()
+		candidate.schedule_build_and_deploy()
 
 		self.status = "Running"
 		self.candidate = candidate.name

--- a/press/press/doctype/deploy_candidate/deploy_candidate.js
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.js
@@ -49,5 +49,38 @@ frappe.ui.form.on('Deploy Candidate', {
 				__('Actions'),
 			);
 		}
+
+		add_redeploy(frm);
 	},
 });
+
+function add_redeploy(frm) {
+	/**
+	 * The methods `fail_and_redeploy` and `redeploy` create
+	 * a new Deploy Candidate from the linked Release Group
+	 * and trigger `deploy_candidate.build_and_deploy`.
+	 */
+
+	let method = 'fail_and_redeploy';
+	let label = __('Fail and Redeploy');
+
+	if (['Draft', 'Failure', 'Success'].includes(frm.doc.status)) {
+		method = 'redeploy';
+		label = __('Redeploy');
+	}
+
+	frm.add_custom_button(label, handler, __('Actions'));
+	async function handler() {
+		const { message } = await frm.call(method);
+
+		frappe.msgprint({
+			title: __('Redeploy Triggered'),
+			indicator: 'green',
+			message: __(`Duplicate {0} created and redeploy triggered.`, [
+				`<a href="/app/deploy-candidate/${message.name}">Deploy Candidate</a>`,
+			]),
+		});
+
+		frm.refresh();
+	}
+}

--- a/press/press/doctype/deploy_candidate/deploy_candidate.js
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.js
@@ -16,38 +16,36 @@ frappe.ui.form.on('Deploy Candidate', {
 		};
 
 		const actions = [
+			[__('Complete'), 'build', true, __('Build')],
 			[
-				__('Generate Build Context'),
+				__('Generate Context'),
 				'generate_build_context',
 				window.dev_server,
+				__('Build'),
 			],
-			[__('Build'), 'build', true],
-			[__('Build without cache'), 'build_without_cache', true],
-			[__('Build without push'), 'build_without_push', window.dev_server],
-			[__('Deploy to Staging'), 'deploy_to_staging', true],
-			[__('Promote to Production'), 'promote_to_production', frm.doc.staged],
+			[__('Without Cache'), 'build_without_cache', true, __('Build')],
 			[
-				__('Deploy to Production (build and deploy)'),
-				'deploy_to_production',
-				true,
+				__('Without Push'),
+				'build_without_push',
+				window.dev_server,
+				__('Build'),
 			],
 			[
-				__('Cleanup Build Directory'),
+				__('Cleanup Directory'),
 				'cleanup_build_directory',
 				frm.doc.status !== 'Draft',
+				__('Build'),
 			],
+			[__('Deploy to Production'), 'deploy_to_production', true, __('Deploy')],
 		];
 
-		for (const [label, method, show] of actions) {
+		for (const [label, method, show, group] of actions) {
 			if (!show) {
 				continue;
 			}
 
-			frm.add_custom_button(
-				label,
-				() => frm.call(method).then((r) => frm.refresh()),
-				__('Actions'),
-			);
+			const callback = () => frm.call(method).then(() => frm.refresh());
+			frm.add_custom_button(label, callback, group);
 		}
 
 		add_redeploy(frm);
@@ -69,7 +67,7 @@ function add_redeploy(frm) {
 		label = __('Redeploy');
 	}
 
-	frm.add_custom_button(label, handler, __('Actions'));
+	frm.add_custom_button(label, handler, __('Deploy'));
 	async function handler() {
 		const { message } = await frm.call(method);
 

--- a/press/press/doctype/deploy_candidate/deploy_candidate.js
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.js
@@ -15,28 +15,29 @@ frappe.ui.form.on('Deploy Candidate', {
 			};
 		};
 
+		const can_build = ['Draft', 'Failure', 'Success'].includes(frm.doc.status);
 		const actions = [
-			[__('Complete'), 'build', true, __('Build')],
+			[__('Complete'), 'build', can_build, __('Build')],
 			[
 				__('Generate Context'),
 				'generate_build_context',
-				window.dev_server,
+				can_build,
 				__('Build'),
 			],
-			[__('Without Cache'), 'build_without_cache', true, __('Build')],
-			[
-				__('Without Push'),
-				'build_without_push',
-				window.dev_server,
-				__('Build'),
-			],
+			[__('Without Cache'), 'build_without_cache', can_build, __('Build')],
+			[__('Without Push'), 'build_without_push', can_build, __('Build')],
 			[
 				__('Cleanup Directory'),
 				'cleanup_build_directory',
 				frm.doc.status !== 'Draft',
 				__('Build'),
 			],
-			[__('Deploy to Production'), 'deploy_to_production', true, __('Deploy')],
+			[
+				__('Schedule Build and Deploy'),
+				'schedule_build_and_deploy',
+				can_build,
+				__('Deploy'),
+			],
 		];
 
 		for (const [label, method, show, group] of actions) {

--- a/press/press/doctype/deploy_candidate/deploy_candidate.json
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.json
@@ -6,6 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "status",
+  "user_addressable_failure",
   "is_single_container",
   "is_ssh_enabled",
   "staged",
@@ -362,6 +363,14 @@
    "fieldtype": "Code",
    "label": "Build Error",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.user_addressable_failure",
+   "description": "Set if the build failure is user addressable, i.e. the cause of failure is not FC.",
+   "fieldname": "user_addressable_failure",
+   "fieldtype": "Check",
+   "label": "User Addressable Failure"
   }
  ],
  "links": [
@@ -374,7 +383,7 @@
    "link_fieldname": "reference_name"
   }
  ],
- "modified": "2024-04-16 11:27:12.314611",
+ "modified": "2024-05-01 09:37:45.162767",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Deploy Candidate",

--- a/press/press/doctype/deploy_candidate/deploy_candidate.json
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.json
@@ -9,7 +9,6 @@
   "user_addressable_failure",
   "is_single_container",
   "is_ssh_enabled",
-  "staged",
   "is_docker_remote_builder_used",
   "column_break_2",
   "group",
@@ -204,14 +203,6 @@
   },
   {
    "default": "0",
-   "fieldname": "staged",
-   "fieldtype": "Check",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Staged"
-  },
-  {
-   "default": "0",
    "fieldname": "is_ssh_enabled",
    "fieldtype": "Check",
    "label": "Is SSH Enabled",
@@ -383,7 +374,7 @@
    "link_fieldname": "reference_name"
   }
  ],
- "modified": "2024-05-01 09:37:45.162767",
+ "modified": "2024-05-01 10:38:45.034681",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Deploy Candidate",

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -2,9 +2,9 @@
 # Copyright (c) 2021, Frappe and contributors
 # For license information, please see license.txt
 
+import glob
 import json
 import os
-import glob
 import re
 import shlex
 import shutil
@@ -107,6 +107,7 @@ class DeployCandidate(Document):
 		team: DF.Link
 		use_app_cache: DF.Check
 		use_rq_workerpool: DF.Check
+		user_addressable_failure: DF.Check
 		user_certificate: DF.Code | None
 		user_private_key: DF.Code | None
 		user_public_key: DF.Code | None
@@ -350,9 +351,11 @@ class DeployCandidate(Document):
 		self._build_failed()
 
 		if create_build_failed_notification(self, exc):
-			# Skip log and raise error if build failure is actionable
+			self.user_addressable_failure = True
+			frappe.db.commit()
 			return
 
+		# Log and raise error if build failure is not actionable
 		log_error("Deploy Candidate Build Exception", name=self.name, doc=self)
 		raise
 

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -812,10 +812,10 @@ class DeployCandidate(Document):
 		validated.
 		"""
 		if not (step := self.get_step("clone", app.app)):
-			raise f"App {app.app} clone step not found"
+			raise frappe.ValidationError(f"App {app.app} clone step not found")
 
 		if not self.build_directory:
-			raise "Build Directory not set"
+			raise frappe.ValidationError("Build Directory not set")
 
 		step.command = f"git clone {app.app}"
 		source, cloned = frappe.db.get_value(

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -1331,9 +1331,16 @@ class DeployCandidate(Document):
 				docname=self.name,
 			)
 
-	def get_dependency_version(self, dependency):
+	def get_dependency_version(self, dependency: str, as_env: bool = False):
+		if dependency.islower():
+			dependency = dependency.upper() + "_VERSION"
+
 		version = find(self.dependencies, lambda x: x.dependency == dependency).version
-		return f"{dependency} {version}"
+
+		if as_env:
+			return f"{dependency} {version}"
+
+		return version
 
 	def get_pull_update_dict(self) -> dict[str, AppReleasePair]:
 		"""

--- a/press/press/doctype/deploy_candidate/test_deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/test_deploy_candidate.py
@@ -178,7 +178,7 @@ class TestDeployCandidate(unittest.TestCase):
 		self.assertEqual(candidate.apps[1].release, release.name)
 
 	@patch("press.press.doctype.deploy_candidate.deploy_candidate.frappe.enqueue_doc")
-	@patch.object(DeployCandidate, "deploy_to_production", new=Mock())
+	@patch.object(DeployCandidate, "schedule_build_and_deploy", new=Mock())
 	def test_creating_new_app_release_with_auto_deploy_deploys_that_app(
 		self, mock_enqueue_doc, mock_commit
 	):

--- a/press/press/doctype/deploy_candidate/utils.py
+++ b/press/press/doctype/deploy_candidate/utils.py
@@ -6,6 +6,7 @@ from typing import Any, Optional, TypedDict
 PackageManagers = TypedDict(
 	"PackageManagers",
 	{
+		"repo_path": str,
 		"pyproject": Optional[dict[str, Any]],
 		"packagejsons": list[dict[str, Any]],
 	},
@@ -29,6 +30,7 @@ def get_package_manager_files_from_repo(app: str, repo_path: str):
 	)
 
 	pm: PackageManagers = {
+		"repo_path": repo_path,
 		"pyproject": None,
 		"packagejsons": [],
 	}

--- a/press/press/doctype/deploy_candidate/utils.py
+++ b/press/press/doctype/deploy_candidate/utils.py
@@ -1,0 +1,96 @@
+import json
+
+from pathlib import Path
+from typing import Any, Optional, TypedDict
+
+PackageManagers = TypedDict(
+	"PackageManagers",
+	{
+		"pyproject": Optional[dict[str, Any]],
+		"packagejsons": list[dict[str, Any]],
+	},
+)
+PackageManagerFiles = dict[str, PackageManagers]
+
+
+def get_package_manager_files(repo_path_map: dict[str, str]) -> PackageManagerFiles:
+	# Return pyproject.toml and package.json files
+	pfiles_map = {}
+	for app, repo_path in repo_path_map.items():
+		pfiles_map[app] = get_package_manager_files_from_repo(app, repo_path)
+
+	return pfiles_map
+
+
+def get_package_manager_files_from_repo(app: str, repo_path: str):
+	pypt, pckjs = _get_package_manager_files_from_repo(
+		repo_path,
+		True,
+	)
+
+	pm: PackageManagers = {
+		"pyproject": None,
+		"packagejsons": [],
+	}
+
+	if pypt is not None:
+		pm["pyproject"] = load_pyproject(app, pypt.absolute().as_posix())
+
+	for pckj in pckjs:
+		package_json = load_package_json(
+			app,
+			pckj.absolute().as_posix(),
+		)
+		pm["packagejsons"].append(package_json)
+
+	return pm
+
+
+def _get_package_manager_files_from_repo(
+	repo_path: str,
+	recursive: bool,
+) -> tuple[Path | None, list[Path]]:
+	pyproject_toml: Optional[Path] = None
+	package_jsons: list[Path] = []  # An app can have multiple
+
+	for p in Path(repo_path).iterdir():
+		if p.name == "pyproject.toml":
+			pyproject_toml = p
+		elif p.name == "package.json":
+			package_jsons.append(p)
+
+		if not (recursive and p.is_dir()):
+			continue
+
+		pypt, pckjs = _get_package_manager_files_from_repo(p, False)
+		if pypt is not None and pyproject_toml is None:
+			pyproject_toml = pypt
+
+		package_jsons.extend(pckjs)
+
+	return pyproject_toml, package_jsons
+
+
+def load_pyproject(app: str, pyproject_path: str):
+	try:
+		from tomli import TOMLDecodeError, load
+	except ImportError:
+		from tomllib import TOMLDecodeError, load
+
+	with open(pyproject_path, "rb") as f:
+		try:
+			return load(f)
+		except TOMLDecodeError:
+			# Do not edit without updating deploy_notifications.py
+			raise Exception("App has invalid pyproject.toml file", app) from None
+
+
+def load_package_json(app: str, package_json_path: str):
+	with open(package_json_path, "rb") as f:
+		try:
+			return json.load(f)
+		except json.JSONDecodeError:
+			# Do not edit without updating deploy_notifications.py
+			raise Exception(
+				"App has invalid package.json file", app, package_json_path
+			) from None

--- a/press/press/doctype/deploy_candidate/validations.py
+++ b/press/press/doctype/deploy_candidate/validations.py
@@ -35,7 +35,7 @@ class PreBuildValidations:
 
 	def _validate_node_version(self, app: str, actual: str, pm: PackageManagers):
 		for pckj in pm["packagejsons"]:
-			expected = pckj.get("engine", {}).get("node")
+			expected = pckj.get("engines", {}).get("node")
 			if expected is None or sv.Version(actual) in sv.SimpleSpec(expected):
 				continue
 

--- a/press/press/doctype/deploy_candidate/validations.py
+++ b/press/press/doctype/deploy_candidate/validations.py
@@ -1,0 +1,33 @@
+from typing import TYPE_CHECKING
+from press.press.doctype.deploy_candidate.utils import (
+	PackageManagerFiles,
+)
+
+
+if TYPE_CHECKING:
+	from press.press.doctype.deploy_candidate.deploy_candidate import (
+		DeployCandidate,
+	)
+
+
+class PreBuildValidations:
+	dc: "DeployCandidate"
+	pmf: PackageManagerFiles
+
+	def __init__(self, dc: "DeployCandidate", pmf: PackageManagerFiles):
+		self.dc = dc
+		self.pmf = pmf
+
+	def validate(self):
+		self._validate_syntax()
+		self._validate_node_requirement()
+		self._validate_frappe_dependencies()
+
+	def _validate_syntax(self):
+		pass
+
+	def _validate_node_requirement(self):
+		pass
+
+	def _validate_frappe_dependencies(self):
+		pass

--- a/press/press/doctype/deploy_candidate/validations.py
+++ b/press/press/doctype/deploy_candidate/validations.py
@@ -51,4 +51,32 @@ class PreBuildValidations:
 			)
 
 	def _validate_frappe_dependencies(self):
-		pass
+		for app, pm in self.pmf.items():
+			if (pypr := pm["pyproject"]) is None:
+				continue
+
+			frappe_deps = pypr.get("tool", {}).get("bench", {}).get("frappe-dependencies")
+			if not frappe_deps:
+				continue
+
+			self._check_frappe_dependencies(app, frappe_deps)
+
+	def _check_frappe_dependencies(self, app: str, frappe_deps: dict[str, str]):
+		for dep_app, actual in frappe_deps.items():
+			expected = get_app_version(dep_app)
+			if sv.Version(expected) in sv.SimpleSpec(actual):
+				continue
+
+			# Do not change args without updating deploy_notifications.py
+			raise Exception(
+				"Incompatible app version found",
+				app,
+				dep_app,
+				actual,
+				expected,
+			)
+
+
+def get_app_version(app: str) -> str:
+	# TODO: Complete this
+	return "0.0.0"

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -8,7 +8,6 @@ from functools import cached_property
 from itertools import chain
 from typing import TYPE_CHECKING, List, Optional
 
-
 import frappe
 import semantic_version as sv
 from frappe import _
@@ -17,6 +16,7 @@ from frappe.core.utils import find, find_all
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
 from frappe.utils import comma_and, cstr, flt, sbool
+from press.api.client import dashboard_whitelist
 from press.overrides import get_permission_query_conditions_for_doctype
 from press.press.doctype.app.app import new_app
 from press.press.doctype.app_source.app_source import AppSource, create_app_source
@@ -29,7 +29,6 @@ from press.utils import (
 	get_last_doc,
 	log_error,
 )
-from press.api.client import dashboard_whitelist
 
 DEFAULT_DEPENDENCIES = [
 	{"dependency": "NVM_VERSION", "version": "0.36.0"},
@@ -465,7 +464,7 @@ class ReleaseGroup(Document, TagHelpers):
 	@dashboard_whitelist()
 	def redeploy(self):
 		dc = self.create_duplicate_deploy_candidate()
-		dc.deploy_to_production()
+		dc.schedule_build_and_deploy()
 
 	@frappe.whitelist()
 	def create_deploy_candidate(self, apps_to_update=None) -> "Optional[DeployCandidate]":

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -6,7 +6,8 @@ import json
 from contextlib import suppress
 from functools import cached_property
 from itertools import chain
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
+
 
 import frappe
 import semantic_version as sv
@@ -467,7 +468,7 @@ class ReleaseGroup(Document, TagHelpers):
 		dc.deploy_to_production()
 
 	@frappe.whitelist()
-	def create_deploy_candidate(self, apps_to_update=None) -> "DeployCandidate":
+	def create_deploy_candidate(self, apps_to_update=None) -> "Optional[DeployCandidate]":
 		if not self.enabled:
 			return
 


### PR DESCRIPTION
- [x] Track if build failure is user addressable
- [x] Add Fail and Redeploy so that an engineer is not required to help user
- [x] Add pre-build node validations
- [x] Add pre-build frappe app validations
- [ ] Add pre-build syntax validations
- [ ] Handle Deploy spam

Note Merging this PR, will address remaining ToDos in the next one.