### PR TITLE
feat: add timezone field support in saas setup page

### DIFF
--- a/dashboard/src/components/Form.vue
+++ b/dashboard/src/components/Form.vue
@@ -24,14 +24,44 @@
 </template>
 
 <script>
+// https://github.com/eggert/tz/blob/main/backward add more if required.
+const TZ_BACKWARD_COMPATBILITY_MAP = {
+	'Asia/Calcutta': 'Asia/Kolkata'
+};
+
 export default {
 	name: 'Form',
 	props: ['fields', 'modelValue'],
 	emits: ['update:modelValue'],
 	data() {
 		return {
-			requiredFieldNotSet: []
+			requiredFieldNotSet: [],
+			guessedTimezone: ''
 		};
+	},
+	mounted() {
+		this.guessedTimezone = this.guessTimezone();
+	},
+	watch: {
+		fields: {
+			handler(new_fields) {
+				let timezoneFields = new_fields.filter(
+					f => f.fieldtype === 'Select' && f.fieldname.endsWith('_tz')
+				);
+				for (let field of timezoneFields) {
+					if (!field.options) {
+						field.options = [];
+					}
+					if (
+						this.guessedTimezone &&
+						field.options.includes(this.guessedTimezone)
+					) {
+						this.onChange(this.guessedTimezone, field);
+					}
+				}
+			},
+			deep: true
+		}
 	},
 	methods: {
 		onChange(value, field) {
@@ -82,6 +112,18 @@ export default {
 				Text: 'textarea',
 				Date: 'date'
 			}[field.fieldtype || 'Data'];
+		},
+		guessTimezone() {
+			try {
+				let tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+				if (TZ_BACKWARD_COMPATBILITY_MAP[tz]) {
+					return TZ_BACKWARD_COMPATBILITY_MAP[tz];
+				}
+				return tz;
+			} catch (e) {
+				console.error("Couldn't guess timezone", e);
+				return null;
+			}
 		}
 	}
 };

--- a/dashboard/src2/pages/app_trial/Setup.vue
+++ b/dashboard/src2/pages/app_trial/Setup.vue
@@ -102,8 +102,14 @@
 											}}
 										</p>
 									</div>
-									<ErrorMessage class="mt-2 sm:max-w-[23rem]" :message="progressError" />
-									<div class="mt-2 text-p-base text-red-600" v-if="progressError">
+									<ErrorMessage
+										class="mt-2 sm:max-w-[23rem]"
+										:message="progressError"
+									/>
+									<div
+										class="mt-2 text-p-base text-red-600"
+										v-if="progressError"
+									>
 										There was an error creating your site. Please contact
 										<a class="underline" href="/support">Frappe Cloud Support</a
 										>.
@@ -148,7 +154,7 @@
 												? `error`
 												: `warning`
 										"
-										class="col-span-1 lg:col-span-2 mb-4"
+										class="col-span-1 mb-4 lg:col-span-2"
 										:title="trialDays(siteRequest?.trial_end_date)"
 										v-if="
 											!isBillingDetailsSet ||
@@ -166,7 +172,7 @@
 									</AlertBanner>
 									<!-- Site -->
 									<div
-										class="flex flex-col items-center justify-between overflow-hidden whitespace-nowrap py-2.5 gap-2.5 text-base"
+										class="flex flex-col items-center justify-between gap-2.5 overflow-hidden whitespace-nowrap py-2.5 text-base"
 									>
 										<!-- Site name -->
 										<p

--- a/press/saas/doctype/product_trial/product_trial.json
+++ b/press/saas/doctype/product_trial/product_trial.json
@@ -25,6 +25,7 @@
   "standby_pool_size",
   "standby_queue_size",
   "signup_details_tab",
+  "column_break_cdhw",
   "signup_fields",
   "email_section",
   "email_account",
@@ -127,6 +128,7 @@
    "label": "Signup Details"
   },
   {
+   "description": "For timezone fields, append _tz at the end of fieldname and choose Select as fieldtype and you can leave the Options field empty. ",
    "fieldname": "signup_fields",
    "fieldtype": "Table",
    "label": "Signup Fields",
@@ -201,6 +203,10 @@
    "label": "Header Content",
    "options": "html",
    "reqd": 1
+  },
+  {
+   "fieldname": "column_break_cdhw",
+   "fieldtype": "Column Break"
   }
  ],
  "image_field": "logo",
@@ -215,7 +221,7 @@
    "link_fieldname": "product_trial"
   }
  ],
- "modified": "2024-08-16 15:49:35.742767",
+ "modified": "2024-08-22 11:20:54.136031",
  "modified_by": "Administrator",
  "module": "SaaS",
  "name": "Product Trial",

--- a/press/saas/doctype/product_trial/product_trial.py
+++ b/press/saas/doctype/product_trial/product_trial.py
@@ -5,6 +5,7 @@ import frappe
 from frappe.model.document import Document
 
 import frappe.utils
+from frappe.utils.momentjs import get_all_timezones
 from press.utils import log_error
 from press.utils.unique_name_generator import generate as generate_random_name
 
@@ -18,7 +19,9 @@ class ProductTrial(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 		from press.saas.doctype.product_trial_app.product_trial_app import ProductTrialApp
-		from press.saas.doctype.product_trial_signup_field.product_trial_signup_field import ProductTrialSignupField
+		from press.saas.doctype.product_trial_signup_field.product_trial_signup_field import (
+			ProductTrialSignupField,
+		)
 
 		apps: DF.Table[ProductTrialApp]
 		domain: DF.Link
@@ -52,12 +55,22 @@ class ProductTrial(Document):
 	def get_doc(self, doc):
 		if not self.published:
 			frappe.throw("Not permitted")
+
+		def _parse_options(field):
+			if field.fieldtype != "Select":
+				return []
+			if field.fieldname.endswith("_tz"):
+				return get_all_timezones()
+			if not field.options:
+				return []
+			return [option for option in ((field.options or "").split("\n")) if option]
+
 		doc.signup_fields = [
 			{
 				"label": field.label,
 				"fieldname": field.fieldname,
 				"fieldtype": field.fieldtype,
-				"options": [option for option in ((field.options or "").split("\n")) if option],
+				"options": _parse_options(field),
 				"required": field.required,
 			}
 			for field in self.signup_fields
@@ -117,9 +130,7 @@ class ProductTrial(Document):
 					"trial_end_date": site.trial_end_date.strftime("%Y-%m-%d"),
 					"app_trial": self.name,
 				},
-				"app_include_js": [
-					"https://frappecloud.com/saas/subscription.js"
-				]
+				"app_include_js": ["https://frappecloud.com/saas/subscription.js"],
 			}
 		)
 		if standby_site:


### PR DESCRIPTION
Now, in saas signup setup page, we can configure select fields for showing timezone.
Need to append `_tz` suffix to the fieldname and fieldtype should be Select.

- In browser, it will show the timezone list + try to auto-select the timezone based on browser's configuration
- Added validation for select fields and timezone