### PR TITLE
 chore(saas): misc saas flow fixes and tweaks

### DIFF
--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -510,7 +510,7 @@ class Site(Document, TagHelpers):
 		if self.has_value_changed("status"):
 			create_site_status_update_webhook_event(self.name)
 
-	def generate_saas_communication_secret(self, create_agent_job=False):
+	def generate_saas_communication_secret(self, create_agent_job=False, save=True):
 		if not self.standby_for and not self.standby_for_product:
 			return
 		if not self.saas_communication_secret:
@@ -521,7 +521,7 @@ class Site(Document, TagHelpers):
 			if create_agent_job:
 				self.update_site_config(config)
 			else:
-				self._update_configuration(config=config, save=True)
+				self._update_configuration(config=config, save=save)
 
 	def rename_upstream(self, new_name: str):
 		proxy_server = frappe.db.get_value("Server", self.server, "proxy_server")

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1965,6 +1965,8 @@ class Site(Document, TagHelpers):
 		log_site_activity(self.name, "Activate Site")
 		self.status = "Active"
 		self.update_site_config({"maintenance_mode": 0})
+		if self.standby_for_product:
+			self.update_site_config({"disable_scheduler": 0})
 		self.update_site_status_on_proxy("activated")
 		self.reactivate_app_subscriptions()
 
@@ -1972,8 +1974,10 @@ class Site(Document, TagHelpers):
 	def suspend(self, reason=None, skip_reload=False):
 		log_site_activity(self.name, "Suspend Site", reason)
 		self.status = "Suspended"
-		self.update_site_config({"maintenance_mode": 1})
-		if not self.standby_for_product:
+		if self.standby_for_product:
+			self.update_site_config({"disable_scheduler": 1})
+		else:
+			self.update_site_config({"maintenance_mode": 1})
 			self.update_site_status_on_proxy("suspended", skip_reload=skip_reload)
 		self.deactivate_app_subscriptions()
 
@@ -1997,6 +2001,8 @@ class Site(Document, TagHelpers):
 		log_site_activity(self.name, "Unsuspend Site", reason)
 		self.status = "Active"
 		self.update_site_config({"maintenance_mode": 0})
+		if self.standby_for_product:
+			self.update_site_config({"disable_scheduler": 0})
 		self.update_site_status_on_proxy("activated")
 		self.reactivate_app_subscriptions()
 

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1974,11 +1974,8 @@ class Site(Document, TagHelpers):
 	def suspend(self, reason=None, skip_reload=False):
 		log_site_activity(self.name, "Suspend Site", reason)
 		self.status = "Suspended"
-		if self.standby_for_product:
-			self.update_site_config({"disable_scheduler": 1})
-		else:
-			self.update_site_config({"maintenance_mode": 1})
-			self.update_site_status_on_proxy("suspended", skip_reload=skip_reload)
+		self.update_site_config({"maintenance_mode": 1})
+		self.update_site_status_on_proxy("suspended", skip_reload=skip_reload)
 		self.deactivate_app_subscriptions()
 
 	def deactivate_app_subscriptions(self):
@@ -2001,8 +1998,6 @@ class Site(Document, TagHelpers):
 		log_site_activity(self.name, "Unsuspend Site", reason)
 		self.status = "Active"
 		self.update_site_config({"maintenance_mode": 0})
-		if self.standby_for_product:
-			self.update_site_config({"disable_scheduler": 0})
 		self.update_site_status_on_proxy("activated")
 		self.reactivate_app_subscriptions()
 

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1973,7 +1973,8 @@ class Site(Document, TagHelpers):
 		log_site_activity(self.name, "Suspend Site", reason)
 		self.status = "Suspended"
 		self.update_site_config({"maintenance_mode": 1})
-		self.update_site_status_on_proxy("suspended", skip_reload=skip_reload)
+		if not self.standby_for_product:
+			self.update_site_status_on_proxy("suspended", skip_reload=skip_reload)
 		self.deactivate_app_subscriptions()
 
 	def deactivate_app_subscriptions(self):

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1965,8 +1965,6 @@ class Site(Document, TagHelpers):
 		log_site_activity(self.name, "Activate Site")
 		self.status = "Active"
 		self.update_site_config({"maintenance_mode": 0})
-		if self.standby_for_product:
-			self.update_site_config({"disable_scheduler": 0})
 		self.update_site_status_on_proxy("activated")
 		self.reactivate_app_subscriptions()
 

--- a/press/saas/api/site.py
+++ b/press/saas/api/site.py
@@ -32,16 +32,15 @@ def get_plans():
 	filtered_plans = []
 
 	for plan in plans:
-		if plan.restricted_plan or plan.is_frappe_plan:
-			continue
-		if plan.is_trial_plan and plan.name != site.plan:
-			continue
-		if is_site_on_private_bench and not plan.private_benches:
-			continue
-		if plan.dedicated_server_plan and is_site_on_shared_server:
-			continue
-		if not plan.dedicated_server_plan and not is_site_on_shared_server:
-			continue
+		if plan.name != site.plan:
+			if plan.restricted_plan or plan.is_frappe_plan or plan.is_trial_plan:
+				continue
+			if is_site_on_private_bench and not plan.private_benches:
+				continue
+			if plan.dedicated_server_plan and is_site_on_shared_server:
+				continue
+			if not plan.dedicated_server_plan and not is_site_on_shared_server:
+				continue
 		filtered_plans.append(plan)
 
 	return filtered_plans

--- a/press/saas/api/site.py
+++ b/press/saas/api/site.py
@@ -32,7 +32,7 @@ def get_plans():
 	filtered_plans = []
 
 	for plan in plans:
-		if plan.restricted_plan:
+		if plan.restricted_plan or plan.is_frappe_plan:
 			continue
 		if plan.is_trial_plan and plan.name != site.plan:
 			continue

--- a/press/saas/api/site.py
+++ b/press/saas/api/site.py
@@ -25,7 +25,26 @@ def change_plan(plan: str):
 
 @whitelist_saas_api
 def get_plans():
-	return site_api.get_site_plans()
+	site = frappe.get_value("Site", frappe.local.site_name, ["server", "group", "plan"], as_dict=True)
+	is_site_on_private_bench = frappe.db.get_value("Release Group", site.group, "public") is False
+	is_site_on_shared_server = frappe.db.get_value("Server", site.server, "public")
+	plans = site_api.get_site_plans()
+	filtered_plans = []
+
+	for plan in plans:
+		if plan.restricted_plan:
+			continue
+		if plan.is_trial_plan and plan.name != site.plan:
+			continue
+		if is_site_on_private_bench and not plan.private_benches:
+			continue
+		if plan.dedicated_server_plan and is_site_on_shared_server:
+			continue
+		if not plan.dedicated_server_plan and not is_site_on_shared_server:
+			continue
+		filtered_plans.append(plan)
+
+	return filtered_plans
 
 
 @whitelist_saas_api

--- a/press/saas/doctype/product_trial/product_trial.py
+++ b/press/saas/doctype/product_trial/product_trial.py
@@ -11,7 +11,6 @@ from frappe.model.document import Document
 from frappe.utils.data import get_url
 from frappe.utils.momentjs import get_all_timezones
 
-from press.press.doctype.site.site import get_plan_config
 from press.utils import log_error
 from press.utils.unique_name_generator import generate as generate_random_name
 
@@ -102,6 +101,8 @@ class ProductTrial(Document):
 					frappe.throw(f"{self.USER_LOGIN_PASSWORD_FIELD} field should be of type Password")
 
 	def setup_trial_site(self, team, plan, cluster=None, account_request=None):
+		from press.press.doctype.site.site import get_plan_config
+
 		standby_site = self.get_standby_site(cluster)
 		team_record = frappe.get_doc("Team", team)
 		trial_end_date = frappe.utils.add_days(None, self.trial_days or 14)


### PR DESCRIPTION
- [x] dont remove site access from proxy while suspending new saas sites
- [x] create app subscriptions and add app related site config on allocation of site
- [x] modify saas site plan api to send only specific plans based on site config + add trial plan in list as well
- [x] add site plan related configs on site allocation 
- [x] cyclic import fixed (original pr - https://github.com/frappe/press/pull/2293) 