### PR TITLE
chore: use ruff for linting and formatting (pt.2)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,12 +20,12 @@ concurrency:
 
 jobs:
   format:
-    name: 'Black and Flake8'
+    name: 'Lint and Format'
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -34,13 +34,31 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install flake8 git+https://github.com/adityahase/black
-      - name: Black Test
+          pip install ruff
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+
+      - name: List all changed files
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-          black --check ${GITHUB_WORKSPACE}/press/press
-      - name: Flake8 Test
+          for file in ${ALL_CHANGED_FILES}; do
+            echo "$file was changed"
+          done
+
+      - name: Lint Check
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-          flake8 --ignore W191,E501,W503 ${GITHUB_WORKSPACE}/press/press
+          ruff check --output-format github ${ALL_CHANGED_FILES}
+
+      - name: Format Check
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          ruff format --check ${ALL_CHANGED_FILES}
 
   semgrep:
     name: Semgrep Rules

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,6 @@ default_stages: [commit]
 fail_fast: false
 
 repos:
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
-    hooks:
-      - id: flake8
-        args: [--ignore, 'W191,E501,W503']
-        additional_dependencies: ['flake8==7.0.0']
-
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.0-alpha.9-for-vscode
     hooks:
@@ -39,8 +32,10 @@ repos:
       - id: check-toml
       - id: check-yaml
 
-  - repo: https://github.com/adityahase/black
-    rev: 9cb0a69f4d0030cdf687eddf314468b39ed54119
+  
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.5
     hooks:
-      - id: black
-        additional_dependencies: ['click==8.0.4']
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/press/ruff.toml
+++ b/press/ruff.toml
@@ -1,0 +1,37 @@
+line-length = 110
+indent-width = 4
+target-version = "py310"
+
+[format]
+quote-style = "double"
+indent-style = "tab"
+
+
+[lint]
+select = [
+  "F",
+  "E",
+  "W",
+  "I",
+  "UP",
+  "B",
+  "RUF",
+  "FA",
+  "TCH",
+  "C90",
+  "RET",
+  "SIM",
+]
+ignore = [
+  "UP015",  # Unnecessary open mode parameters
+  "SIM108", # Use ternary operator {contents} instead of if-else-block
+  "F821",   # Undefined name, cause of DF.Literal
+  "F722",   # syntax error in forward type annotation, cause of DF.Literal
+  "E501",   # line too long, cause hooks.py
+  "W191",   # indentation contains tabs, cause when the world zigs, we zag
+  "B023",   # function doesn't bind loop variable - will have last iteration's value
+]
+
+
+[lint.mccabe]
+max-complexity = 8


### PR DESCRIPTION
First attempt at #2169. CI only runs linter and formatter on
changed files. Ruff does not run only on changed files so anyone
who touches a file will have to fix all the issues in it.

Good thing is 782 of the 1318 errors are fixable with --fix
