### PR TITLE
feat(telegram): Telegram Message DocType to queue message

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -225,6 +225,7 @@ scheduler_events = {
 		],
 		"* * * * * 0/5": [
 			"press.press.doctype.agent_job.agent_job.poll_pending_jobs",
+			"press.press.doctype.telegram_message.telegram_message.send_telegram_message",
 		],
 		"0 */6 * * *": [
 			"press.press.doctype.server.server.cleanup_unused_files",

--- a/press/press/doctype/alertmanager_webhook_log/alertmanager_webhook_log.py
+++ b/press/press/doctype/alertmanager_webhook_log/alertmanager_webhook_log.py
@@ -8,7 +8,7 @@ import json
 from frappe.model.document import Document
 from frappe.utils.background_jobs import enqueue_doc
 from press.press.doctype.incident.incident import INCIDENT_ALERT, INCIDENT_SCOPE
-from press.telegram_utils import Telegram
+from press.press.doctype.telegram_message.telegram_message import TelegramMessage
 from press.utils import log_error
 from frappe.utils import get_url_to_form
 from frappe.utils.data import add_to_date
@@ -248,8 +248,7 @@ class AlertmanagerWebhookLog(Document):
 
 	def send_telegram_notification(self):
 		message = self.generate_telegram_message()
-		client = Telegram(self.severity)
-		client.send(message)
+		TelegramMessage.enqueue(message=message, topic=self.severity)
 
 	@property
 	def bench(self):

--- a/press/press/doctype/audit_log/audit_log.py
+++ b/press/press/doctype/audit_log/audit_log.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe.model.document import Document
 
-from press.telegram_utils import Telegram
+from press.press.doctype.telegram_message.telegram_message import TelegramMessage
 
 
 class AuditLog(Document):
@@ -49,5 +49,4 @@ class AuditLog(Document):
 
 		topic = self.telegram_topic or "Errors"
 		group = self.telegram_group
-		telegram = Telegram(topic=topic, group=group)
-		telegram.send(message)
+		TelegramMessage.enqueue(message=message, topic=topic, group=group)

--- a/press/press/doctype/malware_scan/malware_scan.py
+++ b/press/press/doctype/malware_scan/malware_scan.py
@@ -117,9 +117,4 @@ Malware Scan for *{self.server}* failed.
 		self.send_alert(message)
 
 	def send_alert(self, message):
-		# chat_id = frappe.db.get_value(
-		# 	"Press Settings", "Press Settings", "telegram_alert_chat_id"
-		# )
-		# telegram = Telegram(chat_id)
-		# telegram.send(message)
 		pass

--- a/press/press/doctype/payment_dispute/payment_dispute.py
+++ b/press/press/doctype/payment_dispute/payment_dispute.py
@@ -3,7 +3,7 @@
 
 # import frappe
 from frappe.model.document import Document
-from press.telegram_utils import Telegram
+from press.press.doctype.telegram_message.telegram_message import TelegramMessage
 
 
 class PaymentDispute(Document):
@@ -22,9 +22,7 @@ class PaymentDispute(Document):
 	# end: auto-generated types
 
 	def after_insert(self):
-		telegram = Telegram(topic="Disputes", group="Billing")
-		telegram.send(
-			f"""
+		message = f"""
 			Dispute Update!
 
 			Email: {self.email}
@@ -32,4 +30,4 @@ class PaymentDispute(Document):
 			Event: `{self.event_type}`
 			[Payment reference on Stripe Dashboard](https://dashboard.stripe.com/payments/{self.payment_intent})
 		"""
-		)
+		TelegramMessage.enqueue(message=message, topic="Disputes", group="Billing")

--- a/press/press/doctype/press_settings/press_settings.py
+++ b/press/press/doctype/press_settings/press_settings.py
@@ -12,6 +12,7 @@ from frappe.utils import get_url
 
 from press.api.billing import get_stripe
 from press.telegram_utils import Telegram
+from press.press.doctype.telegram_message.telegram_message import TelegramMessage
 
 
 class PressSettings(Document):
@@ -229,6 +230,10 @@ class PressSettings(Document):
 	@property
 	def telegram(self):
 		return Telegram
+
+	@property
+	def telegram_message(self):
+		return TelegramMessage
 
 	@property
 	def twilio_client(self) -> Client:

--- a/press/press/doctype/security_update_check/security_update_check.py
+++ b/press/press/doctype/security_update_check/security_update_check.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe.model.document import Document
 
-from press.telegram_utils import Telegram
+from press.press.doctype.telegram_message.telegram_message import TelegramMessage
 from press.runner import Ansible
 from press.utils import log_error
 
@@ -70,5 +70,4 @@ Security Update Check for *{self.server}* failed.
 
 [Security Update Check]({domain}{self.get_url()})
 """
-		telegram = Telegram()
-		telegram.send(message)
+		TelegramMessage.enqueue(message=message)

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -12,7 +12,7 @@ from hashlib import blake2b
 from press.utils import log_error, get_valid_teams_for_user
 from frappe.utils import get_fullname
 from frappe.utils import get_url_to_form, random_string
-from press.telegram_utils import Telegram
+from press.press.doctype.telegram_message.telegram_message import TelegramMessage
 from frappe.model.document import Document
 from press.exceptions import FrappeioServerNotSet
 from frappe.contacts.address_and_contact import load_address_and_contact
@@ -1136,13 +1136,13 @@ class Team(Document):
 
 	@frappe.whitelist()
 	def send_telegram_alert_for_failed_payment(self, invoice):
-		telegram = Telegram()
 		team_url = get_url_to_form("Team", self.name)
 		invoice_url = get_url_to_form("Invoice", invoice)
-		telegram.send(
+		message = (
 			f"Failed Invoice Payment [{invoice}]({invoice_url}) of"
 			f" Partner: [{self.name}]({team_url})"
 		)
+		TelegramMessage.enqueue(message=message)
 
 	@frappe.whitelist()
 	def send_email_for_failed_payment(self, invoice, sites=None):

--- a/press/press/doctype/telegram_message/telegram_message.js
+++ b/press/press/doctype/telegram_message/telegram_message.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, Frappe and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Telegram Message", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/press/press/doctype/telegram_message/telegram_message.json
+++ b/press/press/doctype/telegram_message/telegram_message.json
@@ -1,0 +1,99 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-05-21 16:45:23.323529",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "priority",
+  "status",
+  "column_break_pube",
+  "topic",
+  "group",
+  "parse_mode",
+  "section_break_ujme",
+  "message"
+ ],
+ "fields": [
+  {
+   "default": "Queued",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Queued\nSent\nError\nCancelled\nSkipped",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "priority",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Priority",
+   "options": "High\nMedium\nLow",
+   "reqd": 1
+  },
+  {
+   "fieldname": "topic",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Topic"
+  },
+  {
+   "fieldname": "group",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Group"
+  },
+  {
+   "fieldname": "message",
+   "fieldtype": "Code",
+   "label": "Message",
+   "reqd": 1
+  },
+  {
+   "default": "Markdown",
+   "fieldname": "parse_mode",
+   "fieldtype": "Select",
+   "label": "Parse Mode",
+   "options": "Markdown\nHTML",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_pube",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_ujme",
+   "fieldtype": "Section Break"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-05-21 17:00:47.887381",
+ "modified_by": "Administrator",
+ "module": "Press",
+ "name": "Telegram Message",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/press/press/doctype/telegram_message/telegram_message.json
+++ b/press/press/doctype/telegram_message/telegram_message.json
@@ -10,7 +10,6 @@
   "column_break_pube",
   "topic",
   "group",
-  "parse_mode",
   "section_break_ujme",
   "message",
   "section_break_njxf",
@@ -25,7 +24,8 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Queued\nSent\nError\nCancelled\nSkipped",
+   "options": "Queued\nSent\nError",
+   "read_only": 1,
    "reqd": 1,
    "search_index": 1
   },
@@ -36,6 +36,7 @@
    "in_standard_filter": 1,
    "label": "Priority",
    "options": "High\nMedium\nLow",
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -43,27 +44,22 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Topic"
+   "label": "Topic",
+   "read_only": 1
   },
   {
    "fieldname": "group",
    "fieldtype": "Data",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Group"
+   "label": "Group",
+   "read_only": 1
   },
   {
    "fieldname": "message",
    "fieldtype": "Code",
    "label": "Message",
-   "reqd": 1
-  },
-  {
-   "default": "Markdown",
-   "fieldname": "parse_mode",
-   "fieldtype": "Select",
-   "label": "Parse Mode",
-   "options": "Markdown\nHTML",
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -72,6 +68,10 @@
   },
   {
    "fieldname": "section_break_ujme",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_njxf",
    "fieldtype": "Section Break"
   },
   {
@@ -89,7 +89,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-05-21 17:00:47.887381",
+ "modified": "2024-05-22 15:25:47.007102",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Telegram Message",

--- a/press/press/doctype/telegram_message/telegram_message.json
+++ b/press/press/doctype/telegram_message/telegram_message.json
@@ -14,7 +14,8 @@
   "section_break_ujme",
   "message",
   "section_break_njxf",
-  "error"
+  "error",
+  "retry_count"
  ],
  "fields": [
   {
@@ -77,6 +78,12 @@
    "fieldname": "error",
    "fieldtype": "Code",
    "label": "Error",
+   "read_only": 1
+  },
+  {
+   "fieldname": "retry_count",
+   "fieldtype": "Int",
+   "label": "Retry Count",
    "read_only": 1
   }
  ],

--- a/press/press/doctype/telegram_message/telegram_message.json
+++ b/press/press/doctype/telegram_message/telegram_message.json
@@ -12,7 +12,9 @@
   "group",
   "parse_mode",
   "section_break_ujme",
-  "message"
+  "message",
+  "section_break_njxf",
+  "error"
  ],
  "fields": [
   {
@@ -70,6 +72,12 @@
   {
    "fieldname": "section_break_ujme",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "error",
+   "fieldtype": "Code",
+   "label": "Error",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,

--- a/press/press/doctype/telegram_message/telegram_message.py
+++ b/press/press/doctype/telegram_message/telegram_message.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2024, Frappe and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class TelegramMessage(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		group: DF.Data | None
+		message: DF.Code
+		parse_mode: DF.Literal["Markdown", "HTML"]
+		priority: DF.Literal["High", "Medium", "Low"]
+		status: DF.Literal["Queued", "Sent", "Error", "Cancelled", "Skipped"]
+		topic: DF.Data | None
+	# end: auto-generated types
+
+	pass

--- a/press/press/doctype/telegram_message/telegram_message.py
+++ b/press/press/doctype/telegram_message/telegram_message.py
@@ -43,12 +43,14 @@ class TelegramMessage(Document):
 	@staticmethod
 	def enqueue(
 		message: str,
+		priority: str = "Medium",
 	):
 		"""Enqueue message for sending"""
 		return frappe.get_doc(
 			{
 				"doctype": "Telegram Message",
 				"message": message,
+				"priority": priority,
 			}
 		).insert(ignore_permissions=True)
 
@@ -57,6 +59,7 @@ class TelegramMessage(Document):
 		first = frappe.get_all(
 			"Telegram Message",
 			filters={"status": "Queued"},
+			order_by="FIELD(priority, 'High', 'Medium', 'Low'), creation ASC",
 			limit=1,
 			pluck="name",
 		)

--- a/press/press/doctype/telegram_message/telegram_message.py
+++ b/press/press/doctype/telegram_message/telegram_message.py
@@ -30,7 +30,7 @@ class TelegramMessage(Document):
 	def send(self):
 		try:
 			telegram = Telegram()
-			telegram.send(self.message)
+			telegram.send(self.message, reraise=True)
 			self.status = "Sent"
 		except RetryAfter:
 			# Raise an exception that will be caught by the scheduler

--- a/press/press/doctype/telegram_message/telegram_message.py
+++ b/press/press/doctype/telegram_message/telegram_message.py
@@ -21,9 +21,9 @@ class TelegramMessage(Document):
 		error: DF.Code | None
 		group: DF.Data | None
 		message: DF.Code
-		parse_mode: DF.Literal["Markdown", "HTML"]
 		priority: DF.Literal["High", "Medium", "Low"]
 		retry_count: DF.Int
+		status: DF.Literal["Queued", "Sent", "Error"]
 		topic: DF.Data | None
 	# end: auto-generated types
 

--- a/press/press/doctype/telegram_message/telegram_message.py
+++ b/press/press/doctype/telegram_message/telegram_message.py
@@ -29,7 +29,11 @@ class TelegramMessage(Document):
 
 	def send(self):
 		try:
-			telegram = Telegram()
+			telegram = Telegram(self.topic, self.group)
+			if not self.group:
+				self.group = telegram.group
+			if not self.topic:
+				self.topic = telegram.topic
 			telegram.send(self.message, reraise=True)
 			self.status = "Sent"
 		except RetryAfter:
@@ -55,6 +59,8 @@ class TelegramMessage(Document):
 	@staticmethod
 	def enqueue(
 		message: str,
+		topic: str | None = None,
+		group: str | None = None,
 		priority: str = "Medium",
 	):
 		"""Enqueue message for sending"""
@@ -63,6 +69,8 @@ class TelegramMessage(Document):
 				"doctype": "Telegram Message",
 				"message": message,
 				"priority": priority,
+				"topic": topic,
+				"group": group,
 			}
 		).insert(ignore_permissions=True)
 

--- a/press/press/doctype/telegram_message/telegram_message.py
+++ b/press/press/doctype/telegram_message/telegram_message.py
@@ -1,8 +1,11 @@
 # Copyright (c) 2024, Frappe and contributors
 # For license information, please see license.txt
 
+import traceback
+
 import frappe
 from frappe.model.document import Document
+from press.telegram_utils import Telegram
 
 
 class TelegramMessage(Document):
@@ -14,6 +17,7 @@ class TelegramMessage(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		error: DF.Code | None
 		group: DF.Data | None
 		message: DF.Code
 		parse_mode: DF.Literal["Markdown", "HTML"]
@@ -21,6 +25,20 @@ class TelegramMessage(Document):
 		status: DF.Literal["Queued", "Sent", "Error", "Cancelled", "Skipped"]
 		topic: DF.Data | None
 	# end: auto-generated types
+
+	def send(self):
+		try:
+			telegram = Telegram()
+			telegram.send(self.message)
+			self.status = "Sent"
+		except Exception:
+			# It's unlinkely that this error will be resolved by retrying
+			# Fail immediately
+			self.error = traceback.format_exc()
+			self.status = "Error"
+			raise
+		finally:
+			self.save()
 
 	@staticmethod
 	def enqueue(
@@ -34,4 +52,31 @@ class TelegramMessage(Document):
 			}
 		).insert(ignore_permissions=True)
 
-	pass
+	@staticmethod
+	def get_one() -> "TelegramMessage | None":
+		first = frappe.get_all(
+			"Telegram Message",
+			filters={"status": "Queued"},
+			limit=1,
+			pluck="name",
+		)
+		if first:
+			return frappe.get_doc("Telegram Message", first[0])
+
+	@staticmethod
+	def send_one() -> None:
+		message = TelegramMessage.get_one()
+		if message:
+			return message.send()
+
+
+def send_telegram_message():
+	"""Send one queued telegram message"""
+
+	while message := TelegramMessage.get_one():
+		try:
+			message.send()
+			return
+		except Exception:
+			# Try next message
+			pass

--- a/press/press/doctype/telegram_message/telegram_message.py
+++ b/press/press/doctype/telegram_message/telegram_message.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2024, Frappe and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
@@ -21,5 +21,17 @@ class TelegramMessage(Document):
 		status: DF.Literal["Queued", "Sent", "Error", "Cancelled", "Skipped"]
 		topic: DF.Data | None
 	# end: auto-generated types
+
+	@staticmethod
+	def enqueue(
+		message: str,
+	):
+		"""Enqueue message for sending"""
+		return frappe.get_doc(
+			{
+				"doctype": "Telegram Message",
+				"message": message,
+			}
+		).insert(ignore_permissions=True)
 
 	pass

--- a/press/press/doctype/telegram_message/test_telegram_message.py
+++ b/press/press/doctype/telegram_message/test_telegram_message.py
@@ -5,7 +5,10 @@ from unittest.mock import Mock, patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
-from press.press.doctype.telegram_message.telegram_message import TelegramMessage
+from press.press.doctype.telegram_message.telegram_message import (
+	TelegramMessage,
+	send_telegram_message,
+)
 from press.telegram_utils import Telegram
 
 
@@ -26,3 +29,25 @@ class TestTelegramMessage(FrappeTestCase):
 		"""Test if enqueue method creates Telegram Message with Queued status"""
 		message = TelegramMessage.enqueue(message="Test Message")
 		self.assertEqual(message.status, "Queued")
+
+	def test_send_calls_telegram_send(self, mock_send: Mock):
+		"""Test if send method calls Telegram send method"""
+		TelegramMessage.enqueue(message="Test Message")
+		send_telegram_message()
+		mock_send.assert_called_once()
+
+	def test_successful_send_call_sets_sent_status(self, mock_send: Mock):
+		"""Test if successful send call sets status to Sent"""
+		first = TelegramMessage.enqueue(message="Test Message")
+		send_telegram_message()
+		first.reload()
+		self.assertEqual(first.status, "Sent")
+
+	def test_failed_send_call_sets_error_status(self, mock_send: Mock):
+		"""Test if failed send call sets status to Error"""
+		mock_send.side_effect = Exception()
+		first = TelegramMessage.enqueue(message="Test Message")
+		self.assertRaises(Exception, TelegramMessage.send_one)
+		first.reload()
+		self.assertEqual(first.status, "Error")
+		self.assertIn("Exception", first.error)

--- a/press/press/doctype/telegram_message/test_telegram_message.py
+++ b/press/press/doctype/telegram_message/test_telegram_message.py
@@ -1,9 +1,28 @@
 # Copyright (c) 2024, Frappe and Contributors
 # See license.txt
 
-# import frappe
+from unittest.mock import Mock, patch
+
+import frappe
 from frappe.tests.utils import FrappeTestCase
+from press.press.doctype.telegram_message.telegram_message import TelegramMessage
+from press.telegram_utils import Telegram
 
 
+@patch.object(Telegram, "send")
 class TestTelegramMessage(FrappeTestCase):
-	pass
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_enqueue_creates_telegram_message(self, mock_send: Mock):
+		"""Test if enqueue method creates Telegram Message"""
+
+		before = frappe.db.count("Telegram Message")
+		TelegramMessage.enqueue(message="Test Message")
+		after = frappe.db.count("Telegram Message")
+		self.assertEqual(after, before + 1)
+
+	def test_enqueue_creates_telegram_message_with_queued_status(self, mock_send: Mock):
+		"""Test if enqueue method creates Telegram Message with Queued status"""
+		message = TelegramMessage.enqueue(message="Test Message")
+		self.assertEqual(message.status, "Queued")

--- a/press/press/doctype/telegram_message/test_telegram_message.py
+++ b/press/press/doctype/telegram_message/test_telegram_message.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Frappe and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestTelegramMessage(FrappeTestCase):
+	pass

--- a/press/press/doctype/telegram_message/test_telegram_message.py
+++ b/press/press/doctype/telegram_message/test_telegram_message.py
@@ -51,3 +51,37 @@ class TestTelegramMessage(FrappeTestCase):
 		first.reload()
 		self.assertEqual(first.status, "Error")
 		self.assertIn("Exception", first.error)
+
+	def test_sends_messages_in_priority_order(self, mock_send: Mock):
+		"""Test if messages are sent in priority order"""
+		high = TelegramMessage.enqueue(message="Test Message", priority="High")
+		medium = TelegramMessage.enqueue(message="Test Message", priority="Medium")
+		low = TelegramMessage.enqueue(message="Test Message", priority="Low")
+
+		self.assertEqual(TelegramMessage.get_one(), high)
+		send_telegram_message()
+		self.assertEqual(TelegramMessage.get_one(), medium)
+		send_telegram_message()
+		self.assertEqual(TelegramMessage.get_one(), low)
+		send_telegram_message()
+
+		low = TelegramMessage.enqueue(message="Test Message", priority="Low")
+		medium = TelegramMessage.enqueue(message="Test Message", priority="Medium")
+		high = TelegramMessage.enqueue(message="Test Message", priority="High")
+
+		self.assertEqual(TelegramMessage.get_one(), high)
+		send_telegram_message()
+		self.assertEqual(TelegramMessage.get_one(), medium)
+		send_telegram_message()
+		self.assertEqual(TelegramMessage.get_one(), low)
+		send_telegram_message()
+
+	def test_sends_messages_in_creation_order(self, mock_send: Mock):
+		"""Test if messages are sent in creation order"""
+		first = TelegramMessage.enqueue(message="Test Message")
+		second = TelegramMessage.enqueue(message="Test Message")
+
+		self.assertEqual(TelegramMessage.get_one(), first)
+		send_telegram_message()
+		self.assertEqual(TelegramMessage.get_one(), second)
+		send_telegram_message()

--- a/press/telegram_utils.py
+++ b/press/telegram_utils.py
@@ -27,7 +27,7 @@ class Telegram:
 			"Telegram Group Topic", {"parent": self.group, "topic": topic}, "topic_id"
 		)
 
-	def send(self, message, html=False):
+	def send(self, message, html=False, reraise=False):
 		if not message:
 			return
 		try:
@@ -40,6 +40,8 @@ class Telegram:
 				message_thread_id=self.topic_id,
 			)
 		except Exception:
+			if reraise:
+				raise
 			log_error(
 				"Telegram Bot Error",
 				message=message,

--- a/press/telegram_utils.py
+++ b/press/telegram_utils.py
@@ -23,6 +23,7 @@ class Telegram:
 		token, chat_id = telegram_group if telegram_group else (None, None)
 		self.token = token or settings.telegram_bot_token
 		self.chat_id = chat_id
+		self.topic = topic
 		self.topic_id = frappe.db.get_value(
 			"Telegram Group Topic", {"parent": self.group, "topic": topic}, "topic_id"
 		)


### PR DESCRIPTION
Use TelegramMessage as a queue to accept messages and send them out with a  scheduled job.

- Takes care of Telegram rate limits. (Retries sending message after fixed backoff).
- Prioritizes older messages over newer and High-priority messages over low-priority.

replaces
```python
Telegram().send(message=message)
```
with
```python
TelegramMessage.enqueue(message=message)
```

Resolves https://trace.frappe.cloud/organizations/frappe/issues/10775
