### PR TITLE
fix : compatibility for mac os check_python_syntax() during bench deploy

### DIFF
--- a/press/agent.py
+++ b/press/agent.py
@@ -1119,6 +1119,7 @@ class Agent:
 		]
 		return apps
 
+
 class AgentCallbackException(Exception):
 	pass
 

--- a/press/agent.py
+++ b/press/agent.py
@@ -1110,16 +1110,14 @@ class Agent:
 			data={},
 		)
 
-	def sync_apps_list_from_site(self, site):
-		raw_apps_list = self.post(
-			f"benches/{site.bench}/sites/{site.name}/sync_apps_list_from_site",
+	def get_site_apps(self, site):
+		raw_apps_list = self.get(
+			f"benches/{site.bench}/sites/{site.name}/apps",
 		)
 		apps: list[str] = [
 			line.split()[0] for line in raw_apps_list["data"].splitlines() if line
 		]
-		print(apps)
 		return apps
-
 
 class AgentCallbackException(Exception):
 	pass

--- a/press/agent.py
+++ b/press/agent.py
@@ -1110,6 +1110,16 @@ class Agent:
 			data={},
 		)
 
+	def sync_apps_list_from_site(self, site):
+		raw_apps_list = self.post(
+			f"benches/{site.bench}/sites/{site.name}/sync_apps_list_from_site",
+		)
+		apps: list[str] = [
+			line.split()[0] for line in raw_apps_list["data"].splitlines() if line
+		]
+		print(apps)
+		return apps
+
 
 class AgentCallbackException(Exception):
 	pass

--- a/press/press/doctype/app_release/app_release.py
+++ b/press/press/doctype/app_release/app_release.py
@@ -459,7 +459,7 @@ def check_python_syntax(dirpath: str) -> str:
 	- -o: optimize level, 0 is no optimization
 	"""
 
-	command = f"python -m compileall -q -o 0 {dirpath}"
+	command = f"python3 -m compileall -q -o 0 {dirpath}"
 	proc = subprocess.run(
 		shlex.split(command),
 		text=True,

--- a/press/press/doctype/site/site.js
+++ b/press/press/doctype/site/site.js
@@ -97,6 +97,7 @@ frappe.ui.form.on('Site', {
 		[
 			[__('Archive'), 'archive', frm.doc.status !== 'Archived'],
 			[__('Cleanup after Archive'), 'cleanup_after_archive'],
+			[__('Sync Apps List'), 'sync_apps_list_from_site'],
 			[__('Migrate'), 'migrate'],
 			[__('Reinstall'), 'reinstall'],
 			[__('Restore'), 'restore_site'],

--- a/press/press/doctype/site/site.js
+++ b/press/press/doctype/site/site.js
@@ -97,7 +97,7 @@ frappe.ui.form.on('Site', {
 		[
 			[__('Archive'), 'archive', frm.doc.status !== 'Archived'],
 			[__('Cleanup after Archive'), 'cleanup_after_archive'],
-			[__('Sync Apps List'), 'sync_apps_list_from_site'],
+			[__('Sync Apps'), 'sync_apps'],
 			[__('Migrate'), 'migrate'],
 			[__('Reinstall'), 'reinstall'],
 			[__('Restore'), 'restore_site'],

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -475,7 +475,7 @@ class Site(Document, TagHelpers):
 		for app in apps_list:
 			self.append("apps", {"app": app})
 		self.save()
-		
+
 	@frappe.whitelist()
 	def retry_rename(self):
 		"""Retry rename with current subdomain"""

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -468,14 +468,14 @@ class Site(Document, TagHelpers):
 		agent.rename_upstream_site(self.server, self, new_name, site_domains)
 
 	@frappe.whitelist()
-	def sync_apps_list_from_site(self):
+	def sync_apps(self):
 		agent = Agent(self.server)
-		apps_list = agent.sync_apps_list_from_site(site=self)
+		apps_list = agent.get_site_apps(site=self)
 		self.apps = []
 		for app in apps_list:
-			self.append("apps", {"app_name": app})
+			self.append("apps", {"app": app})
 		self.save()
-
+		
 	@frappe.whitelist()
 	def retry_rename(self):
 		"""Retry rename with current subdomain"""

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -468,6 +468,15 @@ class Site(Document, TagHelpers):
 		agent.rename_upstream_site(self.server, self, new_name, site_domains)
 
 	@frappe.whitelist()
+	def sync_apps_list_from_site(self):
+		agent = Agent(self.server)
+		apps_list = agent.sync_apps_list_from_site(site=self)
+		self.apps = []
+		for app in apps_list:
+			self.append("apps", {"app_name": app})
+		self.save()
+
+	@frappe.whitelist()
 	def retry_rename(self):
 		"""Retry rename with current subdomain"""
 		if not self.name == self._get_site_name(self.subdomain):

--- a/press/press/doctype/site/test_site.py
+++ b/press/press/doctype/site/test_site.py
@@ -144,7 +144,6 @@ def create_test_site(
 class TestSite(unittest.TestCase):
 	"""Tests for Site Document methods."""
 
-
 	def setUp(self):
 		frappe.db.truncate("Agent Request Failure")
 
@@ -450,8 +449,11 @@ class TestSite(unittest.TestCase):
 		group = create_test_release_group([app1, app2])
 		bench = create_test_bench(group=group)
 		site = create_test_site(bench=bench)
-		responses.get(f"https://{site.server}:443/agent/benches/{site.bench}/sites/{site.name}/apps",json.dumps({'data': 'frappe\nerpnext'}))
+		responses.get(
+			f"https://{site.server}:443/agent/benches/{site.bench}/sites/{site.name}/apps",
+			json.dumps({"data": "frappe\nerpnext"}),
+		)
 		site.sync_apps()
-		self.assertEqual(site.apps[0].app,"frappe")
-		self.assertEqual(site.apps[1].app,"erpnext")
-		self.assertEqual(len(site.apps),2)
+		self.assertEqual(site.apps[0].app, "frappe")
+		self.assertEqual(site.apps[1].app, "erpnext")
+		self.assertEqual(len(site.apps), 2)


### PR DESCRIPTION
On local press setup on MacOS, the bench deploy step breaks.
<img width="610" alt="image" src="https://github.com/frappe/press/assets/61804369/cb8ef84a-3114-46f3-95f5-937b2be049b0">

Doing an alias wont be useful here as the subprocess context is different