### PR TITLE
fix(mpesa): Use CustomPaybillOnline for both prod and sandbox environment

### DIFF
--- a/press/press/doctype/mpesa_setup/mpesa_connector.py
+++ b/press/press/doctype/mpesa_setup/mpesa_connector.py
@@ -133,7 +133,7 @@ class MpesaConnector:
 			"CallBackURL": callback_url,
 			"AccountReference": reference_code,
 			"TransactionDesc": description,
-			"TransactionType": "CustomerPayBillOnline" if self.env == "sandbox" else "CustomerBuyGoodsOnline",
+			"TransactionType": "CustomerPayBillOnline",
 		}
 		headers = {
 			"Authorization": f"Bearer {self.authentication_token}",


### PR DESCRIPTION
Ensure `CustomerPayBillOnline` is used for both production and sandbox environments in Mpesa Express (STK Push) transactions.