### PR TITLE
refactor: drop pytz

### DIFF
--- a/press/api/analytics.py
+++ b/press/api/analytics.py
@@ -19,7 +19,7 @@ from frappe.utils import (
 	get_datetime,
 )
 from frappe.utils.password import get_decrypted_password
-from pytz import timezone as pytz_timezone
+from zoneinfo import ZoneInfo
 
 from press.agent import Agent
 from press.api.site import protected
@@ -155,7 +155,7 @@ def get_rounded_boundaries(timespan: int, timegrain: int, timezone: str = "UTC")
 	"""
 	Round the start and end time to the nearest interval, because Elasticsearch does this
 	"""
-	end = datetime.now(pytz_timezone(timezone))
+	end = datetime.now(ZoneInfo(timezone))
 	start = frappe.utils.add_to_date(end, seconds=-timespan)
 
 	return rounded_time(start, timegrain), rounded_time(end, timegrain)
@@ -169,7 +169,7 @@ def get_uptime(site, timezone, timespan, timegrain):
 	url = f"https://{monitor_server}/prometheus/api/v1/query_range"
 	password = get_decrypted_password("Monitor Server", monitor_server, "grafana_password")
 
-	end = datetime.now(pytz_timezone(timezone))
+	end = datetime.now(ZoneInfo(timezone))
 	start = frappe.utils.add_to_date(end, seconds=-timespan)
 	query = {
 		"query": (

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -10,11 +10,11 @@ from itertools import groupby
 from typing import TYPE_CHECKING, Generator, Iterable, Literal
 
 import frappe
-import pytz
 from frappe.exceptions import DoesNotExistError
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists, make_autoname
 from frappe.utils import get_system_timezone
+from zoneinfo import ZoneInfo
 
 from press.agent import Agent
 from press.api.client import dashboard_whitelist
@@ -1221,8 +1221,8 @@ def sync_bench_analytics(name):
 
 
 def convert_user_timezone_to_utc(datetime):
-	timezone = pytz.timezone(get_system_timezone())
-	return timezone.localize(datetime).astimezone(pytz.utc)
+	timezone = ZoneInfo(get_system_timezone())
+	return timezone.localize(datetime).astimezone(datetime.timezone.utc)
 
 
 def sort_supervisor_processes(processes: "list[SupervisorProcess]"):

--- a/press/press/doctype/site/backups.py
+++ b/press/press/doctype/site/backups.py
@@ -74,8 +74,9 @@ class BackupRotationScheme:
 				sites.append(site_conf.name)
 			self._expire_backups_of_site_in_bench(sites, config)
 
+	@staticmethod
 	@functools.lru_cache(maxsize=128)
-	def _get_expiry(self, config: str):
+	def _get_expiry(config: str):
 		return frappe.parse_json(config or "{}").keep_backups_for_hours or 24
 
 	def _expire_backups_of_site_in_bench(self, sites: list[str], expiry: int):

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -13,7 +13,6 @@ from typing import Any
 
 import dateutil.parser
 import frappe
-import pytz
 import requests
 from frappe import _
 from frappe.core.utils import find
@@ -32,6 +31,7 @@ from frappe.utils import (
 	sbool,
 	time_diff_in_hours,
 )
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from press.exceptions import (
 	CannotChangePlan,
@@ -1539,8 +1539,8 @@ class Site(Document, TagHelpers):
 		# Empty string is fine, since we default to IST
 		if timezone:
 			try:
-				pytz.timezone(timezone)
-			except pytz.exceptions.UnknownTimeZoneError:
+				ZoneInfo(timezone)
+			except ZoneInfoNotFoundError:
 				return False
 
 		if self.timezone != timezone:

--- a/press/press/doctype/site_update/site_update.py
+++ b/press/press/doctype/site_update/site_update.py
@@ -8,11 +8,11 @@ from datetime import datetime
 from typing import TYPE_CHECKING, ClassVar
 
 import frappe
-import pytz
 from frappe.core.utils import find
 from frappe.model.document import Document
 from frappe.utils import convert_utc_to_system_timezone
 from frappe.utils.caching import site_cache
+from zoneinfo import ZoneInfo
 
 from press.agent import Agent
 from press.api.client import dashboard_whitelist
@@ -499,7 +499,7 @@ def is_site_in_deploy_hours(site):
 		return True
 	server_time = datetime.now()
 	timezone = site.timezone or "Asia/Kolkata"
-	site_timezone = pytz.timezone(timezone)
+	site_timezone = ZoneInfo(timezone)
 	site_time = server_time.astimezone(site_timezone)
 	deploy_hours = frappe.get_hooks("deploy_hours")
 

--- a/press/press/doctype/virtual_disk_snapshot/virtual_disk_snapshot.py
+++ b/press/press/doctype/virtual_disk_snapshot/virtual_disk_snapshot.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import boto3
 import frappe
-import pytz
 from botocore.exceptions import ClientError
 from frappe.model.document import Document
 from oci.core import BlockstorageClient
+from zoneinfo import ZoneInfo
 
 from press.utils import log_error
 
@@ -78,7 +78,7 @@ class VirtualDiskSnapshot(Document):
 			self.size = snapshot.size_in_gbs
 
 			self.start_time = frappe.utils.format_datetime(
-				snapshot.time_created.astimezone(pytz.timezone(frappe.utils.get_system_timezone())),
+				snapshot.time_created.astimezone(ZoneInfo(frappe.utils.get_system_timezone())),
 				"yyyy-MM-dd HH:mm:ss",
 			)
 		self.save()

--- a/press/press/report/binary_log_browser/binary_log_browser.py
+++ b/press/press/report/binary_log_browser/binary_log_browser.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import frappe
-import pytz
 import sqlparse
 from frappe.core.doctype.access_log.access_log import make_access_log
 from frappe.utils import (
@@ -11,6 +10,7 @@ from frappe.utils import (
 	get_datetime_str,
 	get_system_timezone,
 )
+from zoneinfo import ZoneInfo
 
 from press.agent import Agent
 
@@ -106,6 +106,6 @@ def get_files_in_timespan(files: list[dict[str, str]], start: str, stop: str) ->
 
 
 def convert_user_timezone_to_utc(datetime):
-	timezone = pytz.timezone(get_system_timezone())
+	timezone = ZoneInfo(get_system_timezone())
 	datetime = get_datetime(datetime)
-	return get_datetime_str(timezone.localize(datetime).astimezone(pytz.utc))
+	return get_datetime_str(datetime.replace(tzinfo=timezone).astimezone(ZoneInfo("UTC")))

--- a/press/utils/__init__.py
+++ b/press/utils/__init__.py
@@ -13,13 +13,13 @@ from typing import TypedDict, TypeVar
 from urllib.parse import urljoin
 
 import frappe
-import pytz
 import requests
 import wrapt
 from babel.dates import format_timedelta
 from frappe.utils import get_datetime, get_system_timezone
 from frappe.utils.caching import site_cache
 from pymysql.err import InterfaceError
+from zoneinfo import ZoneInfo
 
 
 class SupervisorProcess(TypedDict):
@@ -535,9 +535,9 @@ def group_children_in_result(result, child_field_map):
 
 
 def convert_user_timezone_to_utc(datetime):
-	timezone = pytz.timezone(get_system_timezone())
+	timezone = ZoneInfo(get_system_timezone())
 	datetime_obj = get_datetime(datetime)
-	return timezone.localize(datetime_obj).astimezone(pytz.utc).isoformat()
+	return datetime_obj.replace(tzinfo=timezone).astimezone(ZoneInfo("UTC")).isoformat()
 
 
 class ttl_cache:


### PR DESCRIPTION
Follow up to https://github.com/frappe/frappe/pull/28093 so I can drop the pytz dependency
