### PR TITLE
fix(api): add get_country_timezone_info to ALLOWED_PATHS

### DIFF
--- a/press/auth.py
+++ b/press/auth.py
@@ -48,6 +48,7 @@ ALLOWED_PATHS = [
 	"/api/method/frappe.core.doctype.user.user.test_password_strength",
 	"/api/method/frappe.core.doctype.user.user.update_password",
 	"/api/method/get_central_migration_data",
+	"/api/method/frappe.geo.country_info.get_country_timezone_info",
 ]
 
 ALLOWED_WILDCARD_PATHS = [


### PR DESCRIPTION
This PR adds the `/api/method/frappe.geo.country_info.get_country_timezone_info` endpoint to the ALLOWED_PATHS. This allows users to retrieve timezone information based on country data through the Frappe Geo module.

The change ensures the endpoint is accessible and can be used in scenarios where country-specific timezone information is required.