### PR TITLE
chore(agent-job-notifications): Handle more error types

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -58,7 +58,10 @@
         "behavior",
         "inplace",
         "supectl",
-        "uncollectible"
+        "uncollectible",
+        "hset",
+        "serializability",
+        "oom"
     ],
     "allowCompoundWords": true,
     "ignorePaths": [

--- a/.cspell.json
+++ b/.cspell.json
@@ -13,7 +13,6 @@
         "erpnext",
         "parenttype",
         "parentfield",
-        "subsription",
         "sbool",
         "binlog",
         "ifnull",

--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -341,6 +341,10 @@ class AgentJob(Document):
 			return True
 		return False
 
+	@property
+	def on_public_server(self):
+		return bool(frappe.db.get_value(self.server_type, self.server, "public"))
+
 
 def job_detail(job):
 	job = frappe.get_doc("Agent Job", job)

--- a/press/press/doctype/agent_job/agent_job_notifications.py
+++ b/press/press/doctype/agent_job/agent_job_notifications.py
@@ -58,6 +58,7 @@ class JobErr(Enum):
 	DATA_TRUNCATED_FOR_COLUMN = auto()
 	BROKEN_PIPE_ERR = auto()
 	CANT_CONNECT_TO_MYSQL = auto()
+	GZIP_TAR_ERR = auto()
 
 
 DOC_URLS = {
@@ -66,6 +67,7 @@ DOC_URLS = {
 	JobErr.DATA_TRUNCATED_FOR_COLUMN: "https://frappecloud.com/docs/faq/site#data-truncated-for-column",
 	JobErr.BROKEN_PIPE_ERR: None,
 	JobErr.CANT_CONNECT_TO_MYSQL: "https://frappecloud.com/docs/cant-connect-to-mysql-server",
+	JobErr.GZIP_TAR_ERR: "https://frappecloud.com/docs/sites/migrate-an-existing-site#tar-gzip-command-fails-with-unexpected-eof",
 }
 
 
@@ -96,6 +98,8 @@ def handlers() -> list[UserAddressableHandlerTuple]:
 		("Data truncated for column", update_with_data_truncated_for_column_err),
 		("BrokenPipeError", update_with_broken_pipe_err),
 		("ERROR 2002 (HY000)", update_with_cant_connect_to_mysql_err),
+		("gzip: stdin: unexpected end of file", update_with_gzip_tar_err),
+		("tar: Unexpected EOF in archive", update_with_gzip_tar_err),
 	]
 
 
@@ -254,6 +258,18 @@ def update_with_cant_connect_to_mysql_err(details: Details, job: AgentJob):
 	"""
 
 	details["assistance_url"] = DOC_URLS[JobErr.CANT_CONNECT_TO_MYSQL]
+
+	return True
+
+
+def update_with_gzip_tar_err(details: Details, job: AgentJob):
+	details["title"] = "Corrupt backup file"
+
+	details["message"] = f"""<p>An error occurred when extracting the backup to {job.site}.</p>
+	<p>To rectify this issue, please follow the steps mentioned in <i>Help</i>.</p>
+	"""
+
+	details["assistance_url"] = DOC_URLS[JobErr.GZIP_TAR_ERR]
 
 	return True
 

--- a/press/press/doctype/agent_job/agent_job_notifications.py
+++ b/press/press/doctype/agent_job/agent_job_notifications.py
@@ -59,6 +59,7 @@ class JobErr(Enum):
 	BROKEN_PIPE_ERR = auto()
 	CANT_CONNECT_TO_MYSQL = auto()
 	GZIP_TAR_ERR = auto()
+	UNKNOWN_COMMAND_HYPHEN = auto()
 
 
 DOC_URLS = {
@@ -68,6 +69,7 @@ DOC_URLS = {
 	JobErr.BROKEN_PIPE_ERR: None,
 	JobErr.CANT_CONNECT_TO_MYSQL: "https://frappecloud.com/docs/cant-connect-to-mysql-server",
 	JobErr.GZIP_TAR_ERR: "https://frappecloud.com/docs/sites/migrate-an-existing-site#tar-gzip-command-fails-with-unexpected-eof",
+	JobErr.UNKNOWN_COMMAND_HYPHEN: "https://frappecloud.com/docs/unknown-command-",
 }
 
 
@@ -100,6 +102,7 @@ def handlers() -> list[UserAddressableHandlerTuple]:
 		("ERROR 2002 (HY000)", update_with_cant_connect_to_mysql_err),
 		("gzip: stdin: unexpected end of file", update_with_gzip_tar_err),
 		("tar: Unexpected EOF in archive", update_with_gzip_tar_err),
+		("Unknown command '\\-'.", update_with_unknown_command_hyphen_err),
 	]
 
 
@@ -270,6 +273,19 @@ def update_with_gzip_tar_err(details: Details, job: AgentJob):
 	"""
 
 	details["assistance_url"] = DOC_URLS[JobErr.GZIP_TAR_ERR]
+
+	return True
+
+
+def update_with_unknown_command_hyphen_err(details: Details, job: AgentJob):
+	details["title"] = "Incompatible site backup"
+
+	details["message"] = f"""<p>An error occurred when extracting the backup to {job.site}.</p>
+	<p>This happens when the backup is taken from a later version of MariaDB and restored on a older version.</p>
+	<p>To rectify this issue, please follow the steps mentioned in <i>Help</i>.</p>
+	"""
+
+	details["assistance_url"] = DOC_URLS[JobErr.UNKNOWN_COMMAND_HYPHEN]
 
 	return True
 

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -594,8 +594,8 @@ class Site(Document, TagHelpers):
 			# update the subscription config while renaming the standby site
 			self.update_config_preview()
 			site_config = json.loads(self.config)
-			subsription_config = site_config.get("subscription", {})
-			job = agent.rename_site(self, new_name, create_user, config={"subscription": subsription_config})
+			subscription_config = site_config.get("subscription", {})
+			job = agent.rename_site(self, new_name, create_user, config={"subscription": subscription_config})
 			self.flags.rename_site_agent_job_name = job.name
 		else:
 			agent.rename_site(self, new_name)


### PR DESCRIPTION
- **fix(agent-job-notifications): Handle can't connect to mysql errs**
- **chore(subscription): Correct spelling**
- **fix(agent-job-notification): Handle corrupt backup restore attempts**
- **fix(agent-job-notification): Handle incompatible backup errs**

fixes #2363
