### PR TITLE
fix: in _set_latest_bench if plan is not selected assume it's normal plan

### DIFF
--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1882,15 +1882,17 @@ class Site(Document, TagHelpers):
 		For others, don't allow to deploy on those specific release group benches, choose anything except that
 		"""
 
-		release_group_names = frappe.db.get_all(
-			"Site Plan Release Group",
-			pluck="release_group",
-			filters={
-				"parenttype": "Site Plan",
-				"parentfield": "release_groups",
-				"parent": self.get_plan_name(),
-			},
-		)
+		release_group_names = []
+		if self.get_plan_name():
+			release_group_names = frappe.db.get_all(
+				"Site Plan Release Group",
+				pluck="release_group",
+				filters={
+					"parenttype": "Site Plan",
+					"parentfield": "release_groups",
+					"parent": self.get_plan_name(),
+				},
+			)
 
 		Bench = frappe.qb.DocType("Bench")
 		Server = frappe.qb.DocType("Server")


### PR DESCRIPTION
Ticket - 18767
In case of standby sites, plan name is not provided. In that case it should pick bench which is available for normal plan.