### PR TITLE
fix: invoice item descriptions for missing document types

### DIFF
--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -518,6 +518,11 @@ class Invoice(Document):
 						item.description = f"{server_title} Storage Add-on for {how_many_days}"
 					else:
 						item.description = f"{server_title} active for {how_many_days}"
+				elif item.document_type == "Marketplace App":
+					app_title = frappe.get_cached_value("Marketplace App", item.document_name, "title")
+					item.description = f"Marketplace app {app_title} active for {how_many_days}"
+				else:
+					item.description = "Prepaid Credits"
 
 	def add_usage_record(self, usage_record):
 		if self.type != "Subscription":

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -506,11 +506,18 @@ class Invoice(Document):
 
 	def update_item_descriptions(self):
 		for item in self.items:
-			if not item.description and item.document_type == "Site" and item.plan:
-				site_name = item.document_name.split(".archived")[0]
-				plan = frappe.get_cached_value("Site Plan", item.plan, "plan_title")
+			if not item.description:
 				how_many_days = f"{cint(item.quantity)} day{'s' if item.quantity > 1 else ''}"
-				item.description = f"{site_name} active for {how_many_days} on {plan} plan"
+				if item.document_type == "Site" and item.plan:
+					site_name = item.document_name.split(".archived")[0]
+					plan = frappe.get_cached_value("Site Plan", item.plan, "plan_title")
+					item.description = f"{site_name} active for {how_many_days} on {plan} plan"
+				elif item.document_type in ["Server", "Database Server"]:
+					server_title = frappe.get_cached_value(item.document_type, item.document_name, "title")
+					if item.plan == "Add-on Storage plan":
+						item.description = f"{server_title} Storage Add-on for {how_many_days}"
+					else:
+						item.description = f"{server_title} active for {how_many_days}"
 
 	def add_usage_record(self, usage_record):
 		if self.type != "Subscription":


### PR DESCRIPTION
Item descriptions were only set for Site document type and set as Prepaid credits implicitly in the print format for all others which would make the invoice look something like this

![image](https://github.com/user-attachments/assets/890fab89-c167-4cbd-b345-387cdea79291)
