### PR TITLE
fix(testcase): broken tests in CI

### DIFF
--- a/press/api/tests/test_bench.py
+++ b/press/api/tests/test_bench.py
@@ -8,7 +8,7 @@ import docker
 import frappe
 import requests
 from frappe.core.utils import find
-from frappe.tests.utils import FrappeTestCase, timeout
+from frappe.tests import UnitTestCase, timeout
 
 from press.api.bench import (
 	all,
@@ -40,7 +40,7 @@ from press.utils.test import foreground_enqueue_doc
 
 
 @patch.object(AgentJob, "enqueue_http_request", new=Mock())
-class TestAPIBench(FrappeTestCase):
+class TestAPIBench(UnitTestCase):
 	def setUp(self):
 		self.team = create_test_press_admin_team()
 		self.version = "Version 15"
@@ -85,9 +85,7 @@ class TestAPIBench(FrappeTestCase):
 		"press.press.doctype.deploy_candidate.deploy_candidate.frappe.enqueue_doc",
 		new=foreground_enqueue_doc,
 	)
-	@patch(
-		"press.press.doctype.deploy_candidate.deploy_candidate.frappe.db.commit", new=Mock()
-	)
+	@patch("press.press.doctype.deploy_candidate.deploy_candidate.frappe.db.commit", new=Mock())
 	def test_deploy_fn_deploys_bench_container(self):
 		# mark frappe as approved so that the deploy can happen
 		release = frappe.get_last_doc("App Release", {"source": self.app_source.name})
@@ -122,9 +120,7 @@ class TestAPIBench(FrappeTestCase):
 		new=foreground_enqueue_doc,
 	)
 	@patch.object(DeployCandidate, "schedule_build_and_deploy", new=Mock())
-	@patch(
-		"press.press.doctype.deploy_candidate.deploy_candidate.frappe.db.commit", new=Mock()
-	)
+	@patch("press.press.doctype.deploy_candidate.deploy_candidate.frappe.db.commit", new=Mock())
 	def test_deploy_and_update_fn_creates_bench_update(self):
 		group = new(
 			{
@@ -153,9 +149,7 @@ class TestAPIBench(FrappeTestCase):
 		"press.press.doctype.deploy_candidate.deploy_candidate.frappe.enqueue_doc",
 		new=foreground_enqueue_doc,
 	)
-	@patch(
-		"press.press.doctype.deploy_candidate.deploy_candidate.frappe.db.commit", new=Mock()
-	)
+	@patch("press.press.doctype.deploy_candidate.deploy_candidate.frappe.db.commit", new=Mock())
 	def test_deploy_and_update_fn_fails_without_release_argument(self):
 		group = new(
 			{
@@ -176,9 +170,7 @@ class TestAPIBench(FrappeTestCase):
 			[],
 		)
 
-	@patch(
-		"press.press.doctype.deploy_candidate.deploy_candidate.frappe.db.commit", new=Mock()
-	)
+	@patch("press.press.doctype.deploy_candidate.deploy_candidate.frappe.db.commit", new=Mock())
 	def test_deploy_fn_fails_without_apps(self):
 		frappe.set_user(self.team.user)
 		group = new(
@@ -193,9 +185,7 @@ class TestAPIBench(FrappeTestCase):
 		)
 		self.assertRaises(TypeError, deploy, group)
 
-	@patch(
-		"press.press.doctype.deploy_candidate.deploy_candidate.frappe.db.commit", new=Mock()
-	)
+	@patch("press.press.doctype.deploy_candidate.deploy_candidate.frappe.db.commit", new=Mock())
 	def test_deploy_fn_fails_with_empty_apps(self):
 		frappe.set_user(self.team.user)
 		group = new(
@@ -222,9 +212,7 @@ class TestAPIBench(FrappeTestCase):
 		self.assertIn(image_name, [tag for tag in image.tags])
 
 		test_port = 10501
-		client.containers.run(
-			image=image_name, remove=True, detach=True, ports={"8000/tcp": test_port}
-		)
+		client.containers.run(image=image_name, remove=True, detach=True, ports={"8000/tcp": test_port})
 		while True:
 			# Ensure that gunicorn at least responds. Usually we'll get 404 as there's no site installed *yet*
 			try:
@@ -232,12 +220,12 @@ class TestAPIBench(FrappeTestCase):
 				print("Received Response", response.text)
 				if response.status_code < 500:
 					break
-			except IOError as e:
+			except OSError as e:
 				print("Waitng for container to respond", str(e))
 			time.sleep(0.5)
 
 
-class TestAPIBenchConfig(FrappeTestCase):
+class TestAPIBenchConfig(UnitTestCase):
 	def setUp(self):
 		app = create_test_app()
 		self.rg = create_test_release_group([app])
@@ -474,9 +462,7 @@ class TestAPIBenchConfig(FrappeTestCase):
 			{"key": "BENCH_VERSION", "value": "5.15.2"},
 		]
 		self.assertFalse(dependencies(self.rg.name)["update_available"])
-		create_test_bench(
-			group=self.rg
-		)  # don't show dependency update available for new deploys
+		create_test_bench(group=self.rg)  # don't show dependency update available for new deploys
 		deps[0]["value"] = "16.12"
 		update_dependencies(
 			self.rg.name,
@@ -546,9 +532,7 @@ class TestAPIBenchConfig(FrappeTestCase):
 		bench.memory_swap = 4096
 		bench.vcpu = 2
 		bench.force_update_limits()
-		job = frappe.get_last_doc(
-			"Agent Job", {"job_type": "Force Update Bench Limits", "bench": bench.name}
-		)
+		job = frappe.get_last_doc("Agent Job", {"job_type": "Force Update Bench Limits", "bench": bench.name})
 		job_data = json.loads(job.request_data)
 		self.assertEqual(job_data["memory_high"], 1024)
 		self.assertEqual(job_data["memory_max"], 2048)
@@ -556,7 +540,7 @@ class TestAPIBenchConfig(FrappeTestCase):
 		self.assertEqual(job_data["vcpu"], 2)
 
 
-class TestAPIBenchList(FrappeTestCase):
+class TestAPIBenchList(UnitTestCase):
 	def setUp(self):
 		from press.press.doctype.press_tag.test_press_tag import create_and_add_test_tag
 
@@ -623,9 +607,7 @@ class TestAPIBenchList(FrappeTestCase):
 		)
 
 	def test_list_tagged_benches(self):
-		self.assertEqual(
-			all(bench_filter={"status": "", "tag": "test_tag"}), [self.bench_with_tag_dict]
-		)
+		self.assertEqual(all(bench_filter={"status": "", "tag": "test_tag"}), [self.bench_with_tag_dict])
 
 
 def set_press_settings_for_docker_build() -> None:

--- a/press/api/tests/test_server.py
+++ b/press/api/tests/test_server.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2019, Frappe and Contributors
 # See license.txt
 
+from __future__ import annotations
 
 from unittest.mock import MagicMock, Mock, patch
 
@@ -32,8 +33,8 @@ def create_test_server_plan(
 	document_type: str,
 	price_usd: float = 10.0,
 	price_inr: float = 750.0,
-	title: str = None,
-	plan_name: str = None,
+	title: str | None = None,
+	plan_name: str | None = None,
 ):
 	"""Create test Plan doc."""
 	plan_name = plan_name or f"Test {document_type} plan {make_autoname('.#')}"

--- a/press/api/tests/test_server.py
+++ b/press/api/tests/test_server.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019, Frappe and Contributors
 # See license.txt
 
@@ -8,7 +7,7 @@ from unittest.mock import MagicMock, Mock, patch
 import frappe
 from frappe.core.utils import find
 from frappe.model.naming import make_autoname
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.api.server import all, change_plan, new
 from press.press.doctype.ansible_play.test_ansible_play import create_test_ansible_play
@@ -71,9 +70,7 @@ def successful_ping_ansible(self: BaseServer):
 
 
 def successful_upgrade_mariadb(self: DatabaseServer):
-	create_test_ansible_play(
-		"Upgrade MariaDB", "upgrade_mariadb.yml", self.doctype, self.name
-	)
+	create_test_ansible_play("Upgrade MariaDB", "upgrade_mariadb.yml", self.doctype, self.name)
 
 
 def successful_upgrade_mariadb_patched(self: DatabaseServer):
@@ -101,13 +98,11 @@ def successful_wait_for_cloud_init(self: BaseServer):
 @patch.object(Ansible, "run", new=Mock())
 @patch.object(BaseServer, "ping_ansible", new=successful_ping_ansible)
 @patch.object(DatabaseServer, "upgrade_mariadb", new=successful_upgrade_mariadb)
-@patch.object(
-	DatabaseServer, "upgrade_mariadb_patched", new=successful_upgrade_mariadb_patched
-)
+@patch.object(DatabaseServer, "upgrade_mariadb_patched", new=successful_upgrade_mariadb_patched)
 @patch.object(BaseServer, "wait_for_cloud_init", new=successful_wait_for_cloud_init)
 @patch.object(BaseServer, "update_tls_certificate", new=successful_tls_certificate)
 @patch.object(BaseServer, "update_agent_ansible", new=successful_update_agent_ansible)
-class TestAPIServer(FrappeTestCase):
+class TestAPIServer(UnitTestCase):
 	@patch.object(Cluster, "provision_on_aws_ec2", new=Mock())
 	def setUp(self):
 		self.team = create_test_press_admin_team()
@@ -232,9 +227,7 @@ class TestAPIServer(FrappeTestCase):
 		app_plan_2.db_set("memory", 2048)
 		db_plan_2 = create_test_server_plan(document_type="Database Server")
 
-		self.team.allocate_credit_amount(
-			100000, source="Prepaid Credits", remark="Test Credits"
-		)
+		self.team.allocate_credit_amount(100000, source="Prepaid Credits", remark="Test Credits")
 		frappe.set_user(self.team.user)
 
 		new(
@@ -314,7 +307,7 @@ class TestAPIServer(FrappeTestCase):
 		)
 
 
-class TestAPIServerList(FrappeTestCase):
+class TestAPIServerList(UnitTestCase):
 	def setUp(self):
 		from press.press.doctype.database_server.test_database_server import (
 			create_test_database_server,
@@ -367,9 +360,7 @@ class TestAPIServerList(FrappeTestCase):
 		self.assertEqual(all(), [self.app_server_dict, self.db_server_dict])
 
 	def test_list_app_servers(self):
-		self.assertEqual(
-			all(server_filter={"server_type": "App Servers", "tag": ""}), [self.app_server_dict]
-		)
+		self.assertEqual(all(server_filter={"server_type": "App Servers", "tag": ""}), [self.app_server_dict])
 
 	def test_list_db_servers(self):
 		self.assertEqual(

--- a/press/api/tests/test_site.py
+++ b/press/api/tests/test_site.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, Mock, call, patch
 
 import frappe
 import responses
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.api.site import all
 from press.press.doctype.agent_job.agent_job import AgentJob, poll_pending_jobs
@@ -34,7 +34,7 @@ from press.press.doctype.site_plan.test_site_plan import create_test_plan
 from press.press.doctype.team.test_team import create_test_press_admin_team
 
 
-class TestAPISite(FrappeTestCase):
+class TestAPISite(UnitTestCase):
 	def setUp(self):
 		self.team = create_test_press_admin_team()
 		self.team.allocate_credit_amount(1000, source="Prepaid Credits", remark="Test")
@@ -919,7 +919,7 @@ erpnext 0.8.3	    HEAD
 		pass
 
 
-class TestAPISiteList(FrappeTestCase):
+class TestAPISiteList(UnitTestCase):
 	def setUp(self):
 		from press.press.doctype.press_tag.test_press_tag import create_and_add_test_tag
 		from press.press.doctype.site.test_site import create_test_site

--- a/press/api/tests/test_site.py
+++ b/press/api/tests/test_site.py
@@ -5,6 +5,7 @@ import datetime
 from unittest.mock import MagicMock, Mock, call, patch
 
 import frappe
+from press.press.doctype.database_server.test_database_server import create_test_database_server
 import responses
 from frappe.tests import UnitTestCase
 
@@ -40,6 +41,8 @@ class TestAPISite(UnitTestCase):
 		self.team.allocate_credit_amount(1000, source="Prepaid Credits", remark="Test")
 		self.team.payment_mode = "Prepaid Credits"
 		self.team.save()
+		# create dedicated server plan
+		create_test_plan("Site", dedicated_server_plan=True)
 
 	def tearDown(self):
 		frappe.db.rollback()
@@ -76,8 +79,9 @@ class TestAPISite(UnitTestCase):
 		from press.api.site import new
 
 		app = create_test_app()
+		server = create_test_server(create_test_proxy_server().name, create_test_database_server().name, public=True)
 		group = create_test_release_group([app])
-		bench = create_test_bench(group=group)
+		bench = create_test_bench(group=group, server=server.name)
 		plan = create_test_plan("Site")
 
 		frappe.set_user(self.team.user)
@@ -116,7 +120,7 @@ class TestAPISite(UnitTestCase):
 		frappe.db.set_single_value("Press Settings", "domain", root_domain.name)
 
 		n1_server = create_test_proxy_server(cluster=cluster.name, domain=root_domain.name)
-		f1_server = create_test_server(cluster=cluster.name, proxy_server=n1_server.name)
+		f1_server = create_test_server(cluster=cluster.name, proxy_server=n1_server.name, public=True)
 
 		group = create_test_release_group(
 			[frappe_app, allowed_app, disallowed_app], public=True, frappe_version="Version 15"

--- a/press/api/tests/test_site.py
+++ b/press/api/tests/test_site.py
@@ -5,7 +5,6 @@ import datetime
 from unittest.mock import MagicMock, Mock, call, patch
 
 import frappe
-from press.press.doctype.database_server.test_database_server import create_test_database_server
 import responses
 from frappe.tests import UnitTestCase
 
@@ -16,6 +15,7 @@ from press.press.doctype.app.test_app import create_test_app
 from press.press.doctype.app_release.test_app_release import create_test_app_release
 from press.press.doctype.bench.test_bench import create_test_bench
 from press.press.doctype.cluster.test_cluster import create_test_cluster
+from press.press.doctype.database_server.test_database_server import create_test_database_server
 from press.press.doctype.deploy_candidate_difference.test_deploy_candidate_difference import (
 	create_test_deploy_candidate_differences,
 )
@@ -77,7 +77,9 @@ class TestAPISite(UnitTestCase):
 		from press.api.site import new
 
 		app = create_test_app()
-		server = create_test_server(create_test_proxy_server().name, create_test_database_server().name, public=True)
+		server = create_test_server(
+			create_test_proxy_server().name, create_test_database_server().name, public=True
+		)
 		group = create_test_release_group([app])
 		bench = create_test_bench(group=group, server=server.name)
 		plan = create_test_plan("Site")
@@ -110,7 +112,9 @@ class TestAPISite(UnitTestCase):
 		dedicated_server_site_plan = create_test_plan("Site", dedicated_server_plan=True)
 
 		app = create_test_app()
-		server = create_test_server(create_test_proxy_server().name, create_test_database_server().name, public=False)
+		server = create_test_server(
+			create_test_proxy_server().name, create_test_database_server().name, public=False
+		)
 		group = create_test_release_group([app])
 		bench = create_test_bench(group=group, server=server.name)
 
@@ -143,7 +147,9 @@ class TestAPISite(UnitTestCase):
 		dedicated_server_site_plan = create_test_plan("Site", dedicated_server_plan=True)
 
 		app = create_test_app()
-		server = create_test_server(create_test_proxy_server().name, create_test_database_server().name, public=False)
+		server = create_test_server(
+			create_test_proxy_server().name, create_test_database_server().name, public=False
+		)
 		group = create_test_release_group([app])
 		bench = create_test_bench(group=group, server=server.name)
 

--- a/press/infrastructure/doctype/virtual_machine_migration/test_virtual_machine_migration.py
+++ b/press/infrastructure/doctype/virtual_machine_migration/test_virtual_machine_migration.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestVirtualMachineMigration(FrappeTestCase):
+class TestVirtualMachineMigration(UnitTestCase):
 	pass

--- a/press/marketplace/doctype/marketplace_app_payment/test_marketplace_app_payment.py
+++ b/press/marketplace/doctype/marketplace_app_payment/test_marketplace_app_payment.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestMarketplaceAppPayment(FrappeTestCase):
+class TestMarketplaceAppPayment(UnitTestCase):
 	pass

--- a/press/marketplace/doctype/marketplace_promotional_banner/test_marketplace_promotional_banner.py
+++ b/press/marketplace/doctype/marketplace_promotional_banner/test_marketplace_promotional_banner.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestMarketplacePromotionalBanner(FrappeTestCase):
+class TestMarketplacePromotionalBanner(UnitTestCase):
 	pass

--- a/press/marketplace/doctype/marketplace_settings/test_marketplace_settings.py
+++ b/press/marketplace/doctype/marketplace_settings/test_marketplace_settings.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestMarketplaceSettings(FrappeTestCase):
+class TestMarketplaceSettings(UnitTestCase):
 	pass

--- a/press/partner/doctype/partner_approval_request/test_partner_approval_request.py
+++ b/press/partner/doctype/partner_approval_request/test_partner_approval_request.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestPartnerApprovalRequest(FrappeTestCase):
+class TestPartnerApprovalRequest(UnitTestCase):
 	pass

--- a/press/press/doctype/agent_request_failure/test_agent_request_failure.py
+++ b/press/press/doctype/agent_request_failure/test_agent_request_failure.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestAgentRequestFailure(FrappeTestCase):
+class TestAgentRequestFailure(UnitTestCase):
 	pass

--- a/press/press/doctype/alertmanager_webhook_log_reaction_job/test_alertmanager_webhook_log_reaction_job.py
+++ b/press/press/doctype/alertmanager_webhook_log_reaction_job/test_alertmanager_webhook_log_reaction_job.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestAlertmanagerWebhookLogReactionJob(FrappeTestCase):
+class TestAlertmanagerWebhookLogReactionJob(UnitTestCase):
 	pass

--- a/press/press/doctype/analytics_server/test_analytics_server.py
+++ b/press/press/doctype/analytics_server/test_analytics_server.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestAnalyticsServer(FrappeTestCase):
+class TestAnalyticsServer(UnitTestCase):
 	pass

--- a/press/press/doctype/ansible_console/test_ansible_console.py
+++ b/press/press/doctype/ansible_console/test_ansible_console.py
@@ -2,10 +2,10 @@
 # See license.txt
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestAnsibleConsole(FrappeTestCase):
+class TestAnsibleConsole(UnitTestCase):
 	def test_ansible_console_run(self):
 		console = frappe.get_doc("Ansible Console")
 		console.inventory = "localhost,"

--- a/press/press/doctype/ansible_console_log/test_ansible_console_log.py
+++ b/press/press/doctype/ansible_console_log/test_ansible_console_log.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestAnsibleConsoleLog(FrappeTestCase):
+class TestAnsibleConsoleLog(UnitTestCase):
 	pass

--- a/press/press/doctype/app_patch/test_app_patch.py
+++ b/press/press/doctype/app_patch/test_app_patch.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestAppPatch(FrappeTestCase):
+class TestAppPatch(UnitTestCase):
 	pass

--- a/press/press/doctype/app_rename/test_app_rename.py
+++ b/press/press/doctype/app_rename/test_app_rename.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestAppRename(FrappeTestCase):
+class TestAppRename(UnitTestCase):
 	pass

--- a/press/press/doctype/aws_savings_plan_recommendation/test_aws_savings_plan_recommendation.py
+++ b/press/press/doctype/aws_savings_plan_recommendation/test_aws_savings_plan_recommendation.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestAWSSavingsPlanRecommendation(FrappeTestCase):
+class TestAWSSavingsPlanRecommendation(UnitTestCase):
 	pass

--- a/press/press/doctype/backup_bucket/test_backup_bucket.py
+++ b/press/press/doctype/backup_bucket/test_backup_bucket.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestBackupBucket(FrappeTestCase):
+class TestBackupBucket(UnitTestCase):
 	pass

--- a/press/press/doctype/backup_restoration_test/test_backup_restoration_test.py
+++ b/press/press/doctype/backup_restoration_test/test_backup_restoration_test.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestBackupRestorationTest(FrappeTestCase):
+class TestBackupRestorationTest(UnitTestCase):
 	pass

--- a/press/press/doctype/bench/test_bench.py
+++ b/press/press/doctype/bench/test_bench.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, Mock, patch
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.doctype.agent_job.agent_job import AgentJob, poll_pending_jobs
 from press.press.doctype.agent_job.test_agent_job import fake_agent_job
@@ -58,7 +58,7 @@ class TestStagingSite(unittest.TestCase):
 @patch.object(AgentJob, "after_insert", new=Mock())
 @patch("press.press.doctype.server.server.frappe.enqueue_doc", new=foreground_enqueue_doc)
 @patch("press.press.doctype.server.server.frappe.db.commit", new=MagicMock)
-class TestBench(FrappeTestCase):
+class TestBench(UnitTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 

--- a/press/press/doctype/bench_dependency/test_bench_dependency.py
+++ b/press/press/doctype/bench_dependency/test_bench_dependency.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestBenchDependency(FrappeTestCase):
+class TestBenchDependency(UnitTestCase):
 	pass

--- a/press/press/doctype/bench_get_app_cache/test_bench_get_app_cache.py
+++ b/press/press/doctype/bench_get_app_cache/test_bench_get_app_cache.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestBenchGetAppCache(FrappeTestCase):
+class TestBenchGetAppCache(UnitTestCase):
 	pass

--- a/press/press/doctype/bench_shell/test_bench_shell.py
+++ b/press/press/doctype/bench_shell/test_bench_shell.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestBenchShell(FrappeTestCase):
+class TestBenchShell(UnitTestCase):
 	pass

--- a/press/press/doctype/bench_shell_log/test_bench_shell_log.py
+++ b/press/press/doctype/bench_shell_log/test_bench_shell_log.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestBenchShellLog(FrappeTestCase):
+class TestBenchShellLog(UnitTestCase):
 	pass

--- a/press/press/doctype/bench_site_update/test_bench_site_update.py
+++ b/press/press/doctype/bench_site_update/test_bench_site_update.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestBenchSiteUpdate(FrappeTestCase):
+class TestBenchSiteUpdate(UnitTestCase):
 	pass

--- a/press/press/doctype/bench_update/test_bench_update.py
+++ b/press/press/doctype/bench_update/test_bench_update.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestBenchUpdate(FrappeTestCase):
+class TestBenchUpdate(UnitTestCase):
 	pass

--- a/press/press/doctype/build_cache_shell/test_build_cache_shell.py
+++ b/press/press/doctype/build_cache_shell/test_build_cache_shell.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestBuildCacheShell(FrappeTestCase):
+class TestBuildCacheShell(UnitTestCase):
 	pass

--- a/press/press/doctype/cloud_region/test_cloud_region.py
+++ b/press/press/doctype/cloud_region/test_cloud_region.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCloudRegion(FrappeTestCase):
+class TestCloudRegion(UnitTestCase):
 	pass

--- a/press/press/doctype/cluster_plan/test_cluster_plan.py
+++ b/press/press/doctype/cluster_plan/test_cluster_plan.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestClusterPlan(FrappeTestCase):
+class TestClusterPlan(UnitTestCase):
 	pass

--- a/press/press/doctype/code_server/test_code_server.py
+++ b/press/press/doctype/code_server/test_code_server.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestCodeServer(FrappeTestCase):
+class TestCodeServer(UnitTestCase):
 	pass

--- a/press/press/doctype/dashboard_banner/test_dashboard_banner.py
+++ b/press/press/doctype/dashboard_banner/test_dashboard_banner.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestDashboardBanner(FrappeTestCase):
+class TestDashboardBanner(UnitTestCase):
 	pass

--- a/press/press/doctype/database_server/test_database_server.py
+++ b/press/press/doctype/database_server/test_database_server.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
 
@@ -8,7 +7,7 @@ from unittest.mock import MagicMock, Mock, patch
 import frappe
 from frappe.core.utils import find
 from frappe.model.naming import make_autoname
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.doctype.database_server.database_server import DatabaseServer
 from press.press.doctype.server.server import BaseServer
@@ -38,7 +37,7 @@ def create_test_database_server(ip=None, cluster="Default") -> DatabaseServer:
 
 
 @patch.object(Ansible, "run", new=Mock())
-class TestDatabaseServer(FrappeTestCase):
+class TestDatabaseServer(UnitTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 
@@ -49,9 +48,7 @@ class TestDatabaseServer(FrappeTestCase):
 		"press.press.doctype.database_server.database_server.frappe.enqueue_doc",
 		new=foreground_enqueue_doc,
 	)
-	def test_mariadb_service_restarted_on_restart_mariadb_fn_call(
-		self, Mock_Ansible: Mock
-	):
+	def test_mariadb_service_restarted_on_restart_mariadb_fn_call(self, Mock_Ansible: Mock):
 		server = create_test_database_server()
 		server.restart_mariadb()
 		server.reload()  # modified timestamp datatype
@@ -72,9 +69,7 @@ class TestDatabaseServer(FrappeTestCase):
 		"press.press.doctype.database_server.database_server.frappe.enqueue_doc",
 		new=foreground_enqueue_doc,
 	)
-	def test_memory_limits_updated_on_update_of_corresponding_fields(
-		self, Mock_Ansible: MagicMock
-	):
+	def test_memory_limits_updated_on_update_of_corresponding_fields(self, Mock_Ansible: MagicMock):
 		server = create_test_database_server()
 		server.memory_high = 1
 		server.save()
@@ -103,9 +98,7 @@ class TestDatabaseServer(FrappeTestCase):
 		"press.press.doctype.database_server.database_server.frappe.enqueue_doc",
 		new=foreground_enqueue_doc,
 	)
-	def test_reconfigure_mariadb_exporter_play_runs_on_reconfigure_fn_call(
-		self, Mock_Ansible: Mock
-	):
+	def test_reconfigure_mariadb_exporter_play_runs_on_reconfigure_fn_call(self, Mock_Ansible: Mock):
 		server = create_test_database_server()
 		server.reconfigure_mariadb_exporter()
 		server.reload()

--- a/press/press/doctype/database_server_mariadb_variable/test_database_server_mariadb_variable.py
+++ b/press/press/doctype/database_server_mariadb_variable/test_database_server_mariadb_variable.py
@@ -3,7 +3,7 @@
 from unittest.mock import Mock, patch
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.doctype.database_server.test_database_server import (
 	create_test_database_server,
@@ -13,7 +13,7 @@ from press.utils.test import foreground_enqueue_doc
 
 
 @patch.object(Ansible, "run", new=Mock())
-class TestDatabaseServerMariaDBVariable(FrappeTestCase):
+class TestDatabaseServerMariaDBVariable(UnitTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 
@@ -208,9 +208,7 @@ class TestDatabaseServerMariaDBVariable(FrappeTestCase):
 		"press.press.doctype.database_server.database_server.frappe.enqueue_doc",
 		wraps=foreground_enqueue_doc,
 	)
-	def test_multiple_playbooks_triggered_for_multiple_variables(
-		self, mock_enqueue_doc, Mock_Ansible
-	):
+	def test_multiple_playbooks_triggered_for_multiple_variables(self, mock_enqueue_doc, Mock_Ansible):
 		server = create_test_database_server()
 		server.append(
 			"mariadb_system_variables",
@@ -314,9 +312,7 @@ class TestDatabaseServerMariaDBVariable(FrappeTestCase):
 		self.assertEqual(2, Mock_Ansible.call_count)
 		for call in Mock_Ansible.call_args_list:
 			args, kwargs = call
-			self.assertIn(
-				kwargs["variables"]["variable"], ["innodb_buffer_pool_size", "log_bin"]
-			)
+			self.assertIn(kwargs["variables"]["variable"], ["innodb_buffer_pool_size", "log_bin"])
 
 	@patch(
 		"press.press.doctype.database_server.database_server.frappe.enqueue_doc",
@@ -356,9 +352,7 @@ class TestDatabaseServerMariaDBVariable(FrappeTestCase):
 
 		server.reload()
 		self.assertEqual(1, len(server.mariadb_system_variables))
-		self.assertEqual(
-			"tmp_disk_table_size", server.mariadb_system_variables[0].mariadb_variable
-		)
+		self.assertEqual("tmp_disk_table_size", server.mariadb_system_variables[0].mariadb_variable)
 		self.assertEqual(10241, server.mariadb_system_variables[0].value_int)
 
 		with patch(
@@ -370,9 +364,7 @@ class TestDatabaseServerMariaDBVariable(FrappeTestCase):
 		Mock_Ansible.assert_called_once()
 
 		self.assertEqual(1, len(server.mariadb_system_variables))
-		self.assertEqual(
-			"tmp_disk_table_size", server.mariadb_system_variables[0].mariadb_variable
-		)
+		self.assertEqual("tmp_disk_table_size", server.mariadb_system_variables[0].mariadb_variable)
 		self.assertEqual(10242, server.mariadb_system_variables[0].value_int)
 
 		with patch(
@@ -386,7 +378,5 @@ class TestDatabaseServerMariaDBVariable(FrappeTestCase):
 			"press.press.doctype.database_server_mariadb_variable.database_server_mariadb_variable.Ansible",
 			wraps=Ansible,
 		) as Mock_Ansible:
-			server.add_mariadb_variable(
-				"tmp_disk_table_size", "value_int", 10242, persist=False
-			)  # no change
+			server.add_mariadb_variable("tmp_disk_table_size", "value_int", 10242, persist=False)  # no change
 		Mock_Ansible.assert_called_once()

--- a/press/press/doctype/erpnext_site_settings/test_erpnext_site_settings.py
+++ b/press/press/doctype/erpnext_site_settings/test_erpnext_site_settings.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestERPNextSiteSettings(FrappeTestCase):
+class TestERPNextSiteSettings(UnitTestCase):
 	pass

--- a/press/press/doctype/incident/test_incident.py
+++ b/press/press/doctype/incident/test_incident.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from unittest.mock import Mock, patch
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 from twilio.base.exceptions import TwilioRestException
 
 from press.press.doctype.agent_job.agent_job import AgentJob
@@ -85,7 +85,7 @@ class MockTwilioClient:
 @patch("press.press.doctype.site.site._change_dns_record", new=Mock())
 @patch("press.press.doctype.press_settings.press_settings.Client", new=MockTwilioClient)
 @patch("press.press.doctype.incident.incident.enqueue_doc", new=foreground_enqueue_doc)
-class TestIncident(FrappeTestCase):
+class TestIncident(UnitTestCase):
 	def setUp(self):
 		self.from_ = "+911234567892"
 		frappe.db.set_value("Press Settings", None, "twilio_account_sid", "test")
@@ -147,12 +147,8 @@ class TestIncident(FrappeTestCase):
 		)
 
 	@patch("tenacity.nap.time", new=Mock())  # no sleep
-	@patch.object(
-		MockTwilioCallList, "create", wraps=MockTwilioCallList("completed").create
-	)
-	def test_incident_calls_only_one_person_if_first_person_picks_up(
-		self, mock_calls_create: Mock
-	):
+	@patch.object(MockTwilioCallList, "create", wraps=MockTwilioCallList("completed").create)
+	def test_incident_calls_only_one_person_if_first_person_picks_up(self, mock_calls_create: Mock):
 		frappe.get_doc(
 			{
 				"doctype": "Incident",
@@ -162,9 +158,7 @@ class TestIncident(FrappeTestCase):
 		self.assertEqual(mock_calls_create.call_count, 1)
 
 	@patch("tenacity.nap.time", new=Mock())  # no sleep
-	@patch.object(
-		MockTwilioCallList, "create", wraps=MockTwilioCallList("completed").create
-	)
+	@patch.object(MockTwilioCallList, "create", wraps=MockTwilioCallList("completed").create)
 	def test_incident_calls_stop_for_in_progress_state(self, mock_calls_create):
 		incident = frappe.get_doc(
 			{
@@ -216,9 +210,7 @@ class TestIncident(FrappeTestCase):
 
 	@patch("tenacity.nap.time", new=Mock())  # no sleep
 	def test_call_event_creates_acknowledgement_update(self):
-		with patch.object(
-			MockTwilioCallList, "create", new=MockTwilioCallList("completed").create
-		):
+		with patch.object(MockTwilioCallList, "create", new=MockTwilioCallList("completed").create):
 			incident = frappe.get_doc(
 				{
 					"doctype": "Incident",
@@ -229,9 +221,7 @@ class TestIncident(FrappeTestCase):
 			incident.reload()
 			self.assertEqual(incident.status, "Acknowledged")
 			self.assertEqual(len(incident.updates), 1)
-		with patch.object(
-			MockTwilioCallList, "create", new=MockTwilioCallList("no-answer").create
-		):
+		with patch.object(MockTwilioCallList, "create", new=MockTwilioCallList("no-answer").create):
 			incident = frappe.get_doc(
 				{
 					"doctype": "Incident",
@@ -243,12 +233,8 @@ class TestIncident(FrappeTestCase):
 			self.assertEqual(len(incident.updates), 2)
 
 	@patch("tenacity.nap.time", new=Mock())  # no sleep
-	@patch.object(
-		MockTwilioCallList, "create", wraps=MockTwilioCallList("completed").create
-	)
-	def test_global_phone_call_alerts_disabled_wont_create_phone_calls(
-		self, mock_calls_create
-	):
+	@patch.object(MockTwilioCallList, "create", wraps=MockTwilioCallList("completed").create)
+	def test_global_phone_call_alerts_disabled_wont_create_phone_calls(self, mock_calls_create):
 		frappe.db.set_value("Incident Settings", None, "phone_call_alerts", 0)
 		frappe.get_doc(
 			{
@@ -315,14 +301,10 @@ class TestIncident(FrappeTestCase):
 		site = create_test_site()
 		site2 = create_test_site(server=site.server)
 		alert = create_test_prometheus_alert_rule()
-		create_test_alertmanager_webhook_log(
-			site=site, alert=alert, status="firing"
-		)  # 50% sites down
+		create_test_alertmanager_webhook_log(site=site, alert=alert, status="firing")  # 50% sites down
 		incident = frappe.get_last_doc("Incident")
 		self.assertEqual(incident.status, "Validating")
-		create_test_alertmanager_webhook_log(
-			site=site2, status="firing"
-		)  # other site down, nothing resolved
+		create_test_alertmanager_webhook_log(site=site2, status="firing")  # other site down, nothing resolved
 		resolve_incidents()
 		incident.reload()
 		self.assertEqual(incident.status, "Validating")
@@ -350,19 +332,13 @@ class TestIncident(FrappeTestCase):
 		self.assertEqual(incident.status, "Confirmed")
 		incident.db_set("status", "Validating")
 		incident.db_set("creation", frappe.utils.add_to_date(frappe.utils.now(), minutes=-19))
-		frappe.db.set_value(
-			"Incident Settings", None, "confirmation_threshold_day", str(21 * 60)
-		)
-		frappe.db.set_value(
-			"Incident Settings", None, "confirmation_threshold_night", str(21 * 60)
-		)
+		frappe.db.set_value("Incident Settings", None, "confirmation_threshold_day", str(21 * 60))
+		frappe.db.set_value("Incident Settings", None, "confirmation_threshold_night", str(21 * 60))
 		validate_incidents()
 		incident.reload()
 		self.assertEqual(incident.status, "Validating")
 
-	@patch.object(
-		MockTwilioCallList, "create", wraps=MockTwilioCallList("completed").create
-	)
+	@patch.object(MockTwilioCallList, "create", wraps=MockTwilioCallList("completed").create)
 	def test_calls_repeated_for_acknowledged_incidents(self, mock_calls_create):
 		create_test_alertmanager_webhook_log()
 		incident = frappe.get_last_doc("Incident")
@@ -389,9 +365,7 @@ class TestIncident(FrappeTestCase):
 		incident.db_set(
 			"creation",
 			incident.creation
-			- timedelta(
-				seconds=CONFIRMATION_THRESHOLD_SECONDS_NIGHT + CALL_THRESHOLD_SECONDS_NIGHT + 10
-			),
+			- timedelta(seconds=CONFIRMATION_THRESHOLD_SECONDS_NIGHT + CALL_THRESHOLD_SECONDS_NIGHT + 10),
 		)
 		with patch.object(
 			MockTwilioCallList,
@@ -417,13 +391,9 @@ class TestIncident(FrappeTestCase):
 			)
 
 	@patch.object(Telegram, "send")
-	def test_telegram_message_is_sent_when_unable_to_reach_twilio(
-		self, mock_telegram_send
-	):
+	def test_telegram_message_is_sent_when_unable_to_reach_twilio(self, mock_telegram_send):
 		create_test_alertmanager_webhook_log()
 		incident = frappe.get_last_doc("Incident")
-		with patch.object(
-			MockTwilioCallList, "create", side_effect=TwilioRestException("test", 500)
-		):
+		with patch.object(MockTwilioCallList, "create", side_effect=TwilioRestException("test", 500)):
 			incident.call_humans()
 		mock_telegram_send.assert_called_once()

--- a/press/press/doctype/incident_settings/test_incident_settings.py
+++ b/press/press/doctype/incident_settings/test_incident_settings.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestIncidentSettings(FrappeTestCase):
+class TestIncidentSettings(UnitTestCase):
 	pass

--- a/press/press/doctype/log_counter/test_log_counter.py
+++ b/press/press/doctype/log_counter/test_log_counter.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestLogCounter(FrappeTestCase):
+class TestLogCounter(UnitTestCase):
 	pass

--- a/press/press/doctype/malware_scan/test_malware_scan.py
+++ b/press/press/doctype/malware_scan/test_malware_scan.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestMalwareScan(FrappeTestCase):
+class TestMalwareScan(UnitTestCase):
 	pass

--- a/press/press/doctype/managed_database_service/test_managed_database_service.py
+++ b/press/press/doctype/managed_database_service/test_managed_database_service.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestManagedDatabaseService(FrappeTestCase):
+class TestManagedDatabaseService(UnitTestCase):
 	pass

--- a/press/press/doctype/mariadb_analyze_query/test_mariadb_analyze_query.py
+++ b/press/press/doctype/mariadb_analyze_query/test_mariadb_analyze_query.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestMariaDBAnalyzeQuery(FrappeTestCase):
+class TestMariaDBAnalyzeQuery(UnitTestCase):
 	pass

--- a/press/press/doctype/mariadb_stalk/test_mariadb_stalk.py
+++ b/press/press/doctype/mariadb_stalk/test_mariadb_stalk.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestMariaDBStalk(FrappeTestCase):
+class TestMariaDBStalk(UnitTestCase):
 	pass

--- a/press/press/doctype/mariadb_variable/test_mariadb_variable.py
+++ b/press/press/doctype/mariadb_variable/test_mariadb_variable.py
@@ -2,14 +2,14 @@
 # See license.txt
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.doctype.database_server.test_database_server import (
 	create_test_database_server,
 )
 
 
-class TestMariaDBVariable(FrappeTestCase):
+class TestMariaDBVariable(UnitTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 

--- a/press/press/doctype/oauth_domain_mapping/test_oauth_domain_mapping.py
+++ b/press/press/doctype/oauth_domain_mapping/test_oauth_domain_mapping.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestOAuthDomainMapping(FrappeTestCase):
+class TestOAuthDomainMapping(UnitTestCase):
 	pass

--- a/press/press/doctype/payment_dispute/test_payment_dispute.py
+++ b/press/press/doctype/payment_dispute/test_payment_dispute.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestPaymentDispute(FrappeTestCase):
+class TestPaymentDispute(UnitTestCase):
 	pass

--- a/press/press/doctype/payout_order/test_payout_order.py
+++ b/press/press/doctype/payout_order/test_payout_order.py
@@ -4,7 +4,7 @@
 from unittest.mock import Mock, patch
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.doctype.app.test_app import create_test_app
 from press.press.doctype.invoice.invoice import Invoice
@@ -19,7 +19,7 @@ from press.press.doctype.team.test_team import create_test_team
 
 
 @patch.object(Invoice, "create_invoice_on_frappeio", new=Mock())
-class TestPayoutOrder(FrappeTestCase):
+class TestPayoutOrder(UnitTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 

--- a/press/press/doctype/plan_change/test_plan_change.py
+++ b/press/press/doctype/plan_change/test_plan_change.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestPlanChange(FrappeTestCase):
+class TestPlanChange(UnitTestCase):
 	pass

--- a/press/press/doctype/press_job/test_press_job.py
+++ b/press/press/doctype/press_job/test_press_job.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestPressJob(FrappeTestCase):
+class TestPressJob(UnitTestCase):
 	pass

--- a/press/press/doctype/press_job_step/test_press_job_step.py
+++ b/press/press/doctype/press_job_step/test_press_job_step.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestPressJobStep(FrappeTestCase):
+class TestPressJobStep(UnitTestCase):
 	pass

--- a/press/press/doctype/press_job_type/test_press_job_type.py
+++ b/press/press/doctype/press_job_type/test_press_job_type.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestPressJobType(FrappeTestCase):
+class TestPressJobType(UnitTestCase):
 	pass

--- a/press/press/doctype/press_job_type_step/test_press_job_type_step.py
+++ b/press/press/doctype/press_job_type_step/test_press_job_type_step.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestPressJobTypeStep(FrappeTestCase):
+class TestPressJobTypeStep(UnitTestCase):
 	pass

--- a/press/press/doctype/press_method_permission/test_press_method_permission.py
+++ b/press/press/doctype/press_method_permission/test_press_method_permission.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestPressMethodPermission(FrappeTestCase):
+class TestPressMethodPermission(UnitTestCase):
 	pass

--- a/press/press/doctype/press_notification/test_press_notification.py
+++ b/press/press/doctype/press_notification/test_press_notification.py
@@ -2,7 +2,7 @@
 # See license.txt
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.api.notifications import get_unread_count
 from press.press.doctype.agent_job.agent_job import poll_pending_jobs
@@ -17,7 +17,7 @@ from press.press.doctype.release_group.test_release_group import (
 from press.press.doctype.site.test_site import create_test_bench, create_test_site
 
 
-class TestPressNotification(FrappeTestCase):
+class TestPressNotification(UnitTestCase):
 	def setUp(self):
 		app1 = create_test_app()  # frappe
 		app2 = create_test_app("app2", "App 2")
@@ -32,14 +32,15 @@ class TestPressNotification(FrappeTestCase):
 		bench1 = create_test_bench(group=group)
 		bench2 = create_test_bench(group=group, server=bench1.server)
 
-		create_test_deploy_candidate_differences(
-			bench2.candidate
-		)  # for site update to be available
+		create_test_deploy_candidate_differences(bench2.candidate)  # for site update to be available
 
 		site = create_test_site(bench=bench1.name)
 
 		self.assertEqual(frappe.db.count("Press Notification"), 0)
-		with fake_agent_job("Update Site Pull", "Failure",), fake_agent_job(
+		with fake_agent_job(
+			"Update Site Pull",
+			"Failure",
+		), fake_agent_job(
 			"Recover Failed Site Update",
 			"Success",
 		):

--- a/press/press/doctype/press_permission_group/test_press_permission_group.py
+++ b/press/press/doctype/press_permission_group/test_press_permission_group.py
@@ -2,7 +2,7 @@
 # See license.txt
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.doctype.press_permission_group.press_permission_group import (
 	get_all_restrictable_methods,
@@ -11,7 +11,7 @@ from press.press.doctype.press_permission_group.press_permission_group import (
 from press.press.doctype.team.test_team import create_test_team
 
 
-class TestPressPermissionGroup(FrappeTestCase):
+class TestPressPermissionGroup(UnitTestCase):
 	def setUp(self):
 		frappe.set_user("Administrator")
 		frappe.db.delete("Press Permission Group")
@@ -35,25 +35,17 @@ class TestPressPermissionGroup(FrappeTestCase):
 	def test_add_user(self):
 		self.perm_group.add_user(self.team_member.name)
 		perm_group_users = self.perm_group.get_users()
-		perm_group_user_exists = any(
-			self.team_member.name == pg_user.name for pg_user in perm_group_users
-		)
+		perm_group_user_exists = any(self.team_member.name == pg_user.name for pg_user in perm_group_users)
 		self.assertTrue(perm_group_user_exists)
-		self.assertRaises(
-			frappe.ValidationError, self.perm_group.add_user, self.team_member.name
-		)
+		self.assertRaises(frappe.ValidationError, self.perm_group.add_user, self.team_member.name)
 
 	def test_remove_user(self):
 		self.perm_group.add_user(self.team_member.name)
 		self.perm_group.remove_user(self.team_member.name)
 		perm_group_users = self.perm_group.get_users()
-		perm_group_user_exists = any(
-			self.team_member.name == pg_user.name for pg_user in perm_group_users
-		)
+		perm_group_user_exists = any(self.team_member.name == pg_user.name for pg_user in perm_group_users)
 		self.assertFalse(perm_group_user_exists)
-		self.assertRaises(
-			frappe.ValidationError, self.perm_group.remove_user, self.team_member.name
-		)
+		self.assertRaises(frappe.ValidationError, self.perm_group.remove_user, self.team_member.name)
 
 	def test_update_permissions(self):
 		frappe.set_user("Administrator")
@@ -63,9 +55,7 @@ class TestPressPermissionGroup(FrappeTestCase):
 		self.assertEqual(has_method_permission("Site", "site1.test", "reinstall"), True)
 
 		frappe.set_user("Administrator")
-		self.perm_group.update_permissions(
-			{"Site": {"site1.test": {"*": True, "reinstall": False}}}
-		)
+		self.perm_group.update_permissions({"Site": {"site1.test": {"*": True, "reinstall": False}}})
 		frappe.set_user(self.team_member.name)
 		self.assertEqual(has_method_permission("Site", "site1.test", "reinstall"), False)
 
@@ -131,9 +121,7 @@ class TestPressPermissionGroup(FrappeTestCase):
 
 		# Test case 2: User does not belong to the permission group
 		frappe.set_user("user@example.com")
-		self.assertRaises(
-			frappe.ValidationError, self.perm_group.get_all_document_permissions, "Site"
-		)
+		self.assertRaises(frappe.ValidationError, self.perm_group.get_all_document_permissions, "Site")
 
 		# Test case 3: Invalid restrictable doctype
 		frappe.set_user("Administrator")
@@ -144,9 +132,7 @@ class TestPressPermissionGroup(FrappeTestCase):
 		)
 
 		# Test case 4: No restrictable methods for the doctype
-		self.assertRaises(
-			frappe.ValidationError, self.perm_group.get_all_document_permissions, "DocType2"
-		)
+		self.assertRaises(frappe.ValidationError, self.perm_group.get_all_document_permissions, "DocType2")
 
 
 # utils

--- a/press/press/doctype/press_role/test_press_role.py
+++ b/press/press/doctype/press_role/test_press_role.py
@@ -2,13 +2,13 @@
 # See license.txt
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.doctype.site.test_site import create_test_site
 from press.press.doctype.team.test_team import create_test_team
 
 
-class TestPressRole(FrappeTestCase):
+class TestPressRole(UnitTestCase):
 	def setUp(self):
 		frappe.set_user("Administrator")
 		frappe.db.delete("Press Role")
@@ -36,9 +36,7 @@ class TestPressRole(FrappeTestCase):
 			self.team_member.name == perm_role_user.user for perm_role_user in perm_role_users
 		)
 		self.assertTrue(perm_role_user_exists)
-		self.assertRaises(
-			frappe.ValidationError, self.perm_role.add_user, self.team_member.name
-		)
+		self.assertRaises(frappe.ValidationError, self.perm_role.add_user, self.team_member.name)
 
 	def test_remove_user(self):
 		self.perm_role.add_user(self.team_member.name)
@@ -48,9 +46,7 @@ class TestPressRole(FrappeTestCase):
 			self.team_member.name == perm_role_user.user for perm_role_user in perm_role_users
 		)
 		self.assertFalse(perm_role_user_exists)
-		self.assertRaises(
-			frappe.ValidationError, self.perm_role.remove_user, self.team_member.name
-		)
+		self.assertRaises(frappe.ValidationError, self.perm_role.remove_user, self.team_member.name)
 
 	def test_delete_role(self):
 		perm = frappe.new_doc("Press Role Permission")
@@ -60,9 +56,7 @@ class TestPressRole(FrappeTestCase):
 
 		self.perm_role.delete()
 		self.assertFalse(frappe.db.exists("Press Role", self.perm_role.name))
-		self.assertFalse(
-			frappe.db.get_all("Press Role Permission", filters={"role": self.perm_role.name})
-		)
+		self.assertFalse(frappe.db.get_all("Press Role Permission", filters={"role": self.perm_role.name}))
 
 	def test_delete_permissions(self):
 		perm = frappe.new_doc("Press Role Permission")
@@ -74,9 +68,7 @@ class TestPressRole(FrappeTestCase):
 			"Press Role Permission", filters={"role": self.perm_role.name}, pluck="name"
 		)
 		self.perm_role.delete_permissions(permissions)
-		self.assertFalse(
-			frappe.db.get_all("Press Role Permission", filters={"role": self.perm_role.name})
-		)
+		self.assertFalse(frappe.db.get_all("Press Role Permission", filters={"role": self.perm_role.name}))
 
 	def test_get_list_with_permissions(self):
 		from press.api.client import get_list
@@ -158,9 +150,7 @@ class TestPressRole(FrappeTestCase):
 
 		frappe.set_user(self.team_user.name)
 
-		self.assertTrue(
-			frappe.db.exists("Press Role Permission", {"site": site.name, "role": role.name})
-		)
+		self.assertTrue(frappe.db.exists("Press Role Permission", {"site": site.name, "role": role.name}))
 
 		frappe.set_user("Administrator")
 		frappe.delete_doc("Press Role", role.name, force=1)

--- a/press/press/doctype/press_role_permission/test_press_role_permission.py
+++ b/press/press/doctype/press_role_permission/test_press_role_permission.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestPressRolePermission(FrappeTestCase):
+class TestPressRolePermission(UnitTestCase):
 	pass

--- a/press/press/doctype/press_tag/test_press_tag.py
+++ b/press/press/doctype/press_tag/test_press_tag.py
@@ -2,7 +2,7 @@
 # See license.txt
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.doctype.team.test_team import create_test_team
 
@@ -21,5 +21,5 @@ def create_and_add_test_tag(name: str, doctype: str, tag: str = "test_tag"):
 	return test_tag
 
 
-class TestPressTag(FrappeTestCase):
+class TestPressTag(UnitTestCase):
 	pass

--- a/press/press/doctype/press_user_permission/test_press_user_permission.py
+++ b/press/press/doctype/press_user_permission/test_press_user_permission.py
@@ -2,7 +2,7 @@
 # See license.txt
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.doctype.press_user_permission.press_user_permission import (
 	has_user_permission,
@@ -11,7 +11,7 @@ from press.press.doctype.site.test_site import create_test_site
 from press.press.doctype.team.test_team import create_test_team
 
 
-class TestPressUserPermission(FrappeTestCase):
+class TestPressUserPermission(UnitTestCase):
 	def setUp(self):
 		self.team = create_test_team()
 		self.site = create_test_site(subdomain="testpermsite")
@@ -33,14 +33,10 @@ class TestPressUserPermission(FrappeTestCase):
 		).insert(ignore_permissions=True)
 
 		self.assertTrue(has_user_permission("Site", self.site.name, "press.api.site.login"))
-		self.assertFalse(
-			has_user_permission("Site", self.site.name, "press.api.site.migrate")
-		)
+		self.assertFalse(has_user_permission("Site", self.site.name, "press.api.site.migrate"))
 
 	def test_press_group_permission(self):
-		group = frappe.get_doc(
-			doctype="Press Permission Group", team=self.team.name, title="Test Group"
-		)
+		group = frappe.get_doc(doctype="Press Permission Group", team=self.team.name, title="Test Group")
 		group.append("users", {"user": frappe.session.user})
 		group.insert(ignore_permissions=True)
 
@@ -54,14 +50,10 @@ class TestPressUserPermission(FrappeTestCase):
 		).insert(ignore_permissions=True)
 
 		self.assertTrue(
-			has_user_permission(
-				"Site", self.site.name, "press.api.site.overview", groups=[group.name]
-			)
+			has_user_permission("Site", self.site.name, "press.api.site.overview", groups=[group.name])
 		)
 		self.assertFalse(
-			has_user_permission(
-				"Site", self.site.name, "press.api.site.migrate", groups=[group.name]
-			)
+			has_user_permission("Site", self.site.name, "press.api.site.migrate", groups=[group.name])
 		)
 
 	def test_press_config_permission(self):
@@ -79,12 +71,6 @@ class TestPressUserPermission(FrappeTestCase):
 		).insert(ignore_permissions=True)
 
 		self.assertTrue(has_user_permission("Site", self.site.name, "press.api.site.login"))
-		self.assertFalse(
-			has_user_permission("Site", "sometest.frappe.dev", "press.api.site.restore")
-		)
-		self.assertFalse(
-			has_user_permission("Site", "test.frappe.dev", "press.api.site.migrate")
-		)
-		self.assertTrue(
-			has_user_permission("Site", "test.frappe.dev", "press.api.site.login")
-		)
+		self.assertFalse(has_user_permission("Site", "sometest.frappe.dev", "press.api.site.restore"))
+		self.assertFalse(has_user_permission("Site", "test.frappe.dev", "press.api.site.migrate"))
+		self.assertTrue(has_user_permission("Site", "test.frappe.dev", "press.api.site.login"))

--- a/press/press/doctype/press_webhook/test_press_webhook.py
+++ b/press/press/doctype/press_webhook/test_press_webhook.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestPressWebhook(FrappeTestCase):
+class TestPressWebhook(UnitTestCase):
 	pass

--- a/press/press/doctype/press_webhook_attempt/test_press_webhook_attempt.py
+++ b/press/press/doctype/press_webhook_attempt/test_press_webhook_attempt.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestPressWebhookAttempt(FrappeTestCase):
+class TestPressWebhookAttempt(UnitTestCase):
 	pass

--- a/press/press/doctype/press_webhook_event/test_press_webhook_event.py
+++ b/press/press/doctype/press_webhook_event/test_press_webhook_event.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestPressWebhookEvent(FrappeTestCase):
+class TestPressWebhookEvent(UnitTestCase):
 	pass

--- a/press/press/doctype/press_webhook_log/test_press_webhook_log.py
+++ b/press/press/doctype/press_webhook_log/test_press_webhook_log.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestPressWebhookLog(FrappeTestCase):
+class TestPressWebhookLog(UnitTestCase):
 	pass

--- a/press/press/doctype/proxy_server/test_proxy_server.py
+++ b/press/press/doctype/proxy_server/test_proxy_server.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
 
-from typing import Dict, List
+from __future__ import annotations
+
 from unittest.mock import Mock, patch
 
 import frappe
@@ -24,11 +25,13 @@ from press.utils.test import foreground_enqueue_doc
 def create_test_proxy_server(
 	hostname: str = "n",
 	domain: str = "fc.dev",
-	domains: List[Dict[str, str]] = [{"domain": "fc.dev"}],
+	domains: list[dict[str, str]] | None = None,
 	cluster: str = "Default",
 	is_primary: bool = True,
 ) -> ProxyServer:
 	"""Create test Proxy Server doc"""
+	if domains is None:
+		domains = [{"domain": "fc.dev"}]
 	create_test_press_settings()
 	server = frappe.get_doc(
 		{

--- a/press/press/doctype/proxy_server/test_proxy_server.py
+++ b/press/press/doctype/proxy_server/test_proxy_server.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
 
@@ -7,7 +6,7 @@ from unittest.mock import Mock, patch
 
 import frappe
 from frappe.model.naming import make_autoname
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 from moto import mock_aws
 
 from press.press.doctype.agent_job.test_agent_job import fake_agent_job
@@ -53,7 +52,7 @@ def create_test_proxy_server(
 	foreground_enqueue_doc,
 )
 @patch("press.press.doctype.proxy_server.proxy_server.Ansible", new=Mock())
-class TestProxyServer(FrappeTestCase):
+class TestProxyServer(UnitTestCase):
 	@fake_agent_job("Reload NGINX Job")
 	@mock_aws
 	@patch.object(
@@ -83,9 +82,7 @@ class TestProxyServer(FrappeTestCase):
 		proxy2.db_set("primary", proxy1.name)
 		proxy2.db_set("is_replication_setup", 1)
 		proxy2.trigger_failover()
-		update_dns_records_for_sites.assert_called_once_with(
-			root_domain, [site1.name], proxy2.name
-		)
+		update_dns_records_for_sites.assert_called_once_with(root_domain, [site1.name], proxy2.name)
 		proxy2.reload()
 		proxy1.reload()
 		self.assertTrue(proxy2.is_primary)

--- a/press/press/doctype/security_update/test_security_update.py
+++ b/press/press/doctype/security_update/test_security_update.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestSecurityUpdate(FrappeTestCase):
+class TestSecurityUpdate(UnitTestCase):
 	pass

--- a/press/press/doctype/security_update_check/test_security_update_check.py
+++ b/press/press/doctype/security_update_check/test_security_update_check.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestSecurityUpdateCheck(FrappeTestCase):
+class TestSecurityUpdateCheck(UnitTestCase):
 	pass

--- a/press/press/doctype/self_hosted_server/test_self_hosted_server.py
+++ b/press/press/doctype/self_hosted_server/test_self_hosted_server.py
@@ -6,7 +6,7 @@ import json
 from unittest.mock import patch
 
 import frappe
-from frappe.tests.utils import FrappeTestCase, change_settings
+from frappe.tests import UnitTestCase, change_settings
 
 from press.api.tests.test_server import create_test_server_plan
 from press.press.doctype.ansible_play.test_ansible_play import create_test_ansible_play
@@ -17,7 +17,7 @@ from press.press.doctype.self_hosted_server.self_hosted_server import SelfHosted
 from press.press.doctype.team.test_team import create_test_team
 
 
-class TestSelfHostedServer(FrappeTestCase):
+class TestSelfHostedServer(UnitTestCase):
 	def setUp(self):
 		create_test_press_settings()
 
@@ -263,9 +263,7 @@ class TestSelfHostedServer(FrappeTestCase):
 		self.assertEqual(pre_subscription_count, post_subscription_count - 2)
 
 
-def create_test_self_hosted_server(
-	host, database_plan=None, plan=None
-) -> SelfHostedServer:
+def create_test_self_hosted_server(host, database_plan=None, plan=None) -> SelfHostedServer:
 	"""
 	Plan: is a string that represents the application servers subscription plan name
 	Database Plan: is a string that represents the database servers subscription plan name

--- a/press/press/doctype/serial_console_log/test_serial_console_log.py
+++ b/press/press/doctype/serial_console_log/test_serial_console_log.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestSerialConsoleLog(FrappeTestCase):
+class TestSerialConsoleLog(UnitTestCase):
 	pass

--- a/press/press/doctype/server/test_server.py
+++ b/press/press/doctype/server/test_server.py
@@ -32,6 +32,7 @@ def create_test_server(
 	cluster: str = "Default",
 	plan: str = None,
 	team: str = None,
+	public: bool = True,
 ) -> "Server":
 	"""Create test Server doc."""
 	if not proxy_server:
@@ -55,6 +56,7 @@ def create_test_server(
 			"ram": 16000,
 			"team": team,
 			"plan": plan,
+			"public": public,
 		}
 	).insert()
 	server.reload()

--- a/press/press/doctype/server/test_server.py
+++ b/press/press/doctype/server/test_server.py
@@ -33,6 +33,7 @@ def create_test_server(
 	plan: str | None = None,
 	team: str | None = None,
 	public: bool = False,
+	disable_agent_job_auto_retry: bool = False,
 ) -> "Server":
 	"""Create test Server doc."""
 	if not proxy_server:
@@ -57,6 +58,7 @@ def create_test_server(
 			"team": team,
 			"plan": plan,
 			"public": public,
+			"disable_agent_job_auto_retry": disable_agent_job_auto_retry,
 		}
 	).insert()
 	server.reload()

--- a/press/press/doctype/server/test_server.py
+++ b/press/press/doctype/server/test_server.py
@@ -32,7 +32,7 @@ def create_test_server(
 	cluster: str = "Default",
 	plan: str = None,
 	team: str = None,
-	public: bool = True,
+	public: bool = False,
 ) -> "Server":
 	"""Create test Server doc."""
 	if not proxy_server:

--- a/press/press/doctype/server/test_server.py
+++ b/press/press/doctype/server/test_server.py
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019, Frappe and Contributors
 # See license.txt
 
+from __future__ import annotations
 
 import typing
 import unittest
@@ -27,11 +27,11 @@ if typing.TYPE_CHECKING:
 
 @patch.object(BaseServer, "after_insert", new=Mock())
 def create_test_server(
-	proxy_server: str = None,
-	database_server: str = None,
+	proxy_server: str | None = None,
+	database_server: str | None = None,
 	cluster: str = "Default",
-	plan: str = None,
-	team: str = None,
+	plan: str | None = None,
+	team: str | None = None,
 	public: bool = False,
 ) -> "Server":
 	"""Create test Server doc."""

--- a/press/press/doctype/server_plan/test_server_plan.py
+++ b/press/press/doctype/server_plan/test_server_plan.py
@@ -5,7 +5,7 @@ import typing
 
 import frappe
 from frappe.model.naming import make_autoname
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 if typing.TYPE_CHECKING:
 	from press.press.doctype.server_plan.server_plan import ServerPlan
@@ -28,5 +28,5 @@ def create_test_server_plan(server_type: str = "Server") -> "ServerPlan":
 	return server_plan
 
 
-class TestServerPlan(FrappeTestCase):
+class TestServerPlan(UnitTestCase):
 	pass

--- a/press/press/doctype/server_storage_plan/test_server_storage_plan.py
+++ b/press/press/doctype/server_storage_plan/test_server_storage_plan.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestServerStoragePlan(FrappeTestCase):
+class TestServerStoragePlan(UnitTestCase):
 	pass

--- a/press/press/doctype/silenced_alert/test_silenced_alert.py
+++ b/press/press/doctype/silenced_alert/test_silenced_alert.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestSilencedAlert(FrappeTestCase):
+class TestSilencedAlert(UnitTestCase):
 	pass

--- a/press/press/doctype/site/test_backups.py
+++ b/press/press/doctype/site/test_backups.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from unittest.mock import MagicMock, Mock, patch
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.doctype.agent_job.agent_job import AgentJob
 from press.press.doctype.site.backups import (
@@ -17,7 +17,7 @@ from press.press.doctype.site_backup.test_site_backup import create_test_site_ba
 @patch("press.press.doctype.site.backups.frappe.db.commit", new=MagicMock)
 @patch("press.press.doctype.site.backups.frappe.db.rollback", new=MagicMock)
 @patch.object(AgentJob, "after_insert", new=Mock())
-class TestScheduledBackupJob(FrappeTestCase):
+class TestScheduledBackupJob(UnitTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 
@@ -35,9 +35,7 @@ class TestScheduledBackupJob(FrappeTestCase):
 		return frappe.utils.now_datetime() - timedelta(hours=self.interval)
 
 	def _create_site_requiring_backup(self, **kwargs):
-		return create_test_site(
-			creation=self._interval_hrs_ago() - timedelta(hours=1), **kwargs
-		)
+		return create_test_site(creation=self._interval_hrs_ago() - timedelta(hours=1), **kwargs)
 
 	@patch.object(
 		ScheduledBackupJob,

--- a/press/press/doctype/site/test_backups.py
+++ b/press/press/doctype/site/test_backups.py
@@ -87,7 +87,7 @@ class TestScheduledBackupJob(UnitTestCase):
 	def _create_x_sites_on_1_bench(self, x):
 		site = self._create_site_requiring_backup()
 		bench = site.bench
-		for i in range(x - 1):
+		for _ in range(x - 1):
 			self._create_site_requiring_backup(bench=bench)
 
 	def test_limit_number_of_sites_backed_up(self):

--- a/press/press/doctype/site/test_site.py
+++ b/press/press/doctype/site/test_site.py
@@ -1,17 +1,15 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019, Frappe and Contributors
 # See license.txt
 
+from __future__ import annotations
 
 import json
 import typing
 import unittest
-from datetime import datetime
-from typing import Optional
 from unittest.mock import Mock, PropertyMock, patch
-import responses
 
 import frappe
+import responses
 from frappe.model.naming import make_autoname
 
 from press.exceptions import InsufficientSpaceOnServer
@@ -20,29 +18,31 @@ from press.press.doctype.app.test_app import create_test_app
 from press.press.doctype.database_server.test_database_server import (
 	create_test_database_server,
 )
-from press.press.doctype.release_group.release_group import ReleaseGroup
 from press.press.doctype.release_group.test_release_group import (
 	create_test_release_group,
 )
-from press.press.doctype.server.server import BaseServer, Server
-from press.press.doctype.site.site import Site, process_rename_site_job_update
 from press.press.doctype.remote_file.remote_file import RemoteFile
 from press.press.doctype.remote_file.test_remote_file import (
 	create_test_remote_file,
 )
+from press.press.doctype.server.server import BaseServer, Server
+from press.press.doctype.site.site import Site, process_rename_site_job_update
 from press.telegram_utils import Telegram
 from press.utils import get_current_team
 
 if typing.TYPE_CHECKING:
+	from datetime import datetime
+
 	from press.press.doctype.bench.bench import Bench
+	from press.press.doctype.release_group.release_group import ReleaseGroup
 
 
 def create_test_bench(
-	user: str = None,
-	group: ReleaseGroup = None,
-	server: str = None,
-	apps: Optional[list[dict]] = None,
-	creation: datetime = None,
+	user: str | None = None,
+	group: ReleaseGroup | None = None,
+	server: str | None = None,
+	apps: list[dict] | None = None,
+	creation: datetime | None = None,
 ) -> "Bench":
 	"""
 	Create test Bench doc.
@@ -88,12 +88,12 @@ def create_test_bench(
 def create_test_site(
 	subdomain: str = "",
 	new: bool = False,
-	creation: datetime = None,
-	bench: str = None,
-	server: str = None,
-	team: str = None,
-	standby_for: Optional[str] = None,
-	apps: Optional[list[str]] = None,
+	creation: datetime | None = None,
+	bench: str | None = None,
+	server: str | None = None,
+	team: str | None = None,
+	standby_for: str | None = None,
+	apps: list[str] | None = None,
 	remote_database_file=None,
 	remote_public_file=None,
 	remote_private_file=None,
@@ -152,6 +152,7 @@ class TestSite(unittest.TestCase):
 
 	def tearDown(self):
 		frappe.db.rollback()
+		frappe.db.truncate("Agent Request Failure")
 
 	def test_host_name_updates_perform_checks_on_host_name(self):
 		"""Ensure update of host name triggers verification of host_name."""
@@ -169,9 +170,7 @@ class TestSite(unittest.TestCase):
 		"""Ensure new sites set host_name in site config in f server."""
 		with patch.object(Site, "_update_configuration") as mock_update_config:
 			site = create_test_site("testsubdomain", new=True)
-		mock_update_config.assert_called_with(
-			{"host_name": f"https://{site.name}"}, save=False
-		)
+		mock_update_config.assert_called_with({"host_name": f"https://{site.name}"}, save=False)
 
 	def test_rename_updates_name(self):
 		"""Ensure rename changes name of site."""
@@ -205,9 +204,7 @@ class TestSite(unittest.TestCase):
 		)
 
 		self.assertEqual(rename_jobs_count_after - rename_jobs_count_before, 1)
-		self.assertEqual(
-			rename_upstream_jobs_count_after - rename_upstream_jobs_count_before, 1
-		)
+		self.assertEqual(rename_upstream_jobs_count_after - rename_upstream_jobs_count_before, 1)
 
 	def test_subdomain_update_renames_site(self):
 		"""Ensure updating subdomain renames site."""
@@ -228,9 +225,7 @@ class TestSite(unittest.TestCase):
 		)
 
 		self.assertEqual(rename_jobs_count_after - rename_jobs_count_before, 1)
-		self.assertEqual(
-			rename_upstream_jobs_count_after - rename_upstream_jobs_count_before, 1
-		)
+		self.assertEqual(rename_upstream_jobs_count_after - rename_upstream_jobs_count_before, 1)
 
 	def _fake_succeed_rename_jobs(self):
 		rename_step_name_map = {
@@ -238,9 +233,7 @@ class TestSite(unittest.TestCase):
 			"Rename Site on Upstream": "Rename Site File in Upstream Directory",
 		}
 		rename_job = frappe.get_last_doc("Agent Job", {"job_type": "Rename Site"})
-		rename_upstream_job = frappe.get_last_doc(
-			"Agent Job", {"job_type": "Rename Site on Upstream"}
-		)
+		rename_upstream_job = frappe.get_last_doc("Agent Job", {"job_type": "Rename Site on Upstream"})
 		frappe.db.set_value(
 			"Agent Job Step",
 			{
@@ -436,7 +429,6 @@ class TestSite(unittest.TestCase):
 	def test_restore_site_adds_storage_if_no_sufficient_storage_available_on_public_server(
 		self, mock_increase_disk_size: Mock
 	):
-
 		"""Ensure restore site adds storage if no sufficient storage available."""
 		site = create_test_site()
 		site.remote_database_file = create_test_remote_file(file_size=1024).name
@@ -451,9 +443,7 @@ class TestSite(unittest.TestCase):
 			"public",
 			True,
 		)
-		with patch.object(
-			BaseServer, "free_space", new=PropertyMock(return_value=500 * 1024 * 1024 * 1024)
-		):
+		with patch.object(BaseServer, "free_space", new=PropertyMock(return_value=500 * 1024 * 1024 * 1024)):
 			site.restore_site()
 		mock_increase_disk_size.assert_not_called()
 
@@ -479,8 +469,7 @@ class TestSite(unittest.TestCase):
 		with self.assertRaises(frappe.exceptions.ValidationError) as context:
 			site.save(ignore_permissions=True)
 		self.assertTrue(
-			"Auto updates can't be disabled for sites on public benches"
-			in str(context.exception)
+			"Auto updates can't be disabled for sites on public benches" in str(context.exception)
 		)
 
 	def test_user_can_disable_auto_update_if_site_in_private_bench(self):

--- a/press/press/doctype/site_analytics/test_site_analytics.py
+++ b/press/press/doctype/site_analytics/test_site_analytics.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestSiteAnalytics(FrappeTestCase):
+class TestSiteAnalytics(UnitTestCase):
 	pass

--- a/press/press/doctype/site_backup/test_site_backup.py
+++ b/press/press/doctype/site_backup/test_site_backup.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
 
+from __future__ import annotations
 
 import json
-from datetime import datetime
+from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
 import frappe
@@ -13,11 +14,14 @@ from press.press.doctype.agent_job.agent_job import AgentJob, process_job_update
 from press.press.doctype.remote_file.test_remote_file import create_test_remote_file
 from press.press.doctype.site.test_site import create_test_site
 
+if TYPE_CHECKING:
+	from datetime import datetime
+
 
 @patch.object(AgentJob, "enqueue_http_request", new=Mock())
 def create_test_site_backup(
 	site: str,
-	creation: datetime = None,
+	creation: datetime | None = None,
 	files_availability: str = "Available",
 	offsite: bool = True,
 	status: str = "Success",

--- a/press/press/doctype/site_backup/test_site_backup.py
+++ b/press/press/doctype/site_backup/test_site_backup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
 
@@ -8,7 +7,7 @@ from datetime import datetime
 from unittest.mock import Mock, patch
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.doctype.agent_job.agent_job import AgentJob, process_job_updates
 from press.press.doctype.remote_file.test_remote_file import create_test_remote_file
@@ -47,7 +46,7 @@ def create_test_site_backup(
 	return site_backup
 
 
-class TestSiteBackup(FrappeTestCase):
+class TestSiteBackup(UnitTestCase):
 	def setUp(self):
 		self.site = create_test_site(subdomain="breadshop")
 		self.site_backup = create_test_site_backup(

--- a/press/press/doctype/site_group_deploy/test_site_group_deploy.py
+++ b/press/press/doctype/site_group_deploy/test_site_group_deploy.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestSiteGroupDeploy(FrappeTestCase):
+class TestSiteGroupDeploy(UnitTestCase):
 	pass

--- a/press/press/doctype/site_migration/test_site_migration.py
+++ b/press/press/doctype/site_migration/test_site_migration.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2021, Frappe and Contributors
 # See license.txt
 
@@ -6,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import frappe
 from frappe.core.utils import find
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.doctype.agent_job.agent_job import poll_pending_jobs
 from press.press.doctype.agent_job.test_agent_job import fake_agent_job
@@ -59,10 +58,8 @@ BACKUP_JOB_RES = {
 
 
 @patch.object(RemoteFile, "download_link", new="http://test.com")
-@patch(
-	"press.press.doctype.site_migration.site_migration.frappe.db.commit", new=MagicMock
-)
-class TestSiteMigration(FrappeTestCase):
+@patch("press.press.doctype.site_migration.site_migration.frappe.db.commit", new=MagicMock)
+class TestSiteMigration(UnitTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 
@@ -83,15 +80,9 @@ class TestSiteMigration(FrappeTestCase):
 		with fake_agent_job("Update Site Configuration", "Success"), fake_agent_job(
 			"Backup Site",
 			data=BACKUP_JOB_RES,
-		), fake_agent_job("New Site from Backup"), fake_agent_job(
-			"Archive Site"
-		), fake_agent_job(
+		), fake_agent_job("New Site from Backup"), fake_agent_job("Archive Site"), fake_agent_job(
 			"Remove Site from Upstream"
-		), fake_agent_job(
-			"Add Site to Upstream"
-		), fake_agent_job(
-			"Update Site Configuration"
-		):
+		), fake_agent_job("Add Site to Upstream"), fake_agent_job("Update Site Configuration"):
 			site_migration.start()
 			poll_pending_jobs()
 			poll_pending_jobs()
@@ -127,9 +118,7 @@ class TestSiteMigration(FrappeTestCase):
 		with fake_agent_job("Update Site Configuration"), fake_agent_job(
 			"Backup Site",
 			data=BACKUP_JOB_RES,
-		), fake_agent_job("New Site from Backup", "Failure"), fake_agent_job(
-			"Archive Site"
-		):
+		), fake_agent_job("New Site from Backup", "Failure"), fake_agent_job("Archive Site"):
 			site_migration.start()
 			poll_pending_jobs()
 			poll_pending_jobs()
@@ -156,9 +145,7 @@ class TestSiteMigration(FrappeTestCase):
 			data=BACKUP_JOB_RES,
 		), fake_agent_job("New Site from Backup", "Failure"), fake_agent_job(
 			"Archive Site",
-		), fake_agent_job(
-			"Update Site Configuration"
-		):
+		), fake_agent_job("Update Site Configuration"):
 			site_migration.start()
 			poll_pending_jobs()
 			poll_pending_jobs()
@@ -188,11 +175,7 @@ class TestSiteMigration(FrappeTestCase):
 			data=BACKUP_JOB_RES,
 		), fake_agent_job("New Site from Backup"), fake_agent_job(
 			"Archive Site",  # both archives
-		), fake_agent_job(
-			"Remove Site from Upstream"
-		), fake_agent_job(
-			"Add Site to Upstream", "Failure"
-		):
+		), fake_agent_job("Remove Site from Upstream"), fake_agent_job("Add Site to Upstream", "Failure"):
 			site_migration.start()
 			poll_pending_jobs()
 			poll_pending_jobs()

--- a/press/press/doctype/site_plan/test_site_plan.py
+++ b/press/press/doctype/site_plan/test_site_plan.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2024, Frappe and Contributors
 # See license.txt
 
+from __future__ import annotations
+
 from datetime import date
-from typing import Optional
 from unittest.mock import patch
 
 import frappe
@@ -15,12 +16,12 @@ def create_test_plan(
 	price_usd: float = 10.0,
 	price_inr: float = 750.0,
 	cpu_time: int = 1,
-	plan_title: str = None,
-	plan_name: str = None,
+	plan_title: str | None = None,
+	plan_name: str | None = None,
 	allow_downgrading_from_other_plan: bool = True,
 	dedicated_server_plan: bool = False,
-	allowed_apps: Optional[list[str]] = None,
-	release_groups: Optional[list[str]] = None,
+	allowed_apps: list[str] | None = None,
+	release_groups: list[str] | None = None,
 ):
 	"""Create test Plan doc."""
 	plan_name = plan_name or f"Test {document_type} plan {make_autoname('.#')}"

--- a/press/press/doctype/site_plan/test_site_plan.py
+++ b/press/press/doctype/site_plan/test_site_plan.py
@@ -18,6 +18,7 @@ def create_test_plan(
 	plan_title: str = None,
 	plan_name: str = None,
 	allow_downgrading_from_other_plan: bool = True,
+	dedicated_server_plan: bool = False,
 	allowed_apps: Optional[list[str]] = None,
 	release_groups: Optional[list[str]] = None,
 ):
@@ -34,6 +35,7 @@ def create_test_plan(
 			"price_usd": price_usd,
 			"cpu_time_per_day": cpu_time,
 			"allow_downgrading_from_other_plan": allow_downgrading_from_other_plan,
+			"dedicated_server_plan": dedicated_server_plan,
 			"disk": 50,
 			"instance_type": "t2.micro",
 		}

--- a/press/press/doctype/site_plan/test_site_plan.py
+++ b/press/press/doctype/site_plan/test_site_plan.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import frappe
 from frappe.model.naming import make_autoname
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
 def create_test_plan(
@@ -50,7 +50,7 @@ def create_test_plan(
 	return plan
 
 
-class TestSitePlan(FrappeTestCase):
+class TestSitePlan(UnitTestCase):
 	def setUp(self):
 		self.plan = create_test_plan("Site")
 

--- a/press/press/doctype/site_replication/test_site_replication.py
+++ b/press/press/doctype/site_replication/test_site_replication.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestSiteReplication(FrappeTestCase):
+class TestSiteReplication(UnitTestCase):
 	pass

--- a/press/press/doctype/site_update/test_site_update.py
+++ b/press/press/doctype/site_update/test_site_update.py
@@ -33,6 +33,9 @@ def create_test_site_update(site: str, destination_group: str, status: str):
 
 
 class TestSiteUpdate(UnitTestCase):
+	def setUp(self):
+		frappe.db.truncate("Agent Request Failure")
+
 	def tearDown(self):
 		frappe.db.rollback()
 

--- a/press/press/doctype/site_update/test_site_update.py
+++ b/press/press/doctype/site_update/test_site_update.py
@@ -36,12 +36,8 @@ def create_test_site_update(site: str, destination_group: str, status: str):
 
 
 class TestSiteUpdate(UnitTestCase):
-	def setUp(self):
-		frappe.db.truncate("Agent Request Failure")
-
 	def tearDown(self):
 		frappe.db.rollback()
-		frappe.db.truncate("Agent Request Failure")
 
 	@patch.object(AgentJob, "enqueue_http_request", new=Mock())
 	def test_update_of_v12_site_skips_search_index(self):
@@ -156,6 +152,9 @@ class TestSiteUpdate(UnitTestCase):
 			steps=[{"name": "Disable Maintenance Mode", "status": "Success"}],
 		):
 			site.schedule_update()
+			frappe.db.delete(
+				"Agent Request Failure"
+			)  # truncate agent request failure, so that agent request doesn't skipped
 			poll_pending_jobs()
 
 		bench1.reload()

--- a/press/press/doctype/site_update/test_site_update.py
+++ b/press/press/doctype/site_update/test_site_update.py
@@ -6,7 +6,7 @@ import json
 from unittest.mock import MagicMock, Mock, patch
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.doctype.agent_job.agent_job import AgentJob, poll_pending_jobs
 from press.press.doctype.agent_job.test_agent_job import fake_agent_job
@@ -32,7 +32,7 @@ def create_test_site_update(site: str, destination_group: str, status: str):
 	).insert(ignore_if_duplicate=True)
 
 
-class TestSiteUpdate(FrappeTestCase):
+class TestSiteUpdate(UnitTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 

--- a/press/press/doctype/site_update/test_site_update.py
+++ b/press/press/doctype/site_update/test_site_update.py
@@ -132,8 +132,8 @@ class TestSiteUpdate(UnitTestCase):
 		site.reload()
 
 		server = frappe.get_doc("Server", bench1.server)
-		server.disable_agent_job_auto_retry = True
-		server.save()
+		frappe.db.set_value("Server", server.name, "disable_agent_job_auto_retry", True)
+		server.reload()
 		server.auto_scale_workers()
 		bench1.reload()
 		bench2.reload()

--- a/press/press/doctype/site_update/test_site_update.py
+++ b/press/press/doctype/site_update/test_site_update.py
@@ -152,9 +152,6 @@ class TestSiteUpdate(UnitTestCase):
 			steps=[{"name": "Disable Maintenance Mode", "status": "Success"}],
 		):
 			site.schedule_update()
-			frappe.db.delete(
-				"Agent Request Failure"
-			)  # truncate agent request failure, so that agent request doesn't skipped
 			poll_pending_jobs()
 
 		bench1.reload()

--- a/press/press/doctype/site_update/test_site_update.py
+++ b/press/press/doctype/site_update/test_site_update.py
@@ -38,6 +38,7 @@ class TestSiteUpdate(UnitTestCase):
 
 	def tearDown(self):
 		frappe.db.rollback()
+		frappe.db.truncate("Agent Request Failure")
 
 	@patch.object(AgentJob, "enqueue_http_request", new=Mock())
 	def test_update_of_v12_site_skips_search_index(self):

--- a/press/press/doctype/stripe_micro_charge_record/test_stripe_micro_charge_record.py
+++ b/press/press/doctype/stripe_micro_charge_record/test_stripe_micro_charge_record.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestStripeMicroChargeRecord(FrappeTestCase):
+class TestStripeMicroChargeRecord(UnitTestCase):
 	pass

--- a/press/press/doctype/team_change/test_team_change.py
+++ b/press/press/doctype/team_change/test_team_change.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestTeamChange(FrappeTestCase):
+class TestTeamChange(UnitTestCase):
 	pass

--- a/press/press/doctype/telegram_group/test_telegram_group.py
+++ b/press/press/doctype/telegram_group/test_telegram_group.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestTelegramGroup(FrappeTestCase):
+class TestTelegramGroup(UnitTestCase):
 	pass

--- a/press/press/doctype/telegram_message/test_telegram_message.py
+++ b/press/press/doctype/telegram_message/test_telegram_message.py
@@ -4,7 +4,7 @@
 from unittest.mock import Mock, patch
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 from telegram.error import RetryAfter, TimedOut
 
 from press.press.doctype.telegram_message.telegram_message import (
@@ -15,7 +15,7 @@ from press.telegram_utils import Telegram
 
 
 @patch.object(Telegram, "send")
-class TestTelegramMessage(FrappeTestCase):
+class TestTelegramMessage(UnitTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 

--- a/press/press/doctype/trace_server/test_trace_server.py
+++ b/press/press/doctype/trace_server/test_trace_server.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestTraceServer(FrappeTestCase):
+class TestTraceServer(UnitTestCase):
 	pass

--- a/press/press/doctype/user_2fa/test_user_2fa.py
+++ b/press/press/doctype/user_2fa/test_user_2fa.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestUser2FA(FrappeTestCase):
+class TestUser2FA(UnitTestCase):
 	pass

--- a/press/press/doctype/user_ssh_key/test_user_ssh_key.py
+++ b/press/press/doctype/user_ssh_key/test_user_ssh_key.py
@@ -5,7 +5,7 @@ import cryptography
 import frappe
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.doctype.team.test_team import create_test_press_admin_team
 
@@ -51,7 +51,7 @@ def create_test_user_ssh_key(user: str, str_key: str = None):
 	return ssh_key
 
 
-class TestUserSSHKey(FrappeTestCase):
+class TestUserSSHKey(UnitTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 

--- a/press/press/doctype/user_ssh_key/test_user_ssh_key.py
+++ b/press/press/doctype/user_ssh_key/test_user_ssh_key.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2021, Frappe and Contributors
 # See license.txt
+from __future__ import annotations
 
 import cryptography
 import frappe
@@ -36,7 +37,7 @@ def create_ed25519_key() -> str:
 	return str_key[0].decode("utf-8")
 
 
-def create_test_user_ssh_key(user: str, str_key: str = None):
+def create_test_user_ssh_key(user: str, str_key: str | None = None):
 	"""Create a test SSH key for the given user."""
 	if not str_key:
 		str_key = create_rsa_key()

--- a/press/press/doctype/version_upgrade/test_version_upgrade.py
+++ b/press/press/doctype/version_upgrade/test_version_upgrade.py
@@ -4,7 +4,7 @@
 from unittest.mock import Mock, patch
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.doctype.agent_job.agent_job import AgentJob
 from press.press.doctype.app.test_app import create_test_app
@@ -24,7 +24,7 @@ def create_test_version_upgrade(site: str, destination_group: str) -> VersionUpg
 
 
 @patch.object(AgentJob, "enqueue_http_request", Mock())
-class TestVersionUpgrade(FrappeTestCase):
+class TestVersionUpgrade(UnitTestCase):
 	def tearDown(self) -> None:
 		frappe.db.rollback()
 
@@ -69,9 +69,7 @@ class TestVersionUpgrade(FrappeTestCase):
 
 		group2.add_server(server.name)
 
-		create_test_site_update(
-			site.name, group2.name, "Recovered"
-		)  # cause of failure not resolved
+		create_test_site_update(site.name, group2.name, "Recovered")  # cause of failure not resolved
 		site_updates_before = frappe.db.count("Site Update", {"site": site.name})
 		version_upgrade = create_test_version_upgrade(site.name, group2.name)
 		version_upgrade.start()  # simulate scheduled one. User will be admin

--- a/press/press/doctype/virtual_disk_snapshot/test_virtual_disk_snapshot.py
+++ b/press/press/doctype/virtual_disk_snapshot/test_virtual_disk_snapshot.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestVirtualDiskSnapshot(FrappeTestCase):
+class TestVirtualDiskSnapshot(UnitTestCase):
 	pass

--- a/press/press/doctype/virtual_machine/test_virtual_machine.py
+++ b/press/press/doctype/virtual_machine/test_virtual_machine.py
@@ -5,7 +5,7 @@
 from unittest.mock import MagicMock, patch
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.doctype.cluster.cluster import Cluster
 from press.press.doctype.cluster.test_cluster import create_test_cluster
@@ -39,7 +39,7 @@ def create_test_virtual_machine(
 
 
 @patch.object(VirtualMachine, "client", new=MagicMock())
-class TestVirtualMachine(FrappeTestCase):
+class TestVirtualMachine(UnitTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 

--- a/press/press/doctype/virtual_machine/test_virtual_machine.py
+++ b/press/press/doctype/virtual_machine/test_virtual_machine.py
@@ -1,21 +1,24 @@
 # Copyright (c) 2021, Frappe and Contributors
 # See license.txt
+from __future__ import annotations
 
-
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import frappe
 from frappe.tests import UnitTestCase
 
-from press.press.doctype.cluster.cluster import Cluster
 from press.press.doctype.cluster.test_cluster import create_test_cluster
 from press.press.doctype.root_domain.test_root_domain import create_test_root_domain
 from press.press.doctype.virtual_machine.virtual_machine import VirtualMachine
 
+if TYPE_CHECKING:
+	from press.press.doctype.cluster.cluster import Cluster
+
 
 @patch.object(VirtualMachine, "client", new=MagicMock())
 def create_test_virtual_machine(
-	ip: str = None,
+	ip: str | None = None,
 	cluster: Cluster = None,
 	series: str = "m",
 ) -> VirtualMachine:

--- a/press/press/doctype/virtual_machine_image/test_virtual_machine_image.py
+++ b/press/press/doctype/virtual_machine_image/test_virtual_machine_image.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.doctype.cluster.test_cluster import create_test_cluster
 from press.press.doctype.virtual_machine_image.virtual_machine_image import (
@@ -47,5 +47,5 @@ def create_test_virtual_machine_image(
 	).insert(ignore_if_duplicate=True)
 
 
-class TestVirtualMachineImage(FrappeTestCase):
+class TestVirtualMachineImage(UnitTestCase):
 	pass

--- a/press/press/doctype/wireguard_peer/test_wireguard_peer.py
+++ b/press/press/doctype/wireguard_peer/test_wireguard_peer.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestWireguardPeer(FrappeTestCase):
+class TestWireguardPeer(UnitTestCase):
 	pass

--- a/press/press/report/mariadb_slow_queries/test_db_optimizer.py
+++ b/press/press/report/mariadb_slow_queries/test_db_optimizer.py
@@ -3,7 +3,7 @@
 
 import json
 
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.report.mariadb_slow_queries.db_optimizer import (
 	DBExplain,
@@ -12,7 +12,7 @@ from press.press.report.mariadb_slow_queries.db_optimizer import (
 )
 
 
-class TestDBOptimizer(FrappeTestCase):
+class TestDBOptimizer(UnitTestCase):
 	def test_basic_index_existence_analysis(self):
 		def possible_indexes(q):
 			user = DBTable.from_frappe_ouput(USER_TABLE)
@@ -37,9 +37,7 @@ class TestDBOptimizer(FrappeTestCase):
 
 		self.assertIn(
 			"user",
-			possible_indexes(
-				"select `name` from `tabUser` u join `tabHas Role` h on h.user = u.name"
-			),
+			possible_indexes("select `name` from `tabUser` u join `tabHas Role` h on h.user = u.name"),
 		)
 
 	def test_suggestion_using_table_stats(self):

--- a/press/saas/doctype/hybrid_saas_pool/test_hybrid_saas_pool.py
+++ b/press/saas/doctype/hybrid_saas_pool/test_hybrid_saas_pool.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestHybridSaasPool(FrappeTestCase):
+class TestHybridSaasPool(UnitTestCase):
 	pass

--- a/press/saas/doctype/product_trial/test_product_trial.py
+++ b/press/saas/doctype/product_trial/test_product_trial.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestProductTrial(FrappeTestCase):
+class TestProductTrial(UnitTestCase):
 	pass

--- a/press/saas/doctype/product_trial_request/test_product_trial_request.py
+++ b/press/saas/doctype/product_trial_request/test_product_trial_request.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestProductTrialRequest(FrappeTestCase):
+class TestProductTrialRequest(UnitTestCase):
 	pass

--- a/press/saas/doctype/saas_app/test_saas_app.py
+++ b/press/saas/doctype/saas_app/test_saas_app.py
@@ -2,14 +2,12 @@
 # See license.txt
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
 def create_test_saas_app(app: str):
-	return frappe.get_doc({"doctype": "Saas App", "app": app}).insert(
-		ignore_if_duplicate=True
-	)
+	return frappe.get_doc({"doctype": "Saas App", "app": app}).insert(ignore_if_duplicate=True)
 
 
-class TestSaasApp(FrappeTestCase):
+class TestSaasApp(UnitTestCase):
 	pass

--- a/press/saas/doctype/saas_app_plan/test_saas_app_plan.py
+++ b/press/saas/doctype/saas_app_plan/test_saas_app_plan.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestSaasAppPlan(FrappeTestCase):
+class TestSaasAppPlan(UnitTestCase):
 	pass

--- a/press/saas/doctype/saas_app_subscription/test_saas_app_subscription.py
+++ b/press/saas/doctype/saas_app_subscription/test_saas_app_subscription.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestSaasAppSubscription(FrappeTestCase):
+class TestSaasAppSubscription(UnitTestCase):
 	pass

--- a/press/saas/doctype/saas_app_version/test_saas_app_version.py
+++ b/press/saas/doctype/saas_app_version/test_saas_app_version.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestSaasAppVersion(FrappeTestCase):
+class TestSaasAppVersion(UnitTestCase):
 	pass

--- a/press/saas/doctype/saas_feedback/test_saas_feedback.py
+++ b/press/saas/doctype/saas_feedback/test_saas_feedback.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestSaasFeedback(FrappeTestCase):
+class TestSaasFeedback(UnitTestCase):
 	pass

--- a/press/saas/doctype/saas_remote_login/test_saas_remote_login.py
+++ b/press/saas/doctype/saas_remote_login/test_saas_remote_login.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestSaasRemoteLogin(FrappeTestCase):
+class TestSaasRemoteLogin(UnitTestCase):
 	pass

--- a/press/saas/doctype/saas_settings/test_saas_settings.py
+++ b/press/saas/doctype/saas_settings/test_saas_settings.py
@@ -2,7 +2,7 @@
 # See license.txt
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.doctype.app.test_app import create_test_app
 from press.press.doctype.release_group.release_group import ReleaseGroup
@@ -30,5 +30,5 @@ def create_test_saas_settings(group: ReleaseGroup = None):
 	).insert(ignore_permissions=True)
 
 
-class TestSaasSettings(FrappeTestCase):
+class TestSaasSettings(UnitTestCase):
 	pass

--- a/press/saas/doctype/saas_setup_account_generator/test_saas_setup_account_generator.py
+++ b/press/saas/doctype/saas_setup_account_generator/test_saas_setup_account_generator.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestSaasSetupAccountGenerator(FrappeTestCase):
+class TestSaasSetupAccountGenerator(UnitTestCase):
 	pass

--- a/press/saas/doctype/saas_signup_generator/test_saas_signup_generator.py
+++ b/press/saas/doctype/saas_signup_generator/test_saas_signup_generator.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestSaasSignupGenerator(FrappeTestCase):
+class TestSaasSignupGenerator(UnitTestCase):
 	pass

--- a/press/saas/doctype/site_access_token/test_site_access_token.py
+++ b/press/saas/doctype/site_access_token/test_site_access_token.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestSiteAccessToken(FrappeTestCase):
+class TestSiteAccessToken(UnitTestCase):
 	pass

--- a/press/tests/before_test.py
+++ b/press/tests/before_test.py
@@ -7,7 +7,7 @@ import os
 import frappe
 from frappe import set_user as _set_user
 from frappe.model.document import Document
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.utils import _get_current_team, _system_user
 
@@ -33,7 +33,7 @@ def execute():
 	# Monkey patch certain methods for when tests are running
 	Document.__eq__ = doc_equal
 
-	FrappeTestCase.setUp = lambda self: frappe.db.truncate("Agent Request Failure")
+	UnitTestCase.setUp = lambda self: frappe.db.truncate("Agent Request Failure")
 
 	# patch frappe.set_user that
 	frappe.set_user = set_user_with_current_team
@@ -53,7 +53,5 @@ def create_test_stripe_credentials():
 	secret_key = os.environ.get("STRIPE_SECRET_KEY")
 
 	if publishable_key and secret_key:
-		frappe.db.set_single_value(
-			"Press Settings", "stripe_publishable_key", publishable_key
-		)
+		frappe.db.set_single_value("Press Settings", "stripe_publishable_key", publishable_key)
 		frappe.db.set_single_value("Press Settings", "stripe_secret_key", secret_key)

--- a/press/tests/test_agent.py
+++ b/press/tests/test_agent.py
@@ -4,7 +4,7 @@
 import frappe
 import requests
 import responses
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.agent import Agent, AgentRequestSkippedException
 from press.press.doctype.agent_request_failure.agent_request_failure import (
@@ -13,9 +13,7 @@ from press.press.doctype.agent_request_failure.agent_request_failure import (
 from press.press.doctype.server.test_server import create_test_server
 
 
-def create_test_agent_request_failure(
-	server, traceback="Traceback", error="Error", failure_count=1
-):
+def create_test_agent_request_failure(server, traceback="Traceback", error="Error", failure_count=1):
 	fields = {
 		"server_type": server.doctype,
 		"server": server.name,
@@ -24,12 +22,10 @@ def create_test_agent_request_failure(
 		"failure_count": failure_count,
 	}
 
-	return frappe.new_doc("Agent Request Failure", **fields).insert(
-		ignore_permissions=True
-	)
+	return frappe.new_doc("Agent Request Failure", **fields).insert(ignore_permissions=True)
 
 
-class TestAgent(FrappeTestCase):
+class TestAgent(UnitTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 		frappe.db.truncate("Agent Request Failure")

--- a/press/tests/test_audit.py
+++ b/press/tests/test_audit.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 from press.press.audit import BackupRecordCheck, OffsiteBackupCheck
 from press.press.doctype.agent_job.agent_job import AgentJob
@@ -16,13 +16,11 @@ from press.telegram_utils import Telegram
 
 @patch.object(Telegram, "send", new=Mock())
 @patch.object(AgentJob, "enqueue_http_request", new=Mock())
-class TestBackupRecordCheck(FrappeTestCase):
+class TestBackupRecordCheck(UnitTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 
-	older_than_interval = datetime.now() - timedelta(
-		hours=(BackupRecordCheck.interval + 2)
-	)
+	older_than_interval = datetime.now() - timedelta(hours=(BackupRecordCheck.interval + 2))
 
 	def test_audit_will_fail_if_backup_older_than_interval(self):
 		create_test_press_settings()
@@ -31,9 +29,7 @@ class TestBackupRecordCheck(FrappeTestCase):
 			site.name, creation=datetime.now() - timedelta(hours=BackupRecordCheck.interval + 1)
 		)
 		BackupRecordCheck()
-		audit_log = frappe.get_last_doc(
-			"Audit Log", {"audit_type": BackupRecordCheck.audit_type}
-		)
+		audit_log = frappe.get_last_doc("Audit Log", {"audit_type": BackupRecordCheck.audit_type})
 		self.assertEqual(audit_log.status, "Failure")
 
 	def test_audit_succeeds_when_backup_in_interval_exists(self):
@@ -42,13 +38,10 @@ class TestBackupRecordCheck(FrappeTestCase):
 
 		create_test_site_backup(
 			site.name,
-			creation=frappe.utils.now_datetime()
-			- timedelta(hours=BackupRecordCheck.interval - 1),
+			creation=frappe.utils.now_datetime() - timedelta(hours=BackupRecordCheck.interval - 1),
 		)
 		BackupRecordCheck()
-		audit_log = frappe.get_last_doc(
-			"Audit Log", {"audit_type": BackupRecordCheck.audit_type}
-		)
+		audit_log = frappe.get_last_doc("Audit Log", {"audit_type": BackupRecordCheck.audit_type})
 		self.assertEqual(audit_log.status, "Success")
 
 	def test_audit_log_is_created(self):
@@ -57,13 +50,9 @@ class TestBackupRecordCheck(FrappeTestCase):
 		create_test_site_backup(
 			site.name, creation=datetime.now() - timedelta(hours=BackupRecordCheck.interval + 0)
 		)
-		audit_logs_before = frappe.db.count(
-			"Audit Log", {"audit_type": BackupRecordCheck.audit_type}
-		)
+		audit_logs_before = frappe.db.count("Audit Log", {"audit_type": BackupRecordCheck.audit_type})
 		BackupRecordCheck()
-		audit_logs_after = frappe.db.count(
-			"Audit Log", {"audit_type": BackupRecordCheck.audit_type}
-		)
+		audit_logs_after = frappe.db.count("Audit Log", {"audit_type": BackupRecordCheck.audit_type})
 		self.assertGreater(audit_logs_after, audit_logs_before)
 
 	def test_sites_created_within_interval_are_ignored(self):
@@ -72,15 +61,13 @@ class TestBackupRecordCheck(FrappeTestCase):
 		# no backup
 		BackupRecordCheck()
 
-		audit_log = frappe.get_last_doc(
-			"Audit Log", {"audit_type": BackupRecordCheck.audit_type}
-		)
+		audit_log = frappe.get_last_doc("Audit Log", {"audit_type": BackupRecordCheck.audit_type})
 		self.assertEqual(audit_log.status, "Success")
 
 
 @patch.object(Telegram, "send", new=Mock())
 @patch.object(AgentJob, "enqueue_http_request", new=Mock())
-class TestOffsiteBackupCheck(FrappeTestCase):
+class TestOffsiteBackupCheck(UnitTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 
@@ -88,24 +75,16 @@ class TestOffsiteBackupCheck(FrappeTestCase):
 		create_test_press_settings()
 		site = create_test_site()
 		site_backup = create_test_site_backup(site.name)
-		frappe.db.set_value(
-			"Remote File", site_backup.remote_database_file, "file_path", "remote_file1"
-		)
-		frappe.db.set_value(
-			"Remote File", site_backup.remote_public_file, "file_path", "remote_file2"
-		)
-		frappe.db.set_value(
-			"Remote File", site_backup.remote_private_file, "file_path", "remote_file3"
-		)
+		frappe.db.set_value("Remote File", site_backup.remote_database_file, "file_path", "remote_file1")
+		frappe.db.set_value("Remote File", site_backup.remote_public_file, "file_path", "remote_file2")
+		frappe.db.set_value("Remote File", site_backup.remote_private_file, "file_path", "remote_file3")
 		with patch.object(
 			OffsiteBackupCheck,
 			"_get_all_files_in_s3",
 			new=lambda x: ["remote_file1", "remote_file2", "remote_file3"],
 		):
 			OffsiteBackupCheck()
-		audit_log = frappe.get_last_doc(
-			"Audit Log", {"audit_type": OffsiteBackupCheck.audit_type}
-		)
+		audit_log = frappe.get_last_doc("Audit Log", {"audit_type": OffsiteBackupCheck.audit_type})
 		self.assertEqual(audit_log.status, "Success")
 
 	def test_audit_fails_when_all_remote_files_not_in_remote(self):
@@ -113,14 +92,8 @@ class TestOffsiteBackupCheck(FrappeTestCase):
 		site = create_test_site()
 		# 3 remote files are created here
 		site_backup = create_test_site_backup(site.name)
-		frappe.db.set_value(
-			"Remote File", site_backup.remote_database_file, "file_path", "remote_file1"
-		)
-		with patch.object(
-			OffsiteBackupCheck, "_get_all_files_in_s3", new=lambda x: ["remote_file1"]
-		):
+		frappe.db.set_value("Remote File", site_backup.remote_database_file, "file_path", "remote_file1")
+		with patch.object(OffsiteBackupCheck, "_get_all_files_in_s3", new=lambda x: ["remote_file1"]):
 			OffsiteBackupCheck()
-		audit_log = frappe.get_last_doc(
-			"Audit Log", {"audit_type": OffsiteBackupCheck.audit_type}
-		)
+		audit_log = frappe.get_last_doc("Audit Log", {"audit_type": OffsiteBackupCheck.audit_type})
 		self.assertEqual(audit_log.status, "Failure")


### PR DESCRIPTION
Tests were broken mainly due to changes in framework https://github.com/frappe/frappe/pull/28044
Also, there were few testcases, which was broken due to some recent changes. Those has been fixed.

Few testcases ([ref](https://github.com/frappe/press/pull/2214/files#diff-913e5b306693e7707b39584a192eeccbfd5325c6826617aeb8e1e3e2b04acf5dL75-R177)) added for this site plan override based on type of server (public or dedicated) ([ref](https://github.com/frappe/press/commit/414eb838e0b37698c6e3513dfea591fbefa0d5e6)). 