### PR TITLE
fix: don't update total if no discounts applied

### DIFF
--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -605,6 +605,8 @@ class Invoice(Document):
 		self.reload()
 
 	def set_total_and_discount(self):
+		if not self.discounts:
+			return
 		total_discount_amount = 0
 
 		for invoice_discount in self.discounts:

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -272,6 +272,12 @@ class Invoice(Document):
 				team = frappe.get_cached_doc("Team", self.team)
 				team.unsuspend_sites(f"Invoice {self.name} Payment Successful.")
 
+	def calculate_total(self):
+		total = 0
+		for item in self.items:
+			total += item.amount
+		return total
+
 	def on_submit(self):
 		self.create_invoice_on_frappeio()
 
@@ -551,11 +557,9 @@ class Invoice(Document):
 		if self.docstatus == 1:
 			return
 
-		total = 0
-		for item in self.items:
-			total += item.amount
-
+		total = self.calculate_total()
 		self.total_before_discount = total
+		self.total = total
 		self.set_total_and_discount()
 
 	def compute_free_credits(self):


### PR DESCRIPTION
Ideally total of the invoice should never be updated. (will refactor it in another PR)

This PR fixes the issue when the `amount_due` is 0 but still invoice remains unpaid. Its because the amount due is actually not 0 but very very small decimal.

#### Before:
 ![image](https://github.com/frappe/press/assets/30501401/1ece2c8d-6779-4bfa-aa60-a3b74a1289e3)

#### After:
![image](https://github.com/frappe/press/assets/30501401/d2233690-d543-4694-9c7c-a83917ecfe95)

