### PR TITLE
fix: more build related improvements

### DIFF
--- a/dashboard/src2/pages/BenchDeploy.vue
+++ b/dashboard/src2/pages/BenchDeploy.vue
@@ -122,7 +122,6 @@ export default {
 					document_type: 'Deploy Candidate',
 					document_name: this.id,
 					is_actionable: true,
-					is_addressed: false,
 					class: 'Error'
 				},
 				limit: 1

--- a/press/press/doctype/deploy_candidate/deploy_candidate.js
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.js
@@ -17,7 +17,7 @@ frappe.ui.form.on('Deploy Candidate', {
 
 		const can_build = ['Draft', 'Failure', 'Success'].includes(frm.doc.status);
 		const actions = [
-			[__('Fail'), 'fail', !can_build, __('Build')],
+			[__('Stop and Fail'), 'stop_and_fail', !can_build, __('Build')],
 			[__('Complete'), 'build', can_build, __('Build')],
 			[
 				__('Generate Context'),

--- a/press/press/doctype/deploy_candidate/deploy_candidate.js
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.js
@@ -17,6 +17,7 @@ frappe.ui.form.on('Deploy Candidate', {
 
 		const can_build = ['Draft', 'Failure', 'Success'].includes(frm.doc.status);
 		const actions = [
+			[__('Fail'), 'fail', !can_build, __('Build')],
 			[__('Complete'), 'build', can_build, __('Build')],
 			[
 				__('Generate Context'),

--- a/press/press/doctype/deploy_candidate/deploy_candidate.json
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.json
@@ -361,7 +361,8 @@
    "description": "Set if the build failure is user addressable, i.e. the cause of failure is not FC.",
    "fieldname": "user_addressable_failure",
    "fieldtype": "Check",
-   "label": "User Addressable Failure"
+   "label": "User Addressable Failure",
+   "read_only": 1
   }
  ],
  "links": [
@@ -374,7 +375,7 @@
    "link_fieldname": "reference_name"
   }
  ],
- "modified": "2024-05-01 10:38:45.034681",
+ "modified": "2024-05-10 16:24:07.654398",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Deploy Candidate",

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -261,7 +261,7 @@ class DeployCandidate(Document):
 		self.is_docker_remote_builder_used = True
 
 	def validate_status(self):
-		if self.status in ["Draft", "Success", "Failure"]:
+		if self.status in ["Draft", "Success", "Failure", "Scheduled"]:
 			return True
 
 		frappe.msgprint(

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -288,11 +288,11 @@ class DeployCandidate(Document):
 
 	@frappe.whitelist()
 	def fail_and_redeploy(self):
-		self.fail()
+		self.stop_and_fail()
 		return self.redeploy()
 
 	@frappe.whitelist()
-	def fail(self):
+	def stop_and_fail(self):
 		if self.status in ["Draft", "Failure", "Success"]:
 			return
 

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -528,7 +528,6 @@ class DeployCandidate(Document):
 		job_data = json.loads(job.data or "{}")
 		output_data = json.loads(job_data.get("output", "{}"))
 
-		# TODO: Error Handling
 		"""
 		Due to how agent - press communication takes place, every time an
 		output is published all of it has to be re-parsed from the start.
@@ -553,10 +552,6 @@ class DeployCandidate(Document):
 			upload_step_updater.process(output)
 
 		self._update_status_from_remote_build_job(job, job_data)
-
-		if job.status == "Success":
-			upload_step_updater.end("Success")
-
 		if job.status == "Success" and request_data.get("deploy_after_build"):
 			self.create_deploy()
 

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -1638,11 +1638,11 @@ def toggle_builds(suspend):
 	frappe.db.set_single_value("Press Settings", "suspend_builds", suspend)
 
 
-def run_scheduled_builds():
+def run_scheduled_builds(max_builds: int = 5):
 	candidates = frappe.get_all(
 		"Deploy Candidate",
 		{"status": "Scheduled", "scheduled_time": ("<=", frappe.utils.now_datetime())},
-		limit=1,
+		limit=max_builds,
 	)
 	for candidate in candidates:
 		try:

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -43,12 +43,12 @@ from press.press.doctype.deploy_candidate.utils import (
 from press.press.doctype.deploy_candidate.validations import PreBuildValidations
 from press.press.doctype.release_group.release_group import ReleaseGroup
 from press.utils import (
-	get_background_jobs,
 	get_current_team,
 	log_error,
 	reconnect_on_failure,
-	stop_background_job,
 )
+from press.utils.jobs import get_background_jobs, stop_background_job
+
 from rq.job import Job
 
 TRANSITORY_STATES = ["Scheduled", "Pending", "Preparing", "Running"]
@@ -1501,7 +1501,7 @@ class DeployCandidate(Document):
 		return False
 
 	def stop_build_jobs(self):
-		for job in get_background_jobs(self):
+		for job in get_background_jobs(self.doctype, self.name):
 			if not is_build_job(job):
 				continue
 			stop_background_job(job)

--- a/press/press/doctype/deploy_candidate/deploy_notifications.py
+++ b/press/press/doctype/deploy_candidate/deploy_notifications.py
@@ -41,6 +41,7 @@ DOC_URLS = {
 	"invalid-pyproject-file": "https://frappecloud.com/docs/common-issues/invalid-pyprojecttoml-file",
 	"incompatible-node-version": "https://frappecloud.com/docs/common-issues/incompatible-node-version",
 	"incompatible-dependency-version": "https://frappecloud.com/docs/common-issues/incompatible-dependency-version",
+	"incompatible-app-version": "https://frappecloud.com/docs/common-issues/incompatible-app-version",
 }
 
 
@@ -322,6 +323,7 @@ def update_with_incompatible_app_prebuild(
 	<p>To fix this issue please set <b>{dep_app}</b> to version <b>{expected}</b>.</p>
 	"""
 	details["message"] = fmt(message)
+	details["assistance_url"] = DOC_URLS["incompatible-app-version"]
 
 	# Traceback is not pertinent to issue
 	details["traceback"] = None

--- a/press/press/doctype/deploy_candidate/validations.py
+++ b/press/press/doctype/deploy_candidate/validations.py
@@ -143,7 +143,10 @@ class PreBuildValidations:
 			)
 
 	def _get_app_version(self, app: str) -> Optional[str]:
-		pm = self.pmf[app]
+		pm = self.pmf.get(app)
+		if not pm:
+			return None
+
 		pyproject = pm["pyproject"] or {}
 		version = pyproject.get("project", {}).get("version")
 

--- a/press/press/doctype/deploy_candidate/validations.py
+++ b/press/press/doctype/deploy_candidate/validations.py
@@ -128,9 +128,9 @@ class PreBuildValidations:
 			)
 
 	def _check_frappe_dependencies(self, app: str, frappe_deps: dict[str, str]):
-		for dep_app, actual in frappe_deps.items():
-			expected = self._get_app_version(dep_app)
-			if not expected or sv.Version(expected) in sv.SimpleSpec(actual):
+		for dep_app, expected in frappe_deps.items():
+			actual = self._get_app_version(dep_app)
+			if not actual or sv.Version(actual) in sv.SimpleSpec(expected):
 				continue
 
 			# Do not change args without updating deploy_notifications.py

--- a/press/press/doctype/deploy_candidate/validations.py
+++ b/press/press/doctype/deploy_candidate/validations.py
@@ -48,7 +48,7 @@ class PreBuildValidations:
 			self._validate_python_version(app, actual, pm)
 
 	def _validate_python_version(self, app: str, actual: str, pm: PackageManagers):
-		expected = pm["pyproject"].get("project", {}).get("requires-python")
+		expected = (pm["pyproject"] or {}).get("project", {}).get("requires-python")
 		if expected is None or check_version(actual, expected):
 			return
 

--- a/press/utils/__init__.py
+++ b/press/utils/__init__.py
@@ -14,7 +14,7 @@ import frappe
 import pytz
 import requests
 import wrapt
-from frappe import Document
+from frappe.model.document import Document
 from frappe.core.doctype.rq_job.rq_job import fetch_job_ids
 from frappe.utils import get_datetime, get_system_timezone
 from frappe.utils.background_jobs import get_queues, get_redis_conn

--- a/press/utils/__init__.py
+++ b/press/utils/__init__.py
@@ -7,22 +7,15 @@ import json
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Optional
 from urllib.parse import urljoin
 
 import frappe
 import pytz
 import requests
 import wrapt
-from frappe.model.document import Document
-from frappe.core.doctype.rq_job.rq_job import fetch_job_ids
 from frappe.utils import get_datetime, get_system_timezone
-from frappe.utils.background_jobs import get_queues, get_redis_conn
 from frappe.utils.caching import site_cache
 from pymysql.err import InterfaceError
-from redis import Redis
-from rq.command import send_stop_job_command
-from rq.job import Job, JobStatus
 
 
 def log_error(title, **kwargs):
@@ -614,58 +607,3 @@ def _get_filepath(root: Path, filename: str, max_depth: int) -> Path | None:
 			max_depth - 1,
 		):
 			return possible_path
-
-
-def stop_background_job(job: Job):
-	try:
-		if job.get_status() == JobStatus.STARTED:
-			send_stop_job_command(job.connection, job.id)
-		elif job.get_status() in [JobStatus.QUEUED, JobStatus.SCHEDULED]:
-			job.cancel()
-	except Exception:
-		return
-
-
-def get_background_jobs(
-	doc: Document,
-	connection: "Optional[Redis]" = None,
-):
-	"""
-	Returns background jobs for a `doc` created using the `run_doc_method`
-	Returned jobs are in the QUEUED, SCHEDULED or STARTED state.
-	"""
-	connection = connection or get_redis_conn()
-	for q in get_queues(connection):
-
-		job_ids = [
-			*fetch_job_ids(q, JobStatus.QUEUED),
-			*fetch_job_ids(q, JobStatus.SCHEDULED),
-			*fetch_job_ids(q, JobStatus.STARTED),
-		]
-
-		for job_id in job_ids:
-			job = Job.fetch(job_id, connection=connection)
-			if not does_job_belong_to_doc(job, doc.doctype, doc.name):
-				continue
-
-			yield job
-
-
-def does_job_belong_to_doc(job: Job, doctype: str, name: str) -> bool:
-	site = job.kwargs.get("site")
-	if site and site != frappe.local.site:
-		return False
-
-	job_name = (
-		job.kwargs.get("job_type") or job.kwargs.get("job_name") or job.kwargs.get("method")
-	)
-	if job_name != "frappe.utils.background_jobs.run_doc_method":
-		return False
-
-	if job.kwargs.get("doctype") != doctype:
-		return False
-
-	if job.kwargs.get("name") != name:
-		return False
-
-	return True

--- a/press/utils/jobs.py
+++ b/press/utils/jobs.py
@@ -1,0 +1,83 @@
+import frappe
+from typing import Any, Generator, Optional
+
+from frappe.core.doctype.rq_job.rq_job import fetch_job_ids
+from frappe.utils.background_jobs import get_queues, get_redis_conn
+from redis import Redis
+from rq.command import send_stop_job_command
+from rq.job import Job, JobStatus, NoSuchJobError
+
+
+def stop_background_job(job: Job):
+	try:
+		if job.get_status() == JobStatus.STARTED:
+			send_stop_job_command(job.connection, job.id)
+		elif job.get_status() in [JobStatus.QUEUED, JobStatus.SCHEDULED]:
+			job.cancel()
+	except Exception:
+		return
+
+
+def get_background_jobs(
+	doctype: str,
+	name: str,
+	connection: "Optional[Redis]" = None,
+) -> Generator[Job, Any, None]:
+	"""
+	Returns background jobs for a `doc` created using the `run_doc_method`
+	Returned jobs are in the QUEUED, SCHEDULED or STARTED state.
+	"""
+	connection = connection or get_redis_conn()
+	status = ["queued", "scheduled", "started"]
+	for job_id in get_job_ids(status, connection):
+		try:
+			job = Job.fetch(job_id, connection=connection)
+		except NoSuchJobError:
+			continue
+
+		if not does_job_belong_to_doc(job, doctype, name):
+			continue
+
+		yield job
+
+
+def get_job_ids(
+	status: str | list[str],
+	connection: "Optional[Redis]" = None,
+) -> Generator[str, Any, None]:
+	if isinstance(status, str):
+		status = [status]
+	connection = connection or get_redis_conn()
+
+	for q in get_queues(connection):
+		for s in status:
+			try:
+				job_ids = fetch_job_ids(q, s)
+			# ValueError thrown on macOS
+			# Message: signal only works in main thread of the main interpreter
+			except ValueError:
+				return
+
+			for jid in job_ids:
+				yield jid
+
+
+def does_job_belong_to_doc(job: Job, doctype: str, name: str) -> bool:
+	site = job.kwargs.get("site")
+	if site and site != frappe.local.site:
+		return False
+
+	job_name = (
+		job.kwargs.get("job_type") or job.kwargs.get("job_name") or job.kwargs.get("method")
+	)
+	if job_name != "frappe.utils.background_jobs.run_doc_method":
+		return False
+
+	kwargs = job.kwargs.get("kwargs", {})
+	if kwargs.get("doctype") != doctype:
+		return False
+
+	if kwargs.get("name") != name:
+		return False
+
+	return True


### PR DESCRIPTION
- [x] Prevent dismissing the Build Failure notification
- [x] Skip cleanup if build server
- [x] Kill build job properly on failing

These will be addressed in the next PR:
- [ ] Fail and Redploy on dashboard if no status update for a while
- [ ] Retry Build Context Upload if failure
- [ ] Smarter use of remote builds: select build server depending on usage
- [ ] Track if a build was manually failed
- [ ] Track how long a build was stuck for
- [ ] Auto clear registry when close to 95% full