### PR TITLE
fix: only allow partners and users with allow_partner role

### DIFF
--- a/dashboard/src2/components/NavigationItems.vue
+++ b/dashboard/src2/components/NavigationItems.vue
@@ -107,7 +107,8 @@ export default {
 					route: '/partners',
 					isActive: routeName.startsWith('Partner'),
 					condition:
-						this.$team.doc.erpnext_partner && this.$session.hasPartnerAccess,
+						Boolean(this.$team.doc.erpnext_partner) ||
+						this.$session.hasPartnerAccess,
 					disabled
 				},
 				{

--- a/dashboard/src2/data/session.js
+++ b/dashboard/src2/data/session.js
@@ -39,7 +39,7 @@ export let session = reactive({
 	hasPartnerAccess: computed(() =>
 		session.roles.data.length
 			? session.roles.data.some(role => role.allow_partner)
-			: true
+			: false
 	),
 	hasSiteCreationAccess: computed(() =>
 		session.roles.data.length


### PR DESCRIPTION
Due to this [feature](https://github.com/frappe/press/pull/1874) partner tab was visible for all users.