### PR TITLE
fix: add correct_false_positives hook

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -203,6 +203,7 @@ scheduler_events = {
 		"press.press.doctype.site_update.site_update.mark_stuck_updates_as_fatal",
 		"press.press.doctype.deploy_candidate.deploy_candidate.cleanup_build_directories",
 		"press.press.doctype.deploy_candidate.deploy_candidate.delete_draft_candidates",
+		"press.press.doctype.deploy_candidate.deploy_candidate.correct_false_positives",
 		"press.press.doctype.virtual_disk_snapshot.virtual_disk_snapshot.delete_old_snapshots",
 		"press.press.doctype.app_release.app_release.cleanup_unused_releases",
 	],


### PR DESCRIPTION
Cause remote jobs run remotely, the the output processing is a bit wack rn, their status might not always match what's happened. Hence this job. Will probably remove it later.