### PR TITLE
feat : Migrate script external files

### DIFF
--- a/press/press/doctype/app_release/app_release.py
+++ b/press/press/doctype/app_release/app_release.py
@@ -459,7 +459,7 @@ def check_python_syntax(dirpath: str) -> str:
 	- -o: optimize level, 0 is no optimization
 	"""
 
-	command = f"python -m compileall -q -o 0 {dirpath}"
+	command = f"python3 -m compileall -q -o 0 {dirpath}"
 	proc = subprocess.run(
 		shlex.split(command),
 		text=True,

--- a/press/scripts/migrate.py
+++ b/press/scripts/migrate.py
@@ -472,7 +472,6 @@ def executed_from_temp_dir():
 	cur_file = __file__
 	return cur_file.startswith(temp_dir)
 
-
 if __name__ in ("__main__", "frappe.integrations.frappe_providers.frappecloud"):
 	if executed_from_temp_dir():
 		current_file = os.path.abspath(__file__)


### PR DESCRIPTION
In addition to local site migration, you can pass external backup file paths..
That way you do not need to restore the site, to migrate it to FC.

The accepted files are validated using mime-types similar to FC frontend 