### PR TITLE
feat: Failover Support for Physical Restore

### DIFF
--- a/press/fixtures/agent_job_type.json
+++ b/press/fixtures/agent_job_type.json
@@ -2381,6 +2381,9 @@
    },
    {
     "step_name": "Unlock All Tables"
+   },
+   {
+    "step_name": "Run Container to Restore Tables"
    }
   ]
  },

--- a/press/press/doctype/press_settings/press_settings.json
+++ b/press/press/doctype/press_settings/press_settings.json
@@ -68,6 +68,10 @@
   "backup_offset",
   "column_break_48",
   "backup_limit",
+  "physical_backups_section",
+  "disable_physical_backup",
+  "enable_physical_restore_failover",
+  "physical_restore_docker_image",
   "docker_tab",
   "section_break_59",
   "docker_registry_url",
@@ -197,7 +201,6 @@
   "disable_auto_retry",
   "disable_agent_job_deduplication",
   "enable_email_pre_verification",
-  "disable_physical_backup",
   "section_break_jstu",
   "enable_app_grouping",
   "default_apps",
@@ -1327,11 +1330,28 @@
    "fieldname": "disable_physical_backup",
    "fieldtype": "Check",
    "label": "Disable Physical Backup"
+  },
+  {
+   "fieldname": "physical_backups_section",
+   "fieldtype": "Section Break",
+   "label": "Physical Backups"
+  },
+  {
+   "default": "0",
+   "description": "If physical restore fails, it will spawn up a new database container to try logical restoration.",
+   "fieldname": "enable_physical_restore_failover",
+   "fieldtype": "Check",
+   "label": "Enable Physical Restore Failover"
+  },
+  {
+   "fieldname": "physical_restore_docker_image",
+   "fieldtype": "Data",
+   "label": "Physical Restore Docker Image"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2025-01-28 14:41:49.332529",
+ "modified": "2025-02-12 15:00:45.072392",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Press Settings",

--- a/press/press/doctype/press_settings/press_settings.py
+++ b/press/press/doctype/press_settings/press_settings.py
@@ -67,6 +67,7 @@ class PressSettings(Document):
 		enable_app_grouping: DF.Check
 		enable_email_pre_verification: DF.Check
 		enable_google_oauth: DF.Check
+		enable_physical_restore_failover: DF.Check
 		enable_site_pooling: DF.Check
 		enforce_storage_limits: DF.Check
 		erpnext_api_key: DF.Data | None
@@ -108,6 +109,7 @@ class PressSettings(Document):
 		offsite_backups_secret_access_key: DF.Password | None
 		partnership_fee_inr: DF.Int
 		partnership_fee_usd: DF.Int
+		physical_restore_docker_image: DF.Data | None
 		plausible_api_key: DF.Password | None
 		plausible_site_id: DF.Data | None
 		plausible_url: DF.Data | None


### PR DESCRIPTION
Fixes https://github.com/frappe/press/issues/2471

If normal physical restoration failed for any reason,
We will spin up a new mariadb container with the backup volume mounted.

Then, we will try to dump and import the logical backup in live database.


**Required Tools-**
- `fio` and `docker` on db server
- Docker image to perform the restoration ([source code](https://github.com/tanmoysrt/physical_restore_helper)).  Once ready, will move to this repo.

**Agent PR** - https://github.com/frappe/agent/pull/166

**Flow -**

![image](https://github.com/user-attachments/assets/af5e0250-2dd3-4468-b991-9cec7de0c656)
