### PR TITLE
feat - Validating the tax pattern to ensure user enters the right format f tax id before initiating mpesa transaction

### DIFF
--- a/dashboard/src2/components/billing/mpesa/BuyPrepaidCreditsMpesa.vue
+++ b/dashboard/src2/components/billing/mpesa/BuyPrepaidCreditsMpesa.vue
@@ -37,7 +37,7 @@
 				autocomplete="off"
 				class="mb-5"
 				type="string"
-				placeholder="e.g 78346"
+				placeholder="e.g A123456789A"
 			/>
 		</div>
 		<!-- Show amount after tax -->
@@ -124,6 +124,7 @@ export default {
 					exchange_rate: this.exchangeRate,
 				},
 				validate() {
+					const pattern = /^[A-Z]\d{9}[A-Z]$/;
 					if (this.amount < this.minimumAmount) {
 						throw new DashboardError(
 							`Amount is less than the minimum allowed: ${this.minimumAmount}`,
@@ -144,6 +145,14 @@ export default {
 							'Tax ID is required for payment.',
 						);
 					}
+					if(this.taxIdInput){
+						if (!pattern.test(this.taxIdInput)) {
+							throw new DashboardError(
+								"Tax ID should be in the format 'A123456789A'",
+							);
+						}
+					}
+					
 				},
 				async onSuccess(data) {
 					if (data?.ResponseCode === '0') {


### PR DESCRIPTION
Tax id starts should start with capital letter, also end in capital letter and in between contain 8 numerical numbers.
Validating this using regez expression before initiating a transaction.
eg .
![image](https://github.com/user-attachments/assets/d4c643fc-8afe-4d64-964f-566f9aa07584)
