### PR TITLE
fix(HybridSaaSPool): create standby sites for all hybrid pool rules

### DIFF
--- a/press/press/doctype/site/saas_pool.py
+++ b/press/press/doctype/site/saas_pool.py
@@ -81,7 +81,7 @@ class SaasSitePool:
 				"Site",
 				{
 					"is_standby": 1,
-					"standby_for": "erpnext",
+					"standby_for": self.app,
 					"hybrid_saas_pool": pool_name,
 					"status": "Active",
 				},

--- a/press/press/doctype/site/saas_pool.py
+++ b/press/press/doctype/site/saas_pool.py
@@ -88,7 +88,7 @@ class SaasSitePool:
 			)
 
 			if hybrid_standby_count > self.saas_settings.standby_pool_size:
-				break
+				continue
 
 			sites_created = 0
 			while sites_created < self.saas_settings.standby_queue_size:


### PR DESCRIPTION
- fix(HybridPool): check for specific app as per record instead of erpnext app
- fix(HybridPool): dont stop create pooling only one hybrid pool has been replenished