### PR TITLE
chore(database-server): for new servers enable innodb_print_all_deadlocks in default

### DIFF
--- a/press/fixtures/mariadb_variable.json
+++ b/press/fixtures/mariadb_variable.json
@@ -301,12 +301,12 @@
  },
  {
   "datatype": "Str",
-  "default_value": null,
+  "default_value": "ON",
   "doc_section": "innodb",
   "docstatus": 0,
   "doctype": "MariaDB Variable",
   "dynamic": 1,
-  "modified": "2024-07-03 07:13:23.014958",
+  "modified": "2024-12-04 16:30:16.720727",
   "name": "innodb_print_all_deadlocks",
   "set_on_new_servers": 0,
   "skippable": 0

--- a/press/playbooks/roles/mariadb/templates/mariadb.cnf
+++ b/press/playbooks/roles/mariadb/templates/mariadb.cnf
@@ -48,6 +48,7 @@ innodb-buffer-pool-size         = {{ (ansible_memtotal_mb * 0.6)|round|int }}M
 innodb-file-format              = barracuda
 innodb-large-prefix             = 1
 innodb-old-blocks-time          = 5000
+innodb_print_all_deadlocks		= 1
 collation-server                = utf8mb4_unicode_ci
 character-set-server            = utf8mb4
 character-set-client-handshake  = FALSE


### PR DESCRIPTION
Related https://github.com/frappe/press/issues/2320