### PR TITLE
fix(tests): fix broken testcases

### DIFF
--- a/press/api/site.py
+++ b/press/api/site.py
@@ -1234,6 +1234,9 @@ def installed_apps(name):
 
 
 def get_installed_apps(site, query_filters: dict | None = None):
+	if query_filters is None:
+		query_filters = {}
+
 	installed_apps = [app.app for app in site.apps]
 	bench = frappe.get_doc("Bench", site.bench)
 	installed_bench_apps = [app for app in bench.apps if app.app in installed_apps]

--- a/press/api/tests/test_site.py
+++ b/press/api/tests/test_site.py
@@ -2,11 +2,11 @@
 # See license.txt
 
 import datetime
+import unittest
 from unittest.mock import MagicMock, Mock, call, patch
 
 import frappe
 import responses
-from frappe.tests.utils import FrappeTestCase
 
 from press.api.site import all
 from press.press.doctype.agent_job.agent_job import AgentJob, poll_pending_jobs
@@ -34,7 +34,7 @@ from press.press.doctype.site_plan.test_site_plan import create_test_plan
 from press.press.doctype.team.test_team import create_test_press_admin_team
 
 
-class TestAPISite(FrappeTestCase):
+class TestAPISite(unittest.TestCase):
 	def setUp(self):
 		self.team = create_test_press_admin_team()
 		self.team.allocate_credit_amount(1000, source="Prepaid Credits", remark="Test")
@@ -919,7 +919,7 @@ erpnext 0.8.3	    HEAD
 		pass
 
 
-class TestAPISiteList(FrappeTestCase):
+class TestAPISiteList(unittest.TestCase):
 	def setUp(self):
 		from press.press.doctype.press_tag.test_press_tag import create_and_add_test_tag
 		from press.press.doctype.site.test_site import create_test_site

--- a/press/api/tests/test_site.py
+++ b/press/api/tests/test_site.py
@@ -76,8 +76,10 @@ class TestAPISite(unittest.TestCase):
 		from press.api.site import new
 
 		app = create_test_app()
-		group = create_test_release_group([app])
-		bench = create_test_bench(group=group)
+		cluster = create_test_cluster("Default", public=True)
+		server = create_test_server(cluster=cluster.name, public=True)
+		group = create_test_release_group([app], servers=[server.name])
+		bench = create_test_bench(group=group, server=server.name)
 		plan = create_test_plan("Site")
 
 		frappe.set_user(self.team.user)

--- a/press/press/doctype/server/test_server.py
+++ b/press/press/doctype/server/test_server.py
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019, Frappe and Contributors
 # See license.txt
 
+from __future__ import annotations
 
 import typing
 import unittest
@@ -27,11 +27,12 @@ if typing.TYPE_CHECKING:
 
 @patch.object(BaseServer, "after_insert", new=Mock())
 def create_test_server(
-	proxy_server: str = None,
-	database_server: str = None,
+	proxy_server: str | None = None,
+	database_server: str | None = None,
 	cluster: str = "Default",
-	plan: str = None,
-	team: str = None,
+	plan: str | None = None,
+	team: str | None = None,
+	public: bool = False,
 ) -> "Server":
 	"""Create test Server doc."""
 	if not proxy_server:
@@ -55,6 +56,7 @@ def create_test_server(
 			"ram": 16000,
 			"team": team,
 			"plan": plan,
+			"public": public,
 		}
 	).insert()
 	server.reload()

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -439,16 +439,7 @@ class Site(Document, TagHelpers):
 				},
 			)
 			if allowed_apps:
-				selected_apps = frappe.db.get_all(
-					"Site App",
-					pluck="app",
-					filters={
-						"parenttype": "Site",
-						"parentfield": "apps",
-						"parent": self.name,
-					},
-					distinct=True,
-				)
+				selected_apps = [app.app for app in self.apps]
 
 				for app in selected_apps:
 					if app not in allowed_apps:


### PR DESCRIPTION
- fix(tests): in get_installed_apps fn, set query_filters to blank dict in case of None
- fix(tests): move to unnittest.TestCase from FrappeTestCase due to issues of test discoverability
- fix(tests): in plan validation hooks to check allowed apps use the class variable instead of querying in db as changes not commited yet
-  fix(tests): while testing test_new_fn_creates_site_and_subscription make sure to use a public server
    - the subscription_plan gets overriden if server is not public and it assumes that as dedicated server
    - https://github.com/frappe/press/blob/96734b1fcc2e35b51e29acfb796b09d11362f483/press/press/doctype/site/site.py#L462-L485