### PR TITLE
fix(ProxyServer): Correct actions required for proper failover

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 pre-commit
-moto[all]==4.2.14
+moto[all]~=5.0
 Faker==23.2.0

--- a/press/agent.py
+++ b/press/agent.py
@@ -68,12 +68,6 @@ class Agent:
 			"Archive Bench", f"benches/{bench.name}/archive", bench=bench.name
 		)
 
-	def restart_nginx(self):
-		return self.create_agent_job(
-			"Reload NGINX",
-			"server/reload",
-		)
-
 	def restart_bench(self, bench, web_only=False):
 		return self.create_agent_job(
 			"Bench Restart",

--- a/press/playbooks/failover_prepare_primary_proxy.yml
+++ b/press/playbooks/failover_prepare_primary_proxy.yml
@@ -1,0 +1,16 @@
+---
+- name: Prepare primary proxy for failover
+  hosts: all
+  become: yes
+  become_user: root
+  gather_facts: no
+
+  tasks:
+    - name: Stop Agent to reject jobs
+      command: 'supervisorctl stop agent:'
+
+    - name: Stop lsyncd and disable
+      systemd:
+        name: lsyncd
+        enabled: no
+        state: stopped

--- a/press/playbooks/failover_remove_primary_access.yml
+++ b/press/playbooks/failover_remove_primary_access.yml
@@ -1,0 +1,13 @@
+---
+- name: Remove Primary Proxy Server's access
+  hosts: all
+  become: yes
+  gather_facts: no
+
+  tasks:
+    - name: Remove Primary from Authorized Keys
+      become_user: frappe
+      authorized_key:
+        user: frappe
+        key: "{{ primary_public_key }}"
+        state: absent

--- a/press/playbooks/failover_up_secondary_proxy.yml
+++ b/press/playbooks/failover_up_secondary_proxy.yml
@@ -1,0 +1,25 @@
+---
+- name: Up secondary proxy to serve requests
+  hosts: all
+  become: yes
+  become_user: root
+  gather_facts: no
+
+  tasks:
+    - name: Ensure nginx is enabled and running
+      service:
+        name: nginx
+        enabled: yes
+        state: started
+
+    - name: Reload nginx
+      service:
+        name: nginx
+        state: reloaded
+
+    - name: Remove cron to reload nginx every 5 mins
+      become: yes
+      become_user: frappe
+      cron:
+        name: reload_nginx
+        state: absent

--- a/press/playbooks/fetch_frappe_public_key.yml
+++ b/press/playbooks/fetch_frappe_public_key.yml
@@ -1,0 +1,14 @@
+---
+- name: Fetch Frappe Public Key
+  hosts: all
+  become: yes
+  become_user: root
+  gather_facts: no
+
+  tasks:
+    - name: Fetch Frappe Public Key
+      user:
+        name: frappe
+        generate_ssh_key: yes # Won't overwrite existing key
+
+# Key will be put in server doc by AnsibleCallback

--- a/press/playbooks/roles/agent/tasks/main.yml
+++ b/press/playbooks/roles/agent/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: Generate Agent Configuration File
   become: yes
   become_user: frappe
-  command: '/home/frappe/agent/env/bin/agent setup config --name {{ server }} --workers {{ workers }} {% if proxy_ip is defined %}--proxy-ip {{ proxy_ip }}{% endif %} {% if agent_sentry_dsn is truthy %}--sentry-dsn {{ agent_sentry_dsn }}{% endif %}'
+  command: '/home/frappe/agent/env/bin/agent setup config --name {{ server }} --workers {{ workers }} {% if proxy_ip is defined %}--proxy-ip {{ proxy_ip }}{% endif %} {% if agent_sentry_dsn is defined and agent_sentry_dsn is truthy %}--sentry-dsn {{ agent_sentry_dsn }}{% endif %}'
   args:
     chdir: /home/frappe/agent
 

--- a/press/playbooks/roles/secondary_proxy/tasks/main.yml
+++ b/press/playbooks/roles/secondary_proxy/tasks/main.yml
@@ -1,8 +1,12 @@
 ---
 - name: Add Primary Proxy Server Public Key to Authorized Keys
-  become: yes
-  become_user: frappe
   authorized_key:
     user: frappe
-    key: "{{ primary_public_key }}"
+    key: '{{ primary_public_key }}'
     state: present
+
+- name: Add cron to reload nginx every 5 mins
+  cron:
+    name: reload_nginx
+    minute: '*/5'
+    job: 'sudo systemctl reload nginx'

--- a/press/playbooks/roles/secondary_proxy/tasks/main.yml
+++ b/press/playbooks/roles/secondary_proxy/tasks/main.yml
@@ -10,3 +10,8 @@
     name: reload_nginx
     minute: '*/5'
     job: 'sudo systemctl reload nginx'
+
+- name: Ensure agent is up and running # Might be stopped during previous failover
+  supervisorctl:
+    name: 'agent:'
+    state: started

--- a/press/playbooks/secondary_proxy.yml
+++ b/press/playbooks/secondary_proxy.yml
@@ -2,7 +2,7 @@
 - name: Setup Secondary Proxy Server
   hosts: all
   become: yes
-  become_user: root
+  become_user: frappe
 
   roles:
     - role: secondary_proxy

--- a/press/press/doctype/cluster/test_cluster.py
+++ b/press/press/doctype/cluster/test_cluster.py
@@ -14,7 +14,7 @@ from press.press.doctype.ssh_key.test_ssh_key import create_test_ssh_key
 from press.press.doctype.cluster.cluster import Cluster
 
 from unittest.mock import MagicMock, patch
-from moto import mock_ec2, mock_ssm, mock_iam
+from moto import mock_aws
 
 from press.press.doctype.virtual_machine.virtual_machine import VirtualMachine
 from press.press.doctype.virtual_machine_image.virtual_machine_image import (
@@ -58,8 +58,7 @@ def create_test_cluster(
 
 
 class TestCluster(unittest.TestCase):
-	@mock_ec2
-	@mock_ssm
+	@mock_aws
 	def _setup_fake_vmis(self, series: list[str], cluster: Cluster = None):
 		from press.press.doctype.virtual_machine_image.test_virtual_machine_image import (
 			create_test_virtual_machine_image,
@@ -111,8 +110,7 @@ class TestCluster(unittest.TestCase):
 )
 @patch("press.press.doctype.cluster.cluster.frappe.db.commit", new=MagicMock())
 class TestPrivateCluster(TestCluster):
-	@mock_ec2
-	@mock_ssm
+	@mock_aws
 	def test_add_images_copies_VMIs_from_other_region(self):
 
 		self._setup_fake_vmis(["m", "f"])  # mumbai
@@ -133,8 +131,7 @@ class TestPrivateCluster(TestCluster):
 		self._setup_fake_vmis(["m", "f"], cluster=cluster)  # n is missing
 		self.assertRaises(Exception, cluster.add_images)
 
-	@mock_ec2
-	@mock_ssm
+	@mock_aws
 	def test_creation_of_cluster_in_same_region_reuses_VMIs(self):
 		self._setup_fake_vmis(["m", "f"])  # mumbai
 		vmi_count_before = frappe.db.count("Virtual Machine Image")
@@ -143,9 +140,7 @@ class TestPrivateCluster(TestCluster):
 		self.assertNotEqual(vmi_count_before, 0)
 		self.assertEqual(vmi_count_after, vmi_count_before)
 
-	@mock_ec2
-	@mock_ssm
-	@mock_iam
+	@mock_aws
 	def test_create_private_cluster_without_aws_access_key_and_secret_creates_user_in_predefined_group_and_adds_servers(
 		self,
 	):
@@ -193,8 +188,7 @@ class TestPrivateCluster(TestCluster):
 )
 @patch.object(VirtualMachineImage, "after_insert", new=MagicMock())
 class TestPublicCluster(TestCluster):
-	@mock_ec2
-	@mock_ssm
+	@mock_aws
 	@patch.object(ProxyServer, "validate", new=MagicMock())
 	def test_create_servers_without_vmis_throws_err(self):
 		root_domain = create_test_root_domain("local.fc.frappe.dev")
@@ -212,8 +206,7 @@ class TestPublicCluster(TestCluster):
 		self.assertEqual(database_server_count_after, database_server_count_before)
 		self.assertEqual(proxy_server_count_after, proxy_server_count_before)
 
-	@mock_ec2
-	@mock_ssm
+	@mock_aws
 	def test_add_images_in_public_cluster_only_adds_3_vms(self):
 		self._setup_fake_vmis(["m", "f", "n", "p", "e"])
 		vm_count_before = frappe.db.count("Virtual Machine Image")
@@ -223,7 +216,7 @@ class TestPublicCluster(TestCluster):
 		self.assertNotEqual(vm_count_before, 0)
 		self.assertEqual(vm_count_after, vm_count_before + 3)
 
-	@mock_ec2
+	@mock_aws
 	@patch.object(ProxyServer, "validate", new=MagicMock())
 	def test_creation_of_public_cluster_with_servers_creates_3(self):
 
@@ -246,7 +239,7 @@ class TestPublicCluster(TestCluster):
 		self.assertEqual(database_server_count_after, database_server_count_before + 1)
 		self.assertEqual(proxy_server_count_after, proxy_server_count_before + 1)
 
-	@mock_iam
+	@mock_aws
 	@patch.object(Cluster, "after_insert", new=MagicMock())  # don't create vms/servers
 	def test_creation_of_public_cluster_uses_keys_from_press_settings(self):
 		from press.press.doctype.press_settings.test_press_settings import (

--- a/press/press/doctype/database_server/test_database_server.py
+++ b/press/press/doctype/database_server/test_database_server.py
@@ -44,7 +44,6 @@ class TestDatabaseServer(FrappeTestCase):
 
 	@patch(
 		"press.press.doctype.database_server.database_server.Ansible",
-		wraps=Ansible,
 	)
 	@patch(
 		"press.press.doctype.database_server.database_server.frappe.enqueue_doc",
@@ -68,7 +67,6 @@ class TestDatabaseServer(FrappeTestCase):
 
 	@patch(
 		"press.press.doctype.database_server.database_server.Ansible",
-		wraps=Ansible,
 	)
 	@patch(
 		"press.press.doctype.database_server.database_server.frappe.enqueue_doc",
@@ -100,7 +98,6 @@ class TestDatabaseServer(FrappeTestCase):
 
 	@patch(
 		"press.press.doctype.database_server.database_server.Ansible",
-		wraps=Ansible,
 	)
 	@patch(
 		"press.press.doctype.database_server.database_server.frappe.enqueue_doc",
@@ -123,7 +120,6 @@ class TestDatabaseServer(FrappeTestCase):
 
 	@patch(
 		"press.press.doctype.database_server.database_server.Ansible",
-		wraps=Ansible,
 	)
 	@patch(
 		"press.press.doctype.database_server.database_server.frappe.enqueue_doc",

--- a/press/press/doctype/proxy_server/proxy_server.js
+++ b/press/press/doctype/proxy_server/proxy_server.js
@@ -8,6 +8,12 @@ frappe.ui.form.on('Proxy Server', {
 			[__('Ping Ansible'), 'ping_ansible', true],
 			[__('Ping Ansible Unprepared'), 'ping_ansible_unprepared', true],
 			[__('Update Agent'), 'update_agent', true, frm.doc.is_server_setup],
+			[
+				__('Update Agent Ansible'),
+				'update_agent_ansible',
+				true,
+				frm.doc.is_server_setup,
+			],
 			[__('Prepare Server'), 'prepare_server', true, !frm.doc.is_server_setup],
 			[__('Setup Server'), 'setup_server', true, !frm.doc.is_server_setup],
 			[

--- a/press/press/doctype/proxy_server/proxy_server.py
+++ b/press/press/doctype/proxy_server/proxy_server.py
@@ -4,6 +4,7 @@
 
 
 import frappe
+from press.press.doctype.root_domain.root_domain import RootDomain
 from press.press.doctype.server.server import BaseServer
 from press.runner import Ansible
 from press.agent import Agent
@@ -413,8 +414,8 @@ class ProxyServer(BaseServer):
 			order_by="domain",
 		)
 		for domain_name, sites in groupby(sites_domains, lambda x: x["domain"]):
-			domain = frappe.get_doc("Root Domain", domain_name)
-			domain.update_dns_records_for_sites(sites, self.name)
+			domain: RootDomain = frappe.get_doc("Root Domain", domain_name)
+			domain.update_dns_records_for_sites([site.name for site in sites], self.name)
 
 	def _trigger_failover(self):
 		try:

--- a/press/press/doctype/proxy_server/proxy_server.py
+++ b/press/press/doctype/proxy_server/proxy_server.py
@@ -446,6 +446,7 @@ class ProxyServer(BaseServer):
 		self.is_primary = True
 		self.is_replication_setup = False
 		self.primary = None
+		self.status = "Active"
 
 	@frappe.whitelist()
 	def setup_proxysql_monitor(self):

--- a/press/press/doctype/proxy_server/proxy_server.py
+++ b/press/press/doctype/proxy_server/proxy_server.py
@@ -403,6 +403,10 @@ class ProxyServer(BaseServer):
 		)
 		ansible.run()
 
+	def up_secondary(self):
+		ansible = Ansible(playbook="failover_up_secondary_proxy.yml", server=self)
+		ansible.run()
+
 	def update_dns_records_for_all_sites(self):
 		from itertools import groupby
 
@@ -423,7 +427,7 @@ class ProxyServer(BaseServer):
 			self.stop_primary()
 			self.remove_primarys_access()
 			self.forward_jobs_to_secondary()
-			self.reload_nginx()
+			self.up_secondary()
 			self.update_app_servers()
 			self.move_wildcard_domains_from_primary()
 			self.switch_primary()
@@ -431,10 +435,6 @@ class ProxyServer(BaseServer):
 			self.status = "Broken"
 			log_error("Proxy Server Failover Exception", doc=self)
 		self.save()
-
-	def reload_nginx(self):
-		agent = Agent(self.name, server_type="Proxy Server")
-		agent.reload_nginx()
 
 	def update_app_servers(self):
 		frappe.db.set_value(

--- a/press/press/doctype/proxy_server/test_proxy_server.py
+++ b/press/press/doctype/proxy_server/test_proxy_server.py
@@ -15,6 +15,7 @@ from press.press.doctype.press_settings.test_press_settings import (
 	create_test_press_settings,
 )
 from press.press.doctype.proxy_server.proxy_server import ProxyServer
+from press.press.doctype.root_domain.root_domain import RootDomain
 from press.press.doctype.server.server import BaseServer
 from press.utils.test import foreground_enqueue_doc
 
@@ -59,6 +60,13 @@ class TestProxyServer(FrappeTestCase):
 
 		proxy1 = create_test_proxy_server()
 		proxy2 = create_test_proxy_server()
+
+		root_domain: RootDomain = frappe.get_doc("Root Domain", proxy1.domain)
+		root_domain.boto3_client.create_hosted_zone(
+			Name=proxy1.domain,
+			CallerReference="1",
+			HostedZoneConfig={"Comment": "Test", "PrivateZone": False},
+		)
 
 		server = create_test_server(proxy1.name)
 		create_test_site(server=server.name)

--- a/press/press/doctype/proxy_server/test_proxy_server.py
+++ b/press/press/doctype/proxy_server/test_proxy_server.py
@@ -89,3 +89,5 @@ class TestProxyServer(FrappeTestCase):
 		proxy1.reload()
 		self.assertTrue(proxy2.is_primary)
 		self.assertFalse(proxy1.is_primary)
+		self.assertEqual(proxy2.status, "Active")
+		self.assertEqual(proxy1.status, "Active")

--- a/press/press/doctype/proxy_server/test_proxy_server.py
+++ b/press/press/doctype/proxy_server/test_proxy_server.py
@@ -2,18 +2,21 @@
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
 
-import unittest
+from frappe.tests.utils import FrappeTestCase
 from typing import Dict, List
 from unittest.mock import Mock, patch
 
 import frappe
 from frappe.model.naming import make_autoname
+from moto import mock_s3
 
+from press.press.doctype.agent_job.test_agent_job import fake_agent_job
 from press.press.doctype.press_settings.test_press_settings import (
 	create_test_press_settings,
 )
 from press.press.doctype.proxy_server.proxy_server import ProxyServer
 from press.press.doctype.server.server import BaseServer
+from press.utils.test import foreground_enqueue_doc
 
 
 @patch.object(BaseServer, "after_insert", new=Mock())
@@ -23,7 +26,7 @@ def create_test_proxy_server(
 	domain: str = "fc.dev",
 	domains: List[Dict[str, str]] = [{"domain": "fc.dev"}],
 	cluster: str = "Default",
-):
+) -> ProxyServer:
 	"""Create test Proxy Server doc"""
 	create_test_press_settings()
 	server = frappe.get_doc(
@@ -42,5 +45,20 @@ def create_test_proxy_server(
 	return server
 
 
-class TestProxyServer(unittest.TestCase):
-	pass
+@patch(
+	"press.press.doctype.proxy_server.proxy_server.frappe.enqueue_doc",
+	foreground_enqueue_doc,
+)
+@mock_s3
+@patch("press.press.doctype.proxy_server.proxy_server.Ansible", new=Mock())
+class TestProxyServer(FrappeTestCase):
+	@fake_agent_job("Reload NGINX Job")
+	def test_sites_dns_updated_on_failover(self):
+		proxy1 = create_test_proxy_server()
+		proxy2 = create_test_proxy_server()
+		proxy1.db_set("is_primary", 1)
+		proxy2.db_set("primary", proxy1.name)
+		proxy2.db_set("is_replication_setup", 1)
+		proxy2.trigger_failover()
+		self.assertTrue(proxy2.is_primary)
+		self.assertFalse(proxy1.is_primary)

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -858,6 +858,10 @@ node_filesystem_avail_bytes{{instance="{self.name}", mountpoint="/"}}[3h], 6*360
 		except Exception:
 			log_error("Prune Docker System Exception", doc=self)
 
+	def reload_nginx(self):
+		agent = Agent(self.name, server_type=self.doctype)
+		agent.reload_nginx()
+
 
 class Server(BaseServer):
 	# begin: auto-generated types

--- a/press/press/doctype/server/test_server.py
+++ b/press/press/doctype/server/test_server.py
@@ -26,8 +26,8 @@ if typing.TYPE_CHECKING:
 
 @patch.object(BaseServer, "after_insert", new=Mock())
 def create_test_server(
-	proxy_server=None,
-	database_server=None,
+	proxy_server: str = None,
+	database_server: str = None,
 	cluster: str = "Default",
 	team: str = None,
 ) -> "Server":

--- a/press/press/doctype/site/test_site.py
+++ b/press/press/doctype/site/test_site.py
@@ -82,6 +82,7 @@ def create_test_bench(
 	return bench
 
 
+@patch.object(AgentJob, "enqueue_http_request", new=Mock())
 def create_test_site(
 	subdomain: str = "",
 	new: bool = False,

--- a/press/press/doctype/site/test_site.py
+++ b/press/press/doctype/site/test_site.py
@@ -17,11 +17,9 @@ from press.press.doctype.app.test_app import create_test_app
 from press.press.doctype.database_server.test_database_server import (
 	create_test_database_server,
 )
-from press.press.doctype.proxy_server.test_proxy_server import create_test_proxy_server
 from press.press.doctype.release_group.test_release_group import (
 	create_test_release_group,
 )
-from press.press.doctype.server.test_server import create_test_server
 from press.press.doctype.site.site import Site, process_rename_site_job_update
 
 from press.press.doctype.remote_file.remote_file import RemoteFile
@@ -49,6 +47,9 @@ def create_test_bench(
 
 	API call to agent will be faked when creating the doc.
 	"""
+	from press.press.doctype.proxy_server.test_proxy_server import create_test_proxy_server
+	from press.press.doctype.server.test_server import create_test_server
+
 	creation = creation or frappe.utils.now_datetime()
 	user = user or frappe.session.user
 	if not server:


### PR DESCRIPTION
- **fix(Agent): Setup should check for defined sentry_dsn also**
- **fix(ProxyServer): Ensure primary's frappe public key exists before replication**
- **fix(ProxyServer): Update failover method for additional things to be done**
- **perf(TestDatabaseServer): Remove unnecessary wraps**
- **fix(ProxyServer): Correct dns update query**
- **test(ProxyServer): Add test for proxy failover**
