### PR TITLE
fix(build): Support for ARM builds

### DIFF
--- a/press/docker/Dockerfile
+++ b/press/docker/Dockerfile
@@ -82,6 +82,19 @@ RUN --mount=type=cache,target=/var/cache/apt add-apt-repository ppa:deadsnakes/p
 
 # Install wkhtmltopdf
 ENV {{ doc.get_dependency_version("wkhtmltopdf", True) }}
+{% if doc.platform == "arm64" %}
+{% if doc.get_dependency_version("wkhtmltopdf") == '0.12.5' %}
+RUN wget https://github.com/adityahase/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.focal_arm64.deb \
+  && dpkg -i wkhtmltox_0.12.5-1.focal_arm64.deb \
+  && rm wkhtmltox_0.12.5-1.focal_arm64.deb \
+  `#stage-pre-wkhtmltopdf`
+{% else %}
+RUN wget https://github.com/wkhtmltopdf/packaging/releases/download/${WKHTMLTOPDF_VERSION}-1/wkhtmltox_${WKHTMLTOPDF_VERSION}-1.focal_arm64.deb \
+  && dpkg -i wkhtmltox_${WKHTMLTOPDF_VERSION}-1.focal_arm64.deb \
+  && rm wkhtmltox_${WKHTMLTOPDF_VERSION}-1.focal_arm64.deb \
+  `#stage-pre-wkhtmltopdf`
+{% endif %}
+{% else %}
 {% if doc.get_dependency_version("wkhtmltopdf") == '0.12.6' %}
 RUN wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb \
   && dpkg -i wkhtmltox_0.12.6-1.focal_amd64.deb \
@@ -98,6 +111,7 @@ RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkh
   && mv wkhtmltox/bin/wkhtmlto* /usr/local/bin/ \
   && rm -rf wkhtmltox-0.12.4_linux-generic-amd64.tar.xz wkhtmltox \
   `#stage-pre-wkhtmltopdf`
+{% endif %}
 {% endif %}
 
 {% if doc.is_code_server_enabled %}

--- a/press/docker/wkhtmltopdf.md
+++ b/press/docker/wkhtmltopdf.md
@@ -1,0 +1,135 @@
+# Building wkhtmltopdf 0.12.5 for Ubuntu 20.04 ARM
+
+90% of the benches still use wkhtmltopdf 0.12.5. The [pre-built binaries](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/0.12.5/) are only available for Ubuntu 18.04 and 20.04
+
+Because of this we haven't been able to update our container base image (Ubuntu 20.04).
+
+It's not nice to force people to upgrade to 0.12.6. Lot of people have reported broken print formats.
+
+So, let's try and build 0.12.5 for Ubuntu 20.04 ARM. If this goes well then we should be able to migrate to ARM.
+
+I have tried following the docs (for 0.12.6/0.12.5 with 20 and 22) but it usually fails with
+
+```sh
+make[1]: *** [Makefile:128361: .obj/release-static/qfiledialog.o] Error 1
+make[1]: Leaving directory '/tgt/qt/src/gui'
+make: *** [Makefile:375: sub-gui-make_default-ordered] Error 2
+docker run --rm -v/root/0.12.6.x:/src -v/root/packaging/targets/jammy-amd64:/tgt -v/root/packaging:/pkg -w/tgt/qt --user 0:0 wkhtmltopdf/0.12:jammy-amd64 make -j8
+command failed: exit code 2
+```
+
+### Prepare
+
+Note: Do this on an **ARM** machine.
+
+#### Install Prerequisites
+
+```sh
+apt update
+apt install -y python3-yaml python-is-python3 docker.io p7zip-full
+```
+
+#### Run docker in experimental mode
+
+```sh
+echo '{ "experimental": true }' | sudo tee /etc/docker/daemon.json
+sudo systemctl restart docker
+```
+
+#### Download wkhtmltopdf and the Qt submodule
+
+```sh
+git clone --branch 0.12.5 --recursive https://github.com/wkhtmltopdf/wkhtmltopdf
+```
+
+#### Update qt
+
+Found out the hard way that the repo can't be build as-is.
+
+https://github.com/wkhtmltopdf/packaging/releases/tag/0.12.6.1-3
+
+> All packages were built and uploaded automatically as a part of [this run](https://github.com/wkhtmltopdf/packaging/actions/runs/5038814761), using this [wkhtmltopdf branch/tag](https://github.com/wkhtmltopdf/wkhtmltopdf/tree/0.12.6.x).
+
+https://github.com/wkhtmltopdf/packaging/issues/149?ref=https://giter.site
+
+> please use the `0.12.6.x` branch, it should work 👍
+
+https://github.com/wkhtmltopdf/packaging/issues/114
+
+> So the issue is, the patched Qt in wkhtmltopdf uses very old code and doesn't work with the latest gcc versions. In 20.04, an [older version of gcc was used](https://github.com/wkhtmltopdf/packaging/blob/master/docker/Dockerfile.focal?rgh-link-date=2022-04-27T05%3A25%3A43Z) which isn't available in jammy. Need to figure out how to get it fixed there 🤷‍♂️
+
+We need to apply a [small change](https://github.com/wkhtmltopdf/wkhtmltopdf/compare/0.12.6...0.12.6.x) to the [qt submodule](https://github.com/wkhtmltopdf/qt/compare/7480f44f696fb7db1d473cf447a2c99a656789a9...c8a847338fac96fed89f40116d88468440891099).
+
+We'll checkout https://github.com/wkhtmltopdf/wkhtmltopdf/commit/c61ecdeed13b8e001f77c4a2b4050d0c732e9e72.
+
+```sh
+cd wkhtmltopdf/qt
+git checkout c8a847338fac96fed89f40116d88468440891099
+cd ../..
+```
+
+#### Download packaging script
+
+```sh
+git clone https://github.com/wkhtmltopdf/packaging
+cd packaging
+```
+
+### Build
+
+```sh
+python build --no-qemu package-docker focal-arm64 ../wkhtmltopdf --clean
+```
+
+This takes ~10 minutes on a 16 core machine. ~5 minutes on 32 cores.
+
+If everything goes well then you should get `wkhtmltox_0.12.5-1.focal_arm64.deb` inside `targets/`.
+
+### Install
+
+#### Install dependencies
+
+```sh
+apt update
+apt install ca-certificates \
+	fontconfig \
+	libfreetype6 \
+	libjpeg-turbo8 \
+	libpng16-16 \
+	libx11-6 \
+	libxcb1 \
+	libxext6 \
+	libxrender1 \
+	xfonts-75dpi \
+	xfonts-base \
+```
+
+#### Install wkhtmltopdf
+
+```
+dpkg -i targets/wkhtmltox_0.12.5-1.focal_arm64.deb
+```
+
+If everything worked well then you should get
+
+```sh
+wkhtmltopdf --version
+wkhtmltopdf 0.12.5 (with patched qt)
+```
+
+Installing this package anywhere else (except Ubuntu 20.04) wouldn't work.
+
+---
+
+Building 0.12.6 for 22.04 also failed, but can be fixed with installing Qt packages in the build container.
+
+```diff
++    libqt5webkit5 \
++    libqt5webkit5-dev \
+```
+
+### Host
+
+We're temporarily hosting the built binary at https://github.com/adityahase/wkhtmltopdf/releases/tag/0.12.5
+
+TODO: Move this repository to frappe org.

--- a/press/press/doctype/deploy_candidate/deploy_candidate.json
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.json
@@ -28,6 +28,8 @@
   "pending_end",
   "build_server",
   "no_cache",
+  "platform",
+  "build_platform",
   "section_break_11",
   "docker_image",
   "docker_image_id",
@@ -415,6 +417,25 @@
    "fieldname": "no_cache",
    "fieldtype": "Check",
    "label": "No Cache"
+  },
+  {
+   "default": "x86_64",
+   "fetch_from": "build_server.platform",
+   "fieldname": "platform",
+   "fieldtype": "Select",
+   "label": "Platform",
+   "options": "x86_64\narm64",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "default": "linux/amd64",
+   "fieldname": "build_platform",
+   "fieldtype": "Select",
+   "label": "Build Platform",
+   "options": "linux/amd64\nlinux/arm64",
+   "read_only": 1,
+   "reqd": 1
   }
  ],
  "links": [
@@ -431,7 +452,7 @@
    "link_fieldname": "document_name"
   }
  ],
- "modified": "2024-06-21 14:12:47.335402",
+ "modified": "2024-12-12 18:10:16.212187",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Deploy Candidate",

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -73,9 +73,7 @@ class DeployCandidate(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		from press.press.doctype.deploy_candidate_app.deploy_candidate_app import (
-			DeployCandidateApp,
-		)
+		from press.press.doctype.deploy_candidate_app.deploy_candidate_app import DeployCandidateApp
 		from press.press.doctype.deploy_candidate_build_step.deploy_candidate_build_step import (
 			DeployCandidateBuildStep,
 		)
@@ -95,6 +93,7 @@ class DeployCandidate(Document):
 		build_end: DF.Datetime | None
 		build_error: DF.Code | None
 		build_output: DF.Code | None
+		build_platform: DF.Literal["linux/amd64", "linux/arm64"]
 		build_server: DF.Link | None
 		build_start: DF.Datetime | None
 		build_steps: DF.Table[DeployCandidateBuildStep]
@@ -118,6 +117,7 @@ class DeployCandidate(Document):
 		pending_duration: DF.Time | None
 		pending_end: DF.Datetime | None
 		pending_start: DF.Datetime | None
+		platform: DF.Literal["x86_64", "arm64"]
 		retry_count: DF.Int
 		scheduled_time: DF.Datetime | None
 		status: DF.Literal["Draft", "Scheduled", "Pending", "Preparing", "Running", "Success", "Failure"]
@@ -236,6 +236,7 @@ class DeployCandidate(Document):
 
 		no_build = kwargs.get("no_build", False)
 		self.set_build_server(no_build)
+		self.set_build_platform()
 		self._set_status_pending()
 		self.add_pre_build_steps()
 		self.save()
@@ -272,6 +273,15 @@ class DeployCandidate(Document):
 			return
 
 		throw_no_build_server()
+
+	def set_build_platform(self):
+		DEFAULT_BUILD_PLATFORM = "linux/amd64"
+		PLATFORM_MAP = {
+			"x86_64": "linux/amd64",
+			"arm64": "linux/arm64",
+		}
+		self.platform = frappe.db.get_value("Server", self.build_server, "platform")
+		self.build_platform = PLATFORM_MAP.get(self.platform, DEFAULT_BUILD_PLATFORM)
 
 	def validate_status(self):
 		if self.status in ["Draft", "Success", "Failure", "Scheduled"]:
@@ -512,6 +522,7 @@ class DeployCandidate(Document):
 				# read in `process_run_build`
 				"deploy_candidate": self.name,
 				"deploy_after_build": deploy_after_build,
+				"platform": self.build_platform,
 			}
 		)
 		self.last_updated = now()

--- a/press/press/doctype/server/server.json
+++ b/press/press/doctype/server/server.json
@@ -15,6 +15,7 @@
   "cluster",
   "provider",
   "virtual_machine",
+  "platform",
   "ignore_incidents_since",
   "is_server_prepared",
   "is_server_setup",
@@ -536,10 +537,18 @@
    "fieldtype": "Table",
    "label": "Mounts",
    "options": "Server Mount"
+  },
+  {
+   "default": "x86_64",
+   "fetch_from": "virtual_machine.platform",
+   "fieldname": "platform",
+   "fieldtype": "Select",
+   "label": "Platform",
+   "options": "x86_64\narm64"
   }
  ],
  "links": [],
- "modified": "2024-11-12 14:45:00.123456",
+ "modified": "2024-12-12 16:23:14.868758",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Server",

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1265,6 +1265,7 @@ class Server(BaseServer):
 		mounts: DF.Table[ServerMount]
 		new_worker_allocation: DF.Check
 		plan: DF.Link | None
+		platform: DF.Literal["x86_64", "arm64"]
 		primary: DF.Link | None
 		private_ip: DF.Data | None
 		private_mac_address: DF.Data | None


### PR DESCRIPTION
Uses [docker multi-platform builds](https://docs.docker.com/build/building/multi-platform/).

Depends on frappe/agent@c4fb7bed224f323758b597e11c5ffbe48746f152