### PR TITLE
fix(Site): Fix deactivate action using Plan instead of Site Plan

### DIFF
--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1538,7 +1538,7 @@ class Site(Document, TagHelpers):
 	@site_action(["Active", "Broken"])
 	def deactivate(self):
 		plan = frappe.db.get_value(
-			"Plan", self.plan, ["is_frappe_plan", "is_trial_plan"], as_dict=True
+			"Site Plan", self.plan, ["is_frappe_plan", "is_trial_plan"], as_dict=True
 		)
 		if self.plan and plan.is_trial_plan:
 			frappe.throw(_("Cannot deactivate site on a trial plan"))


### PR DESCRIPTION
`site.plan` is a **Site Plan**, not a **Plan**.

https://github.com/frappe/press/blob/d1bbf473487914c6c8564180290bf191b0eaba0b/press/press/doctype/site/site.json#L346-L352