### PR TITLE
fix: posthog start session recording error

### DIFF
--- a/dashboard/src2/components/Onboarding.vue
+++ b/dashboard/src2/components/Onboarding.vue
@@ -287,7 +287,7 @@ export default {
 		TextInsideCircle
 	},
 	mounted() {
-		if (window.posthog) {
+		if (window.posthog && window.posthog.__loaded) {
 			window.posthog.identify(this.$team.doc.user, {
 				app: 'frappe_cloud',
 				action: 'onboarding'
@@ -296,7 +296,7 @@ export default {
 		}
 	},
 	unmounted() {
-		if (window.posthog && window.posthog.sessionRecordingStarted()) {
+		if (window.posthog && window.posthog.sessionRecordingStarted() && window.posthog.__loaded) {
 			window.posthog.stopSessionRecording();
 		}
 	},

--- a/dashboard/src2/components/Onboarding.vue
+++ b/dashboard/src2/components/Onboarding.vue
@@ -296,7 +296,7 @@ export default {
 		}
 	},
 	unmounted() {
-		if (window.posthog && window.posthog.sessionRecordingStarted() && window.posthog.__loaded) {
+		if (window.posthog && window.posthog.__loaded && window.posthog.sessionRecordingStarted()) {
 			window.posthog.stopSessionRecording();
 		}
 	},

--- a/dashboard/src2/pages/NewSite.vue
+++ b/dashboard/src2/pages/NewSite.vue
@@ -247,7 +247,7 @@ export default {
 		Header
 	},
 	mounted() {
-		if (window.posthog && !this.$team.doc.onboarding.site_created) {
+		if (window.posthog && !this.$team.doc.onboarding.site_created && window.posthog.__loaded) {
 			window.posthog.identify(this.$team.doc.user, {
 				app: 'frappe_cloud',
 				action: 'first_new_site_creation'
@@ -256,7 +256,7 @@ export default {
 		}
 	},
 	unmounted() {
-		if (window.posthog && window.posthog.sessionRecordingStarted()) {
+		if (window.posthog && window.posthog.sessionRecordingStarted() && window.posthog.__loaded) {
 			window.posthog.stopSessionRecording();
 		}
 	},

--- a/dashboard/src2/pages/NewSite.vue
+++ b/dashboard/src2/pages/NewSite.vue
@@ -256,7 +256,7 @@ export default {
 		}
 	},
 	unmounted() {
-		if (window.posthog && window.posthog.sessionRecordingStarted() && window.posthog.__loaded) {
+		if (window.posthog && window.posthog.__loaded && window.posthog.sessionRecordingStarted()) {
 			window.posthog.stopSessionRecording();
 		}
 	},


### PR DESCRIPTION
Related **DASHBOARD-V2-3W8**

The error may be thrown when posthog js SDK is not correctly loaded for any reason (can be network issue, or posthog server issue). After this changes, posthog will try to do session recording/capturing only if posthog is loaded successfully.