### PR TITLE
perf: Do not apply usage limit tracking on dedicated servers

### DIFF
--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -69,7 +69,7 @@ from press.press.doctype.resource_tag.tag_helpers import TagHelpers
 from press.press.doctype.server.server import is_dedicated_server
 from press.press.doctype.site_activity.site_activity import log_site_activity
 from press.press.doctype.site_analytics.site_analytics import create_site_analytics
-from press.press.doctype.site_plan.site_plan import get_plan_config
+from press.press.doctype.site_plan.site_plan import UNLIMITED_PLANS, get_plan_config
 from press.press.report.mariadb_slow_queries.mariadb_slow_queries import (
 	get_doctype_name,
 )
@@ -2124,7 +2124,12 @@ class Site(Document, TagHelpers):
 		return plan
 
 	def get_plan_config(self, plan=None):
-		return get_plan_config(self.get_plan_name(plan))
+		plan = self.get_plan_name(plan)
+		config = get_plan_config(plan)
+		if plan in UNLIMITED_PLANS:
+			# PERF: do not enable usage tracking on unlimited sites.
+			config.pop("rate_limit", None)
+		return config
 
 	def set_latest_bench(self):
 		from pypika.terms import PseudoColumn

--- a/press/press/doctype/site_plan/site_plan.py
+++ b/press/press/doctype/site_plan/site_plan.py
@@ -6,6 +6,8 @@ import frappe
 
 from press.press.doctype.site_plan.plan import Plan
 
+UNLIMITED_PLANS = ["Unlimited", "Unlimited - Supported"]
+
 
 class SitePlan(Plan):
 	# begin: auto-generated types


### PR DESCRIPTION
It's extra overhead. It doesn't do anything right now as it is kept
very high to avoid ever hitting that limit on dedicated servers.

closes https://github.com/frappe/caffeine/issues/48