### PR TITLE
feat: Throttle agent requests if we see request failures

### DIFF
--- a/press/agent.py
+++ b/press/agent.py
@@ -800,6 +800,17 @@ class Agent:
 			)
 			frappe.new_doc("Agent Request Failure", **fields).insert(ignore_permissions=True)
 
+	def raw_request(self, method, path, data=None, raises=True, timeout=None):
+		url = f"https://{self.server}:{self.port}/agent/{path}"
+		password = get_decrypted_password(self.server_type, self.server, "agent_password")
+		headers = {"Authorization": f"bearer {password}"}
+		timeout = timeout or (10, 30)
+		response = requests.request(method, url, headers=headers, json=data, timeout=timeout)
+		json_response = response.json()
+		if raises:
+			response.raise_for_status()
+		return json_response
+
 	def should_skip_requests(self):
 		return bool(frappe.db.count("Agent Request Failure", {"server": self.server}))
 

--- a/press/agent.py
+++ b/press/agent.py
@@ -800,6 +800,9 @@ class Agent:
 			)
 			frappe.new_doc("Agent Request Failure", **fields).insert(ignore_permissions=True)
 
+	def should_skip_requests(self):
+		return bool(frappe.db.count("Agent Request Failure", {"server": self.server}))
+
 	def handle_request_failure(self, agent_job, result):
 		if not agent_job:
 			return

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -257,6 +257,7 @@ scheduler_events = {
 		],
 		"* * * * *": [
 			"press.press.doctype.deploy_candidate.deploy_candidate.run_scheduled_builds",
+			"press.press.doctype.agent_request_failure.agent_request_failure.remove_old_failures",
 		],
 		"*/10 * * * *": [
 			"press.saas.doctype.saas_product.saas_product.replenish_standby_sites",

--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -17,7 +17,7 @@ from frappe.utils import (
 	get_datetime,
 	now_datetime,
 )
-from press.agent import Agent, AgentCallbackException
+from press.agent import Agent, AgentCallbackException, AgentRequestSkippedException
 from press.api.client import is_owned_by_team
 from press.press.doctype.agent_job_type.agent_job_type import (
 	get_retryable_job_types_and_max_retry_count,
@@ -174,6 +174,9 @@ class AgentJob(Document):
 
 			self.status = "Pending"
 			self.save()
+		except AgentRequestSkippedException:
+			self.retry_count = 0
+			self.set_status_and_next_retry_at()
 
 		except Exception:
 			if 400 <= cint(self.flags.get("status_code", 0)) <= 499:

--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -160,6 +160,11 @@ class AgentJob(Document):
 	def create_http_request(self):
 		try:
 			agent = Agent(self.server, server_type=self.server_type)
+			if agent.should_skip_requests():
+				self.retry_count = 0
+				self.set_status_and_next_retry_at()
+				return
+
 			data = json.loads(self.request_data)
 			files = json.loads(self.request_files)
 
@@ -393,6 +398,10 @@ def poll_pending_jobs_server(server):
 	if frappe.db.get_value(server.server_type, server.server, "status") != "Active":
 		return
 
+	agent = Agent(server.server, server_type=server.server_type)
+	if agent.should_skip_requests():
+		return
+
 	pending_jobs = frappe.get_all(
 		"Agent Job",
 		fields=["name", "job_id", "status", "callback_failure_count"],
@@ -408,8 +417,6 @@ def poll_pending_jobs_server(server):
 	if not pending_jobs:
 		retry_undelivered_jobs(server)
 		return
-
-	agent = Agent(server.server, server_type=server.server_type)
 
 	pending_ids = [j.job_id for j in pending_jobs]
 	random_pending_ids = random.sample(pending_ids, k=min(100, len(pending_ids)))

--- a/press/press/doctype/agent_request_failure/agent_request_failure.js
+++ b/press/press/doctype/agent_request_failure/agent_request_failure.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, Frappe and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Agent Request Failure", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/press/press/doctype/agent_request_failure/agent_request_failure.json
+++ b/press/press/doctype/agent_request_failure/agent_request_failure.json
@@ -1,0 +1,97 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-06-10 15:55:14.514080",
+ "doctype": "DocType",
+ "engine": "MyISAM",
+ "field_order": [
+  "server_type",
+  "server",
+  "column_break_bxet",
+  "failure_count",
+  "section_break_xror",
+  "error",
+  "traceback"
+ ],
+ "fields": [
+  {
+   "fieldname": "server_type",
+   "fieldtype": "Link",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Server Type",
+   "options": "DocType",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "server",
+   "fieldtype": "Dynamic Link",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Server",
+   "options": "server_type",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_bxet",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_xror",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "error",
+   "fieldtype": "Code",
+   "label": "Error",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "traceback",
+   "fieldtype": "Code",
+   "label": "Traceback",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "default": "1",
+   "fieldname": "failure_count",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Failure Count",
+   "read_only": 1,
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-06-10 16:07:06.977363",
+ "modified_by": "Administrator",
+ "module": "Press",
+ "name": "Agent Request Failure",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "show_title_field_in_link": 1,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "server"
+}

--- a/press/press/doctype/agent_request_failure/agent_request_failure.json
+++ b/press/press/doctype/agent_request_failure/agent_request_failure.json
@@ -34,7 +34,8 @@
    "label": "Server",
    "options": "server_type",
    "read_only": 1,
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "column_break_bxet",
@@ -70,7 +71,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-10 16:07:06.977363",
+ "modified": "2024-06-12 15:05:52.948905",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Agent Request Failure",

--- a/press/press/doctype/agent_request_failure/agent_request_failure.py
+++ b/press/press/doctype/agent_request_failure/agent_request_failure.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024, Frappe and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class AgentRequestFailure(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		error: DF.Code
+		failure_count: DF.Int
+		server: DF.DynamicLink
+		server_type: DF.Link
+		traceback: DF.Code
+	# end: auto-generated types
+
+	pass

--- a/press/press/doctype/agent_request_failure/agent_request_failure.py
+++ b/press/press/doctype/agent_request_failure/agent_request_failure.py
@@ -1,7 +1,12 @@
 # Copyright (c) 2024, Frappe and contributors
 # For license information, please see license.txt
 
+import requests
+
+import frappe
 from frappe.model.document import Document
+from press.utils import log_error
+from press.agent import Agent
 
 
 class AgentRequestFailure(Document):
@@ -21,3 +26,43 @@ class AgentRequestFailure(Document):
 	# end: auto-generated types
 
 	pass
+
+
+def remove_old_failures():
+	failures = frappe.get_all(
+		"Agent Request Failure",
+		["name", "server_type", "server", "failure_count"],
+		order_by="creation ASC",
+	)
+	for failure in failures:
+		delta = 0
+		try:
+			agent = Agent(failure.server, failure.server_type)
+			agent.raw_request("GET", "ping", raises=True, timeout=(1, 5))
+		except (requests.ConnectTimeout, requests.ReadTimeout, requests.ConnectionError):
+			# Server is still down, either because
+			# 1. Couldn't connect
+			# 2. Couldn't respond in time,
+			# increment the failure count
+			delta = 1
+		except requests.RequestException:
+			# Something still wrong with the connection, ignore for now.
+			pass
+		except Exception:
+			# Something weird happened, probably not related to requests
+			log_error("Agent Status Check Failure", failure=failure)
+		else:
+			# Server responded, aggressively decrement the failure count
+			# Aggressively
+			delta = -100
+
+		if delta:
+			if failure.failure_count + delta <= 0:
+				frappe.delete_doc("Agent Request Failure", failure.name)
+			else:
+				frappe.db.set_value(
+					"Agent Request Failure",
+					failure.name,
+					"failure_count",
+					failure.failure_count + delta,
+				)

--- a/press/press/doctype/agent_request_failure/test_agent_request_failure.py
+++ b/press/press/doctype/agent_request_failure/test_agent_request_failure.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Frappe and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestAgentRequestFailure(FrappeTestCase):
+	pass

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -346,6 +346,8 @@ class Bench(Document):
 			last_synced_time = None
 
 		agent = Agent(self.server)
+		if agent.should_skip_requests():
+			return
 		data = agent.get_sites_info(self, since=last_synced_time)
 		if data:
 			for site, info in data.items():
@@ -367,6 +369,8 @@ class Bench(Document):
 	@frappe.whitelist()
 	def sync_analytics(self):
 		agent = Agent(self.server)
+		if agent.should_skip_requests():
+			return
 		data = agent.get_sites_analytics(self)
 		if not data:
 			return

--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -817,6 +817,8 @@ class DatabaseServer(BaseServer):
 		)
 
 	def get_stalks(self):
+		if self.agent.should_skip_requests():
+			return []
 		result = self.agent.get("database/stalks", raises=False)
 		if (not result) or ("error" in result):
 			return []

--- a/press/tests/test_agent.py
+++ b/press/tests/test_agent.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2024, Frappe and contributors
+# For license information, please see license.txt
+
+import requests
+import responses
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from press.agent import Agent
+from press.press.doctype.server.test_server import create_test_server
+
+
+class TestAgent(FrappeTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+		frappe.db.truncate("Agent Request Failure")
+
+	@responses.activate
+	def test_ping_request(self):
+		server = create_test_server()
+
+		responses.add(
+			responses.GET,
+			f"https://{server.name}:443/agent/ping",
+			status=200,
+			json={"message": "pong"},
+		)
+
+		agent = Agent(server.name, server.doctype)
+		agent.request("GET", "ping")
+
+	@responses.activate
+	def test_request_failure_creates_failure_record(self):
+		server = create_test_server()
+
+		responses.add(
+			responses.GET,
+			f"https://{server.name}:443/agent/ping",
+			body=requests.ConnectTimeout(),
+		)
+
+		failures_before = frappe.db.count("Agent Request Failure")
+
+		agent = Agent(server.name, server.doctype)
+		self.assertRaises(requests.ConnectTimeout, agent.request, "GET", "ping")
+
+		failures_after = frappe.db.count("Agent Request Failure")
+		self.assertEqual(failures_after, failures_before + 1)
+
+		failure = frappe.get_last_doc("Agent Request Failure")
+		self.assertEqual(failure.server, server.name)
+		self.assertEqual(failure.server_type, server.doctype)
+		self.assertEqual(failure.failure_count, 1)


### PR DESCRIPTION
In case of broken communication with the Agent, prevent cascading failures and error-log spam by 
1. Throttling Agent jobs. Let them sit in the queue (status = Undelivered). 
2. Preventing other requests
 	- Politely by checking `should_skip_requests` before attempting requests
	- Forcefully by throwing AgentRequestSkippedException

These are likely sources of errors
- Broken network
- Broken TLS
- Agent down (502 Bad Gateway on /agent)
- Overloaded/Frozen server (Slow responses on /agent/ping)

Note: Even a single failure will trigger this throttling.

Track the failures in `Agent Request Failure` with the first traceback/error, and failure_count. Removing this entry will let agent requests through (and attempt job delivery).

A scheduled job (every minute) will remove these entries if we get `HTTP 200` on `/agent/ping`.

TODO: Show a message in site, bench, and server dashboards to let users know about potential delays in Job deliveries. @BreadGenie 