### PR TITLE
chore: configurable binlog format: MIXED, ROW, STATEMENT

### DIFF
--- a/press/fixtures/mariadb_variable.json
+++ b/press/fixtures/mariadb_variable.json
@@ -157,18 +157,6 @@
  },
  {
   "datatype": "Str",
-  "default_value": "3307",
-  "doc_section": "server",
-  "docstatus": 0,
-  "doctype": "MariaDB Variable",
-  "dynamic": 0,
-  "modified": "2024-11-22 12:52:35.958089",
-  "name": "extra_port",
-  "set_on_new_servers": 0,
-  "skippable": 0
- },
- {
-  "datatype": "Str",
   "default_value": "200",
   "doc_section": "server",
   "docstatus": 0,
@@ -380,6 +368,30 @@
   "dynamic": 0,
   "modified": "2024-11-22 12:31:31.593757",
   "name": "myisam_recover_options",
+  "set_on_new_servers": 0,
+  "skippable": 0
+ },
+ {
+  "datatype": "Str",
+  "default_value": "3307",
+  "doc_section": "server",
+  "docstatus": 0,
+  "doctype": "MariaDB Variable",
+  "dynamic": 0,
+  "modified": "2024-11-22 12:52:35.958089",
+  "name": "extra_port",
+  "set_on_new_servers": 0,
+  "skippable": 0
+ },
+ {
+  "datatype": "Str",
+  "default_value": "MIXED",
+  "doc_section": "replication-and-binary-log",
+  "docstatus": 0,
+  "doctype": "MariaDB Variable",
+  "dynamic": 0,
+  "modified": "2024-12-12 12:59:33.579411",
+  "name": "binlog_format",
   "set_on_new_servers": 0,
   "skippable": 0
  }


### PR DESCRIPTION
For MariaDB >= 10.2.4, Default is set to MIXED