### PR TITLE
feat: allocate free credits on signup

### DIFF
--- a/dashboard/src2/components/Onboarding.vue
+++ b/dashboard/src2/components/Onboarding.vue
@@ -105,11 +105,14 @@
 				<div v-if="!isBillingDetailsSet">
 					<div class="flex items-center space-x-2">
 						<TextInsideCircle>2</TextInsideCircle>
-						<span class="text-base font-medium"> Update billing details </span>
+						<span class="text-base font-medium"> Update billing address </span>
 					</div>
 					<div class="pl-7">
 						<!-- Offer -->
-						<p class="my-3 text-p-sm text-gray-800">
+						<p
+							class="my-3 text-p-sm text-gray-800"
+							v-if="!$team.doc.onboarding.is_saas_user"
+						>
 							🎉 You are eligible for
 							<span class="font-medium">{{ free_credits }}</span> worth of free
 							credits. No card required.
@@ -173,7 +176,10 @@
 							<!-- Automated Billing Section -->
 							<div v-if="isAutomatedBilling">
 								<!-- Offer -->
-								<p class="my-3 text-p-sm text-gray-800">
+								<p
+									class="my-3 text-p-sm text-gray-800"
+									v-if="!$team.doc.onboarding.is_saas_user"
+								>
 									🎉 You are eligible for
 									<span class="font-medium">{{ free_credits }}</span> worth of
 									free credits for enabling automated billing.

--- a/dashboard/src2/components/Onboarding.vue
+++ b/dashboard/src2/components/Onboarding.vue
@@ -108,6 +108,12 @@
 						<span class="text-base font-medium"> Update billing details </span>
 					</div>
 					<div class="pl-7">
+						<!-- Offer -->
+						<p class="my-3 text-p-sm text-gray-800">
+							🎉 You are eligible for
+							<span class="font-medium">{{ free_credits }}</span> worth of free
+							credits. No card required.
+						</p>
 						<UpdateBillingDetailsForm @updated="onBillingAddresUpdateSuccess" />
 					</div>
 				</div>
@@ -252,7 +258,7 @@
 								/>
 								<div>
 									<span class="text-base font-semibold">{{ app.title }}</span>
-									<p class="line-clamp-1 mt-1 text-sm text-gray-600">
+									<p class="mt-1 line-clamp-1 text-sm text-gray-600">
 										{{ app.description }}
 									</p>
 								</div>

--- a/press/api/marketplace.py
+++ b/press/api/marketplace.py
@@ -23,6 +23,7 @@ from press.press.doctype.app_source.app_source import AppSource
 from press.press.doctype.marketplace_app.marketplace_app import (
 	MarketplaceApp,
 	get_plans_for_app,
+	get_total_installs_by_app,
 )
 from press.utils import get_app_tag, get_current_team, get_last_doc, unique
 from press.utils.billing import get_frappe_io_connection
@@ -585,12 +586,17 @@ def options_for_marketplace_app() -> Dict[str, Dict]:
 
 @frappe.whitelist()
 def get_marketplace_apps_for_onboarding() -> List[Dict]:
-	return frappe.get_all(
+	marketplace_apps = frappe.get_all(
 		"Marketplace App",
 		fields=["name", "title", "image", "description"],
 		filters={"show_for_site_creation": True, "status": "Published"},
 	)
-
+	total_installs_by_app = get_total_installs_by_app()
+	for app in marketplace_apps:
+		app["total_installs"] = total_installs_by_app.get(app.name, 0)
+	# sort by total installs in descending order
+	marketplace_apps.sort(key=lambda x: x["total_installs"], reverse=True)
+	return marketplace_apps
 
 def is_on_marketplace(app: str) -> bool:
 	"""Returns `True` if this `app` is on marketplace else `False`"""

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -627,6 +627,7 @@ class Team(Document):
 				"links",
 				{"link_doctype": self.doctype, "link_name": self.name, "link_title": self.name},
 			)
+			self.allocate_free_credits()
 
 		address_doc.update(
 			{

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -1009,6 +1009,7 @@ class Team(Document):
 		return frappe._dict(
 			{
 				"site_created": site_created,
+				"is_saas_user": bool(self.via_erpnext or self.is_saas_user),
 				"saas_site_request": saas_site_request,
 				"complete": complete,
 			}


### PR DESCRIPTION
https://github.com/user-attachments/assets/6d846ae1-c331-4953-858e-4514ed8c76d6

- Allocate free credits, once user has updated the billing address
- If user has already availed saas trial, don't allocate free credis + don't show the offer on FC dashboard for them