### PR TITLE
fix: api.site.get_site_plans ProgrammingError DASHBOARD-V2-3D9

### DIFF
--- a/press/api/site.py
+++ b/press/api/site.py
@@ -709,8 +709,10 @@ def get_site_plans():
 	)
 
 	filtered_plans = []
-
 	plan_names = [x.name for x in plans]
+
+	if len(plan_names) == 0:
+		return filtered_plans
 
 	SitePlan = frappe.qb.DocType("Site Plan")
 	Bench = frappe.qb.DocType("Bench")
@@ -743,6 +745,10 @@ def get_site_plans():
 		.on(ReleaseGroup.name == plan_details_query.release_group)
 		.where(Bench.status == "Active")
 	)
+
+	# print query
+	print(plan_details_with_bench_query.get_sql())
+	print(plan_details_with_bench_query.walk())
 
 	plan_details = plan_details_with_bench_query.run(as_dict=True)
 	plan_details_dict = {}

--- a/press/api/site.py
+++ b/press/api/site.py
@@ -708,11 +708,11 @@ def get_site_plans():
 		filters={"document_type": "Site"},
 	)
 
-	filtered_plans = []
 	plan_names = [x.name for x in plans]
-
 	if len(plan_names) == 0:
-		return filtered_plans
+		return []
+	
+	filtered_plans = []
 
 	SitePlan = frappe.qb.DocType("Site Plan")
 	Bench = frappe.qb.DocType("Bench")

--- a/press/api/site.py
+++ b/press/api/site.py
@@ -746,10 +746,6 @@ def get_site_plans():
 		.where(Bench.status == "Active")
 	)
 
-	# print query
-	print(plan_details_with_bench_query.get_sql())
-	print(plan_details_with_bench_query.walk())
-
 	plan_details = plan_details_with_bench_query.run(as_dict=True)
 	plan_details_dict = {}
 


### PR DESCRIPTION
Sentry Issue ID - DASHBOARD-V2-3D9

In Sentry, the error has been grouped with other issues.
Actual error - "/api/method/press.api.site.get_site_plans ProgrammingError" 

---
https://github.com/frappe/press/blob/27e2972d204ef40ae045ba869c85064fbfacc9a1/press/api/site.py#L721-L728

On line 728 , in the query builder, it has a where clause to check record in plan names.
In some cases, if the plan list is empty > (), this sql statement become invalid.
![Screenshot 2024-07-31 at 2 10 57 PM](https://github.com/user-attachments/assets/9c4f4595-8065-4d64-98f9-1874ade09bb6)


That has been fixed in this PR with a guard clause (don't run the query if site plan list is already empty).