### PR TITLE
fix(Site): Run marketplace hooks for free apps on backup restore

### DIFF
--- a/press/press/doctype/marketplace_app/marketplace_app.py
+++ b/press/press/doctype/marketplace_app/marketplace_app.py
@@ -6,6 +6,7 @@ from base64 import b64decode
 from typing import Dict, List
 
 import frappe
+from frappe.types.DF import Data
 import requests
 from frappe.query_builder.functions import Cast_
 from frappe.utils.caching import redis_cache
@@ -640,7 +641,7 @@ def get_plans_for_app(
 	return plans
 
 
-def marketplace_app_hook(app=None, site="", op="install"):
+def marketplace_app_hook(app=None, site: Data | None = "", op="install"):
 	if app is None:
 		site_apps = frappe.get_all("Site App", filters={"parent": site}, pluck="app")
 		for app in site_apps:

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -2775,9 +2775,15 @@ def process_marketplace_hooks_for_backup_restore(
 	apps_to_install = apps_from_backup - site_apps
 	apps_to_uninstall = site_apps - apps_from_backup
 	for app in apps_to_install:
-		marketplace_app_hook(app=app, site=site.name, op="install")
+		if (
+			frappe.get_cached_value("Marketplace App", app, "subscription_type") == "Free"
+		):  # like india_compliance; no need to check subscription
+			marketplace_app_hook(app=app, site=site.name, op="install")
 	for app in apps_to_uninstall:
-		marketplace_app_hook(app=app, site=site.name, op="uninstall")
+		if (
+			frappe.get_cached_value("Marketplace App", app, "subscription_type") == "Free"
+		):  # like india_compliance; no need to check subscription
+			marketplace_app_hook(app=app, site=site.name, op="uninstall")
 
 
 def process_restore_job_update(job, force=False):
@@ -2798,7 +2804,7 @@ def process_restore_job_update(job, force=False):
 			apps_from_backup: list[str] = [
 				line.split()[0] for line in job.output.splitlines() if line
 			]
-			site = Site(job.site)
+			site = Site("Site", job.site)
 			process_marketplace_hooks_for_backup_restore(set(apps_from_backup), site)
 			site.set_apps(apps_from_backup)
 		frappe.db.set_value("Site", job.site, "status", updated_status)


### PR DESCRIPTION
- **refactor(Site): Split up marketplace app install stuff**
- **fix(Site): On restore, process marketplace hooks for apps changed**
- **refactor(Site): Add set_apps method**
- **test(Site): Add tests for marketplace app hooks on restore job**
- **fix(Site): Only Install/Uninstall marketplace hooks for free apps**
