### PR TITLE
feat: custom mail account for current saas signup

### DIFF
--- a/press/press/doctype/account_request/account_request.py
+++ b/press/press/doctype/account_request/account_request.py
@@ -140,7 +140,7 @@ class AccountRequest(Document):
 			print(f"\nOTP for {self.email}:")
 			print(self.otp)
 			print()
-			return
+			# return
 
 		subject = f"{self.otp} - OTP for Frappe Cloud Account Verification"
 		args = {}
@@ -152,7 +152,7 @@ class AccountRequest(Document):
 		if self.is_saas_signup() or custom_template:
 			subject = "Verify your email for Frappe"
 			template = "saas_verify_account"
-			# If product trial, get the product trial details
+			# If product trial(new saas flow), get the product trial details
 			if self.product_trial:
 				template = "product_trial_verify_account"
 				product_trial = frappe.get_doc("Product Trial", self.product_trial)
@@ -163,6 +163,11 @@ class AccountRequest(Document):
 				if product_trial.email_full_logo:
 					args.update({"image_path": get_url(product_trial.email_full_logo, True)})
 				args.update({"header_content": product_trial.email_header_content or ""})
+			# If saas_app is set, check for email account in saas settings of that app
+			elif self.saas_app:
+				email_account = frappe.get_value("Saas Settings", self.saas_app, "email_account")
+				if email_account:
+					sender = frappe.get_value("Email Account", email_account, "email_id")
 		else:
 			template = "verify_account"
 

--- a/press/press/doctype/account_request/account_request.py
+++ b/press/press/doctype/account_request/account_request.py
@@ -140,7 +140,7 @@ class AccountRequest(Document):
 			print(f"\nOTP for {self.email}:")
 			print(self.otp)
 			print()
-			# return
+			return
 
 		subject = f"{self.otp} - OTP for Frappe Cloud Account Verification"
 		args = {}

--- a/press/saas/doctype/saas_settings/saas_settings.json
+++ b/press/saas/doctype/saas_settings/saas_settings.json
@@ -12,6 +12,7 @@
   "domain",
   "cluster",
   "group",
+  "email_account",
   "column_break_9",
   "apps",
   "multi_subscription",
@@ -150,11 +151,18 @@
    "fieldname": "multi_subscription",
    "fieldtype": "Check",
    "label": "Multi Subscription"
+  },
+  {
+   "description": "Email account for sending signup/verification mails",
+   "fieldname": "email_account",
+   "fieldtype": "Link",
+   "label": "Email Account",
+   "options": "Email Account"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-02-05 23:05:21.977051",
+ "modified": "2024-09-13 09:55:11.473243",
  "modified_by": "Administrator",
  "module": "SaaS",
  "name": "Saas Settings",

--- a/press/saas/doctype/saas_settings/saas_settings.py
+++ b/press/saas/doctype/saas_settings/saas_settings.py
@@ -6,4 +6,32 @@ from frappe.model.document import Document
 
 
 class SaasSettings(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+		from press.press.doctype.erpnext_app.erpnext_app import ERPNextApp
+
+		app: DF.Link | None
+		apps: DF.Table[ERPNextApp]
+		billing_type: DF.Literal["prepaid", "postpaid"]
+		cluster: DF.Link | None
+		default_team: DF.Link | None
+		domain: DF.Link | None
+		email_account: DF.Link | None
+		enable_hybrid_pools: DF.Check
+		enable_pooling: DF.Check
+		group: DF.Link | None
+		multi_subscription: DF.Check
+		multiplier_pricing: DF.Check
+		plan: DF.Link | None
+		site_plan: DF.Link | None
+		standby_pool_size: DF.Int
+		standby_queue_size: DF.Int
+		whitelisted_apps: DF.Table[ERPNextApp]
+	# end: auto-generated types
+
 	pass


### PR DESCRIPTION
If we configure an email account under `SaaS Settings`, that mail will be used to send verification mails instead of default sending mail.