### PR TITLE
fix: check for duplicate records before submit

### DIFF
--- a/press/press/doctype/usage_record/usage_record.py
+++ b/press/press/doctype/usage_record/usage_record.py
@@ -41,6 +41,9 @@ class UsageRecord(Document):
 		if not self.time:
 			self.time = frappe.utils.nowtime()
 
+	def before_submit(self):
+		self.validate_duplicate_usage_record()
+
 	def on_submit(self):
 		self.update_usage_in_invoice()
 
@@ -71,6 +74,28 @@ class UsageRecord(Document):
 		invoice = team.get_upcoming_invoice()
 		if invoice:
 			invoice.remove_usage_record(self)
+
+	def validate_duplicate_usage_record(self):
+		usage_record = frappe.get_all(
+			"Usage Record",
+			{
+				"name": ("!=", self.name),
+				"team": self.team,
+				"document_type": self.document_type,
+				"document_name": self.document_name,
+				"interval": self.interval,
+				"date": self.date,
+				"plan": self.plan,
+				"docstatus": 1,
+			},
+			pluck="name",
+		)
+
+		if usage_record:
+			frappe.throw(
+				f"Usage Record {usage_record[0]} already exists for this document",
+				frappe.DuplicateEntryError,
+			)
 
 
 def link_unlinked_usage_records():


### PR DESCRIPTION
Sometimes duplicate usage record for same resource gets created in the same background job and validation is skipped 

This prevents the duplication by checking before submission of UR