### PR TITLE
fix: minor-ish improvements to Deploy Candidate (Pt.2) (misleading title)

### DIFF
--- a/press/press/doctype/app_release/app_release.json
+++ b/press/press/doctype/app_release/app_release.json
@@ -15,6 +15,9 @@
   "author",
   "timestamp",
   "message",
+  "validation_section",
+  "invalid_release",
+  "invalidation_reason",
   "clone_section",
   "clone_directory",
   "column_break_9",
@@ -141,6 +144,25 @@
    "fieldtype": "Datetime",
    "label": "Timestamp",
    "read_only": 1
+  },
+  {
+   "fieldname": "validation_section",
+   "fieldtype": "Section Break",
+   "label": "Validation"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.invalid_release",
+   "description": "A release is invalid if it fails validations checks. For instance if it has syntax errors.",
+   "fieldname": "invalid_release",
+   "fieldtype": "Check",
+   "label": "Invalid Release"
+  },
+  {
+   "depends_on": "eval:doc.invalid_release",
+   "fieldname": "invalidation_reason",
+   "fieldtype": "Code",
+   "label": "Invalidation Reason"
   }
  ],
  "in_create": 1,
@@ -176,7 +198,7 @@
    "link_fieldname": "destination_release"
   }
  ],
- "modified": "2024-01-02 12:57:26.450172",
+ "modified": "2024-05-09 11:30:20.907001",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "App Release",

--- a/press/press/doctype/app_release/app_release.py
+++ b/press/press/doctype/app_release/app_release.py
@@ -103,7 +103,7 @@ class AppRelease(Document):
 		if (
 			self.invalid_release
 			or not self.clone_directory
-			or os.path.isdir(self.clone_directory)
+			or not os.path.isdir(self.clone_directory)
 		):
 			return
 
@@ -474,6 +474,6 @@ def check_pyproject_syntax(dirpath: str) -> str:
 		try:
 			load(f)
 		except TOMLDecodeError as err:
-			return "Invalid pyproject.toml at project root\n".join(err.args)
+			return "Invalid pyproject.toml at project root\n" + "\n".join(err.args)
 
 	return ""

--- a/press/press/doctype/app_release/app_release.py
+++ b/press/press/doctype/app_release/app_release.py
@@ -47,6 +47,8 @@ class AppRelease(Document):
 		cloned: DF.Check
 		code_server_url: DF.Text | None
 		hash: DF.Data
+		invalid_release: DF.Check
+		invalidation_reason: DF.Code | None
 		message: DF.Code | None
 		output: DF.Code | None
 		public: DF.Check
@@ -94,7 +96,19 @@ class AppRelease(Document):
 		self._set_code_server_url()
 		self._clone_repo()
 		self.cloned = True
+		self.validate_repo()
 		self.save(ignore_permissions=True)
+
+	def validate_repo(self):
+		if not self.clone_directory or os.path.isdir(self.clone_directory):
+			return
+
+		if syntax_error := check_python_syntax(self.clone_directory):
+			self.set_invalid(syntax_error)
+
+	def set_invalid(self, reason: str):
+		self.invalid_release = True
+		self.invalidation_reason = reason
 
 	def run(self, command):
 		try:
@@ -412,3 +426,30 @@ def run(command, cwd):
 	return subprocess.check_output(
 		shlex.split(command), stderr=subprocess.STDOUT, cwd=cwd
 	).decode()
+
+
+def check_python_syntax(dirpath: str) -> str:
+	"""
+	Script `compileall` will compile all the Python files
+	in the given directory.
+
+	If there are errors then return code will be non-zero.
+
+	Flags:
+	- -q: quiet, only print errors (stdout)
+	- -o: optimize level, 0 is no optimization
+	"""
+
+	command = f"python -m compileall -q -o 0 {dirpath}"
+	proc = subprocess.run(
+		shlex.split(command),
+		text=True,
+		capture_output=True,
+	)
+	if proc.returncode == 0:
+		return ""
+
+	if not proc.stdout:
+		return proc.stderr
+
+	return proc.stdout

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -11,6 +11,7 @@ from frappe.exceptions import DoesNotExistError
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists, make_autoname
 from press.agent import Agent
+from press.api.client import dashboard_whitelist
 from press.overrides import get_permission_query_conditions_for_doctype
 from press.press.doctype.bench_shell_log.bench_shell_log import (
 	ExecuteResult,
@@ -18,7 +19,9 @@ from press.press.doctype.bench_shell_log.bench_shell_log import (
 )
 from press.press.doctype.site.site import Site
 from press.utils import log_error
-from press.api.client import dashboard_whitelist
+
+TRANSITORY_STATES = ["Pending", "Installing"]
+FINAL_STATES = ["Active", "Broken", "Archived"]
 
 if TYPE_CHECKING:
 	SupervisorctlActions = Literal[

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -1466,6 +1466,26 @@ class DeployCandidate(Document):
 		self.save()
 		return dc
 
+	def has_app(self, name: str) -> bool:
+		org = None
+		if "/" in name:
+			org, name = name.split("/")
+
+		for app in self.apps:
+			if app.app != name:
+				continue
+
+			if org is None:
+				return True
+
+			owner = frappe.db.get_value(
+				"App Source",
+				app.release,
+				"repository_owner",
+			)
+			return owner == org
+		return False
+
 
 def can_pull_update(file_paths: list[str]) -> bool:
 	"""

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -500,9 +500,10 @@ class DeployCandidate(Document):
 
 		if not upload_filename:
 			step.status = "Failure"
+			response_text = agent.response and agent.response.text
 			raise Exception(
 				"Failed to upload build context to remote docker builder"
-				+ f"\nagent response: `{agent.response.text}`",
+				+ f"\nagent response: `{response_text}`",
 			)
 		else:
 			step.status = "Success"

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -14,7 +14,7 @@ import tempfile
 import typing
 from datetime import datetime, timedelta
 from subprocess import Popen
-from typing import Any, List, Literal, Optional, Tuple, Generator
+from typing import Any, Generator, List, Literal, Optional, Tuple
 
 import docker
 import frappe
@@ -31,18 +31,21 @@ from press.press.doctype.app_release.app_release import (
 from press.press.doctype.deploy_candidate.deploy_notifications import (
 	create_build_failed_notification,
 )
-from press.press.doctype.deploy_candidate.utils import (
-	load_pyproject,
-	get_package_manager_files,
-	PackageManagerFiles,
-)
-from press.press.doctype.deploy_candidate.validations import PreBuildValidations
 from press.press.doctype.deploy_candidate.docker_output_parsers import (
 	DockerBuildOutputParser,
 	UploadStepUpdater,
 )
+from press.press.doctype.deploy_candidate.utils import (
+	PackageManagerFiles,
+	get_package_manager_files,
+	load_pyproject,
+)
+from press.press.doctype.deploy_candidate.validations import PreBuildValidations
 from press.press.doctype.release_group.release_group import ReleaseGroup
 from press.utils import get_current_team, log_error, reconnect_on_failure
+
+TRANSITORY_STATES = ["Scheduled", "Pending", "Preparing", "Running"]
+RESTING_STATES = ["Draft", "Success", "Failure"]
 
 if typing.TYPE_CHECKING:
 

--- a/press/press/doctype/deploy_candidate/deploy_notifications.py
+++ b/press/press/doctype/deploy_candidate/deploy_notifications.py
@@ -119,7 +119,7 @@ def get_details(dc: "DeployCandidate", exc: BaseException) -> "Details":
 	elif "Incompatible app version found" in tb:
 		update_with_incompatible_app_prebuild(details, exc)
 
-	elif "Invalid release found":
+	elif "Invalid release found" in tb:
 		update_with_invalid_release_prebuild(details, exc)
 
 	return details

--- a/press/press/doctype/deploy_candidate/deploy_notifications.py
+++ b/press/press/doctype/deploy_candidate/deploy_notifications.py
@@ -313,7 +313,7 @@ def update_with_incompatible_app_prebuild(
 	_, app, dep_app, actual, expected = exc.args
 
 	details["is_actionable"] = True
-	details["title"] = "Validation Failed: Incompatible  version"
+	details["title"] = "Validation Failed: Incompatible app version"
 
 	message = f"""
 	<p><b>{app}</b> depends on version <b>{expected}</b> of <b>{dep_app}</b>.
@@ -328,27 +328,6 @@ def update_with_incompatible_app_prebuild(
 
 
 def update_with_invalid_release_prebuild(details: "Details", exc: "BaseException"):
-	if len(exc.args) != 3:
-		return
-
-	_, app, required_app = exc.args
-
-	details["is_actionable"] = True
-	details["title"] = "Validation Failed: Required app not found"
-	message = f"""
-	<p>App <b>{app}</b> has a dependency on the app <b>{required_app}</b>
-	which was not found on your bench</p>
-
-	<p>To rectify this issue, please add the required app to your Bench
-	and try again.</p>
-	"""
-	details["traceback"] = None
-	details["message"] = fmt(message)
-
-
-def update_with_required_app_not_found_prebuild(
-	details: "Details", exc: "BaseException"
-):
 	if len(exc.args) != 4:
 		return
 
@@ -360,12 +339,32 @@ def update_with_required_app_not_found_prebuild(
 	<p>App <b>{app}</b> has an invalid release with the commit hash
 	<b>{hash[:10]}</b></p>
 
-	<p>To rectify this issue, please fix the issue mentioned below and
+	<p>To rectify this, please fix the issue mentioned below and
 	push a new update.</p>
 	"""
 	details["traceback"] = invalidation_reason
 	details["message"] = fmt(message)
-	details["assistance_url"] = DOC_URLS["invalid-pyproject-file"]
+
+
+def update_with_required_app_not_found_prebuild(
+	details: "Details", exc: "BaseException"
+):
+	if len(exc.args) != 3:
+		return
+
+	_, app, required_app = exc.args
+
+	details["is_actionable"] = True
+	details["title"] = "Validation Failed: Required app not found"
+	message = f"""
+	<p><b>{app}</b> has a dependency on the app <b>{required_app}</b>
+	which was not found on your bench.</p>
+
+	<p>To rectify this issue, please add the required app to your Bench
+	and try again.</p>
+	"""
+	details["traceback"] = None
+	details["message"] = fmt(message)
 
 
 def fmt(message: str) -> str:

--- a/press/press/doctype/deploy_candidate/deploy_notifications.py
+++ b/press/press/doctype/deploy_candidate/deploy_notifications.py
@@ -129,6 +129,10 @@ def get_details(dc: "DeployCandidate", exc: BaseException) -> "Details":
 	elif "Invalid release found" in tb:
 		update_with_invalid_release_prebuild(details, exc)
 
+	# Required app (from hooks.py) not found
+	elif "Required app not found" in tb:
+		update_with_required_app_not_found_prebuild(details, exc)
+
 	return details
 
 
@@ -324,6 +328,27 @@ def update_with_incompatible_app_prebuild(
 
 
 def update_with_invalid_release_prebuild(details: "Details", exc: "BaseException"):
+	if len(exc.args) != 3:
+		return
+
+	_, app, required_app = exc.args
+
+	details["is_actionable"] = True
+	details["title"] = "Validation Failed: Required app not found"
+	message = f"""
+	<p>App <b>{app}</b> has a dependency on the app <b>{required_app}</b>
+	which was not found on your bench</p>
+
+	<p>To rectify this issue, please add the required app to your Bench
+	and try again.</p>
+	"""
+	details["traceback"] = None
+	details["message"] = fmt(message)
+
+
+def update_with_required_app_not_found_prebuild(
+	details: "Details", exc: "BaseException"
+):
 	if len(exc.args) != 4:
 		return
 

--- a/press/press/doctype/deploy_candidate/deploy_notifications.py
+++ b/press/press/doctype/deploy_candidate/deploy_notifications.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import typing
+import re
 from textwrap import dedent
 from typing import Optional, TypedDict
 
@@ -287,7 +288,6 @@ def update_with_incompatible_python_prebuild(
 	details["title"] = "Validation Failed: Incompatible Python version"
 	message = f"""
 	<p><b>{app}</b> requires Python version <b>{expected}</b>, found version is <b>{actual}</b>.
-
 	Please set the correct Python version on your Bench.</p>
 
 	<p>To rectify this issue, please follow the the steps mentioned in <i>Help</i>.</p>
@@ -344,7 +344,9 @@ def update_with_invalid_release_prebuild(details: "Details", exc: "BaseException
 
 
 def fmt(message: str) -> str:
-	return dedent(message.strip()).replace("\n", " ")
+	message = message.strip()
+	message = dedent(message)
+	return re.sub(r"\s+", " ", message)
 
 
 def get_build_output_line(dc: "DeployCandidate", needle: str):

--- a/press/press/doctype/deploy_candidate/validations.py
+++ b/press/press/doctype/deploy_candidate/validations.py
@@ -46,7 +46,7 @@ class PreBuildValidations:
 
 	def _validate_python_version(self, app: str, actual: str, pm: PackageManagers):
 		expected = pm["pyproject"].get("project", {}).get("requires-python")
-		if expected is None or sv.Version(actual) in sv.SimpleSpec(expected):
+		if expected is None or check_version(actual, expected):
 			return
 
 		# Do not change args without updating deploy_notifications.py
@@ -65,7 +65,7 @@ class PreBuildValidations:
 	def _validate_node_version(self, app: str, actual: str, pm: PackageManagers):
 		for pckj in pm["packagejsons"]:
 			expected = pckj.get("engines", {}).get("node")
-			if expected is None or sv.Version(actual) in sv.SimpleSpec(expected):
+			if expected is None or check_version(actual, expected):
 				continue
 
 			package_name = pckj.get("name")
@@ -128,3 +128,14 @@ class PreBuildValidations:
 				break
 
 		return None
+
+
+def check_version(actual: str, expected: str) -> bool:
+	# Python version mentions on press dont mention the patch version.
+	if actual.count(".") == 1:
+		actual += ".0"
+
+	sv_actual = sv.Version(actual)
+	sv_expected = sv.SimpleSpec(expected)
+
+	return sv_actual in sv_expected

--- a/press/press/doctype/deploy_candidate/validations.py
+++ b/press/press/doctype/deploy_candidate/validations.py
@@ -27,6 +27,7 @@ class PreBuildValidations:
 		self._validate_python_requirement()
 		self._validate_node_requirement()
 		self._validate_frappe_dependencies()
+		self._validate_required_apps()
 
 	def _validate_repos(self):
 		for app in self.dc.apps:

--- a/press/utils/__init__.py
+++ b/press/utils/__init__.py
@@ -6,6 +6,7 @@ import functools
 import json
 import time
 from datetime import datetime, timedelta
+from pathlib import Path
 from urllib.parse import urljoin
 
 import frappe
@@ -571,3 +572,38 @@ def reconnect_on_failure():
 			return wrapped(*args, **kwargs)
 
 	return wrapper
+
+
+def get_filepath(root: str, filename: str, max_depth: int = 1):
+	"""
+	Returns the absolute path of a `filename` under `root`. If
+	it is not found, returns None.
+
+	Example: get_filepath("apps/hrms", "hooks.py", 2)
+
+	Depth of search under file tree can be set using `max_depth`.
+	"""
+	path = _get_filepath(
+		Path(root),
+		filename,
+		max_depth,
+	)
+
+	if path is None:
+		return path
+
+	return path.absolute().as_posix()
+
+
+def _get_filepath(root: Path, filename: str, max_depth: int) -> Path | None:
+	if root.name == filename:
+		return root
+	if max_depth == 0 or not root.is_dir():
+		return None
+	for new_root in root.iterdir():
+		if possible_path := _get_filepath(
+			new_root,
+			filename,
+			max_depth - 1,
+		):
+			return possible_path


### PR DESCRIPTION
Continuation of https://github.com/frappe/press/pull/1735

- [x] Add post-clone and pre-build validations
  - [x] https://github.com/frappe/press/issues/1676
  - ~~[ ] JavaScript (?)~~
  - [x] `pyproject.toml`
  - [x] Python version
  - [x] Required apps from `hooks.py`
- [x] Deploy and redeploy
  - [x] https://github.com/frappe/press/issues/1733

Set of changes commented out below (can't be see). Will be addressed in the next PR.
<!--
- [ ] https://github.com/frappe/press/issues/1689
- [ ] Fail and redeploy on the frontend if build has been running for a while
- [ ] https://github.com/frappe/press/issues/1648
-->