### PR TITLE
fix: don't show tiny plan in product trial subscription plans

### DIFF
--- a/press/api/site.py
+++ b/press/api/site.py
@@ -805,6 +805,7 @@ def get_plans(name=None, rg=None):
 			"private_benches",
 			"monitor_access",
 			"dedicated_server_plan",
+			"allow_downgrading_from_other_plan"
 		],
 		# TODO: Remove later, temporary change because site plan has all document_type plans
 		filters={"document_type": "Site"},
@@ -837,6 +838,8 @@ def get_plans(name=None, rg=None):
 	out = []
 	for plan in plans:
 		if is_paywalled_bench and plan.price_usd == 10:
+			continue
+		if not plan.allow_downgrading_from_other_plan and plan.price_usd == 5:
 			continue
 		if not on_dedicated_server and plan.dedicated_server_plan:
 			continue


### PR DESCRIPTION
Sites created through SaaS flow,, it has a option to subscribe to a plan from desk. 

![Screenshot 2024-07-16 at 9 57 10 AM](https://github.com/user-attachments/assets/87cb8700-262b-4a56-bcfc-093694d84c8f)

This uses a different api to fetch plans and upgrade to a plan. This can allow users to choose this tiny plan. That's now disabled. This plan will not be shown in desk now.