### PR TITLE
feat: migrate secret key from  customized to normal field

### DIFF
--- a/press/press/doctype/subscription/subscription.json
+++ b/press/press/doctype/subscription/subscription.json
@@ -15,7 +15,8 @@
   "interval",
   "site",
   "marketplace_app_subscription",
-  "additional_storage"
+  "additional_storage",
+  "secret_key"
  ],
  "fields": [
   {
@@ -90,6 +91,11 @@
    "fieldname": "additional_storage",
    "fieldtype": "Data",
    "label": "Additional Storage"
+  },
+  {
+   "fieldname": "secret_key",
+   "fieldtype": "Data",
+   "label": "Secret Key"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -99,7 +105,7 @@
    "link_fieldname": "subscription"
   }
  ],
- "modified": "2024-08-23 17:11:04.481626",
+ "modified": "2024-08-30 12:55:23.639210",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Subscription",

--- a/press/press/doctype/subscription/subscription.py
+++ b/press/press/doctype/subscription/subscription.py
@@ -33,6 +33,7 @@ class Subscription(Document):
 		marketplace_app_subscription: DF.Link | None
 		plan: DF.DynamicLink
 		plan_type: DF.Link
+		secret_key: DF.Data | None
 		site: DF.Link | None
 		team: DF.Link
 	# end: auto-generated types


### PR DESCRIPTION
**Steps for migration -**
1.  As per [docs](https://frappeframework.com/docs/user/en/guides/deployment/migrations#:~:text=Fields%20are%20soft%20deleted%20ie.%20the%20columns%20are%20not%20removed%20from%20the%20database%20table%20and%20however%2C%20they%20will%20not%20be%20visible%20in%20the%20documents.%20This%20is%20done%20to%20avoid%20any%20potential%20data%20loss%20situations%20and%20to%20allow%20you%20write%20related%20data%20migrations%20which%20might%20need%20values%20from%20deleted%20fields.), removing field shouldn't drop the column from db. Also, in dev environment it also doesn't. But for safety, take backup of `secret_key` field to `secret_key_backup` column to prevent any mishap.

    Use `bench mariadb` to run this SQL code.

    ```sql
    ALTER TABLE `tabSubscription` ADD secret_key_backup varchar(140);
    SET SQL_SAFE_UPDATES = 0;
    UPDATE `tabSubscription` SET  secret_key_backup=secret_key;
    SET SQL_SAFE_UPDATES = 1;
    ```
2. Remove `Secret Key` field from `Subscription` doctype using `Customize`
2. Run `git pull` and `bench migrate` and `bench restart --web` on prod
3. If everything looks good, drop the backup column

    ```sql
   ALTER TABLE `tabSubscription`  DROP COLUMN secret_key_backup;
    ```