### PR TITLE
fix(mpesa): Make tax id mandatory for vat purpose

### DIFF
--- a/dashboard/src2/components/billing/mpesa/BuyPrepaidCreditsMpesa.vue
+++ b/dashboard/src2/components/billing/mpesa/BuyPrepaidCreditsMpesa.vue
@@ -139,6 +139,11 @@ export default {
 							'Both partner and phone number are required for payment.',
 						);
 					}
+					if (!this.taxIdInput) {
+						throw new DashboardError(
+							'Tax ID is required for payment.',
+						);
+					}
 				},
 				async onSuccess(data) {
 					if (data?.ResponseCode === '0') {


### PR DESCRIPTION
Make tax id mendatory while initiating mpesa payments.
![image](https://github.com/user-attachments/assets/86cc0491-7ff6-4e10-81e3-d5990fae6d1a)
