### PR TITLE
fix: grammar on site update dialog

### DIFF
--- a/dashboard/src2/components/SiteUpdateDialog.vue
+++ b/dashboard/src2/components/SiteUpdateDialog.vue
@@ -18,7 +18,7 @@
 							v-model="skipFailingPatches"
 						/>
 						<FormControl
-							label="Skip taking backup for this update (If the update fails, rollback will not be happen)"
+							label="Skip taking backup for this update (If the update fails, rollback will not happen)"
 							type="checkbox"
 							v-model="skipBackups"
 						/>

--- a/dashboard/src2/components/SiteUpdateDialog.vue
+++ b/dashboard/src2/components/SiteUpdateDialog.vue
@@ -18,7 +18,7 @@
 							v-model="skipFailingPatches"
 						/>
 						<FormControl
-							label="Skip taking backup for this update (If the update fails, rollback will not happen)"
+							label="Skip taking backup for this update (If the update fails, rollback will not occur)"
 							type="checkbox"
 							v-model="skipBackups"
 						/>


### PR DESCRIPTION
Could also change this to: "If the update fails, rollback will not occur"