### PR TITLE
fix: UX for inplace updates

### DIFF
--- a/dashboard/src2/components/group/UpdateReleaseGroupDialog.vue
+++ b/dashboard/src2/components/group/UpdateReleaseGroupDialog.vue
@@ -440,8 +440,15 @@ export default {
 				return false;
 			}
 
+			// Failed in place update benches have to be regular updated.
+			const inPlaceUpdateFailedBenches =
+				this.benchDocResource?.doc?.inplace_update_failed_benches ?? [];
+
 			const allSites = this.siteOptions.data
-				.filter(s => benches.has(s.bench))
+				.filter(
+					s =>
+						benches.has(s.bench) || inPlaceUpdateFailedBenches.includes(s.bench)
+				)
 				.map(s => s.name);
 
 			// All sites under a bench should be updated

--- a/dashboard/src2/components/group/UpdateReleaseGroupDialog.vue
+++ b/dashboard/src2/components/group/UpdateReleaseGroupDialog.vue
@@ -80,12 +80,20 @@
 					</div>
 				</div>
 
-				<div v-if="canUpdateInPlace">
+				<div v-if="canUpdateInPlace" class="flex gap-2">
 					<FormControl
-						label="Use regular update"
+						label="Use in place update"
 						type="checkbox"
-						v-model="useRegularUpdate"
+						v-model="useInPlaceUpdate"
 					/>
+					<Tooltip text="View documentation">
+						<a
+							href="https://frappecloud.com/docs/in-place-updates"
+							target="_blank"
+						>
+							<i-lucide-help-circle :class="`h-4 w-4 text-gray-600`" />
+						</a>
+					</Tooltip>
 				</div>
 
 				<ErrorMessage :message="errorMessage" />
@@ -136,7 +144,7 @@ export default {
 			step: '',
 			errorMessage: '',
 			ignoreWillFailCheck: false,
-			useRegularUpdate: false,
+			useInPlaceUpdate: false,
 			restrictMessage: '',
 			selectedApps: [],
 			selectedSites: []
@@ -149,18 +157,6 @@ export default {
 			this.step = 'removed-apps';
 		} else {
 			this.step = 'select-sites';
-		}
-	},
-	watch: {
-		useUpdateInPlace(v) {
-			if (!v) {
-				return;
-			}
-
-			for (const site of this.selectedSites) {
-				site.skip_failing_patches = true;
-				site.skip_backups = true;
-			}
 		}
 	},
 	computed: {
@@ -337,7 +333,7 @@ export default {
 			 * If In Place update is being used failed patches are skipped
 			 * and site backups are not taken by default.
 			 */
-			const disabled = this.useUpdateInPlace;
+			const disabled = this.useInPlaceUpdate;
 
 			return {
 				data: siteData,
@@ -422,7 +418,7 @@ export default {
 				site = `${this.selectedSites.length} sites`;
 			}
 
-			if (this.useUpdateInPlace) {
+			if (this.useInPlaceUpdate) {
 				return `Update ${site} in place`;
 			}
 
@@ -454,9 +450,6 @@ export default {
 			}
 
 			return true;
-		},
-		useUpdateInPlace() {
-			return !this.useRegularUpdate && this.canUpdateInPlace;
 		}
 	},
 	resources: {
@@ -593,10 +586,17 @@ export default {
 			}
 
 			this.errorMessage = '';
-			if (this.useUpdateInPlace) {
+			if (this.canUpdateInPlace && this.useInPlaceUpdate) {
+				this.setSkipBackupsAndFailingPatches();
 				this.$resources.updateInPlace.submit();
 			} else {
 				this.$resources.deployAndUpdate.submit();
+			}
+		},
+		setSkipBackupsAndFailingPatches() {
+			for (const site of this.selectedSites) {
+				site.skip_failing_patches = true;
+				site.skip_backups = true;
 			}
 		},
 		setErrorMessage(error) {

--- a/press/press/doctype/bench/bench.json
+++ b/press/press/doctype/bench/bench.json
@@ -17,6 +17,7 @@
   "deploy_section",
   "candidate",
   "resetting_bench",
+  "last_inplace_update_failed",
   "column_break_gxqm",
   "docker_image",
   "inplace_update_docker_image",
@@ -353,11 +354,21 @@
    "description": "Attempting to reset bench after failed In Place Update.",
    "fieldname": "resetting_bench",
    "fieldtype": "Check",
-   "label": "Resetting Bench"
+   "label": "Resetting Bench",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.last_inplace_update_failed",
+   "description": "Previous attempt at updating bench in place failed. Only regular deploy should be attempted.",
+   "fieldname": "last_inplace_update_failed",
+   "fieldtype": "Check",
+   "label": "Last In Place Update Failed",
+   "read_only": 1
   }
  ],
  "links": [],
- "modified": "2024-09-09 12:20:10.404694",
+ "modified": "2024-10-07 11:05:42.340197",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Bench",

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -76,6 +76,7 @@ class Bench(Document):
 		is_code_server_enabled: DF.Check
 		is_ssh_proxy_setup: DF.Check
 		last_archive_failure: DF.Datetime | None
+		last_inplace_update_failed: DF.Check
 		managed_database_service: DF.Link | None
 		memory_high: DF.Int
 		memory_max: DF.Int
@@ -720,7 +721,7 @@ class Bench(Document):
 			status="Broken",
 			site_status="Broken",
 		)
-
+		self.last_inplace_update_failed = True
 		self.recover_update_inplace(sites)
 
 	def recover_update_inplace(self, sites: list[str]):
@@ -779,6 +780,7 @@ class Bench(Document):
 			status="Active",
 			site_status="Active",
 		)
+		self.last_inplace_update_failed = False
 
 	def set_self_and_site_status(
 		self,

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -179,6 +179,15 @@ class ReleaseGroup(Document, TagHelpers):
 			self.team,
 			"enable_inplace_updates",
 		)
+		if doc.enable_inplace_updates:
+			doc.inplace_update_failed_benches = self.get_inplace_update_failed_benches()
+
+	def get_inplace_update_failed_benches(self):
+		return frappe.db.get_all(
+			"Bench",
+			{"group": self.name, "status": "Active", "last_inplace_update_failed": True},
+			pluck="name",
+		)
 
 	def get_actions(self):
 		return [


### PR DESCRIPTION
Two changes:
- Changes **Use regular updates** to **Use in place updates**
- Prevents in place updates if last in place update for a bench failed

docs updated: https://frappecloud.com/docs/in-place-updates