### PR TITLE
feat: support to configure max database connections for site database users

### DIFF
--- a/dashboard/src2/components/SiteDatabaseAccessDialog.vue
+++ b/dashboard/src2/components/SiteDatabaseAccessDialog.vue
@@ -2,7 +2,7 @@
 	<Dialog
 		:options="{
 			title: 'Manage Database Users',
-			size: planSupportsDatabaseAccess ? '2xl' : 'xl'
+			size: planSupportsDatabaseAccess ? '3xl' : 'xl'
 		}"
 		v-model="show"
 	>
@@ -137,7 +137,7 @@ export default {
 					{
 						label: 'Username',
 						fieldname: 'username',
-						width: 1
+						width: 0.5
 					},
 					{
 						label: 'Status',
@@ -145,6 +145,13 @@ export default {
 						width: 0.5,
 						align: 'center',
 						type: 'Badge'
+					},
+					{
+						label: 'DB Connections',
+						fieldname: 'max_connections',
+						width: 0.5,
+						align: 'center',
+						format: value => `${value} Connection` + (value > 1 ? 's' : '')
 					},
 					{
 						label: 'Mode',
@@ -168,7 +175,7 @@ export default {
 					}
 				],
 				rowActions: ({ row, listResource, documentResource }) => {
-					if (row.status === 'Archived') {
+					if (row.status === 'Archived' || row.status === 'Pending') {
 						return [];
 					}
 					return [

--- a/dashboard/src2/components/SiteDatabaseAccessDialog.vue
+++ b/dashboard/src2/components/SiteDatabaseAccessDialog.vue
@@ -122,7 +122,7 @@ export default {
 					site: this.site,
 					status: ['!=', 'Archived']
 				},
-				searchField: 'username',
+				searchField: 'label',
 				filterControls() {
 					return [
 						{
@@ -135,9 +135,9 @@ export default {
 				},
 				columns: [
 					{
-						label: 'Username',
-						fieldname: 'username',
-						width: 0.5
+						label: 'Label',
+						fieldname: 'label',
+						width: '150px'
 					},
 					{
 						label: 'Status',

--- a/dashboard/src2/components/site_database_user/SiteDatabaseAddEditUserDialog.vue
+++ b/dashboard/src2/components/site_database_user/SiteDatabaseAddEditUserDialog.vue
@@ -49,6 +49,7 @@
 					v-model="mode"
 				/>
 				<FormControl
+					v-if="!isEditMode"
 					class="mt-2"
 					type="number"
 					size="sm"
@@ -247,6 +248,7 @@ export default {
 						dn: this.db_user_name,
 						method: 'save_and_apply_changes',
 						args: {
+							label: this.label,
 							mode: this.mode,
 							permissions: permissions
 						}

--- a/dashboard/src2/components/site_database_user/SiteDatabaseAddEditUserDialog.vue
+++ b/dashboard/src2/components/site_database_user/SiteDatabaseAddEditUserDialog.vue
@@ -40,6 +40,14 @@
 					label="Access Mode"
 					v-model="mode"
 				/>
+				<FormControl
+					class="mt-2"
+					type="number"
+					size="sm"
+					variant="subtle"
+					label="Database Connections"
+					v-model="database_connections"
+				/>
 				<!-- Permission configuration for Granular Mode -->
 				<div v-if="mode == 'granular'">
 					<div
@@ -131,6 +139,7 @@ export default {
 	data() {
 		return {
 			mode: 'read_only',
+			database_connections: 1,
 			permissions: [],
 			lastGeneratedRowId: 0
 		};
@@ -171,6 +180,7 @@ export default {
 						};
 					});
 					this.permissions = fetched_permissions;
+					this.database_connections = data?.max_connections ?? 1;
 				}
 			};
 		},
@@ -195,7 +205,8 @@ export default {
 							team: this.$team.doc.name,
 							site: this.site,
 							mode: this.mode,
-							permissions: permissions
+							permissions: permissions,
+							max_connections: parseInt(this.database_connections || 1)
 						}
 					};
 				},

--- a/dashboard/src2/components/site_database_user/SiteDatabaseAddEditUserDialog.vue
+++ b/dashboard/src2/components/site_database_user/SiteDatabaseAddEditUserDialog.vue
@@ -19,6 +19,14 @@
 				>
 				</AlertBanner>
 				<FormControl
+					class="mt-2"
+					type="text"
+					size="sm"
+					variant="subtle"
+					label="Label (to identify the user)"
+					v-model="label"
+				/>
+				<FormControl
 					type="select"
 					:options="[
 						{
@@ -138,6 +146,7 @@ export default {
 	},
 	data() {
 		return {
+			label: '',
 			mode: 'read_only',
 			database_connections: 1,
 			permissions: [],
@@ -172,6 +181,7 @@ export default {
 				name: this.db_user_name,
 				auto: false,
 				onSuccess: data => {
+					this.label = data?.label;
 					this.mode = data?.mode;
 					let fetched_permissions = (data?.permissions ?? []).map(x => {
 						return {
@@ -202,6 +212,7 @@ export default {
 					return {
 						doc: {
 							doctype: 'Site Database User',
+							label: this.label,
 							team: this.$team.doc.name,
 							site: this.site,
 							mode: this.mode,

--- a/dashboard/src2/components/site_database_user/SiteDatabaseUserCredentialDialog.vue
+++ b/dashboard/src2/components/site_database_user/SiteDatabaseUserCredentialDialog.vue
@@ -35,6 +35,11 @@
 						Password: {{ databaseCredential?.password }}
 					</p>
 					<p class="ml-1 font-mono text-sm">Use SSL: Yes</p>
+					<p class="ml-1 font-mono text-sm">
+						Max Database Connection{{
+							databaseCredential?.max_connections > 1 ? 's' : ''
+						}}: {{ databaseCredential?.max_connections }}
+					</p>
 				</div>
 				<div class="pb-2 pt-5">
 					<p class="mb-2 text-base font-semibold text-gray-700">

--- a/press/agent.py
+++ b/press/agent.py
@@ -620,12 +620,21 @@ class Agent:
 		)
 
 	def add_proxysql_user(
-		self, site, database, username, password, database_server, reference_doctype=None, reference_name=None
+		self,
+		site,
+		database: str,
+		username: str,
+		password: str,
+		max_connections: int,
+		database_server,
+		reference_doctype=None,
+		reference_name=None,
 	):
 		data = {
 			"username": username,
 			"password": password,
 			"database": database,
+			"max_connections": max_connections,
 			"backend": {"ip": database_server.private_ip, "id": database_server.server_id},
 		}
 		return self.create_agent_job(

--- a/press/patches.txt
+++ b/press/patches.txt
@@ -134,3 +134,4 @@ press.patches.v0_7_0.update_enable_performance_tuning
 press.press.doctype.server.patches.set_plan_and_subscription
 press.patches.v0_7_0.move_site_db_access_users_to_site_db_perm_manager
 press.press.doctype.drip_email.patches.set_correct_field_for_html
+press.patches.v0_7_0.set_label_for_site_database_user

--- a/press/patches/v0_7_0/set_label_for_site_database_user.py
+++ b/press/patches/v0_7_0/set_label_for_site_database_user.py
@@ -1,0 +1,12 @@
+import frappe
+
+
+def execute():
+	db_users = frappe.get_all(
+		"Site Database User",
+		filters={"status": ("!=", "Archived")},
+		fields=["name", "username"],
+	)
+
+	for db_user in db_users:
+		frappe.db.set_value("Site Database User", db_user.name, "label", f"User {db_user.username}")

--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -896,7 +896,6 @@ def process_job_updates(job_name: str, response_data: dict | None = None):  # no
 			process_setup_erpnext_site_job_update,
 		)
 		from press.press.doctype.site.site import (
-			process_add_proxysql_user_job_update,
 			process_archive_site_job_update,
 			process_complete_setup_wizard_job_update,
 			process_create_user_job_update,
@@ -905,7 +904,6 @@ def process_job_updates(job_name: str, response_data: dict | None = None):  # no
 			process_move_site_to_bench_job_update,
 			process_new_site_job_update,
 			process_reinstall_site_job_update,
-			process_remove_proxysql_user_job_update,
 			process_rename_site_job_update,
 			process_restore_job_update,
 			process_restore_tables_job_update,
@@ -979,16 +977,9 @@ def process_job_updates(job_name: str, response_data: dict | None = None):  # no
 			process_add_ssh_user_job_update(job)
 		elif job.job_type == "Remove User from Proxy":
 			process_remove_ssh_user_job_update(job)
-		elif job.job_type == "Add User to ProxySQL":
+		elif job.job_type == "Add User to ProxySQL" or job.job_type == "Remove User from ProxySQL":
 			if job.reference_doctype == "Site Database User":
 				SiteDatabaseUser.process_job_update(job)
-			else:
-				process_add_proxysql_user_job_update(job)
-		elif job.job_type == "Remove User from ProxySQL":
-			if job.reference_doctype == "Site Database User":
-				SiteDatabaseUser.process_job_update(job)
-			else:
-				process_remove_proxysql_user_job_update(job)
 		elif job.job_type == "Reload NGINX":
 			process_update_nginx_job_update(job)
 		elif job.job_type == "Move Site to Bench":

--- a/press/press/doctype/site/site.js
+++ b/press/press/doctype/site/site.js
@@ -185,29 +185,6 @@ frappe.ui.form.on('Site', {
 		});
 		frm.toggle_enable(['host_name'], frm.doc.status === 'Active');
 
-		if (frm.doc.is_database_access_enabled) {
-			frm.add_custom_button(
-				__('Show Database Credentials'),
-				() =>
-					frm.call('get_database_credentials').then((r) => {
-						let message = `Host: ${r.message.host}
-
-Port: ${r.message.port}
-
-Database: ${r.message.database}
-
-Username: ${r.message.username}
-
-Password: ${r.message.password}
-
-\`\`\`\nmysql -u ${r.message.username} -p${r.message.password} -h ${r.message.host} -P ${r.message.port} --ssl --ssl-verify-server-cert\n\`\`\``;
-
-						frappe.msgprint(frappe.markdown(message), 'Database Credentials');
-					}),
-				__('Actions'),
-			);
-		}
-
 		frm.add_custom_button(
 			__('Replicate Site'),
 			() => {

--- a/press/press/doctype/site/site.json
+++ b/press/press/doctype/site/site.json
@@ -72,11 +72,7 @@
   "setup_wizard_status_check_retries",
   "setup_wizard_status_check_next_retry_on",
   "database_section",
-  "is_database_access_enabled",
-  "database_access_mode",
-  "column_break_lfuz",
-  "database_access_user",
-  "database_access_password",
+  "database_access_connection_limit",
   "saas_section",
   "is_standby",
   "standby_for",
@@ -453,13 +449,6 @@
    "label": "Database Access"
   },
   {
-   "default": "0",
-   "fieldname": "is_database_access_enabled",
-   "fieldtype": "Check",
-   "label": "Is Database Access Enabled",
-   "read_only": 1
-  },
-  {
    "fieldname": "standby_for",
    "fieldtype": "Link",
    "label": "Standby For",
@@ -527,29 +516,6 @@
    "fieldname": "hide_config",
    "fieldtype": "Check",
    "label": "Hide Config"
-  },
-  {
-   "fieldname": "database_access_password",
-   "fieldtype": "Password",
-   "label": "Database Access Password",
-   "read_only": 1
-  },
-  {
-   "fieldname": "database_access_mode",
-   "fieldtype": "Select",
-   "label": "Database Access Mode",
-   "options": "\nread_only\nread_write",
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_lfuz",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "database_access_user",
-   "fieldtype": "Data",
-   "label": "Database Access User",
-   "read_only": 1
   },
   {
    "collapsible": 1,
@@ -628,6 +594,12 @@
    "fieldname": "setup_wizard_status_check_next_retry_on",
    "fieldtype": "Datetime",
    "label": "Next Retry On"
+  },
+  {
+   "default": "16",
+   "fieldname": "database_access_connection_limit",
+   "fieldtype": "Int",
+   "label": "Database Access Connection Limit"
   }
  ],
  "links": [
@@ -702,7 +674,7 @@
    "link_fieldname": "site"
   }
  ],
- "modified": "2024-11-04 09:40:44.252728",
+ "modified": "2024-11-28 15:40:02.431631",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site",

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -125,9 +125,7 @@ class Site(Document, TagHelpers):
 		current_cpu_usage: DF.Int
 		current_database_usage: DF.Int
 		current_disk_usage: DF.Int
-		database_access_mode: DF.Literal["", "read_only", "read_write"]
-		database_access_password: DF.Password | None
-		database_access_user: DF.Data | None
+		database_access_connection_limit: DF.Int
 		database_name: DF.Data | None
 		domain: DF.Link | None
 		erpnext_consultant: DF.Link | None
@@ -136,7 +134,6 @@ class Site(Document, TagHelpers):
 		hide_config: DF.Check
 		host_name: DF.Data | None
 		hybrid_saas_pool: DF.Link | None
-		is_database_access_enabled: DF.Check
 		is_erpnext_setup: DF.Check
 		is_standby: DF.Check
 		notify_email: DF.Data | None
@@ -189,7 +186,7 @@ class Site(Document, TagHelpers):
 		"cluster",
 		"bench",
 		"group",
-		"is_database_access_enabled",
+		"database_access_connection_limit",
 		"trial_end_date",
 		"tags",
 		"server",

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -3032,17 +3032,6 @@ def process_rename_site_job_update(job):  # noqa: C901
 		create_site_status_update_webhook_event(job.site)
 
 
-# TODO
-def process_add_proxysql_user_job_update(job):
-	if job.status == "Success":
-		frappe.db.set_value("Site", job.site, "is_database_access_enabled", True)
-
-
-def process_remove_proxysql_user_job_update(job):
-	if job.status == "Success":
-		frappe.db.set_value("Site", job.site, "is_database_access_enabled", False)
-
-
 def process_move_site_to_bench_job_update(job):
 	updated_status = {
 		"Pending": "Pending",

--- a/press/press/doctype/site_database_user/site_database_user.json
+++ b/press/press/doctype/site_database_user/site_database_user.json
@@ -131,7 +131,8 @@
    "default": "4",
    "fieldname": "max_database_connections",
    "fieldtype": "Int",
-   "label": "Max Database Connections"
+   "label": "Max Database Connections",
+   "set_only_once": 1
   }
  ],
  "index_web_pages_for_search": 1,
@@ -142,7 +143,7 @@
    "link_fieldname": "reference_name"
   }
  ],
- "modified": "2024-11-28 17:17:57.639463",
+ "modified": "2024-11-29 12:25:19.446170",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site Database User",

--- a/press/press/doctype/site_database_user/site_database_user.json
+++ b/press/press/doctype/site_database_user/site_database_user.json
@@ -6,6 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "status",
+  "label",
   "mode",
   "site",
   "team",
@@ -133,6 +134,12 @@
    "fieldtype": "Int",
    "label": "Max Connections",
    "set_only_once": 1
+  },
+  {
+   "fieldname": "label",
+   "fieldtype": "Data",
+   "label": "Label",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
@@ -143,7 +150,7 @@
    "link_fieldname": "reference_name"
   }
  ],
- "modified": "2024-11-29 13:49:11.220888",
+ "modified": "2024-11-29 15:25:08.468806",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site Database User",

--- a/press/press/doctype/site_database_user/site_database_user.json
+++ b/press/press/doctype/site_database_user/site_database_user.json
@@ -10,6 +10,7 @@
   "site",
   "team",
   "column_break_udtx",
+  "max_database_connections",
   "username",
   "password",
   "user_created_in_database",
@@ -125,6 +126,12 @@
    "options": "Team",
    "reqd": 1,
    "search_index": 1
+  },
+  {
+   "default": "4",
+   "fieldname": "max_database_connections",
+   "fieldtype": "Int",
+   "label": "Max Database Connections"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -135,7 +142,7 @@
    "link_fieldname": "reference_name"
   }
  ],
- "modified": "2024-11-07 13:03:27.265288",
+ "modified": "2024-11-28 17:17:57.639463",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site Database User",

--- a/press/press/doctype/site_database_user/site_database_user.json
+++ b/press/press/doctype/site_database_user/site_database_user.json
@@ -128,7 +128,7 @@
    "search_index": 1
   },
   {
-   "default": "4",
+   "default": "16",
    "fieldname": "max_database_connections",
    "fieldtype": "Int",
    "label": "Max Database Connections",
@@ -143,7 +143,7 @@
    "link_fieldname": "reference_name"
   }
  ],
- "modified": "2024-11-29 12:25:19.446170",
+ "modified": "2024-11-29 12:42:22.786821",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site Database User",

--- a/press/press/doctype/site_database_user/site_database_user.json
+++ b/press/press/doctype/site_database_user/site_database_user.json
@@ -150,7 +150,7 @@
    "link_fieldname": "reference_name"
   }
  ],
- "modified": "2024-11-29 15:25:08.468806",
+ "modified": "2024-11-29 15:54:25.951266",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site Database User",

--- a/press/press/doctype/site_database_user/site_database_user.json
+++ b/press/press/doctype/site_database_user/site_database_user.json
@@ -10,7 +10,7 @@
   "site",
   "team",
   "column_break_udtx",
-  "max_database_connections",
+  "max_connections",
   "username",
   "password",
   "user_created_in_database",
@@ -129,9 +129,9 @@
   },
   {
    "default": "16",
-   "fieldname": "max_database_connections",
+   "fieldname": "max_connections",
    "fieldtype": "Int",
-   "label": "Max Database Connections",
+   "label": "Max Connections",
    "set_only_once": 1
   }
  ],
@@ -143,7 +143,7 @@
    "link_fieldname": "reference_name"
   }
  ],
- "modified": "2024-11-29 12:42:22.786821",
+ "modified": "2024-11-29 13:49:11.220888",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site Database User",

--- a/press/press/doctype/site_database_user/site_database_user.json
+++ b/press/press/doctype/site_database_user/site_database_user.json
@@ -138,6 +138,7 @@
   {
    "fieldname": "label",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Label",
    "reqd": 1
   }
@@ -150,7 +151,7 @@
    "link_fieldname": "reference_name"
   }
  ],
- "modified": "2024-11-29 15:54:25.951266",
+ "modified": "2024-11-29 16:29:57.632579",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site Database User",

--- a/press/press/doctype/site_database_user/site_database_user.py
+++ b/press/press/doctype/site_database_user/site_database_user.py
@@ -59,6 +59,9 @@ class SiteDatabaseUser(Document):
 		if self.mode != "granular":
 			self.permissions.clear()
 
+		if not self.is_new() and self.has_value_changed("max_database_connections"):
+			frappe.throw("You can't update the max database connections. Archive it and create a new one.")
+
 	def before_insert(self):
 		site = frappe.get_doc("Site", self.site)
 		if not site.has_permission():
@@ -186,6 +189,7 @@ class SiteDatabaseUser(Document):
 			database,
 			self.username,
 			self.get_password("password"),
+			self.max_database_connections,
 			database_server,
 			reference_doctype="Site Database User",
 			reference_name=self.name,

--- a/press/press/doctype/site_database_user/site_database_user.py
+++ b/press/press/doctype/site_database_user/site_database_user.py
@@ -28,6 +28,7 @@ class SiteDatabaseUser(Document):
 
 		failed_agent_job: DF.Link | None
 		failure_reason: DF.SmallText
+		label: DF.Data
 		max_connections: DF.Int
 		mode: DF.Literal["read_only", "read_write", "granular"]
 		password: DF.Password
@@ -41,6 +42,7 @@ class SiteDatabaseUser(Document):
 	# end: auto-generated types
 
 	dashboard_fields = (
+		"label",
 		"status",
 		"site",
 		"username",

--- a/press/press/doctype/site_database_user/site_database_user.py
+++ b/press/press/doctype/site_database_user/site_database_user.py
@@ -62,6 +62,11 @@ class SiteDatabaseUser(Document):
 		if not self.is_new() and self.has_value_changed("max_connections"):
 			frappe.throw("You can't update the max database connections. Archive it and create a new one.")
 
+		if not self.max_connections:
+			frappe.throw(
+				"Max database connections can't be zero. You need to opt for at least one connection."
+			)
+
 	def before_insert(self):
 		site = frappe.get_doc("Site", self.site)
 		if not site.has_permission():
@@ -76,10 +81,10 @@ class SiteDatabaseUser(Document):
 			pluck="max_connections",
 		)
 		total_used_connections = sum(exists_db_users_connection_limit)
-		allowed_max_connections_for_site = site.max_connections - total_used_connections
+		allowed_max_connections_for_site = site.database_access_connection_limit - total_used_connections
 		if self.max_connections > allowed_max_connections_for_site:
 			frappe.throw(
-				f"Your site has quota of {site.max_connections} connections. You can't allocate more than {allowed_max_connections_for_site} connections. You can drop other database users to allocate more connections."
+				f"Your site has quota of {site.database_access_connection_limit} database connections.\nYou can't allocate more than {allowed_max_connections_for_site} connections for new user. You can drop other database users to allocate more connections."
 			)
 
 		self.status = "Pending"

--- a/press/press/doctype/site_database_user/site_database_user.py
+++ b/press/press/doctype/site_database_user/site_database_user.py
@@ -28,6 +28,7 @@ class SiteDatabaseUser(Document):
 
 		failed_agent_job: DF.Link | None
 		failure_reason: DF.SmallText
+		max_database_connections: DF.Int
 		mode: DF.Literal["read_only", "read_write", "granular"]
 		password: DF.Password
 		permissions: DF.Table[SiteDatabaseTablePermission]


### PR DESCRIPTION
Fixes https://github.com/frappe/press/issues/2315 https://github.com/frappe/press/issues/2317
(Check issue for more details)

- [x] Clean up non required fields and functions of old implementation
- [x] Limit database user's max connection. The total allowed connections for each site will be 16 by default. But upon any request, we can configure it from backend
- [x] Frontend Changes
- [x] Allow to set label/title for database user to identify easily (Fixes 2317)

**Previews -**

**Manage Users -**

![Screenshot 2024-12-03 at 10 33 38 AM](https://github.com/user-attachments/assets/75020a53-bdf4-4f6e-836a-b2464ef9afe5)

**Add Users -**

![Screenshot 2024-12-03 at 10 33 51 AM](https://github.com/user-attachments/assets/a9e0530a-bffe-4270-b539-57d10303d360)

**Error regarding database connection limit during adding new user -**

![Screenshot 2024-12-03 at 10 36 04 AM](https://github.com/user-attachments/assets/d444d169-6526-4671-bdd4-7bd8626ef513)

**Edit Database User -**
> Currently, user can't change database connection limit once added

![Screenshot 2024-12-03 at 10 59 37 AM](https://github.com/user-attachments/assets/15eb140e-b413-4dbe-9acf-b9e768bfc11e)


Agent PR - https://github.com/frappe/agent/pull/145