### PR TITLE
fix: rename `Plan` to `Site Plan` in all places

### DIFF
--- a/press/api/saas.py
+++ b/press/api/saas.py
@@ -454,7 +454,7 @@ def subscription(site):
 		frappe.throw("Invalid Site")
 
 	plans = frappe.db.get_all(
-		"Plan",
+		"Site Plan",
 		fields=[
 			"name",
 			"plan_title",

--- a/press/config/press.py
+++ b/press/config/press.py
@@ -24,7 +24,7 @@ def get_data():
 		{
 			"label": _("Setup"),
 			"items": [
-				{"type": "doctype", "name": "Plan"},
+				{"type": "doctype", "name": "Site Plan"},
 				{"type": "doctype", "name": "App"},
 				{"type": "doctype", "name": "Release Group"},
 				{"type": "doctype", "name": "App Release"},

--- a/press/saas/doctype/saas_app/saas_app.py
+++ b/press/saas/doctype/saas_app/saas_app.py
@@ -64,7 +64,7 @@ def get_plans_for_app(app, site):
 
 def get_plan_prices(plan_name):
 	plan_prices = frappe.db.get_value(
-		"Plan", plan_name, ["plan_title", "price_usd", "price_inr"], as_dict=True
+		"Site Plan", plan_name, ["plan_title", "price_usd", "price_inr"], as_dict=True
 	)
 
 	return plan_prices

--- a/press/saas/doctype/saas_app_plan/saas_app_plan.py
+++ b/press/saas/doctype/saas_app_plan/saas_app_plan.py
@@ -16,7 +16,7 @@ class SaasAppPlan(Document):
 		self.validate_payout_percentage()
 
 	def validate_plan(self):
-		dt = frappe.db.get_value("Plan", self.plan, "document_type")
+		dt = frappe.db.get_value("Site Plan", self.plan, "document_type")
 
 		if dt != "Saas App":
 			frappe.throw("The plan must be a Saas App plan.")

--- a/press/saas/doctype/saas_app_plan/saas_app_plan.py
+++ b/press/saas/doctype/saas_app_plan/saas_app_plan.py
@@ -27,7 +27,7 @@ class SaasAppPlan(Document):
 		:option "Monthly" or "Annual"
 		"""
 		team = get_current_team(True)
-		amount = frappe.db.get_value("Plan", self.plan, f"price_{team.currency.lower()}")
+		amount = frappe.db.get_value("Site Plan", self.plan, f"price_{team.currency.lower()}")
 		amount = amount * 12 if payment_option == "Annual" else amount
 
 		if team.country == "India" and self.gst_inclusive:
@@ -44,8 +44,8 @@ class SaasAppPlan(Document):
 		if self.is_free:
 			return
 
-		site_plan = frappe.db.get_value("Plan", self.site_plan, "price_usd")
-		saas_plan = frappe.db.get_value("Plan", self.plan, "price_usd")
+		site_plan = frappe.db.get_value("Site Plan", self.site_plan, "price_usd")
+		saas_plan = frappe.db.get_value("Site Plan", self.plan, "price_usd")
 		self.payout_percentage = 100 - float("{:.2f}".format((site_plan / saas_plan) * 100))
 
 

--- a/press/saas/doctype/saas_app_subscription/saas_app_subscription.py
+++ b/press/saas/doctype/saas_app_subscription/saas_app_subscription.py
@@ -146,7 +146,7 @@ class SaasAppSubscription(Document):
 		if not team.get_upcoming_invoice():
 			team.create_upcoming_invoice()
 
-		plan = frappe.get_cached_doc("Plan", self.plan)
+		plan = frappe.get_cached_doc("Site Plan", self.plan)
 		amount = plan.get_price_for_interval(self.interval, team.currency)
 		payout = self.calculate_payout(amount)
 
@@ -303,7 +303,7 @@ def create_saas_invoice(
 			"description": "Saas Prepaid Purchase",
 			"document_type": "Saas App",
 			"document_name": document_name,
-			"plan": frappe.db.get_value("Plan", plan, "plan_title"),
+			"plan": frappe.db.get_value("Site Plan", plan, "plan_title"),
 			"quantity": 1,
 			"rate": amount,
 		},


### PR DESCRIPTION
It looks like previously `Plan` doctype was changed to `Site Plan`
But in code in some places, it's still query the db with `Plan` doctype which raises error in local setup.

https://github.com/frappe/press/blob/9020665ac008ea7e8bd4d82fd76463f9ffa93c2e/press/patches/v0_7_0/rename_plan_to_site_plan.py#L4-L8