### PR TITLE
feat(partner): Partnership Fees via dashboard

### DIFF
--- a/dashboard/src2/components/NavigationItems.vue
+++ b/dashboard/src2/components/NavigationItems.vue
@@ -153,7 +153,7 @@ export default {
 					disabled: enforce2FA
 				},
 				{
-					name: 'Partners',
+					name: 'Partner Portal',
 					icon: () => h(Globe),
 					route: '/partners',
 					isActive: routeName.startsWith('Partner'),

--- a/dashboard/src2/components/billing/BuyCreditsRazorpay.vue
+++ b/dashboard/src2/components/billing/BuyCreditsRazorpay.vue
@@ -47,6 +47,10 @@ const props = defineProps({
 	minimumAmount: {
 		type: Number,
 		default: 0
+	},
+	type: {
+		type: String,
+		default: 'prepaid-credits'
 	}
 });
 
@@ -72,9 +76,15 @@ onBeforeUnmount(() => {
 	razorpayCheckoutJS.value?.remove();
 });
 
+let order_type =
+	props.type === 'prepaid-credits' ? 'Prepaid Credits' : 'Partnership Fee';
+
 const createRazorpayOrder = createResource({
 	url: 'press.api.billing.create_razorpay_order',
-	params: { amount: props.amount },
+	params: {
+		amount: props.amount,
+		type: order_type
+	},
 	onSuccess: data => processOrder(data),
 	validate: () => {
 		if (props.amount < props.minimumAmount) {

--- a/dashboard/src2/components/billing/PaymentDetails.vue
+++ b/dashboard/src2/components/billing/PaymentDetails.vue
@@ -1,15 +1,13 @@
 <template>
 	<div class="flex flex-col gap-4">
-		<div class="text-lg font-semibold text-gray-900">
-			{{ 'Payment details' }}
-		</div>
+		<div class="text-lg font-semibold text-gray-900">Payment details</div>
 		<div class="flex flex-col">
 			<div
 				v-if="team.doc.payment_mode == 'Card'"
 				class="flex items-center justify-between text-base text-gray-900"
 			>
 				<div class="flex flex-col gap-1.5">
-					<div class="font-medium">{{ 'Active card' }}</div>
+					<div class="font-medium">Active Card</div>
 					<div class="overflow-hidden text-ellipsis text-gray-700">
 						<div
 							v-if="team.doc.payment_method"
@@ -42,7 +40,7 @@
 			/>
 			<div class="flex items-center justify-between text-base text-gray-900">
 				<div class="flex flex-col gap-1.5">
-					<div class="font-medium">{{ 'Mode of payment' }}</div>
+					<div class="font-medium">Mode of payment</div>
 					<div
 						v-if="team.doc.payment_mode"
 						class="inline-flex items-center gap-2 text-gray-700"
@@ -72,7 +70,7 @@
 			<div class="my-3 h-px bg-gray-100" />
 			<div class="flex items-center justify-between text-base text-gray-900">
 				<div class="flex flex-col gap-1.5">
-					<div class="font-medium">{{ 'Credit balance' }}</div>
+					<div class="font-medium">Credit balance</div>
 					<div class="text-gray-700">
 						{{ availableCredits || currency + ' 0.00' }}
 					</div>
@@ -101,7 +99,7 @@
 			<div class="my-3 h-px bg-gray-100" />
 			<div class="flex items-center justify-between text-base text-gray-900">
 				<div class="flex flex-col gap-1.5">
-					<div class="font-medium">{{ 'Billing address' }}</div>
+					<div class="font-medium">Billing address</div>
 					<div v-if="billingDetailsSummary" class="leading-5 text-gray-700">
 						{{ billingDetailsSummary }}
 					</div>

--- a/dashboard/src2/components/partners/BuyPartnerCreditsRazorpay.vue
+++ b/dashboard/src2/components/partners/BuyPartnerCreditsRazorpay.vue
@@ -44,9 +44,13 @@ const props = defineProps({
 		type: Number,
 		default: 0
 	},
-	minimumAmount: {
+	maximumAmount: {
 		type: Number,
 		default: 0
+	},
+	type: {
+		type: String,
+		default: 'prepaid-credits'
 	}
 });
 
@@ -72,15 +76,19 @@ onBeforeUnmount(() => {
 	razorpayCheckoutJS.value?.remove();
 });
 
+let order_type =
+	props.type === 'prepaid-credits' ? 'Prepaid Credits' : 'Partnership Fee';
+
 const createRazorpayOrder = createResource({
 	url: 'press.api.billing.create_razorpay_order',
 	params: {
-		amount: props.amount
+		amount: props.amount,
+		type: order_type
 	},
 	onSuccess: data => processOrder(data),
 	validate: () => {
-		if (props.amount < props.minimumAmount) {
-			throw new DashboardError('Amount less than minimum amount required');
+		if (props.amount > props.maximumAmount) {
+			throw new DashboardError('Amount more than maximum amount required');
 		}
 	}
 });

--- a/dashboard/src2/components/partners/BuyPartnerCreditsStripe.vue
+++ b/dashboard/src2/components/partners/BuyPartnerCreditsStripe.vue
@@ -55,7 +55,7 @@ const props = defineProps({
 		type: Number,
 		default: 0
 	},
-	minimumAmount: {
+	maximumAmount: {
 		type: Number,
 		default: 0
 	}
@@ -82,9 +82,9 @@ const createPaymentIntent = createResource({
 	url: 'press.api.billing.create_payment_intent_for_partnership_fees',
 	params: { amount: props.amount },
 	validate() {
-		if (props.amount < props.minimumAmount && !team.doc.erpnext_partner) {
+		if (props.amount > props.maximumAmount && !team.doc.erpnext_partner) {
 			throw new DashboardError(
-				`Amount must be greater than or equal to ${props.minimumAmount}`
+				`Amount must be lesser than or equal to ${props.maximumAmount}`
 			);
 		}
 	},

--- a/dashboard/src2/components/partners/BuyPartnerCreditsStripe.vue
+++ b/dashboard/src2/components/partners/BuyPartnerCreditsStripe.vue
@@ -82,7 +82,7 @@ const createPaymentIntent = createResource({
 	url: 'press.api.billing.create_payment_intent_for_partnership_fees',
 	params: { amount: props.amount },
 	validate() {
-		if (props.amount > props.maximumAmount && !team.doc.erpnext_partner) {
+		if (props.amount > props.maximumAmount) {
 			throw new DashboardError(
 				`Amount must be lesser than or equal to ${props.maximumAmount}`
 			);

--- a/dashboard/src2/components/partners/BuyPartnerCreditsStripe.vue
+++ b/dashboard/src2/components/partners/BuyPartnerCreditsStripe.vue
@@ -1,0 +1,168 @@
+<template>
+	<div>
+		<label
+			class="block"
+			:class="{
+				'pointer-events-none h-0.5 opacity-0': step != 'Add Card Details',
+				'mt-4': step == 'Add Card Details'
+			}"
+		>
+			<span class="text-sm leading-4 text-gray-700">
+				Credit or Debit Card
+			</span>
+			<div class="form-input mt-2 block w-full pl-3" ref="cardElementRef"></div>
+			<ErrorMessage class="mt-1" :message="cardErrorMessage" />
+		</label>
+
+		<div v-if="step == 'Setting up Stripe'" class="mt-8 flex justify-center">
+			<Spinner class="h-4 w-4 text-gray-700" />
+		</div>
+		<ErrorMessage
+			class="mt-2"
+			:message="createPaymentIntent.error || errorMessage"
+		/>
+		<div class="mt-8">
+			<Button
+				v-if="step == 'Get Amount'"
+				class="w-full"
+				size="md"
+				variant="solid"
+				label="Proceed to payment using Stripe"
+				:loading="createPaymentIntent.loading"
+				@click="createPaymentIntent.submit()"
+			/>
+			<Button
+				v-else-if="step == 'Add Card Details'"
+				class="w-full"
+				size="md"
+				variant="solid"
+				label="Make payment via Stripe"
+				:loading="paymentInProgress"
+				@click="onBuyClick"
+			/>
+		</div>
+	</div>
+</template>
+<script setup>
+import { Button, ErrorMessage, Spinner, createResource } from 'frappe-ui';
+import { loadStripe } from '@stripe/stripe-js';
+import { ref, nextTick, inject } from 'vue';
+import { toast } from 'vue-sonner';
+import { DashboardError } from '../../utils/error';
+
+const props = defineProps({
+	amount: {
+		type: Number,
+		default: 0
+	},
+	minimumAmount: {
+		type: Number,
+		default: 0
+	}
+});
+
+const emit = defineEmits(['success']);
+
+const team = inject('team');
+
+const step = ref('Get Amount');
+const clientSecret = ref(null);
+const cardErrorMessage = ref(null);
+const errorMessage = ref(null);
+const paymentInProgress = ref(false);
+
+const stripe = ref(null);
+const card = ref(null);
+const elements = ref(null);
+const ready = ref(false);
+
+const cardElementRef = ref(null);
+
+const createPaymentIntent = createResource({
+	url: 'press.api.billing.create_payment_intent_for_partnership_fees',
+	params: { amount: props.amount },
+	validate() {
+		if (props.amount < props.minimumAmount && !team.doc.erpnext_partner) {
+			throw new DashboardError(
+				`Amount must be greater than or equal to ${props.minimumAmount}`
+			);
+		}
+	},
+	async onSuccess(data) {
+		step.value = 'Setting up Stripe';
+		let { publishable_key, client_secret } = data;
+		clientSecret.value = client_secret;
+		stripe.value = await loadStripe(publishable_key);
+		elements.value = stripe.value.elements();
+		const style = {
+			base: {
+				color: '#171717',
+				fontFamily: [
+					'ui-sans-serif',
+					'system-ui',
+					'-apple-system',
+					'BlinkMacSystemFont',
+					'"Segoe UI"',
+					'Roboto',
+					'"Helvetica Neue"',
+					'Arial',
+					'"Noto Sans"',
+					'sans-serif',
+					'"Apple Color Emoji"',
+					'"Segoe UI Emoji"',
+					'"Segoe UI Symbol"',
+					'"Noto Color Emoji"'
+				].join(', '),
+				fontSmoothing: 'antialiased',
+				fontSize: '13px',
+				'::placeholder': {
+					color: '#C7C7C7'
+				}
+			},
+			invalid: {
+				color: '#7C7C7C',
+				iconColor: '#7C7C7C'
+			}
+		};
+		card.value = elements.value.create('card', {
+			hidePostalCode: true,
+			style: style,
+			classes: {
+				complete: '',
+				focus: 'bg-gray-100'
+			}
+		});
+
+		step.value = 'Add Card Details';
+		nextTick(() => {
+			card.value.mount(cardElementRef.value);
+		});
+
+		card.value.addEventListener('change', event => {
+			cardErrorMessage.value = event.error?.message || null;
+		});
+		card.value.addEventListener('ready', () => {
+			ready.value = true;
+		});
+	}
+});
+
+async function onBuyClick() {
+	paymentInProgress.value = true;
+	let payload = await stripe.value.confirmCardPayment(clientSecret.value, {
+		payment_method: { card: card.value }
+	});
+
+	if (payload.error) {
+		errorMessage.value = payload.error.message;
+		paymentInProgress.value = false;
+	} else {
+		toast.success(
+			'Payment processed successfully, we will update your account shortly on confirmation from Stripe'
+		);
+		paymentInProgress.value = false;
+		emit('success');
+		errorMessage.value = null;
+	}
+}
+</script>

--- a/dashboard/src2/components/partners/PartnerContribution.vue
+++ b/dashboard/src2/components/partners/PartnerContribution.vue
@@ -20,7 +20,7 @@ export default {
 	resources: {
 		getPartnerContribution() {
 			return {
-				url: 'press.api.partner.get_partner_contribution',
+				url: 'press.api.partner.get_partner_contribution_list',
 				auto: true,
 				params: {
 					partner_email: this.partnerEmail

--- a/dashboard/src2/components/partners/PartnerCreditsForm.vue
+++ b/dashboard/src2/components/partners/PartnerCreditsForm.vue
@@ -66,15 +66,15 @@
 		<BuyPartnerCreditsStripe
 			v-if="paymentGateway === 'Stripe'"
 			:amount="creditsToBuy"
-			:minimumAmount="minimumAmount"
+			:minimumAmount="maximumAmount"
 			@success="() => emit('success')"
 			@cancel="show = false"
 		/>
 
-		<BuyCreditsRazorpay
+		<BuyPartnerCreditsRazorpay
 			v-if="paymentGateway === 'Razorpay'"
 			:amount="creditsToBuy"
-			:minimumAmount="minimumAmount"
+			:maximumAmount="maximumAmount"
 			type="Partnership Fee"
 			@success="() => emit('success')"
 			@cancel="show = false"
@@ -83,15 +83,10 @@
 </template>
 <script setup>
 import BuyPartnerCreditsStripe from './BuyPartnerCreditsStripe.vue';
-import BuyCreditsRazorpay from '../billing/BuyCreditsRazorpay.vue';
+import BuyPartnerCreditsRazorpay from './BuyPartnerCreditsRazorpay.vue';
 import RazorpayLogo from '../../logo/RazorpayLogo.vue';
 import StripeLogo from '../../logo/StripeLogo.vue';
-import {
-	FormControl,
-	Button,
-	createResource,
-	createDocumentResource
-} from 'frappe-ui';
+import { FormControl, Button, createDocumentResource } from 'frappe-ui';
 import { ref, computed, inject, defineEmits } from 'vue';
 
 const emit = defineEmits(['success']);
@@ -105,7 +100,7 @@ const pressSettings = createDocumentResource({
 	initialData: {}
 });
 
-const minimumAmount = computed(() => {
+const maximumAmount = computed(() => {
 	if (!pressSettings.doc) return 0;
 	const feeAmount =
 		team.doc?.currency == 'INR'
@@ -114,7 +109,7 @@ const minimumAmount = computed(() => {
 	return Math.ceil(feeAmount);
 });
 
-const creditsToBuy = ref(minimumAmount.value);
+const creditsToBuy = ref(maximumAmount.value);
 const paymentGateway = ref('');
 
 const totalAmount = computed(() => {

--- a/dashboard/src2/components/partners/PartnerCreditsForm.vue
+++ b/dashboard/src2/components/partners/PartnerCreditsForm.vue
@@ -66,7 +66,7 @@
 		<BuyPartnerCreditsStripe
 			v-if="paymentGateway === 'Stripe'"
 			:amount="creditsToBuy"
-			:minimumAmount="maximumAmount"
+			:maximumAmount="maximumAmount"
 			@success="() => emit('success')"
 			@cancel="show = false"
 		/>

--- a/dashboard/src2/components/partners/PartnerCreditsForm.vue
+++ b/dashboard/src2/components/partners/PartnerCreditsForm.vue
@@ -1,0 +1,132 @@
+<template>
+	<div>
+		<!-- Amount -->
+		<div>
+			<FormControl
+				:label="`Amount (Minimum Amount: ${minimumAmount})`"
+				class="mb-3"
+				v-model.number="creditsToBuy"
+				name="amount"
+				autocomplete="off"
+				type="number"
+				:min="minimumAmount"
+			>
+				<template #prefix>
+					<div class="grid w-4 place-items-center text-sm text-gray-700">
+						{{ team.doc.currency === 'INR' ? '₹' : '$' }}
+					</div>
+				</template>
+			</FormControl>
+			<FormControl
+				v-if="team.doc.currency === 'INR'"
+				:label="`Total Amount + GST (${
+					team.doc?.billing_info.gst_percentage * 100
+				}%)`"
+				disabled
+				:modelValue="totalAmount"
+				name="total"
+				autocomplete="off"
+				type="number"
+			>
+				<template #prefix>
+					<div class="grid w-4 place-items-center text-sm text-gray-700">
+						{{ team.doc.currency === 'INR' ? '₹' : '$' }}
+					</div>
+				</template>
+			</FormControl>
+		</div>
+
+		<!-- Payment Gateway -->
+		<div class="mt-4">
+			<div class="text-xs text-gray-600">Select Payment Gateway</div>
+			<div class="mt-1.5 grid grid-cols-1 gap-2 sm:grid-cols-2">
+				<Button
+					v-if="team.doc.currency === 'INR' || team.doc.razorpay_enabled"
+					size="lg"
+					:class="{
+						'border-[1.5px] border-gray-700': paymentGateway === 'Razorpay'
+					}"
+					@click="paymentGateway = 'Razorpay'"
+				>
+					<RazorpayLogo class="w-24" />
+				</Button>
+				<Button
+					size="lg"
+					:class="{
+						'border-[1.5px] border-gray-700': paymentGateway === 'Stripe'
+					}"
+					@click="paymentGateway = 'Stripe'"
+				>
+					<StripeLogo class="h-7 w-24" />
+				</Button>
+			</div>
+		</div>
+
+		<!-- Payment Button -->
+		<BuyPartnerCreditsStripe
+			v-if="paymentGateway === 'Stripe'"
+			:amount="creditsToBuy"
+			:minimumAmount="minimumAmount"
+			@success="() => emit('success')"
+			@cancel="show = false"
+		/>
+
+		<BuyPartnerCreditsRazorpay
+			v-if="paymentGateway === 'Razorpay'"
+			:amount="creditsToBuy"
+			:minimumAmount="minimumAmount"
+			@success="() => emit('success')"
+			@cancel="show = false"
+		/>
+	</div>
+</template>
+<script setup>
+import BuyPartnerCreditsStripe from './BuyPartnerCreditsStripe.vue';
+import BuyPartnerCreditsRazorpay from './BuyPartnerCreditsRazorpay.vue';
+import RazorpayLogo from '../../logo/RazorpayLogo.vue';
+import StripeLogo from '../../logo/StripeLogo.vue';
+import {
+	FormControl,
+	Button,
+	createResource,
+	createDocumentResource
+} from 'frappe-ui';
+import { ref, computed, inject, defineEmits } from 'vue';
+import { auto } from '@popperjs/core';
+
+const emit = defineEmits(['success']);
+
+const team = inject('team');
+
+const pressSettings = createDocumentResource({
+	doctype: 'Press Settings',
+	name: 'Press Settings',
+	auto: true,
+	initialData: {}
+});
+
+const minimumAmount = computed(() => {
+	if (!pressSettings.doc) return 0;
+	const feeAmount =
+		team.doc?.currency == 'INR'
+			? pressSettings.doc.partnership_fee_inr
+			: pressSettings.doc.partnership_fee_usd;
+	return Math.ceil(feeAmount);
+});
+
+const creditsToBuy = ref(minimumAmount.value);
+const paymentGateway = ref('');
+
+const totalAmount = computed(() => {
+	const _creditsToBuy = creditsToBuy.value || 0;
+
+	if (team.doc?.currency === 'INR') {
+		return (
+			_creditsToBuy +
+			_creditsToBuy * (team.doc.billing_info.gst_percentage || 0)
+		).toFixed(2);
+	} else {
+		return _creditsToBuy;
+	}
+});
+</script>

--- a/dashboard/src2/components/partners/PartnerCreditsForm.vue
+++ b/dashboard/src2/components/partners/PartnerCreditsForm.vue
@@ -3,13 +3,13 @@
 		<!-- Amount -->
 		<div>
 			<FormControl
-				:label="`Amount (Minimum Amount: ${minimumAmount})`"
+				:label="`Amount (Minimum Amount: ${maximumAmount})`"
 				class="mb-3"
 				v-model.number="creditsToBuy"
 				name="amount"
 				autocomplete="off"
 				type="number"
-				:min="minimumAmount"
+				:max="maximumAmount"
 			>
 				<template #prefix>
 					<div class="grid w-4 place-items-center text-sm text-gray-700">

--- a/dashboard/src2/components/partners/PartnerCreditsForm.vue
+++ b/dashboard/src2/components/partners/PartnerCreditsForm.vue
@@ -71,10 +71,11 @@
 			@cancel="show = false"
 		/>
 
-		<BuyPartnerCreditsRazorpay
+		<BuyCreditsRazorpay
 			v-if="paymentGateway === 'Razorpay'"
 			:amount="creditsToBuy"
 			:minimumAmount="minimumAmount"
+			type="Partnership Fee"
 			@success="() => emit('success')"
 			@cancel="show = false"
 		/>
@@ -82,7 +83,7 @@
 </template>
 <script setup>
 import BuyPartnerCreditsStripe from './BuyPartnerCreditsStripe.vue';
-import BuyPartnerCreditsRazorpay from './BuyPartnerCreditsRazorpay.vue';
+import BuyCreditsRazorpay from '../billing/BuyCreditsRazorpay.vue';
 import RazorpayLogo from '../../logo/RazorpayLogo.vue';
 import StripeLogo from '../../logo/StripeLogo.vue';
 import {
@@ -92,7 +93,6 @@ import {
 	createDocumentResource
 } from 'frappe-ui';
 import { ref, computed, inject, defineEmits } from 'vue';
-import { auto } from '@popperjs/core';
 
 const emit = defineEmits(['success']);
 

--- a/dashboard/src2/components/partners/PartnerMembers.vue
+++ b/dashboard/src2/components/partners/PartnerMembers.vue
@@ -32,7 +32,7 @@ const partnerMembers = createResource({
 
 const partnerMembersList = computed(() => {
 	return {
-		data: partnerMembers.data,
+		data: partnerMembers.data || [],
 		selectable: false,
 		columns: [
 			{

--- a/dashboard/src2/components/partners/PartnerMembers.vue
+++ b/dashboard/src2/components/partners/PartnerMembers.vue
@@ -1,0 +1,49 @@
+<template>
+	<div class="px-2">
+		<GenericList :options="partnerMembersList" />
+	</div>
+</template>
+<script setup>
+import { computed } from 'vue';
+import GenericList from '../GenericList.vue';
+import { createResource } from 'frappe-ui';
+
+const props = defineProps({
+	partnerName: String
+});
+
+const partnerMembers = createResource({
+	url: 'press.api.partner.get_partner_members',
+	cache: 'partnerMembers',
+	auto: true,
+	params: {
+		partner: props.partnerName
+	},
+	transform(data) {
+		data = data.map(d => {
+			return {
+				full_name: d.member_name,
+				email: d.member_email
+			};
+		});
+		return data;
+	}
+});
+
+const partnerMembersList = computed(() => {
+	return {
+		data: partnerMembers.data,
+		selectable: false,
+		columns: [
+			{
+				label: 'Name',
+				fieldname: 'full_name'
+			},
+			{
+				label: 'Email',
+				fieldname: 'email'
+			}
+		]
+	};
+});
+</script>

--- a/dashboard/src2/components/partners/PartnerOverview.vue
+++ b/dashboard/src2/components/partners/PartnerOverview.vue
@@ -1,149 +1,125 @@
 <template>
-	<div class="flex flex-col gap-5 overflow-y-auto px-60 pt-6">
-		<div class="rounded-lg text-base text-gray-900 shadow">
-			<div class="flex flex-col gap-2.5 p-4">
-				<div class="flex items-center justify-between mb-3">
-					<h3 class="text-lg font-semibold">Revenue Contribution</h3>
-					<Button
-						label="View Details"
-						@click="showPartnerContributionDialog = true"
-					/>
-				</div>
-				<div class="grid grid-cols-2 gap-7">
-					<div>
-						<div class="text-sm text-gray-600">Current Month Contribution</div>
-						<div class="text-xl font-bold mt-2">
-							{{ currency }}
-							{{
-								partnerDetails.data?.custom_ongoing_period_fc_invoice_contribution.toFixed(
-									2
-								) || '0.0'
-							}}
-						</div>
-					</div>
-					<div>
-						<div class="text-sm text-gray-600">Previous Month Contribution</div>
-						<div class="text-xl font-bold mt-1">
-							{{ currency }}
-							{{
-								partnerDetails.data?.custom_fc_invoice_contribution.toFixed(
-									2
-								) || '0.0'
-							}}
-						</div>
-					</div>
-				</div>
-				<div class="col-span-2">
-					<div class="flex items-center space-x-2">
-						<p class="text-sm text-gray-600">Month-over-Month Change:</p>
-						<div class="flex items-center">
-							<FeatherIcon
-								:name="revenueChangeIcon"
-								class="w-4 h-4"
-								:class="revenueChangeColor"
-							/>
-							<span class="ml-1 font-semibold" :class="revenueChangeColor">
-								{{ Math.abs(revenueChange).toFixed(1) }}%
-							</span>
-						</div>
-					</div>
-				</div>
+	<div class="flex flex-col gap-5 overflow-y-auto px-60 py-6">
+		<div class="flex flex-col">
+			<div class="text-gray-500">Welcome back!</div>
+			<div>
+				<h1 class="text-3xl font-semibold">
+					{{ partnerDetails.data?.company_name }}
+				</h1>
 			</div>
 		</div>
 		<div class="rounded-lg text-base text-gray-900 shadow">
 			<div class="flex flex-col gap-2.5 p-4">
-				<div class="flex items-center mb-3">
-					<h3 class="font-semibold text-lg">Partner Details</h3>
+				<div class="flex items-center justify-between">
+					<div class="flex">
+						<FeatherIcon name="award" class="h-5 text-gray-700" />
+						<h3 class="text-xl font-semibold">
+							{{ partnerDetails.data?.partner_type }} Tier
+						</h3>
+					</div>
 				</div>
-				<!-- <div class="my-3 h-px bg-gray-100"/> -->
+				<div class="pt-2">
+					<Progress
+						size="lg"
+						:value="tierProgressValue"
+						label="Current Progress"
+						:hint="false"
+					>
+						<template #hint>
+							<span class="text-base font-medium text-gray-500">
+								{{ formatNumber(nextTierTarget) }} to reach {{ nextTier }}
+							</span>
+						</template>
+					</Progress>
+				</div>
+				<div class="my-1 h-px bg-gray-100" />
+
 				<div class="grid grid-cols-2 gap-4">
 					<div>
-						<div class="text-sm text-gray-600">Name</div>
-						<div class="text-base font-medium mt-1">
-							{{ partner.partnerName }}
+						<div class="flex items-center justify-between">
+							<div class="text-sm text-gray-600">
+								Current Month Contribution
+							</div>
+							<Button
+								label="Details"
+								@click="showPartnerContributionDialog = true"
+							/>
+						</div>
+						<div class="text-xl font-semibold py-2">
+							{{
+								formatCurrency(
+									partnerDetails.data
+										?.custom_ongoing_period_fc_invoice_contribution
+								) || '0.0'
+							}}
+						</div>
+						<div class="text-sm text-gray-600">
+							<span
+								>Previous Month:
+								{{
+									formatCurrency(
+										partnerDetails.data?.custom_fc_invoice_contribution
+									) || '0.0'
+								}}</span
+							>
 						</div>
 					</div>
 					<div>
-						<div class="text-sm text-gray-600">Company Name</div>
-						<div class="text-base font-medium mt-1">
-							{{ partner.companyName }}
+						<div class="flex items-center justify-between">
+							<div class="text-sm text-gray-600">Certified Members</div>
+							<Button label="View" />
 						</div>
-					</div>
-					<div>
-						<div>
-							<div class="text-sm text-gray-600">Code</div>
-							<div class="text-base font-medium mt-1">
-								{{ partner.partnerCode }}
-							</div>
-						</div>
-					</div>
-					<div>
-						<div>
-							<div class="text-sm text-gray-600">Tier</div>
-							<div>
-								<Badge :theme="getTierVariant(partner.partnerTier)" size="lg">
-									{{ partner.partnerTier }}
-								</Badge>
-							</div>
-						</div>
-					</div>
-				</div>
-				<div class="my-2 h-px bg-gray-100" />
-				<div class="bg-gray-50 p-3 rounded flex flex-col gap-3">
-					<div class="flex gap-2 justify-between">
-						<div class="flex gap-1">
-							<div>
-								<FeatherIcon name="calendar" class="h-4 text-gray-600" />
-							</div>
-							<div>
-								<p class="text-sm text-gray-600">Next Renewal Date</p>
-								<p class="text-base font-medium my-2">
-									{{ formatDate(partnerDetails.data?.end_date) }}
-								</p>
-								<p class="text-sm text-gray-500">
-									{{ daysUntilRenewal }} days remaining
-								</p>
-							</div>
-						</div>
-						<div class="flex gap-1">
-							<div>
-								<FeatherIcon name="users" class="h-4 text-gray-600" />
-							</div>
-							<div>
-								<p class="text-sm text-gray-600">Certified Members</p>
-								<p class="text-base font-medium my-2">5</p>
-							</div>
-						</div>
-						<div class="flex gap-1">
-							<div>
-								<FeatherIcon name="percent" class="h-4 text-gray-600" />
-							</div>
-							<div>
-								<p class="text-sm text-gray-600">Discount Applied</p>
-								<p class="text-base font-medium my-2">8%</p>
-							</div>
-						</div>
-					</div>
-					<div v-if="isRenewalPeriod()">
-						<div class="my-1 h-px bg-gray-300" />
-						<div
-							class="flex items-center justify-between rounded py-2 bg-gray-300 px-2"
-						>
-							<div>
-								<p>Click here to pay for Partnership Renewal Fee</p>
-							</div>
-							<div>
-								<Button
-									label="Renew Now"
-									variant="solid"
-									@click="buyPartnershipCreditsDialog = true"
-								/>
+						<div class="flex items-center">
+							<div class="text-xl font-semibold py-2">
+								{{
+									partnerDetails.data?.custom_number_of_certified_members || 5
+								}}
 							</div>
 						</div>
 					</div>
 				</div>
 			</div>
 		</div>
+
+		<div class="flex gap-4">
+			<div class="rounded-lg text-base w-full text-gray-900 shadow">
+				<div class="flex items-center px-4 pt-4">
+					<h3 class="font-semibold text-lg">Partner Referral Code</h3>
+				</div>
+				<div class="flex flex-col p-4 gap-2">
+					<ClickToCopyField :textContent="team.doc?.partner_referral_code" />
+					<span class="text-sm text-gray-600"
+						>Share code with customers to link with your account.</span
+					>
+				</div>
+			</div>
+			<div class="rounded-lg text-base w-full text-gray-900 p-4 shadow">
+				<div class="flex h-full flex-col justify-between">
+					<div class="flex">
+						<h3 class="font-semibold text-lg">Renewal Details</h3>
+					</div>
+					<div class="flex items-center justify-between">
+						<div class="flex flex-col gap-2">
+							<span class="text-base font-medium text-gray-700">
+								{{ formatDate(partnerDetails.data?.end_date) }}
+							</span>
+						</div>
+						<div v-if="isRenewalPeriod()">
+							<Button
+								label="Renew"
+								:disabled="false"
+								:variant="'solid'"
+								@click="showPartnerCreditsDialog = true"
+							/>
+						</div>
+					</div>
+					<span class="text-sm text-gray-600"
+						>Renewal in {{ daysUntilRenewal }} days</span
+					>
+				</div>
+			</div>
+		</div>
+
 		<Dialog
 			:show="showPartnerContributionDialog"
 			v-model="showPartnerContributionDialog"
@@ -153,20 +129,37 @@
 				<PartnerContribution :partnerEmail="team.doc.partner_email" />
 			</template>
 		</Dialog>
+
+		<Dialog
+			:show="showPartnerCreditsDialog"
+			v-model="showPartnerCreditsDialog"
+			:options="{ title: 'Pay Partnership Fee' }"
+		>
+			<template #body-content>
+				<PartnerCreditsForm
+					@success="
+						() => {
+							showPartnerCreditsDialog = false;
+						}
+					"
+				/>
+			</template>
+		</Dialog>
 	</div>
 </template>
 
 <script setup>
 import { computed, inject, ref } from 'vue';
 import dayjs from '../../utils/dayjs';
-import { FeatherIcon, Badge, Button, createResource } from 'frappe-ui';
+import { FeatherIcon, Button, createResource, Progress } from 'frappe-ui';
 import PartnerContribution from './PartnerContribution.vue';
+import ClickToCopyField from '../ClickToCopyField.vue';
+import PartnerCreditsForm from './PartnerCreditsForm.vue';
 
 const team = inject('team');
-const currency = computed(() => (team.doc.currency == 'INR' ? '₹' : '$'));
 
 const showPartnerContributionDialog = ref(false);
-const buyPartnershipCreditsDialog = ref(false);
+const showPartnerCreditsDialog = ref(false);
 
 const partnerDetails = createResource({
 	url: 'press.api.partner.get_partner_details',
@@ -174,21 +167,11 @@ const partnerDetails = createResource({
 	cache: 'partnerDetails',
 	params: {
 		partner_email: team.doc.partner_email
+	},
+	onSuccess() {
+		calculateNextTier(partnerDetails.data.partner_type);
 	}
 });
-
-const partner = {
-	partnerName: partnerDetails.data?.partner_name,
-	companyName: partnerDetails.data?.company_name,
-	currentMonthRevenue:
-		partnerDetails.data?.custom_ongoing_period_fc_invoice_contribution,
-	previousMonthRevenue: partnerDetails.data?.custom_fc_invoice_contribution,
-	partnerTier: partnerDetails.data?.partner_type,
-	partnerCode: team.doc.partner_referral_code,
-	renewalDate: partnerDetails.data?.end_date,
-	certifiedMembers: partnerDetails.data?.custom_number_of_certified_members,
-	discountPercentage: 25
-};
 
 const daysUntilRenewal = computed(() => {
 	const today = new Date();
@@ -205,38 +188,63 @@ function isRenewalPeriod() {
 	return Boolean(daysDifference >= 0 && daysDifference <= 15);
 }
 
-const revenueChangeIcon = computed(() => {
-	if (revenueChange.value > 0) return 'trending-up';
-	if (revenueChange.value < 0) return 'trending-down';
-	return 'minus';
-});
+const tierProgressValue = ref(0);
+const nextTier = ref('');
+const nextTierTarget = ref(0);
 
-const revenueChangeColor = computed(() => {
-	if (revenueChange.value > 0) return 'text-green-500';
-	if (revenueChange.value < 0) return 'text-red-500';
-	return 'text-gray-500';
-});
-
-const revenueChange = computed(() => {
-	return (
-		((partner.currentMonthRevenue - partner.previousMonthRevenue) /
-			partner.previousMonthRevenue) *
-		100
+function calculateTierProgress(next_tier_value) {
+	console.log(
+		partnerDetails.data?.custom_ongoing_period_fc_invoice_contribution,
+		next_tier_value
 	);
-});
+	return Math.ceil(
+		(partnerDetails.data?.custom_ongoing_period_fc_invoice_contribution /
+			next_tier_value) *
+			100
+	);
+}
 
-const getTierVariant = tier => {
-	switch (tier) {
-		case 'Gold':
-			return 'orange';
-		case 'Silver':
-			return 'blue';
+function calculateNextTier(tier) {
+	const target_inr = {
+		Gold: 500000,
+		Silver: 200000,
+		Bronze: 50000
+	};
+	const target_usd = {
+		Gold: 6000,
+		Silver: 2500,
+		Bronze: 600
+	};
+
+	const current_tier = partnerDetails.data?.partner_type;
+	let next_tier = '';
+	switch (current_tier) {
+		case 'Entry':
+			next_tier = 'Bronze';
+			nextTierTarget.value =
+				team.doc.currency === 'INR' ? target_inr.Bronze : target_usd.Bronze;
+			break;
 		case 'Bronze':
-			return 'red';
+			next_tier = 'Silver';
+			nextTierTarget.value =
+				team.doc.currency === 'INR' ? target_inr.Silver : target_usd.Silver;
+			break;
+		case 'Silver':
+			next_tier = 'Gold';
+			nextTierTarget.value =
+				team.doc.currency === 'INR' ? target_inr.Gold : target_usd.Gold;
+			break;
 		default:
-			return 'gray';
+			next_tier = 'Gold';
+			nextTierTarget.value =
+				team.doc.currency === 'INR' ? target_inr.Gold : target_usd.Gold;
 	}
-};
+	nextTier.value = next_tier;
+	tierProgressValue.value = calculateTierProgress(nextTierTarget.value);
+	nextTierTarget.value =
+		nextTierTarget.value -
+		partnerDetails.data?.custom_ongoing_period_fc_invoice_contribution;
+}
 
 const formatDate = dateString => {
 	return new Date(dateString).toLocaleDateString('en-US', {
@@ -244,5 +252,20 @@ const formatDate = dateString => {
 		month: 'long',
 		day: 'numeric'
 	});
+};
+
+const formatCurrency = amount => {
+	return new Intl.NumberFormat('en-US', {
+		style: 'currency',
+		currency: team.doc.currency,
+		maximumFractionDigits: 2
+	}).format(amount);
+};
+
+const formatNumber = value => {
+	return new Intl.NumberFormat('en-US', {
+		notation: 'compact',
+		compactDisplay: 'short'
+	}).format(value);
 };
 </script>

--- a/dashboard/src2/components/partners/PartnerOverview.vue
+++ b/dashboard/src2/components/partners/PartnerOverview.vue
@@ -10,8 +10,8 @@
 		</div>
 		<div class="rounded-lg text-base text-gray-900 shadow">
 			<div class="flex flex-col gap-2.5 p-4">
-				<div class="flex items-center justify-between">
-					<div class="flex">
+				<div class="flex">
+					<div class="flex items-center gap-0.5">
 						<FeatherIcon name="award" class="h-5 text-gray-700" />
 						<h3 class="text-xl font-semibold">
 							{{ partnerDetails.data?.partner_type }} Tier
@@ -34,8 +34,8 @@
 				</div>
 				<div class="my-1 h-px bg-gray-100" />
 
-				<div class="grid grid-cols-2 gap-4">
-					<div>
+				<div class="flex justify-between gap-4">
+					<div class="flex-1">
 						<div class="flex items-center justify-between">
 							<div class="text-sm text-gray-600">
 								Current Month Contribution
@@ -64,7 +64,8 @@
 							>
 						</div>
 					</div>
-					<div>
+					<div class="mx-1 w-px border-r" />
+					<div class="flex-1">
 						<div class="flex items-center justify-between">
 							<div class="text-sm text-gray-600">Certified Members</div>
 							<Button label="View" @click="showPartnerMembersDialog = true" />
@@ -81,25 +82,25 @@
 			</div>
 		</div>
 
-		<div class="flex gap-4">
-			<div class="rounded-lg text-base w-full text-gray-900 shadow">
-				<div class="flex items-center px-4 pt-4">
-					<h3 class="font-semibold text-lg">Partner Referral Code</h3>
-				</div>
-				<div class="flex flex-col p-4 gap-2">
+		<div class="flex justify-between gap-4">
+			<div class="rounded-lg text-base flex-1 text-gray-900 p-4 shadow">
+				<div class="flex h-full flex-col justify-between gap-2">
+					<div class="flex">
+						<h3 class="font-semibold text-lg">Partner Referral Code</h3>
+					</div>
 					<ClickToCopyField :textContent="team.doc?.partner_referral_code" />
 					<span class="text-sm text-gray-600"
 						>Share code with customers to link with your account.</span
 					>
 				</div>
 			</div>
-			<div class="rounded-lg text-base w-full text-gray-900 p-4 shadow">
+			<div class="rounded-lg text-base flex-1 text-gray-900 p-4 shadow">
 				<div class="flex h-full flex-col justify-between">
 					<div class="flex">
 						<h3 class="font-semibold text-lg">Renewal Details</h3>
 					</div>
 					<div class="flex items-center justify-between">
-						<div class="flex flex-col gap-2">
+						<div class="flex">
 							<span class="text-base font-medium text-gray-700">
 								{{ formatDate(partnerDetails.data?.end_date) }}
 							</span>

--- a/dashboard/src2/components/partners/PartnerOverview.vue
+++ b/dashboard/src2/components/partners/PartnerOverview.vue
@@ -1,47 +1,144 @@
 <template>
-	<div class="p-5">
-		<div class="pt-3 grid grid-cols-1 items-start gap-5 sm:grid-cols-2">
-			<div class="rounded-md border">
-				<div class="h-12 border-b px-5 py-4">
-					<h2 class="text-lg font-medium text-gray-900">Partner Details</h2>
+	<div class="flex flex-col gap-5 overflow-y-auto px-60 pt-6">
+		<div class="rounded-lg text-base text-gray-900 shadow">
+			<div class="flex flex-col gap-2.5 p-4">
+				<div class="flex items-center justify-between mb-3">
+					<h3 class="text-lg font-semibold">Revenue Contribution</h3>
+					<Button
+						label="View Details"
+						@click="showPartnerContributionDialog = true"
+					/>
 				</div>
-				<div>
-					<div
-						v-for="d in partnerDetails"
-						:key="d.label"
-						class="flex items-center px-5 py-3 last:pb-5 even:bg-gray-50/70"
-					>
-						<div class="w-1/3 text-base text-gray-700">{{ d.label }}</div>
-						<div class="w-2/3 text-base font-medium">{{ d.value }}</div>
+				<div class="grid grid-cols-2 gap-7">
+					<div>
+						<div class="text-sm text-gray-600">Current Month Contribution</div>
+						<div class="text-xl font-bold mt-2">
+							{{ currency }}
+							{{
+								partnerDetails.data?.custom_ongoing_period_fc_invoice_contribution.toFixed(
+									2
+								) || '0.0'
+							}}
+						</div>
+					</div>
+					<div>
+						<div class="text-sm text-gray-600">Previous Month Contribution</div>
+						<div class="text-xl font-bold mt-1">
+							{{ currency }}
+							{{
+								partnerDetails.data?.custom_fc_invoice_contribution.toFixed(
+									2
+								) || '0.0'
+							}}
+						</div>
+					</div>
+				</div>
+				<div class="col-span-2">
+					<div class="flex items-center space-x-2">
+						<p class="text-sm text-gray-600">Month-over-Month Change:</p>
+						<div class="flex items-center">
+							<FeatherIcon
+								:name="revenueChangeIcon"
+								class="w-4 h-4"
+								:class="revenueChangeColor"
+							/>
+							<span class="ml-1 font-semibold" :class="revenueChangeColor">
+								{{ Math.abs(revenueChange).toFixed(1) }}%
+							</span>
+						</div>
 					</div>
 				</div>
 			</div>
-			<div class="rounded-md border">
-				<div class="h-12 border-b px-5 py-4">
-					<h2
-						class="text-lg font-medium text-gray-900 flex items-center justify-between"
-					>
-						Partner Contribution
-						<Button @click="showPartnerContributionDialog = true"
-							>Details</Button
-						>
-					</h2>
+		</div>
+		<div class="rounded-lg text-base text-gray-900 shadow">
+			<div class="flex flex-col gap-2.5 p-4">
+				<div class="flex items-center mb-3">
+					<h3 class="font-semibold text-lg">Partner Details</h3>
 				</div>
-				<div>
-					<div
-						v-for="d in contributions"
-						:key="d.label"
-						class="flex items-center px-5 py-3 last:pb-5 even:bg-gray-50/70"
-					>
-						<div class="w-1/3 text-base text-gray-700">{{ d.label }}</div>
-						<div
-							v-if="d.label != 'Certification'"
-							class="w-2/3 text-base font-medium"
-						>
-							{{ formatCurrency(d.value) }}
+				<!-- <div class="my-3 h-px bg-gray-100"/> -->
+				<div class="grid grid-cols-2 gap-4">
+					<div>
+						<div class="text-sm text-gray-600">Name</div>
+						<div class="text-base font-medium mt-1">
+							{{ partner.partnerName }}
 						</div>
-						<div v-else class="w-2/3 text-base font-medium">
-							{{ d.value }}
+					</div>
+					<div>
+						<div class="text-sm text-gray-600">Company Name</div>
+						<div class="text-base font-medium mt-1">
+							{{ partner.companyName }}
+						</div>
+					</div>
+					<div>
+						<div>
+							<div class="text-sm text-gray-600">Code</div>
+							<div class="text-base font-medium mt-1">
+								{{ partner.partnerCode }}
+							</div>
+						</div>
+					</div>
+					<div>
+						<div>
+							<div class="text-sm text-gray-600">Tier</div>
+							<div>
+								<Badge :theme="getTierVariant(partner.partnerTier)" size="lg">
+									{{ partner.partnerTier }}
+								</Badge>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div class="my-2 h-px bg-gray-100" />
+				<div class="bg-gray-50 p-3 rounded flex flex-col gap-3">
+					<div class="flex gap-2 justify-between">
+						<div class="flex gap-1">
+							<div>
+								<FeatherIcon name="calendar" class="h-4 text-gray-600" />
+							</div>
+							<div>
+								<p class="text-sm text-gray-600">Next Renewal Date</p>
+								<p class="text-base font-medium my-2">
+									{{ formatDate(partnerDetails.data?.end_date) }}
+								</p>
+								<p class="text-sm text-gray-500">
+									{{ daysUntilRenewal }} days remaining
+								</p>
+							</div>
+						</div>
+						<div class="flex gap-1">
+							<div>
+								<FeatherIcon name="users" class="h-4 text-gray-600" />
+							</div>
+							<div>
+								<p class="text-sm text-gray-600">Certified Members</p>
+								<p class="text-base font-medium my-2">5</p>
+							</div>
+						</div>
+						<div class="flex gap-1">
+							<div>
+								<FeatherIcon name="percent" class="h-4 text-gray-600" />
+							</div>
+							<div>
+								<p class="text-sm text-gray-600">Discount Applied</p>
+								<p class="text-base font-medium my-2">8%</p>
+							</div>
+						</div>
+					</div>
+					<div v-if="isRenewalPeriod()">
+						<div class="my-1 h-px bg-gray-300" />
+						<div
+							class="flex items-center justify-between rounded py-2 bg-gray-300 px-2"
+						>
+							<div>
+								<p>Click here to pay for Partnership Renewal Fee</p>
+							</div>
+							<div>
+								<Button
+									label="Renew Now"
+									variant="solid"
+									@click="buyPartnershipCreditsDialog = true"
+								/>
+							</div>
 						</div>
 					</div>
 				</div>
@@ -53,90 +150,99 @@
 			:options="{ size: '3xl', title: 'Contributions of this month' }"
 		>
 			<template #body-content>
-				<PartnerContribution :partnerEmail="$team.doc.partner_email" />
+				<PartnerContribution :partnerEmail="team.doc.partner_email" />
 			</template>
 		</Dialog>
 	</div>
 </template>
 
-<script>
+<script setup>
+import { computed, inject, ref } from 'vue';
+import dayjs from '../../utils/dayjs';
+import { FeatherIcon, Badge, Button, createResource } from 'frappe-ui';
 import PartnerContribution from './PartnerContribution.vue';
-export default {
-	name: 'PartnerOverview',
-	data() {
-		return {
-			showPartnerContributionDialog: false
-		};
-	},
-	components: {
-		PartnerContribution
-	},
-	resources: {
-		partner() {
-			return {
-				url: 'press.api.partner.get_partner_details',
-				auto: true,
-				params: {
-					partner_email: this.$team.doc.partner_email
-				}
-			};
-		}
-	},
-	computed: {
-		partnerDetails() {
-			return [
-				{
-					label: 'Name',
-					value: this.$resources.partner.data?.partner_name
-				},
-				{
-					label: 'Email',
-					value: this.$resources.partner.data?.email
-				},
-				{
-					label: 'Company Name',
-					value: this.$resources.partner.data?.company_name
-				},
-				{
-					label: 'Current Tier',
-					value: this.$resources.partner.data?.partner_type
-				},
-				{
-					label: 'Code',
-					value: this.$team.doc.partner_referral_code
-				}
-			];
-		},
-		contributions() {
-			return [
-				{
-					label: 'Frappe Cloud',
-					value:
-						this.$resources.partner.data
-							?.custom_ongoing_period_fc_invoice_contribution
-				},
-				{
-					label: 'Enterprise',
-					value:
-						this.$resources.partner.data
-							?.custom_ongoing_period_enterprise_invoice_contribution
-				},
-				{
-					label: 'Certification',
-					value:
-						this.$resources.partner.data?.custom_number_of_certified_members
-				}
-			];
-		}
-	},
-	methods: {
-		formatCurrency(value) {
-			if (value === 0) {
-				return '';
-			}
-			let currency = this.$team.doc.currency;
-			return this.$format.currency(value, currency);
-		}
+
+const team = inject('team');
+const currency = computed(() => (team.doc.currency == 'INR' ? '₹' : '$'));
+
+const showPartnerContributionDialog = ref(false);
+const buyPartnershipCreditsDialog = ref(false);
+
+const partnerDetails = createResource({
+	url: 'press.api.partner.get_partner_details',
+	auto: true,
+	cache: 'partnerDetails',
+	params: {
+		partner_email: team.doc.partner_email
 	}
+});
+
+const partner = {
+	partnerName: partnerDetails.data?.partner_name,
+	companyName: partnerDetails.data?.company_name,
+	currentMonthRevenue:
+		partnerDetails.data?.custom_ongoing_period_fc_invoice_contribution,
+	previousMonthRevenue: partnerDetails.data?.custom_fc_invoice_contribution,
+	partnerTier: partnerDetails.data?.partner_type,
+	partnerCode: team.doc.partner_referral_code,
+	renewalDate: partnerDetails.data?.end_date,
+	certifiedMembers: partnerDetails.data?.custom_number_of_certified_members,
+	discountPercentage: 25
+};
+
+const daysUntilRenewal = computed(() => {
+	const today = new Date();
+	const renewal = new Date(partnerDetails.data?.end_date);
+	return Math.ceil((renewal - today) / (1000 * 60 * 60 * 24));
+});
+
+function isRenewalPeriod() {
+	// 15 days before renewal date
+	const renewal = dayjs(partnerDetails.data?.end_date);
+	const today = dayjs();
+	const daysDifference = renewal.diff(today, 'days');
+
+	return Boolean(daysDifference >= 0 && daysDifference <= 15);
+}
+
+const revenueChangeIcon = computed(() => {
+	if (revenueChange.value > 0) return 'trending-up';
+	if (revenueChange.value < 0) return 'trending-down';
+	return 'minus';
+});
+
+const revenueChangeColor = computed(() => {
+	if (revenueChange.value > 0) return 'text-green-500';
+	if (revenueChange.value < 0) return 'text-red-500';
+	return 'text-gray-500';
+});
+
+const revenueChange = computed(() => {
+	return (
+		((partner.currentMonthRevenue - partner.previousMonthRevenue) /
+			partner.previousMonthRevenue) *
+		100
+	);
+});
+
+const getTierVariant = tier => {
+	switch (tier) {
+		case 'Gold':
+			return 'orange';
+		case 'Silver':
+			return 'blue';
+		case 'Bronze':
+			return 'red';
+		default:
+			return 'gray';
+	}
+};
+
+const formatDate = dateString => {
+	return new Date(dateString).toLocaleDateString('en-US', {
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric'
+	});
 };
 </script>

--- a/dashboard/src2/components/partners/PartnerOverview.vue
+++ b/dashboard/src2/components/partners/PartnerOverview.vue
@@ -67,7 +67,7 @@
 					<div>
 						<div class="flex items-center justify-between">
 							<div class="text-sm text-gray-600">Certified Members</div>
-							<Button label="View" />
+							<Button label="View" @click="showPartnerMembersDialog = true" />
 						</div>
 						<div class="flex items-center">
 							<div class="text-xl font-semibold py-2">
@@ -145,6 +145,16 @@
 				/>
 			</template>
 		</Dialog>
+
+		<Dialog
+			:show="showPartnerMembersDialog"
+			v-model="showPartnerMembersDialog"
+			:options="{ size: 'xl', title: 'Certified Members' }"
+		>
+			<template #body-content>
+				<PartnerMembers :partnerName="partnerDetails.data?.company_name" />
+			</template>
+		</Dialog>
 	</div>
 </template>
 
@@ -155,11 +165,13 @@ import { FeatherIcon, Button, createResource, Progress } from 'frappe-ui';
 import PartnerContribution from './PartnerContribution.vue';
 import ClickToCopyField from '../ClickToCopyField.vue';
 import PartnerCreditsForm from './PartnerCreditsForm.vue';
+import PartnerMembers from './PartnerMembers.vue';
 
 const team = inject('team');
 
 const showPartnerContributionDialog = ref(false);
 const showPartnerCreditsDialog = ref(false);
+const showPartnerMembersDialog = ref(false);
 
 const partnerDetails = createResource({
 	url: 'press.api.partner.get_partner_details',

--- a/dashboard/src2/pages/BillingInvoices.vue
+++ b/dashboard/src2/pages/BillingInvoices.vue
@@ -106,6 +106,8 @@ export default {
 							if (row.type == 'Subscription') {
 								let end = dayjsLocal(row.period_end);
 								return end.format('MMMM YYYY');
+							} else if (row.type == 'Partnership Fees') {
+								return 'Partnership Fees';
 							}
 							return 'Prepaid Credits';
 						},

--- a/dashboard/src2/pages/Partners.vue
+++ b/dashboard/src2/pages/Partners.vue
@@ -2,7 +2,9 @@
 	<div class="sticky top-0 z-10 shrink-0">
 		<Header>
 			<FBreadcrumbs
-				:items="[{ label: 'Partners', route: { name: 'Partners' } }]"
+				:items="[
+					{ label: 'Partner Portal', route: { name: 'Partner Portal' } }
+				]"
 			/>
 		</Header>
 		<TabsWithRouter

--- a/dashboard/src2/router.js
+++ b/dashboard/src2/router.js
@@ -181,7 +181,7 @@ let router = createRouter({
 			]
 		},
 		{
-			name: 'Partners',
+			name: 'Partner Portal',
 			path: '/partners',
 			redirect: { name: 'PartnerOverview' },
 			component: () => import('./pages/Partners.vue'),

--- a/press/api/billing.py
+++ b/press/api/billing.py
@@ -612,7 +612,7 @@ def team_has_balance_for_invoice(prepaid_mode_invoice):
 
 
 @frappe.whitelist()
-def create_razorpay_order(amount):
+def create_razorpay_order(amount, type=None):
 	client = get_razorpay_client()
 	team = get_current_team(get_doc=True)
 
@@ -630,10 +630,12 @@ def create_razorpay_order(amount):
 			"gst": gst_amount if team.currency == "INR" else 0,
 		},
 	}
+	if type and type == "Partnership Fee":
+		data.get("notes").update({"Type": type})
 	order = client.order.create(data=data)
 
 	payment_record = frappe.get_doc(
-		{"doctype": "Razorpay Payment Record", "order_id": order.get("id"), "team": team.name}
+		{"doctype": "Razorpay Payment Record", "order_id": order.get("id"), "team": team.name, "type": type}
 	).insert(ignore_permissions=True)
 
 	return {

--- a/press/api/client.py
+++ b/press/api/client.py
@@ -75,6 +75,7 @@ ALLOWED_DOCTYPES = [
 	"Press Webhook",
 	"SQL Playground Log",
 	"Site Database User",
+	"Press Settings",
 ]
 
 ALLOWED_DOCTYPES_FOR_SUPPORT = [

--- a/press/api/partner.py
+++ b/press/api/partner.py
@@ -57,9 +57,9 @@ def get_partner_details(partner_email):
 			"partner_type",
 			"company_name",
 			"custom_ongoing_period_fc_invoice_contribution",
-			"custom_ongoing_period_enterprise_invoice_contribution",
 			"partner_name",
 			"custom_number_of_certified_members",
+			"end_date",
 		],
 	)
 	if data:

--- a/press/api/partner.py
+++ b/press/api/partner.py
@@ -188,6 +188,18 @@ def get_partner_customers():
 
 
 @frappe.whitelist()
+def get_partner_members(partner):
+	from press.utils.billing import get_frappe_io_connection
+
+	client = get_frappe_io_connection()
+	return client.get_list(
+		"LMS Certificate",
+		filters={"partner": partner},
+		fields=["member_name", "member_email"],
+	)
+
+
+@frappe.whitelist()
 def remove_partner():
 	team = get_current_team(get_doc=True)
 	if team.payment_mode == "Paid By Partner":

--- a/press/api/partner.py
+++ b/press/api/partner.py
@@ -57,6 +57,7 @@ def get_partner_details(partner_email):
 			"partner_type",
 			"company_name",
 			"custom_ongoing_period_fc_invoice_contribution",
+			"custom_fc_invoice_contribution",
 			"partner_name",
 			"custom_number_of_certified_members",
 			"end_date",
@@ -119,7 +120,7 @@ def transfer_credits(amount, customer, partner):
 
 
 @frappe.whitelist()
-def get_partner_contribution(partner_email):
+def get_partner_contribution_list(partner_email):
 	partner_currency = frappe.db.get_value(
 		"Team", {"erpnext_partner": 1, "partner_email": partner_email}, "currency"
 	)

--- a/press/partner/doctype/partner_tier/partner_tier.js
+++ b/press/partner/doctype/partner_tier/partner_tier.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, Frappe and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Partner Tier", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/press/partner/doctype/partner_tier/partner_tier.json
+++ b/press/partner/doctype/partner_tier/partner_tier.json
@@ -1,0 +1,70 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:title",
+ "creation": "2024-10-29 23:03:54.259118",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "enabled",
+  "title",
+  "column_break_fnzp",
+  "target_in_inr",
+  "target_in_usd"
+ ],
+ "fields": [
+  {
+   "default": "0",
+   "fieldname": "enabled",
+   "fieldtype": "Check",
+   "label": "Enabled"
+  },
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "label": "Title",
+   "unique": 1
+  },
+  {
+   "fieldname": "column_break_fnzp",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "target_in_inr",
+   "fieldtype": "Float",
+   "label": "Target in INR"
+  },
+  {
+   "fieldname": "target_in_usd",
+   "fieldtype": "Float",
+   "label": "Target in USD"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-10-29 23:08:37.110935",
+ "modified_by": "Administrator",
+ "module": "Partner",
+ "name": "Partner Tier",
+ "naming_rule": "Expression (old style)",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "show_title_field_in_link": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "title"
+}

--- a/press/partner/doctype/partner_tier/partner_tier.py
+++ b/press/partner/doctype/partner_tier/partner_tier.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, Frappe and contributors
+# For license information, please see license.txt
+from __future__ import annotations
+
+# import frappe
+from frappe.model.document import Document
+
+
+class PartnerTier(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		enabled: DF.Check
+		target_in_inr: DF.Float
+		target_in_usd: DF.Float
+		title: DF.Data | None
+	# end: auto-generated types
+
+	pass

--- a/press/partner/doctype/partner_tier/test_partner_tier.py
+++ b/press/partner/doctype/partner_tier/test_partner_tier.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Frappe and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestPartnerTier(FrappeTestCase):
+	pass

--- a/press/press/doctype/balance_transaction/balance_transaction.json
+++ b/press/press/doctype/balance_transaction/balance_transaction.json
@@ -33,7 +33,7 @@
    "fieldname": "type",
    "fieldtype": "Select",
    "label": "Type",
-   "options": "Adjustment\nApplied To Invoice"
+   "options": "Adjustment\nApplied To Invoice\nPartnership Fee"
   },
   {
    "fetch_from": "team.currency",
@@ -104,7 +104,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-01-04 22:28:44.740627",
+ "modified": "2024-12-19 13:06:26.343005",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Balance Transaction",

--- a/press/press/doctype/invoice/invoice.json
+++ b/press/press/doctype/invoice/invoice.json
@@ -302,7 +302,7 @@
    "fieldname": "type",
    "fieldtype": "Select",
    "label": "Type",
-   "options": "Subscription\nPrepaid Credits\nService\nSummary"
+   "options": "Subscription\nPrepaid Credits\nService\nSummary\nPartnership Fees"
   },
   {
    "depends_on": "eval:doc.type == 'Prepaid Credits'",
@@ -494,7 +494,7 @@
    "link_fieldname": "invoice"
   }
  ],
- "modified": "2024-12-16 20:08:37.566622",
+ "modified": "2024-12-18 22:28:29.793591",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Invoice",

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -82,7 +82,7 @@ class Invoice(Document):
 		transaction_fee: DF.Currency
 		transaction_fee_details: DF.Table[InvoiceTransactionFee]
 		transaction_net: DF.Currency
-		type: DF.Literal["Subscription", "Prepaid Credits", "Service", "Summary"]
+		type: DF.Literal["Subscription", "Prepaid Credits", "Service", "Summary", "Partnership Fees"]
 		write_off_amount: DF.Float
 	# end: auto-generated types
 

--- a/press/press/doctype/press_settings/press_settings.json
+++ b/press/press/doctype/press_settings/press_settings.json
@@ -199,12 +199,17 @@
   "section_break_jstu",
   "enable_app_grouping",
   "default_apps",
-  "code_spaces_tab",
-  "spaces_domain",
+  "partner_tab",
+  "partnership_fees_section",
+  "partnership_fee_usd",
+  "column_break_yxrj",
+  "partnership_fee_inr",
   "hybrid_server_tab",
   "hybrid_cluster",
   "hybrid_domain",
-  "tls_renewal_queue_size"
+  "tls_renewal_queue_size",
+  "code_spaces_tab",
+  "spaces_domain"
  ],
  "fields": [
   {
@@ -1285,6 +1290,30 @@
    "fieldname": "redis_cache_size",
    "fieldtype": "Int",
    "label": "Redis Cache Size (MB)"
+  },
+  {
+   "fieldname": "partner_tab",
+   "fieldtype": "Tab Break",
+   "label": "Partner"
+  },
+  {
+   "fieldname": "partnership_fees_section",
+   "fieldtype": "Section Break",
+   "label": "Partnership Fees"
+  },
+  {
+   "fieldname": "partnership_fee_usd",
+   "fieldtype": "Int",
+   "label": "Partnership Fee USD"
+  },
+  {
+   "fieldname": "column_break_yxrj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "partnership_fee_inr",
+   "fieldtype": "Int",
+   "label": "Partnership Fee INR"
   }
  ],
  "issingle": 1,

--- a/press/press/doctype/press_settings/press_settings.py
+++ b/press/press/doctype/press_settings/press_settings.py
@@ -104,6 +104,8 @@ class PressSettings(Document):
 		offsite_backups_count: DF.Int
 		offsite_backups_provider: DF.Literal["AWS S3"]
 		offsite_backups_secret_access_key: DF.Password | None
+		partnership_fee_inr: DF.Int
+		partnership_fee_usd: DF.Int
 		plausible_api_key: DF.Password | None
 		plausible_site_id: DF.Data | None
 		plausible_url: DF.Data | None

--- a/press/press/doctype/press_settings/press_settings.py
+++ b/press/press/doctype/press_settings/press_settings.py
@@ -158,6 +158,11 @@ class PressSettings(Document):
 		webroot_directory: DF.Data | None
 	# end: auto-generated types
 
+	dashboard_fields = (
+		"partnership_fee_inr",
+		"partnership_fee_usd",
+	)
+
 	@frappe.whitelist()
 	def create_stripe_webhook(self):
 		stripe = get_stripe()

--- a/press/press/doctype/razorpay_payment_record/razorpay_payment_record.json
+++ b/press/press/doctype/razorpay_payment_record/razorpay_payment_record.json
@@ -10,6 +10,7 @@
   "payment_id",
   "order_id",
   "signature",
+  "type",
   "status",
   "failure_reason"
  ],
@@ -57,11 +58,18 @@
    "fieldtype": "Small Text",
    "label": "Failure Reason",
    "read_only": 1
+  },
+  {
+   "default": "Prepaid Credits",
+   "fieldname": "type",
+   "fieldtype": "Select",
+   "label": "Type",
+   "options": "Prepaid Credits\nPartnership Fee"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-01-20 16:34:15.352515",
+ "modified": "2025-01-05 22:06:31.980472",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Razorpay Payment Record",
@@ -82,5 +90,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "order_id"
 }

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -811,11 +811,11 @@ class Team(Document):
 					invoice.stripe_link_expired = True
 		return invoices
 
-	def allocate_credit_amount(self, amount, source, remark=None):
+	def allocate_credit_amount(self, amount, source, remark=None, type="Adjustment"):
 		doc = frappe.get_doc(
 			doctype="Balance Transaction",
 			team=self.name,
-			type="Adjustment",
+			type=type,
 			source=source,
 			amount=amount,
 			description=remark,
@@ -886,7 +886,7 @@ class Team(Document):
 	def get_balance(self):
 		res = frappe.get_all(
 			"Balance Transaction",
-			filters={"team": self.name, "docstatus": 1},
+			filters={"team": self.name, "docstatus": 1, "type": ("!=", "Partnership Fee")},
 			order_by="creation desc",
 			limit=1,
 			pluck="ending_balance",
@@ -1313,6 +1313,10 @@ def process_stripe_webhook(doc, method):
 		process_micro_debit_test_charge(event)
 		return
 
+	if payment_for and payment_for == "partnership_fee":
+		process_partnership_fee(payment_intent)
+		return
+
 	handle_payment_intent_succeeded(payment_intent)
 
 
@@ -1410,6 +1414,64 @@ def enqueue_finalize_unpaid_for_team(team: str):
 	for invoice in invoices:
 		doc = frappe.get_doc("Invoice", invoice)
 		doc.finalize_invoice()
+
+
+def procees_partnership_fee(payment_intent):
+	from datetime import datetime
+
+	if isinstance(payment_intent, str):
+		stripe = get_stripe()
+		payment_intent = stripe.PaymentIntent.retrieve(payment_intent)
+
+	metadata = payment_intent.get("metadata")
+	if frappe.db.exists("Invoice", {"stripe_payment_intent_id": payment_intent["id"], "status": "Paid"}):
+		# ignore creating duplicate partnership fee invoice
+		return
+
+	team = frappe.get_doc("Team", {"stripe_customer_id": payment_intent["customer"]})
+	amount_with_tax = payment_intent["amount"] / 100
+	gst = float(metadata.get("gst", 0))
+	amount = amount_with_tax - gst
+	balance_transaction = team.allocate_credit_amount(
+		amount, source="Prepaid Credits", remark=payment_intent["id"], type="Partnership Fee"
+	)
+
+	invoice = frappe.get_doc(
+		doctype="Invoice",
+		team=team.name,
+		type="Partnership Fee",
+		status="Paid",
+		due_date=datetime.fromtimestamp(payment_intent["created"]),
+		total=amount,
+		amount_due=amount,
+		gst=gst or 0,
+		amount_due_with_tax=amount_with_tax,
+		amount_paid=amount_with_tax,
+		stripe_payment_intent_id=payment_intent["id"],
+	)
+	invoice.append(
+		"items",
+		{
+			"description": "Partnership Fee",
+			"document_type": "Balance Transaction",
+			"document_name": balance_transaction.name,
+			"quantity": 1,
+			"rate": amount,
+		},
+	)
+	invoice.insert()
+	invoice.reload()
+
+	# latest stripe API sets charge id in latest_charge
+	charge = payment_intent.get("latest_charge")
+	if not charge:
+		# older stripe API sets charge id in charges.data
+		charges = payment_intent.get("charges", {}).get("data", [])
+		charge = charges[0]["id"] if charges else None
+	if charge:
+		# update transaction amount, fee and exchange rate
+		invoice.update_transaction_details(charge)
+		invoice.submit()
 
 
 def get_permission_query_conditions(user):

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -527,7 +527,7 @@ class Team(Document):
 
 	def create_partner_referral_code(self):
 		if not self.partner_referral_code:
-			self.partner_referral_code = random_string(10)
+			self.partner_referral_code = random_string(10).upper()
 			self.save(ignore_permissions=True)
 
 	def get_partnership_start_date(self):

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -1416,7 +1416,7 @@ def enqueue_finalize_unpaid_for_team(team: str):
 		doc.finalize_invoice()
 
 
-def procees_partnership_fee(payment_intent):
+def process_partnership_fee(payment_intent):
 	from datetime import datetime
 
 	if isinstance(payment_intent, str):
@@ -1439,7 +1439,7 @@ def procees_partnership_fee(payment_intent):
 	invoice = frappe.get_doc(
 		doctype="Invoice",
 		team=team.name,
-		type="Partnership Fee",
+		type="Partnership Fees",
 		status="Paid",
 		due_date=datetime.fromtimestamp(payment_intent["created"]),
 		total=amount,


### PR DESCRIPTION
This will allow partners to pay for Partnership renewal Fee directly from FC To enable this a new Invoice type and Balance Transaction Type called as Partnership Fee has been introduced.

![image](https://github.com/user-attachments/assets/569e74de-84ad-48bc-b0ee-90b550234c51)


ToDo:
- Show Terms & Conditions check acting as Partner Agreement
- Send Email on Successful renewal & Update renewal date