### PR TITLE
fix : Faulty deploy status post image build while remote image push

### DIFF
--- a/press/press/doctype/app_release/app_release.py
+++ b/press/press/doctype/app_release/app_release.py
@@ -459,7 +459,7 @@ def check_python_syntax(dirpath: str) -> str:
 	- -o: optimize level, 0 is no optimization
 	"""
 
-	command = f"python -m compileall -q -o 0 {dirpath}"
+	command = f"python3 -m compileall -q -o 0 {dirpath}"
 	proc = subprocess.run(
 		shlex.split(command),
 		text=True,

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -641,7 +641,7 @@ class DeployCandidate(Document):
 		match job.status:
 			case "Pending" | "Running":
 				return self._set_status_running()
-			case "Failure" | "Undelivered" | "Delivery Failure":
+			case "Failure" | "Undelivered" | "Delivery Failure" | "Error":
 				return self._set_status_failure()
 			case "Success":
 				return self._set_status_success()


### PR DESCRIPTION
fixes #1923 

Even though the sanity parse code is written to rightfully check for the error in the response of docker sdk.
While setting self._set_status_failure() for failure cases, the returned value "Error" is missed.

https://github.com/frappe/press/blob/master/press/press/doctype/deploy_candidate/docker_output_parsers.py#L288-L309