### PR TITLE
feat: show Pay Now btn for both card & prepaid credits Inv

### DIFF
--- a/dashboard/src2/pages/BillingInvoices.vue
+++ b/dashboard/src2/pages/BillingInvoices.vue
@@ -57,6 +57,27 @@ export default {
 			return {
 				doctype: 'Invoice',
 				fields: ['type', 'invoice_pdf', 'payment_mode', 'stripe_invoice_url'],
+				filterControls() {
+					return [
+						{
+							type: 'select',
+							label: 'Status',
+							class: 'w-36',
+							fieldname: 'status',
+							options: [
+								'',
+								'Draft',
+								'Invoice Created',
+								'Unpaid',
+								'Paid',
+								'Refunded',
+								'Uncollectible',
+								'Collected',
+								'Empty'
+							]
+						}
+					];
+				},
 				columns: [
 					{ label: 'Invoice', fieldname: 'name' },
 					{ label: 'Status', fieldname: 'status', type: 'Badge' },

--- a/dashboard/src2/pages/BillingInvoices.vue
+++ b/dashboard/src2/pages/BillingInvoices.vue
@@ -129,7 +129,6 @@ export default {
 									},
 									onClick: () => {
 										if (row.stripe_invoice_url && row.payment_mode == 'Card') {
-											console.log(row.stripe_invoice_url);
 											window.open(
 												`/api/method/run_doc_method?dt=Invoice&dn=${row.name}&method=stripe_payment_url`
 											);

--- a/dashboard/src2/pages/BillingInvoices.vue
+++ b/dashboard/src2/pages/BillingInvoices.vue
@@ -17,6 +17,16 @@
 				</template>
 			</template>
 		</Dialog>
+		<BuyPrepaidCreditsDialog
+			v-if="showBuyPrepaidCreditsDialog"
+			v-model="showBuyPrepaidCreditsDialog"
+			:minimumAmount="minimumAmount"
+			@success="
+				() => {
+					showBuyPrepaidCreditsDialog = false;
+				}
+			"
+		/>
 	</div>
 </template>
 <script>
@@ -24,46 +34,29 @@ import ObjectList from '../components/ObjectList.vue';
 import InvoiceTable from '../components/InvoiceTable.vue';
 import { userCurrency } from '../utils/format';
 import { icon } from '../utils/components';
+import BuyPrepaidCreditsDialog from '../components/BuyPrepaidCreditsDialog.vue';
 
 export default {
 	name: 'BillingInvoices',
 	props: ['tab'],
 	components: {
 		ObjectList,
-		InvoiceTable
+		InvoiceTable,
+		BuyPrepaidCreditsDialog
 	},
 	data() {
 		return {
 			invoiceDialog: false,
-			showInvoice: null
+			showInvoice: null,
+			showBuyPrepaidCreditsDialog: false,
+			minimumAmount: 0
 		};
 	},
 	computed: {
 		options() {
 			return {
 				doctype: 'Invoice',
-				fields: ['type', 'invoice_pdf'],
-				filterControls() {
-					return [
-						{
-							type: 'select',
-							label: 'Status',
-							class: 'w-36',
-							fieldname: 'status',
-							options: [
-								'',
-								'Draft',
-								'Invoice Created',
-								'Unpaid',
-								'Paid',
-								'Refunded',
-								'Uncollectible',
-								'Collected',
-								'Empty'
-							]
-						}
-					];
-				},
+				fields: ['type', 'invoice_pdf', 'payment_mode', 'stripe_invoice_url'],
 				columns: [
 					{ label: 'Invoice', fieldname: 'name' },
 					{ label: 'Status', fieldname: 'status', type: 'Badge' },
@@ -95,7 +88,7 @@ export default {
 						label: '',
 						type: 'Button',
 						align: 'right',
-						Button({ row }) {
+						Button: ({ row }) => {
 							if (row.invoice_pdf) {
 								return {
 									label: 'Download Invoice',
@@ -107,20 +100,22 @@ export default {
 									}
 								};
 							}
-							if (
-								row.status !== 'Paid' &&
-								row.amount_due > 0 &&
-								row.stripe_invoice_url
-							) {
+							if (row.status !== 'Paid' && row.amount_due > 0) {
 								return {
 									label: 'Pay Now',
 									slots: {
 										prefix: icon('external-link')
 									},
 									onClick: () => {
-										window.open(
-											`/api/method/run_doc_method?dt=Invoice&dn=${row.name}&method=stripe_payment_url`
-										);
+										if (row.stripe_invoice_url && row.payment_mode == 'Card') {
+											console.log(row.stripe_invoice_url);
+											window.open(
+												`/api/method/run_doc_method?dt=Invoice&dn=${row.name}&method=stripe_payment_url`
+											);
+										} else {
+											this.showBuyPrepaidCreditsDialog = true;
+											this.minimumAmount = row.amount_due;
+										}
 									}
 								};
 							}


### PR DESCRIPTION
Earlier "Pay Now" button was only visible for Card invoices where `stripe_invoice_url` is set. 
With this change it will also be visible to Prepaid Credit invoices so users can pay directly from invoice page and finalize the invoice after credits allocated.

Better fix of https://github.com/frappe/press/pull/1743