### PR TITLE
fix(agent): Suppress creation of err logs for req failures

### DIFF
--- a/press/agent.py
+++ b/press/agent.py
@@ -14,6 +14,7 @@ import requests
 from frappe.utils.password import get_decrypted_password
 from requests.exceptions import HTTPError
 
+from press.exceptions import AgentHTTPError
 from press.utils import get_mariadb_root_password, log_error, sanitize_config
 
 if TYPE_CHECKING:
@@ -777,7 +778,7 @@ class Agent:
 				output = "\n\n".join([json_response.get("output", ""), json_response.get("traceback", "")])
 				if output == "\n\n":
 					output = json.dumps(json_response, indent=2, sort_keys=True)
-				raise HTTPError(
+				raise AgentHTTPError(
 					f"{response.status_code} {response.reason}\n\n{output}",
 					response=response,
 				)

--- a/press/exceptions.py
+++ b/press/exceptions.py
@@ -1,4 +1,5 @@
 from frappe.exceptions import ValidationError
+from requests import HTTPError
 
 
 class CentralServerNotSet(ValidationError):
@@ -55,3 +56,11 @@ class SiteAlreadyArchived(ValidationError):
 
 class InactiveDomains(ValidationError):
 	pass
+
+
+class AgentHTTPError(HTTPError):
+	def __init__(
+		self, *args, request=None, response=None, status_code=555
+	):  # custom status_code exception to suppress err logs
+		self.http_status_code = status_code
+		super().__init__(*args, request=request, response=response)


### PR DESCRIPTION
This is possible by setting http_status_code to < 500. Using custom
status code 420 for this purpose.

- [ ] Need to figure out way to push whole traceback to sentry before doing this. Seems neither press nor [agent](https://trace.frappe.cloud/organizations/frappe/issues/38185/?project=3&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=1) does this at this point.
    - [x] Nicely formatting the trace (https://github.com/frappe/agent/commit/3ac57211c06edf20648be4710c0c62849b48d6a4) also doesn't seem to help