### PR TITLE
feat: dashboard banner

### DIFF
--- a/dashboard/src2/pages/ListPage.vue
+++ b/dashboard/src2/pages/ListPage.vue
@@ -20,6 +20,12 @@
 				class="mb-5"
 				v-if="!$team.doc.billing_details?.name"
 			/>
+			<AlertBanner
+				v-if="banner?.enabled"
+				class="mb-5"
+				:title="`<b>${banner.title}</b>: ${banner.message}`"
+				:type="banner.type.toLowerCase()"
+			/>
 			<ObjectList :options="listOptions" />
 		</div>
 	</div>
@@ -32,6 +38,7 @@ import { Breadcrumbs, Button, Dropdown, TextInput } from 'frappe-ui';
 import { getObject } from '../objects';
 import { defineAsyncComponent } from 'vue';
 import dayjs from '../utils/dayjs';
+import AlertBanner from '../components/AlertBanner.vue';
 
 export default {
 	components: {
@@ -41,6 +48,7 @@ export default {
 		Button,
 		Dropdown,
 		TextInput,
+		AlertBanner,
 		AlertAddPaymentMode: defineAsyncComponent(() =>
 			import('../components/AlertAddPaymentMode.vue')
 		),
@@ -89,6 +97,18 @@ export default {
 			} else {
 				return false;
 			}
+		},
+		banner() {
+			return this.$resources.banner.doc;
+		}
+	},
+	resources: {
+		banner() {
+			return {
+				type: 'document',
+				doctype: 'Dashboard Banner',
+				name: 'Dashboard Banner'
+			};
 		}
 	}
 };

--- a/press/api/client.py
+++ b/press/api/client.py
@@ -66,6 +66,7 @@ ALLOWED_DOCTYPES = [
 	"Press Notification",
 	"User SSH Key",
 	"Frappe Version",
+	"Dashboard Banner",
 ]
 
 ALLOWED_DOCTYPES_FOR_SUPPORT = [

--- a/press/press/doctype/dashboard_banner/dashboard_banner.js
+++ b/press/press/doctype/dashboard_banner/dashboard_banner.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, Frappe and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Dashboard Banner", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/press/press/doctype/dashboard_banner/dashboard_banner.json
+++ b/press/press/doctype/dashboard_banner/dashboard_banner.json
@@ -1,0 +1,60 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-06-24 09:20:47.114289",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "enabled",
+  "title",
+  "message",
+  "type"
+ ],
+ "fields": [
+  {
+   "default": "0",
+   "fieldname": "enabled",
+   "fieldtype": "Check",
+   "label": "Enabled"
+  },
+  {
+   "fieldname": "message",
+   "fieldtype": "Data",
+   "label": "Message"
+  },
+  {
+   "fieldname": "type",
+   "fieldtype": "Select",
+   "label": "Type",
+   "options": "Info\nSuccess\nError\nWarning"
+  },
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "label": "Title"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2024-06-24 09:36:26.970846",
+ "modified_by": "Administrator",
+ "module": "Press",
+ "name": "Dashboard Banner",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/press/press/doctype/dashboard_banner/dashboard_banner.py
+++ b/press/press/doctype/dashboard_banner/dashboard_banner.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024, Frappe and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class DashboardBanner(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		enabled: DF.Check
+		message: DF.Data | None
+		title: DF.Data | None
+		type: DF.Literal["Info", "Success", "Error", "Warning"]
+	# end: auto-generated types
+
+	dashboard_fields = ["enabled", "message", "title", "type"]

--- a/press/press/doctype/dashboard_banner/test_dashboard_banner.py
+++ b/press/press/doctype/dashboard_banner/test_dashboard_banner.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Frappe and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestDashboardBanner(FrappeTestCase):
+	pass


### PR DESCRIPTION
![image](https://github.com/frappe/press/assets/63963181/c1b4936b-c2db-44e2-b19b-1a5f8613a786)

will be shown in sites, benches and server pages