### PR TITLE
fix: invalid http_port

### DIFF
--- a/press/docker/common_site_config.json
+++ b/press/docker/common_site_config.json
@@ -4,6 +4,5 @@
     "redis_queue": "redis://localhost:11000",
     "redis_socketio": "redis://localhost:13000",
     "shallow_clone": true,
-    "socketio_port": 9000,
-    "webserver_port": 8000
+    "socketio_port": 9000
 }

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -194,7 +194,6 @@ class Bench(Document):
 			"redis_queue": "redis://redis-queue:6379",
 			"redis_socketio": "redis://redis-socketio:6379",
 			"socketio_port": 9000,
-			"webserver_port": 8000,
 			"restart_supervisor_on_update": True,
 		}
 		if self.is_single_container:


### PR DESCRIPTION
`webserver_port` is supposed to be port for accessing site from outside, not gunicorn port. 
This should be left unset to assume 80/443 in prod.


refer: https://github.com/frappe/frappe/pull/26267 