### PR TITLE
fix: cors issue for saas login apis

### DIFF
--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -346,6 +346,42 @@ server {
 		http2_push_preload on;
 	}
 
+	location ~ ^/api/method/press.api.developer.saas.* {
+		if ($request_method = 'OPTIONS') {
+			add_header Access-Control-Allow-Origin "*";
+			add_header Access-Control-Allow-Methods "GET, POST, OPTIONS";
+			add_header Access-Control-Max-Age 1728000;
+			add_header Content-Type "text/plain; charset=utf-8";
+			add_header Content-Length 0;
+			return 204;
+		}
+
+		proxy_cache assets_cache;
+		proxy_cache_key $scheme$host$request_uri;
+		proxy_cache_valid 200 302 10m;
+		proxy_cache_valid 404 1m;
+
+		proxy_ignore_headers "Set-Cookie";
+		proxy_hide_header "Set-Cookie";
+		proxy_set_header Cookie "";
+
+		add_header Access-Control-Allow-Origin "*";
+		add_header Access-Control-Allow-Methods "GET, POST, OPTIONS";
+
+		add_header X-Cache-Status $upstream_cache_status;
+
+		proxy_set_header X-Forwarded-For $REMOTE_ADDR;
+		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_set_header X-Frappe-Site-Name $site_name_sxjfjnv;
+		proxy_set_header Host $host;
+		proxy_set_header X-Use-X-Accel-Redirect True;
+		proxy_read_timeout 120;
+		proxy_redirect off;
+
+		proxy_pass http://frappe-bench-frappe;
+		http2_push_preload on;
+	}
+
 	location / {
 
 		rewrite ^(.+)/$ $1 permanent;

--- a/press/api/developer/saas.py
+++ b/press/api/developer/saas.py
@@ -172,7 +172,7 @@ def request_login_to_fc(domain: str):
 def validate_login_to_fc(domain: str, otp: str):
 	otp_hash = frappe.cache().get_value(f"otp_hash_for_fc_login_via_saas_flow:{domain}", expires=True)
 	if not otp_hash or otp_hash != frappe.utils.sha256_hash(str(otp)):
-		frappe.throw("Invalid OTP. Please try again.")
+		frappe.throw("Invalid Code. Please try again.")
 
 	site = frappe.get_value("Site Domain", domain, "site")
 	team = frappe.get_value("Site", site, "team")

--- a/press/www/saas/billing.js
+++ b/press/www/saas/billing.js
@@ -101,7 +101,7 @@ $(document).ready(function () {
 function add_frappe_cloud_dashboard_link() {
 	$('.dropdown-navbar-user .dropdown-menu .dropdown-divider').before(
 		`<a class="dropdown-item"
-		href="${frappe_cloud_base_endpoint}/dashboard"
+		onclick="initiateRequestForLoginToFrappeCloud()"
 		>Log In to Frappe Cloud</a>`,
 	);
 }
@@ -196,9 +196,8 @@ function showFCLogindialog(email) {
 		if (!otp) {
 			return;
 		}
-		frappe.call({
-			url: frappe_cloud_base_endpoint,
-			method: 'press.api.developer.saas.validate_login_to_fc',
+		frappe.request.call({
+			url: `${frappe_cloud_base_endpoint}/api/method/press.api.developer.saas.validate_login_to_fc`,
 			type: 'POST',
 			args: {
 				domain: window.location.hostname,
@@ -207,7 +206,7 @@ function showFCLogindialog(email) {
 			freeze: true,
 			silent: true,
 			freeze_message: 'Validating verification code',
-			callback: function (r) {
+			success: function (r) {
 				if (r.login_token) {
 					fc_login_dialog.hide();
 					window.open(


### PR DESCRIPTION
We have added a simplified login for SaaS sites, so that user can login to frappe cloud easily.
PR - https://github.com/frappe/press/pull/2233

We need to allow cross-site-request for those SaaS apis.
APIs - https://github.com/frappe/press/blob/master/press/api/developer/saas.py#L84-L203