### PR TITLE
feat(site-database-user): add ssl instructions for database user

### DIFF
--- a/dashboard/src2/components/site_database_user/SiteDatabaseUserCredentialDialog.vue
+++ b/dashboard/src2/components/site_database_user/SiteDatabaseUserCredentialDialog.vue
@@ -72,6 +72,19 @@
 						:message="this.$resources.downloadSSLCert.error"
 					/>
 				</div>
+				<div class="pb-2 pt-5">
+					<p class="mb-2 text-base font-semibold text-gray-700">Need Help?</p>
+					<p class="text-sm">
+						Please check out the
+						<a
+							href="https://frappecloud.com/docs/database-users-and-permission-manager#faq"
+							target="_blank"
+							class="underline"
+							>documentation</a
+						>
+						to get guides on troubleshooting.
+					</p>
+				</div>
 			</div>
 		</template>
 	</Dialog>

--- a/dashboard/src2/components/site_database_user/SiteDatabaseUserCredentialDialog.vue
+++ b/dashboard/src2/components/site_database_user/SiteDatabaseUserCredentialDialog.vue
@@ -43,7 +43,7 @@
 				</div>
 				<div class="pb-2 pt-5">
 					<p class="mb-2 text-base font-semibold text-gray-700">
-						Using MariaDB Client
+						Using MariaDB CLI
 					</p>
 					<p class="mb-2 text-base">
 						Run this command in your terminal to access MariaDB console
@@ -55,12 +55,30 @@
 						computer.
 					</p>
 				</div>
+				<div class="pb-2 pt-5">
+					<p class="mb-2 text-base font-semibold text-gray-700">SSL Info</p>
+					<p class="text-sm">
+						You need to <b>use SSL</b> to connect to the database.
+					</p>
+					<Button
+						class="mt-3"
+						:loading="this.$resources.downloadSSLCert.loading"
+						loading-text="Downloading SSL Certificate (.pem)"
+						@click="this.$resources.downloadSSLCert.submit()"
+						>Download SSL Certificate (.pem)</Button
+					>
+					<ErrorMessage
+						class="mt-2"
+						:message="this.$resources.downloadSSLCert.error"
+					/>
+				</div>
 			</div>
 		</template>
 	</Dialog>
 </template>
 <script>
 import ClickToCopyField from '../ClickToCopyField.vue';
+import { toast } from 'vue-sonner';
 
 export default {
 	name: 'SiteDatabaseUserCredentialDialog',
@@ -83,6 +101,28 @@ export default {
 				},
 				initialData: {},
 				auto: true
+			};
+		},
+		downloadSSLCert() {
+			return {
+				url: 'press.api.download_ssl_cert',
+				makeParams: () => {
+					return {
+						domain: this.databaseCredential?.host ?? ''
+					};
+				},
+				auto: false,
+				onSuccess: data => {
+					// create a blob and trigger a download
+					const blob = new Blob([data], { type: 'text/plain' });
+					const filename = `${this.databaseCredential?.host ?? ''}.pem`;
+					const link = document.createElement('a');
+					link.href = URL.createObjectURL(blob);
+					link.download = filename;
+					link.click();
+					URL.revokeObjectURL(link.href);
+					toast.success('SSL Certificate downloaded successfully');
+				}
 			};
 		}
 	},

--- a/press/api/__init__.py
+++ b/press/api/__init__.py
@@ -1,9 +1,10 @@
 import frappe
 
-from press.utils import get_minified_script, get_minified_script_2
+from press.api.client import dashboard_whitelist
 from press.saas.doctype.product_trial_request.product_trial_request import (
 	get_app_trial_page_url,
 )
+from press.utils import get_full_chain_cert_of_domain, get_minified_script, get_minified_script_2, log_error
 
 
 @frappe.whitelist(allow_guest=True)
@@ -20,3 +21,18 @@ def script_2():
 def handle_suspended_site_redirection():
 	frappe.local.response["type"] = "redirect"
 	frappe.local.response["location"] = get_app_trial_page_url() or "/dashboard"
+
+
+@dashboard_whitelist()
+def download_ssl_cert(domain: str):
+	if (
+		not (domain.endswith("frappe.cloud") or domain.endswith("frappecloud.com"))
+		and not frappe.conf.developer_mode
+	):
+		frappe.throw("Invalid domain provided")
+
+	try:
+		return get_full_chain_cert_of_domain(domain)
+	except Exception as e:
+		log_error("Error downloading SSL certificate", data=e)
+		frappe.throw("Failed to download SSL certificate. Please try again later.")

--- a/press/utils/__init__.py
+++ b/press/utils/__init__.py
@@ -6,17 +6,23 @@ import contextlib
 import functools
 import json
 import re
+import socket
+import ssl
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TypedDict, TypeVar
 from urllib.parse import urljoin
+from urllib.request import urlopen
 
 import frappe
 import pytz
 import requests
 import wrapt
 from babel.dates import format_timedelta
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.x509.oid import ExtensionOID
 from frappe.utils import get_datetime, get_system_timezone
 from frappe.utils.caching import site_cache
 from pymysql.err import InterfaceError
@@ -840,3 +846,36 @@ def get_mariadb_root_password(site):
 		field = "mariadb_root_password"
 
 	return get_decrypted_password(doctype, name, field)
+
+
+def get_full_chain_cert_of_domain(domain: str) -> str:
+	cert_chain = []
+
+	# Get initial certificate
+	context = ssl.create_default_context()
+	with socket.create_connection((domain, 443)) as sock:  # noqa: SIM117
+		with context.wrap_socket(sock, server_hostname=domain) as ssl_socket:
+			cert_pem = ssl.DER_cert_to_PEM_cert(ssl_socket.getpeercert(True))
+			cert = x509.load_pem_x509_certificate(cert_pem.encode(), default_backend())
+			cert_chain.append(cert_pem)
+
+	# Walk up the chain via certificate authority information access (AIA)
+	while True:
+		try:
+			aia = cert.extensions.get_extension_for_oid(ExtensionOID.AUTHORITY_INFORMATION_ACCESS)
+			for access in aia.value:
+				if access.access_method._name == "caIssuers":
+					uri = access.access_location._value
+					with urlopen(uri) as response:
+						der_cert = response.read()
+						pem_cert = ssl.DER_cert_to_PEM_cert(der_cert)
+						cert = x509.load_pem_x509_certificate(pem_cert.encode(), default_backend())
+						cert_chain.append(pem_cert)
+						break
+		except:  # noqa: E722
+			break
+
+	cert_chain_str = ""
+	for cert in cert_chain:
+		cert_chain_str += cert + "\n"
+	return cert_chain_str


### PR DESCRIPTION
Fixes https://github.com/frappe/press/issues/2364

- Some SSL Instructions + Documentation link added
- Users can download the ssl fullchain from dashboard iteself.
   - Validated download ssl cert chain with looker studio. It's working.

![Untitled design](https://github.com/user-attachments/assets/bd7e1ba6-b018-4897-ae33-8b2a978d0d06)
