### PR TITLE
fix: site creation posthog event capture

### DIFF
--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -672,7 +672,7 @@ class Site(Document, TagHelpers):
 		)
 
 		team = frappe.get_doc("Team", self.team)
-		if frappe.db.count("Site", {"team": team.name, "status": "Active"}) <= 1:
+		if frappe.db.count("Site", {"team": team.name}) <= 1:
 			from press.utils.telemetry import capture
 
 			if team.account_request:
@@ -1530,7 +1530,7 @@ class Site(Document, TagHelpers):
 		# Telemetry: Send event if first site status changed to Active
 		if self.setup_wizard_complete:
 			team = frappe.get_doc("Team", self.team)
-			if frappe.db.count("Site", {"team": team.name, "status": "Active"}) <= 1:
+			if frappe.db.count("Site", {"team": team.name}) <= 1:
 				from press.utils.telemetry import capture
 
 				if team.account_request:


### PR DESCRIPTION
In current logic `created_first_site`, `first_site_setup_wizard_completed` can also invoked, when the user has old team account and he has no active site in his account. While creating new one, these events can invoked.

Now, we will only capture these events, if the team has only single site regardless of status and team has been created through FC signup.