### PR TITLE
fix: posthog session replay

### DIFF
--- a/dashboard/.prettierignore
+++ b/dashboard/.prettierignore
@@ -1,0 +1,1 @@
+index.html

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -30,5 +30,9 @@
 		</script>
         <!-- <script type="module" src="/src/main.js"></script> -->
 		<script type="module" src="/src2/main.js"></script>
+		<!-- Posthog SDK -->
+		<script >
+			!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+		</script>
 	</body>
 </html>

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -32,7 +32,6 @@
 		"lodash": "^4.17.19",
 		"luxon": "^1.22.0",
 		"markdown-it": "^12.3.2",
-		"posthog-js": "^1.148.0",
 		"register-service-worker": "^1.6.2",
 		"socket.io-client": "^4.5.1",
 		"unplugin-icons": "^0.17.0",

--- a/dashboard/src2/main.js
+++ b/dashboard/src2/main.js
@@ -12,7 +12,6 @@ import { subscribeToJobUpdates } from './utils/agentJob';
 import { fetchPlans } from './data/plans.js';
 import * as Sentry from '@sentry/vue';
 import { session } from './data/session.js';
-import posthog from 'posthog-js';
 import { toast } from 'vue-sonner';
 
 let request = options => {
@@ -93,7 +92,7 @@ getInitialData().then(() => {
 		window.press_frontend_posthog_project_id &&
 		window.press_frontend_posthog_host
 	) {
-		posthog.init(window.press_frontend_posthog_project_id, {
+		window.posthog.init(window.press_frontend_posthog_project_id, {
 			api_host: window.press_frontend_posthog_host,
 			person_profiles: 'identified_only',
 			autocapture: false,
@@ -102,7 +101,9 @@ getInitialData().then(() => {
 				maskAllInputs: true
 			}
 		});
-		window.posthog = posthog;
+	} else {
+		// unset posthog if not configured
+		window.posthog = undefined;
 	}
 
 	importGlobals().then(() => {

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -4353,11 +4353,6 @@ fetch-blob@^3.1.2, fetch-blob@^3.1.4:
     node-domexception "^1.0.0"
     web-streams-polyfill "^3.0.3"
 
-fflate@^0.4.8:
-  version "0.4.8"
-  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.4.8.tgz#f90b82aefbd8ac174213abb338bd7ef848f0f5ae"
-  integrity sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==
-
 figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz"
@@ -6199,20 +6194,6 @@ postcss@^8.4.35:
     picocolors "^1.0.0"
     source-map-js "^1.2.0"
 
-posthog-js@^1.148.0:
-  version "1.148.0"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.148.0.tgz#c9a70dfc679d5fcb512c902b06044af72337f8eb"
-  integrity sha512-nydf+aret26YViDBwH7DdN/c8dmCzQGNQ1yredeE47UlbpJ3J/iTgskNdmGJIofFcdSagcwAE/FF7s++YfTtvg==
-  dependencies:
-    fflate "^0.4.8"
-    preact "^10.19.3"
-    web-vitals "^4.0.1"
-
-preact@^10.19.3:
-  version "10.22.1"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.22.1.tgz#6a3589973fe0c6e53211091607d31f4b7b27334d"
-  integrity sha512-jRYbDDgMpIb5LHq3hkI0bbl+l/TQ9UnkdQ0ww+lp+4MMOdqaUYdFc5qeyP+IV8FAd/2Em7drVPeKdQxsiWCf/A==
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
@@ -7559,11 +7540,6 @@ web-streams-polyfill@^3.0.3:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
   integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
-
-web-vitals@^4.0.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-4.2.1.tgz#67eec387ddd0ef4c25574a01ab9dae723eee2b97"
-  integrity sha512-U6bAxeudnhDqcXNl50JC4hLlqox9DZnngxfISZm3DMZnonW35xtJOVUc091L+DOY+6hVZVpKXoiCP0RiT6339Q==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Instead of using the official posthog SDK from npm registry, use the posthog snippet to fetch the library from api server and use that. Else there can be conflict between client SDK version and posthog server version