### PR TITLE
fix(RemoteFile): Don't try to delete unavailable S3 file

### DIFF
--- a/press/press/doctype/remote_file/remote_file.py
+++ b/press/press/doctype/remote_file/remote_file.py
@@ -231,7 +231,8 @@ class RemoteFile(Document):
 		)
 
 	def on_trash(self):
-		self.delete_remote_object()
+		if self.status != "Unavailable":
+			self.delete_remote_object()
 
 	@frappe.whitelist()
 	def get_download_link(self):


### PR DESCRIPTION
If I'm not mistaken, unavailable files could be removed (like other Log Types) once they become unavailable