### PR TITLE
fix(payments): Set invoice status as Paid when stripe invoice is pending

### DIFF
--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -256,12 +256,22 @@ class Invoice(Document):
 			self.status = "Paid"
 
 		if self.status == "Paid" and self.stripe_invoice_id and self.amount_paid == 0:
-			self.change_stripe_invoice_status("Void")
-			self.add_comment(
-				text=(
-					f"Stripe Invoice {self.stripe_invoice_id} voided because" " payment is done via credits."
+			stripe = get_stripe()
+			invoice = stripe.Invoice.retrieve(self.stripe_invoice_id)
+			payment_intent = stripe.PaymentIntent.retrieve(invoice.payment_intent)
+			if payment_intent.status == "processing":
+				# mark the fc invoice as Paid
+				# if the payment intent is processing, it means the invoice cannot be voided yet
+				# wait for invoice to be updated and then mark it as void if payment failed
+				# or issue a refund if succeeded
+				self.save()  # status is already Paid, so no need to set again
+			else:
+				self.change_stripe_invoice_status("Void")
+				self.add_comment(
+					text=(
+						f"Stripe Invoice {self.stripe_invoice_id} voided because payment is done via credits."
+					)
 				)
-			)
 
 		self.save()
 


### PR DESCRIPTION
When stripe invoice is in processing (payments pending) state, invoices cannot be marked as void and thus the fc invoice remains unpaid even when credits are available and applied.

> Note: This has been tested in a very hacky manner since there is no way to set invoice in processing state. You can either immediately fail or succeeded a transaction on Stripe.