### PR TITLE
chore: bump default bench from 5.22.1 to 5.22.6

### DIFF
--- a/press/fixtures/frappe_version.json
+++ b/press/fixtures/frappe_version.json
@@ -129,7 +129,7 @@
     "parent": "Version 15",
     "parentfield": "dependencies",
     "parenttype": "Frappe Version",
-    "version": "5.22.1"
+    "version": "5.22.6"
    }
   ],
   "docstatus": 0,
@@ -176,7 +176,7 @@
     "parent": "Nightly",
     "parentfield": "dependencies",
     "parenttype": "Frappe Version",
-    "version": "5.22.1"
+    "version": "5.22.6"
    }
   ],
   "docstatus": 0,

--- a/press/press/doctype/deploy_candidate/test_deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/test_deploy_candidate.py
@@ -305,7 +305,7 @@ def create_cache_test_release_group(
 	for dep in release_group.dependencies:
 		if dep.dependency != "BENCH_VERSION":
 			continue
-		dep.version = "5.22.1"
+		dep.version = "5.22.6"
 
 	release_group.insert(ignore_if_duplicate=True)
 	release_group.reload()

--- a/press/press/doctype/frappe_version/frappe_version.py
+++ b/press/press/doctype/frappe_version/frappe_version.py
@@ -13,7 +13,7 @@ DEFAULT_DEPENDENCIES = [
 	{"dependency": "NODE_VERSION", "version": "18.16.0"},
 	{"dependency": "PYTHON_VERSION", "version": "3.11"},
 	{"dependency": "WKHTMLTOPDF_VERSION", "version": "0.12.5"},
-	{"dependency": "BENCH_VERSION", "version": "5.22.1"},
+	{"dependency": "BENCH_VERSION", "version": "5.22.6"},
 ]
 
 


### PR DESCRIPTION
https://github.com/frappe/bench/pull/1555