### PR TITLE
feat: allow changing source if app is same

### DIFF
--- a/dashboard/src2/components/AlertBanner.vue
+++ b/dashboard/src2/components/AlertBanner.vue
@@ -2,9 +2,13 @@
 	<div
 		:class="`flex items-center rounded-md border border-${color}-200 bg-${color}-100 px-3.5 py-2.5`"
 	>
-		<i-lucide-alert-triangle :class="`h-4 w-4 text-${color}-600`" />
+		<i-lucide-alert-triangle
+			v-if="showIcon"
+			:class="`h-4 w-4 text-${color}-600`"
+		/>
 		<div
-			class="ml-3 text-p-base font-medium text-gray-800"
+			:class="{ 'ml-3': showIcon }"
+			class="text-p-base font-medium text-gray-800"
 			v-html="title"
 		></div>
 
@@ -27,6 +31,10 @@ export default {
 		type: {
 			type: String,
 			default: 'info'
+		},
+		showIcon: {
+			type: Boolean,
+			default: true
 		}
 	},
 	computed: {

--- a/dashboard/src2/components/NewAppDialog.vue
+++ b/dashboard/src2/components/NewAppDialog.vue
@@ -1,17 +1,14 @@
 <template>
 	<Dialog
 		:options="{
-			title: 'Add a new app',
+			title: 'Update bench apps',
 			size: 'xl',
 			actions: [
 				{
-					label: 'Add App',
+					label: isAppOnBench ? 'Replace App' : 'Add App',
 					variant: 'solid',
 					disabled: !app || !appValidated,
-					onClick() {
-						$emit('app-added', app);
-						show = false;
-					}
+					onClick: addAppHandler
 				}
 			]
 		}"
@@ -102,6 +99,17 @@
 					</div>
 				</div>
 			</FTabs>
+			<AlertBanner
+				v-if="isAppOnBench"
+				class="mt-4"
+				:show-icon="false"
+				:title="
+					`App <strong>${app.name}</strong> already exists on this Bench. ` +
+					`Clicking on Replace App will change app source to the selected one.`
+				"
+				type="warning"
+			/>
+
 			<ErrorMessage
 				:message="$resources.validateApp.error || $resources.branches.error"
 			/>
@@ -113,13 +121,21 @@
 import { FormControl, Tabs } from 'frappe-ui';
 import { DashboardError } from '../utils/error';
 import GitHubAppSelector from './GitHubAppSelector.vue';
+import AlertBanner from './AlertBanner.vue';
 
 export default {
 	name: 'NewAppDialog',
 	components: {
 		GitHubAppSelector,
 		FTabs: Tabs,
-		FormControl
+		FormControl,
+		AlertBanner
+	},
+	props: {
+		group: {
+			type: Object,
+			required: true
+		}
 	},
 	emits: ['app-added'],
 	data() {
@@ -233,6 +249,23 @@ export default {
 				label: branch.name,
 				value: branch.name
 			}));
+		},
+		isAppOnBench() {
+			if (!this.app) {
+				return false;
+			}
+
+			for (const app of this.group.apps) {
+				if (app.app == this.app.name) return true;
+			}
+
+			return false;
+		}
+	},
+	methods: {
+		addAppHandler() {
+			this.$emit('app-added', this.app, this.isAppOnBench);
+			this.show = false;
 		}
 	}
 };

--- a/dashboard/src2/components/NewAppDialog.vue
+++ b/dashboard/src2/components/NewAppDialog.vue
@@ -5,7 +5,7 @@
 			size: 'xl',
 			actions: [
 				{
-					label: isAppOnBench ? 'Replace App' : 'Add App',
+					label: isAppOnBench ? 'Update App' : 'Add App',
 					variant: 'solid',
 					disabled: !app || !appValidated,
 					onClick: addAppHandler
@@ -105,7 +105,7 @@
 				:show-icon="false"
 				:title="
 					`App <strong>${app.name}</strong> already exists on this Bench. ` +
-					`Clicking on Replace App will change app source to the selected one.`
+					`Clicking on Update App will change app source to the selected one.`
 				"
 				type="warning"
 			/>

--- a/dashboard/src2/components/bench/AddAppDialog.vue
+++ b/dashboard/src2/components/bench/AddAppDialog.vue
@@ -125,7 +125,11 @@
 			</div>
 		</template>
 	</Dialog>
-	<NewAppDialog v-if="showNewAppDialog" @app-added="addAppFromGithub" />
+	<NewAppDialog
+		v-if="showNewAppDialog"
+		@app-added="addAppFromGithub"
+		:group="group"
+	/>
 </template>
 
 <script>
@@ -146,7 +150,12 @@ import NewAppDialog from '../NewAppDialog.vue';
 
 export default {
 	name: 'AddAppDialog',
-	props: ['groupName', 'groupVersion'],
+	props: {
+		group: {
+			type: Object,
+			required: true
+		}
+	},
 	components: {
 		ListView,
 		ListHeader,
@@ -181,7 +190,7 @@ export default {
 			return {
 				url: 'press.api.bench.all_apps',
 				params: {
-					name: this.groupName
+					name: this.group.name
 				},
 				transform(data) {
 					return data.map(app => {
@@ -315,9 +324,9 @@ export default {
 		}
 	},
 	methods: {
-		addAppFromGithub(app) {
-			app.group = this.groupName;
-			this.$emit('newApp', app);
+		addAppFromGithub(app, isReplacement) {
+			app.group = this.group.name;
+			this.$emit('newApp', app, isReplacement);
 		},
 		addApp(row) {
 			if (!this.selectedAppSources.includes(row))
@@ -327,7 +336,7 @@ export default {
 
 			this.$resources.addApp
 				.submit({
-					name: this.groupName,
+					name: this.group.name,
 					source: app.source.name,
 					app: app.name
 				})

--- a/dashboard/src2/components/bench/AddAppDialog.vue
+++ b/dashboard/src2/components/bench/AddAppDialog.vue
@@ -324,9 +324,9 @@ export default {
 		}
 	},
 	methods: {
-		addAppFromGithub(app, isReplacement) {
+		addAppFromGithub(app, isUpdate) {
 			app.group = this.group.name;
-			this.$emit('newApp', app, isReplacement);
+			this.$emit('newApp', app, isUpdate);
 		},
 		addApp(row) {
 			if (!this.selectedAppSources.includes(row))

--- a/dashboard/src2/objects/bench.js
+++ b/dashboard/src2/objects/bench.js
@@ -364,15 +364,15 @@ export default {
 											apps.reload();
 											releaseGroup.reload();
 										},
-										onNewApp(app, isReplacement) {
-											const loading = isReplacement
+										onNewApp(app, isUpdate) {
+											const loading = isUpdate
 												? 'Replacing App...'
 												: 'Adding App...';
 
 											toast.promise(
 												releaseGroup.addApp.submit({
 													app,
-													is_replacement: isReplacement
+													is_update: isUpdate
 												}),
 												{
 													loading,
@@ -380,7 +380,7 @@ export default {
 														apps.reload();
 														releaseGroup.reload();
 
-														if (isReplacement) {
+														if (isUpdate) {
 															return `App ${app.title} updated`;
 														}
 

--- a/dashboard/src2/objects/bench.js
+++ b/dashboard/src2/objects/bench.js
@@ -359,26 +359,35 @@ export default {
 							onClick() {
 								renderDialog(
 									h(AddAppDialog, {
-										groupName: releaseGroup.name,
-										groupVersion: releaseGroup.doc.version,
+										group: releaseGroup.doc,
 										onAppAdd() {
 											apps.reload();
 											releaseGroup.reload();
 										},
-										onNewApp(app) {
+										onNewApp(app, isReplacement) {
+											const loading = isReplacement
+												? 'Replacing App...'
+												: 'Adding App...';
+
 											toast.promise(
 												releaseGroup.addApp.submit({
-													app: app
+													app,
+													is_replacement: isReplacement
 												}),
 												{
-													loading: 'Adding App...',
+													loading,
 													success: () => {
 														apps.reload();
 														releaseGroup.reload();
-														return `App ${app.title} added to the bench`;
+
+														if (isReplacement) {
+															return `App ${app.title} updated`;
+														}
+
+														return `App ${app.title} added`;
 													},
 													error: e => {
-														return e.messages.length
+														return e?.messages.length
 															? e.messages.join('\n')
 															: e.message;
 													}

--- a/dashboard/src2/objects/marketplace.js
+++ b/dashboard/src2/objects/marketplace.js
@@ -67,11 +67,11 @@ export default {
 					prefix: icon('plus')
 				},
 				onClick() {
-					const NewAppDialog = defineAsyncComponent(() =>
+					const NewMarketplaceAppDialog = defineAsyncComponent(() =>
 						import('../components/marketplace/NewMarketplaceAppDialog.vue')
 					);
 
-					renderDialog(h(NewAppDialog));
+					renderDialog(h(NewMarketplaceAppDialog));
 				}
 			};
 		}

--- a/press/api/app.py
+++ b/press/api/app.py
@@ -7,7 +7,6 @@ import json
 from typing import TYPE_CHECKING
 
 import frappe
-
 from press.press.doctype.app.app import new_app
 from press.utils import get_current_team
 
@@ -38,5 +37,5 @@ def new(app):
 		app["github_installation_id"] if "github_installation_id" in app else None,
 	)
 
-	group.append_source(source)
+	group.update_source(source)
 	return group.name

--- a/press/api/bench.py
+++ b/press/api/bench.py
@@ -521,10 +521,10 @@ def add_app(name, source, app):
 @frappe.whitelist()
 @protected("Release Group")
 def add_apps(name, apps):
-	release_group = frappe.get_doc("Release Group", name)
+	release_group: "ReleaseGroup" = frappe.get_doc("Release Group", name)
 	for app in apps:
 		app_name, source = app.values()
-		release_group.append_source(frappe._dict(name=source, app=app_name))
+		release_group.update_source(frappe._dict(name=source, app=app_name))
 
 
 @frappe.whitelist()

--- a/press/press/doctype/app/app.py
+++ b/press/press/doctype/app/app.py
@@ -80,7 +80,7 @@ class App(Document):
 
 
 def new_app(name, title):
-	app = frappe.get_doc({"doctype": "App", "name": name, "title": title}).insert()
+	app: "App" = frappe.get_doc({"doctype": "App", "name": name, "title": title}).insert()
 	return app
 
 

--- a/press/press/doctype/deploy_candidate/test_deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/test_deploy_candidate.py
@@ -176,7 +176,7 @@ class TestDeployCandidate(unittest.TestCase):
 		app = create_test_app("erpnext", "ERPNext")
 		source = create_test_app_source(group.version, app)
 		release = create_test_app_release(source)
-		group.append_source(source)
+		group.update_source(source)
 		candidate = group.create_deploy_candidate([{"app": app.name}])
 		self.assertEqual(candidate.apps[1].app, app.name)
 		self.assertEqual(candidate.apps[1].release, release.name)
@@ -194,7 +194,7 @@ class TestDeployCandidate(unittest.TestCase):
 		group = frappe.get_doc("Release Group", bench.group)
 		app = create_test_app("erpnext", "ERPNext")
 		erpnext_source = create_test_app_source(group.version, app)
-		group.append_source(erpnext_source)
+		group.update_source(erpnext_source)
 		first_candidate = group.create_deploy_candidate(group.apps)
 
 		dc_count_before = frappe.db.count("Deploy Candidate", filters={"group": group.name})

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -1103,9 +1103,9 @@ class ReleaseGroup(Document, TagHelpers):
 
 		return removed_apps
 
-	def update_source(self, source: "AppSource", is_replacement: bool = False):
+	def update_source(self, source: "AppSource", is_update: bool = False):
 		self.remove_app_if_invalid(source)
-		if is_replacement:
+		if is_update:
 			update_rg_app_source(self, source)
 		else:
 			self.append("apps", {"source": source.name, "app": source.app})
@@ -1280,7 +1280,7 @@ class ReleaseGroup(Document, TagHelpers):
 			frappe.get_doc("Bench", bench.name).update_bench_config(force=True)
 
 	@dashboard_whitelist()
-	def add_app(self, app, is_replacement: bool = False):
+	def add_app(self, app, is_update: bool = False):
 		if isinstance(app, str):
 			app = json.loads(app)
 
@@ -1299,7 +1299,7 @@ class ReleaseGroup(Document, TagHelpers):
 			self.team,
 			app.get("github_installation_id", None),
 		)
-		self.update_source(source, is_replacement)
+		self.update_source(source, is_update)
 
 	@dashboard_whitelist()
 	def remove_app(self, app: str):

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -52,6 +52,7 @@ LastDeployInfo = TypedDict(
 
 if TYPE_CHECKING:
 	from press.press.doctype.deploy_candidate.deploy_candidate import DeployCandidate
+	from press.press.doctype.app.app import App
 
 
 class ReleaseGroup(Document, TagHelpers):
@@ -1102,9 +1103,12 @@ class ReleaseGroup(Document, TagHelpers):
 
 		return removed_apps
 
-	def append_source(self, source: "AppSource"):
+	def update_source(self, source: "AppSource", is_replacement: bool = False):
 		self.remove_app_if_invalid(source)
-		self.append("apps", {"source": source.name, "app": source.app})
+		if is_replacement:
+			update_rg_app_source(self, source)
+		else:
+			self.append("apps", {"source": source.name, "app": source.app})
 		self.save()
 
 	def remove_app_if_invalid(self, source: "AppSource"):
@@ -1276,7 +1280,7 @@ class ReleaseGroup(Document, TagHelpers):
 			frappe.get_doc("Bench", bench.name).update_bench_config(force=True)
 
 	@dashboard_whitelist()
-	def add_app(self, app):
+	def add_app(self, app, is_replacement: bool = False):
 		if isinstance(app, str):
 			app = json.loads(app)
 
@@ -1284,7 +1288,7 @@ class ReleaseGroup(Document, TagHelpers):
 			return
 
 		if frappe.db.exists("App", name):
-			app_doc = frappe.get_doc("App", name)
+			app_doc: "App" = frappe.get_doc("App", name)
 		else:
 			app_doc = new_app(name, app["title"])
 
@@ -1295,7 +1299,7 @@ class ReleaseGroup(Document, TagHelpers):
 			self.team,
 			app.get("github_installation_id", None),
 		)
-		self.append_source(source)
+		self.update_source(source, is_replacement)
 
 	@dashboard_whitelist()
 	def remove_app(self, app: str):
@@ -1486,3 +1490,10 @@ def can_use_release(app_src):
 		return True
 
 	return app_src.status == "Approved"
+
+
+def update_rg_app_source(rg: "ReleaseGroup", source: "AppSource"):
+	for app in rg.apps:
+		if app.app == source.app:
+			app.source = source.name
+			break


### PR DESCRIPTION
Allow updation of an App's Source if the app already exists on the bench. Not cleanly separated from Add App, but should allow users to switch to custom `frappe` should they choose to do so.


![Screenshot 2024-08-08 at 16 09 33](https://github.com/user-attachments/assets/7f978dc2-cbf9-470e-b646-806cb4c9cc04)

docs: https://frappecloud.com/docs/benches/custom-app#updating-app-source