### PR TITLE
feat: provision to configure default apps while creating bench

### DIFF
--- a/dashboard/src2/components/SitePlansCards.vue
+++ b/dashboard/src2/components/SitePlansCards.vue
@@ -32,6 +32,7 @@ export default {
 		},
 		plans() {
 			let plans = getPlans();
+
 			if (this.isPrivateBenchSite) {
 				plans = plans.filter(plan => plan.private_benches);
 			}

--- a/dashboard/src2/components/site/NewSiteAppSelector.vue
+++ b/dashboard/src2/components/site/NewSiteAppSelector.vue
@@ -41,6 +41,7 @@ import SiteAppPlanSelectorDialog from './SiteAppPlanSelectorDialog.vue';
 import { Badge } from 'frappe-ui';
 import { icon } from '../../utils/components';
 import ObjectList from '../ObjectList.vue';
+import { toast } from 'vue-sonner';
 
 export default {
 	props: ['availableApps', 'siteOnPublicBench', 'modelValue'],
@@ -72,7 +73,7 @@ export default {
 
 			if (!publicApps.length) return;
 
-			this.apps = this.availableApps.filter(app => app.is_default === true);
+			this.apps = this.availableApps.filter(app => app.preinstalled === true);
 
 			return {
 				data: () => publicApps,
@@ -95,6 +96,13 @@ export default {
 										src: row.image
 									}),
 									h('span', { class: 'ml-2' }, row.title || row.app_title),
+									row?.preinstalled
+										? h(Badge, {
+												class: 'ml-2',
+												theme: 'green',
+												label: 'Pre-Installed'
+										  })
+										: '',
 									row.subscription_type !== 'Free'
 										? h(Badge, {
 												class: 'ml-2',
@@ -194,8 +202,8 @@ export default {
 	},
 	methods: {
 		toggleApp(app) {
-			if (app.is_default) {
-				throw new Error('Cannot remove default app');
+			if (app.preinstalled) {
+				toast.error(app.title + ' is pre-installed and cannot be removed');
 			} else if (this.apps.map(a => a.app).includes(app.app)) {
 				this.apps = this.apps.filter(a => a.app !== app.app);
 			} else {

--- a/dashboard/src2/components/site/NewSiteAppSelector.vue
+++ b/dashboard/src2/components/site/NewSiteAppSelector.vue
@@ -72,6 +72,8 @@ export default {
 
 			if (!publicApps.length) return;
 
+			this.apps = this.availableApps.filter(app => app.is_default === true);
+
 			return {
 				data: () => publicApps,
 				columns: [
@@ -192,7 +194,9 @@ export default {
 	},
 	methods: {
 		toggleApp(app) {
-			if (this.apps.map(a => a.app).includes(app.app)) {
+			if (app.is_default) {
+				throw new Error('Cannot remove default app');
+			} else if (this.apps.map(a => a.app).includes(app.app)) {
 				this.apps = this.apps.filter(a => a.app !== app.app);
 			} else {
 				if (app.subscription_type && app.subscription_type !== 'Free') {

--- a/dashboard/src2/pages/NewReleaseGroup.vue
+++ b/dashboard/src2/pages/NewReleaseGroup.vue
@@ -170,6 +170,13 @@ export default {
 		};
 	},
 	resources: {
+		defaultApps() {
+			return {
+				url: 'press.api.bench.get_default_apps',
+				initialData: {},
+				auto: true
+			};
+		},
 		options() {
 			return {
 				url: 'press.api.bench.options',
@@ -219,13 +226,14 @@ export default {
 			});
 
 			// add default apps
-			this.defaultApps.forEach(app => {
-				apps.push({
-					name: app.name,
-					source: app.source
-				});
-			});
-
+			apps.push(
+				...this.defaultApps[this.benchVersion].map(app => {
+					return {
+						name: app.app,
+						source: app.source
+					};
+				})
+			);
 			return apps;
 		}
 	},
@@ -234,27 +242,7 @@ export default {
 			return this.$resources.options.data;
 		},
 		defaultApps() {
-			let defaultApps = [];
-			this.options.versions.forEach(version => {
-				version.apps.forEach(app => {
-					if (app.is_default) {
-						let d = {
-							name: app.name,
-							source: app.source.name,
-							app_title: app.title,
-							route: app.source.repository_url
-						};
-						if (
-							defaultApps.filter(app => app.app_title === d.app_title)
-								.length === 0
-						) {
-							defaultApps.push(d);
-						}
-					}
-				});
-			});
-
-			return defaultApps;
+			return this.$resources.defaultApps.data;
 		},
 		defaultAppsList() {
 			return {
@@ -284,6 +272,13 @@ export default {
 				{
 					label: 'Frappe Framework Version',
 					value: this.benchVersion
+				},
+				{
+					label: 'Default Apps',
+					value: this.defaultApps[this.benchVersion]
+						.map(app => app.title)
+						.join(', '),
+					condition: () => this.defaultApps[this.benchVersion].length
 				},
 				{
 					label: 'Region',

--- a/dashboard/src2/pages/NewReleaseGroup.vue
+++ b/dashboard/src2/pages/NewReleaseGroup.vue
@@ -274,7 +274,7 @@ export default {
 					value: this.benchVersion
 				},
 				{
-					label: 'Default Apps',
+					label: 'Preinstalled Apps',
 					value: this.defaultApps[this.benchVersion]
 						.map(app => app.title)
 						.join(', '),

--- a/dashboard/src2/pages/NewReleaseGroup.vue
+++ b/dashboard/src2/pages/NewReleaseGroup.vue
@@ -64,9 +64,6 @@
 					</div>
 				</div>
 			</div>
-			<div v-if="benchVersion && defaultApps.length">
-				<ObjectList :options="defaultAppsList" />
-			</div>
 			<div
 				class="flex flex-col"
 				v-if="options?.clusters.length && benchVersion && !server"
@@ -170,7 +167,7 @@ export default {
 		};
 	},
 	resources: {
-		defaultApps() {
+		preInstalledApps() {
 			return {
 				url: 'press.api.bench.get_default_apps',
 				initialData: {},
@@ -227,7 +224,7 @@ export default {
 
 			// add default apps
 			apps.push(
-				...this.defaultApps[this.benchVersion].map(app => {
+				...this.preInstalledApps[this.benchVersion].map(app => {
 					return {
 						name: app.app,
 						source: app.source
@@ -241,12 +238,12 @@ export default {
 		options() {
 			return this.$resources.options.data;
 		},
-		defaultApps() {
-			return this.$resources.defaultApps.data;
+		preInstalledApps() {
+			return this.$resources.preInstalledApps.data;
 		},
-		defaultAppsList() {
+		preInstalledAppsList() {
 			return {
-				data: () => this.defaultApps,
+				data: () => this.preInstalledApps,
 				columns: [
 					{
 						label: 'Default Apps',
@@ -275,10 +272,10 @@ export default {
 				},
 				{
 					label: 'Preinstalled Apps',
-					value: this.defaultApps[this.benchVersion]
+					value: this.preInstalledApps[this.benchVersion]
 						.map(app => app.title)
 						.join(', '),
-					condition: () => this.defaultApps[this.benchVersion].length
+					condition: () => this.preInstalledApps[this.benchVersion].length
 				},
 				{
 					label: 'Region',

--- a/dashboard/src2/pages/NewReleaseGroup.vue
+++ b/dashboard/src2/pages/NewReleaseGroup.vue
@@ -64,6 +64,9 @@
 					</div>
 				</div>
 			</div>
+			<div v-if="benchVersion && defaultApps.length">
+				<ObjectList :options="defaultAppsList" />
+			</div>
 			<div
 				class="flex flex-col"
 				v-if="options?.clusters.length && benchVersion && !server"
@@ -129,17 +132,7 @@
 								version: benchVersion,
 								cluster: benchRegion,
 								saas_app: null,
-								apps: [
-									// some wizardry to only pick frappe for the chosen version
-									options.versions
-										.find(v => v.name === benchVersion)
-										.apps.find(app => app.name === 'frappe')
-								].map(app => {
-									return {
-										name: app.name,
-										source: app.source.name
-									};
-								}),
+								apps: getAppsToInstall(),
 								server: server || null
 							}
 						})
@@ -156,12 +149,16 @@
 import Summary from '../components/Summary.vue';
 import Header from '../components/Header.vue';
 import { DashboardError } from '../utils/error';
+import { h } from 'vue';
+import { Badge } from 'frappe-ui';
+import ObjectList from '../components/ObjectList.vue';
 
 export default {
 	name: 'NewReleaseGroup',
 	components: {
 		Summary,
-		Header
+		Header,
+		ObjectList
 	},
 	props: ['server'],
 	data() {
@@ -208,9 +205,79 @@ export default {
 			};
 		}
 	},
+	methods: {
+		getAppsToInstall() {
+			let apps = [
+				this.options.versions
+					.find(v => v.name === this.benchVersion)
+					.apps.find(app => app.name === 'frappe')
+			].map(app => {
+				return {
+					name: app.name,
+					source: app.source.name
+				};
+			});
+
+			// add default apps
+			this.defaultApps.forEach(app => {
+				apps.push({
+					name: app.name,
+					source: app.source
+				});
+			});
+
+			return apps;
+		}
+	},
 	computed: {
 		options() {
 			return this.$resources.options.data;
+		},
+		defaultApps() {
+			let defaultApps = [];
+			this.options.versions.forEach(version => {
+				version.apps.forEach(app => {
+					if (app.is_default) {
+						let d = {
+							name: app.name,
+							source: app.source.name,
+							app_title: app.title,
+							route: app.source.repository_url
+						};
+						if (
+							defaultApps.filter(app => app.app_title === d.app_title)
+								.length === 0
+						) {
+							defaultApps.push(d);
+						}
+					}
+				});
+			});
+
+			return defaultApps;
+		},
+		defaultAppsList() {
+			return {
+				data: () => this.defaultApps,
+				columns: [
+					{
+						label: 'Default Apps',
+						fieldname: 'app_title',
+						type: 'Component',
+						component: ({ row }) => {
+							return h(
+								'a',
+								{
+									class: 'flex items-center text-sm',
+									href: `${row.route}`,
+									target: '_blank'
+								},
+								[h('span', { class: 'ml-2' }, row.app_title)]
+							);
+						}
+					}
+				]
+			};
 		},
 		summaryOptions() {
 			return [

--- a/dashboard/src2/pages/NewSite.vue
+++ b/dashboard/src2/pages/NewSite.vue
@@ -544,11 +544,11 @@ export default {
 			else
 				apps = this.selectedVersion.group.bench_app_sources.map(app_source => {
 					let app_source_details = this.options.app_source_details[app_source];
-					console.log(app_source_details);
+
 					let marketplace_details = app_source_details
 						? this.options.marketplace_details[app_source_details.app]
 						: {};
-					console.log(marketplace_details);
+
 					return {
 						app_title: app_source,
 						...app_source_details,

--- a/dashboard/src2/pages/NewSite.vue
+++ b/dashboard/src2/pages/NewSite.vue
@@ -544,9 +544,11 @@ export default {
 			else
 				apps = this.selectedVersion.group.bench_app_sources.map(app_source => {
 					let app_source_details = this.options.app_source_details[app_source];
+					console.log(app_source_details);
 					let marketplace_details = app_source_details
 						? this.options.marketplace_details[app_source_details.app]
 						: {};
+					console.log(marketplace_details);
 					return {
 						app_title: app_source,
 						...app_source_details,

--- a/press/api/bench.py
+++ b/press/api/bench.py
@@ -224,15 +224,25 @@ def options():
 		.run(as_dict=True)
 	)
 
+	approved_apps = frappe.get_all(
+		"Marketplace App", filters={"frappe_approved": 1}, pluck="app"
+	)
+
+	press_settings = frappe.get_single("Press Settings")
+	apps_group = press_settings.get_app_group()
+
 	version_list = unique(rows, lambda x: x.version)
 	versions = []
 	for d in version_list:
 		version_dict = {"name": d.version, "status": d.status, "default": d.default}
 		version_rows = find_all(rows, lambda x: x.version == d.version)
 		app_list = frappe.utils.unique([row.app for row in version_rows])
+		app_list = sorted(app_list, key=lambda x: x not in approved_apps)
+
 		for app in app_list:
 			app_rows = find_all(version_rows, lambda x: x.app == app)
 			app_dict = {"name": app, "title": app_rows[0].title}
+
 			for source in app_rows:
 				source_dict = {
 					"name": source.source,
@@ -242,7 +252,10 @@ def options():
 					"repository_owner": source.repository_owner,
 				}
 				app_dict.setdefault("sources", []).append(source_dict)
+
 			app_dict["source"] = app_dict["sources"][0]
+			app_dict["is_default"] = True if app in apps_group else False
+
 			version_dict.setdefault("apps", []).append(app_dict)
 		versions.append(version_dict)
 

--- a/press/api/site.py
+++ b/press/api/site.py
@@ -590,7 +590,7 @@ def set_default_apps(app_source_details_grouped):
 
 	for app_source in app_source_details_grouped.values():
 		if app_source["app"] in default_apps:
-			app_source["is_default"] = True
+			app_source["preinstalled"] = True
 
 
 def get_available_versions(for_bench: str = None):  # noqa

--- a/press/press/doctype/app_group/app_group.json
+++ b/press/press/doctype/app_group/app_group.json
@@ -1,0 +1,46 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-09-03 15:07:30.256352",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "app",
+  "column_break_jvou",
+  "app_title"
+ ],
+ "fields": [
+  {
+   "fieldname": "app",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "App",
+   "options": "App",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_jvou",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "app.title",
+   "fieldname": "app_title",
+   "fieldtype": "Read Only",
+   "in_list_view": 1,
+   "label": "App Title"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-09-04 12:02:25.463128",
+ "modified_by": "Administrator",
+ "module": "Press",
+ "name": "App Group",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/press/press/doctype/app_group/app_group.py
+++ b/press/press/doctype/app_group/app_group.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, Frappe and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class AppGroup(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		app: DF.Link
+		app_title: DF.ReadOnly | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+	# end: auto-generated types
+
+	pass

--- a/press/press/doctype/app_group/app_group.py
+++ b/press/press/doctype/app_group/app_group.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2024, Frappe and contributors
 # For license information, please see license.txt
 
+from __future__ import annotations
+
 # import frappe
 from frappe.model.document import Document
 

--- a/press/press/doctype/press_settings/press_settings.json
+++ b/press/press/doctype/press_settings/press_settings.json
@@ -193,6 +193,9 @@
   "column_break_rdlr",
   "disable_auto_retry",
   "disable_agent_job_deduplication",
+  "section_break_jstu",
+  "enable_app_grouping",
+  "default_apps",
   "code_spaces_tab",
   "spaces_domain",
   "hybrid_server_tab",
@@ -1246,6 +1249,22 @@
    "fieldtype": "Link",
    "label": "Press Trial Plan",
    "options": "Site Plan"
+   },
+   {
+   "fieldname": "section_break_jstu",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_app_grouping",
+   "fieldtype": "Check",
+   "label": "Enable App Grouping"
+  },
+  {
+   "fieldname": "default_apps",
+   "fieldtype": "Table",
+   "label": "Default Apps",
+   "options": "App Group"
   }
  ],
  "issingle": 1,

--- a/press/press/doctype/press_settings/press_settings.py
+++ b/press/press/doctype/press_settings/press_settings.py
@@ -22,7 +22,7 @@ class PressSettings(Document):
 
 	if TYPE_CHECKING:
 		from frappe.types import DF
-
+		from press.press.doctype.app_group.app_group import AppGroup
 		from press.press.doctype.erpnext_app.erpnext_app import ERPNextApp
 
 		agent_github_access_token: DF.Data | None
@@ -51,6 +51,7 @@ class PressSettings(Document):
 		commission: DF.Float
 		compress_app_cache: DF.Check
 		data_40: DF.Data | None
+		default_apps: DF.Table[AppGroup]
 		default_outgoing_id: DF.Data | None
 		default_outgoing_pass: DF.Data | None
 		disable_agent_job_deduplication: DF.Check
@@ -61,6 +62,7 @@ class PressSettings(Document):
 		docker_registry_username: DF.Data | None
 		domain: DF.Link | None
 		eff_registration_email: DF.Data
+		enable_app_grouping: DF.Check
 		enable_google_oauth: DF.Check
 		enable_site_pooling: DF.Check
 		enforce_storage_limits: DF.Check
@@ -245,3 +247,8 @@ class PressSettings(Document):
 		api_key_sid = self.twilio_api_key_sid
 		api_key_secret = self.get_password("twilio_api_key_secret")
 		return Client(api_key_sid, api_key_secret, account_sid)
+
+	def get_app_group(self):
+		if self.enable_app_grouping:
+			return [app.app for app in self.default_apps]
+		return []

--- a/press/press/doctype/press_settings/press_settings.py
+++ b/press/press/doctype/press_settings/press_settings.py
@@ -250,6 +250,7 @@ class PressSettings(Document):
 		return Client(api_key_sid, api_key_secret, account_sid)
 
 	def get_default_apps(self):
-		if self.enable_app_grouping:
-			return [app.app for app in self.default_apps]
+		if hasattr(self, "enable_app_grouping") and hasattr(self, "default_apps"):  # noqa
+			if self.enable_app_grouping:
+				return [app.app for app in self.default_apps]
 		return []

--- a/press/press/doctype/press_settings/press_settings.py
+++ b/press/press/doctype/press_settings/press_settings.py
@@ -22,6 +22,7 @@ class PressSettings(Document):
 
 	if TYPE_CHECKING:
 		from frappe.types import DF
+
 		from press.press.doctype.app_group.app_group import AppGroup
 		from press.press.doctype.erpnext_app.erpnext_app import ERPNextApp
 
@@ -248,7 +249,7 @@ class PressSettings(Document):
 		api_key_secret = self.get_password("twilio_api_key_secret")
 		return Client(api_key_sid, api_key_secret, account_sid)
 
-	def get_app_group(self):
+	def get_default_apps(self):
 		if self.enable_app_grouping:
 			return [app.app for app in self.default_apps]
 		return []


### PR DESCRIPTION
### Settings to control and configure default apps
<img width="1334" alt="Screenshot 2024-09-04 at 2 26 00 PM" src="https://github.com/user-attachments/assets/2c70a99b-cb10-4d01-9dac-46bc5cc63ebd">

### Display default apps
<img width="612" alt="Screenshot 2024-11-21 at 1 21 59 PM" src="https://github.com/user-attachments/assets/cba139eb-fb04-4e4f-963a-d5c8b2e7760a">

### New bench with preinstalled apps
<img width="1213" alt="Screenshot 2024-11-21 at 1 22 46 PM" src="https://github.com/user-attachments/assets/d9759461-44b7-41b3-8dd4-4c7bcd5569dd">

### Site Creation with preinstalled apps
![screencapture-press-local-8080-dashboard-groups-bench-0003-sites-new-2024-11-21-13_23_41](https://github.com/user-attachments/assets/da6e349f-294f-4796-8b65-996d7d5f0859)

### Site apps
<img width="1208" alt="Screenshot 2024-11-21 at 1 24 08 PM" src="https://github.com/user-attachments/assets/38a5ce82-40dd-4f29-b557-5d2a3ae1ef6b">


