### PR TITLE
fix: handle 'NoneType' object has no attribute 'strip'

### DIFF
--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -612,7 +612,7 @@ class Team(Document):
 				"address_line1": billing_details.address,
 				"city": billing_details.city,
 				"state": billing_details.state,
-				"pincode": (billing_details.postal_code).strip().replace(" ", ""),
+				"pincode": billing_details.get("postal_code", "").strip().replace(" ", ""),
 				"country": billing_details.country,
 				"gstin": billing_details.gstin,
 			}


### PR DESCRIPTION
Sentry issue id: 18739