### PR TITLE
refactor(billing): Disable account

### DIFF
--- a/dashboard/src2/components/settings/profile/AccountProfile.vue
+++ b/dashboard/src2/components/settings/profile/AccountProfile.vue
@@ -9,7 +9,7 @@
 					:upload-args="{
 						doctype: 'User',
 						docname: user.name,
-						method: 'press.api.account.update_profile_picture'
+						method: 'press.api.account.update_profile_picture',
 					}"
 				>
 					<template v-slot="{ openFileSelector, uploading, progress, error }">
@@ -98,9 +98,9 @@
 					{
 						variant: 'solid',
 						label: 'Save Changes',
-						onClick: () => $resources.updateProfile.submit()
-					}
-				]
+						onClick: () => $resources.updateProfile.submit(),
+					},
+				],
 			}"
 			v-model="showProfileEditDialog"
 		>
@@ -122,12 +122,9 @@
 						variant: 'solid',
 						theme: 'red',
 						loading: $resources.disableAccount.loading,
-						onClick: () =>
-							$resources.disableAccount.submit({
-								totp_code: disableAccount2FACode
-							})
-					}
-				]
+						onClick: () => deactivateAccount(disableAccount2FACode),
+					},
+				],
 			}"
 			v-model="showDisableAccountDialog"
 		>
@@ -162,9 +159,9 @@
 						label: 'Enable Account',
 						variant: 'solid',
 						loading: $resources.enableAccount.loading,
-						onClick: () => $resources.enableAccount.submit()
-					}
-				]
+						onClick: () => $resources.enableAccount.submit(),
+					},
+				],
 			}"
 			v-model="showEnableAccountDialog"
 		>
@@ -181,6 +178,13 @@
 				<ErrorMessage class="mt-2" :message="$resources.enableAccount.error" />
 			</template>
 		</Dialog>
+
+		<AddPrepaidCreditsDialog
+			:showMessage="showMessage"
+			v-if="showAddPrepaidCreditsDialog"
+			v-model="showAddPrepaidCreditsDialog"
+			@success="reloadAccount"
+		/>
 	</Card>
 	<TFADialog v-model="show2FADialog" />
 </template>
@@ -191,12 +195,15 @@ import { defineAsyncComponent, h } from 'vue';
 import FileUploader from '@/components/FileUploader.vue';
 import { confirmDialog, renderDialog } from '../../../utils/components';
 import TFADialog from './TFADialog.vue';
+import router from '../../../router';
+import AddPrepaidCreditsDialog from '../../billing/AddPrepaidCreditsDialog.vue';
 
 export default {
 	name: 'AccountProfile',
 	components: {
 		TFADialog,
-		FileUploader
+		FileUploader,
+		AddPrepaidCreditsDialog,
 	},
 	data() {
 		return {
@@ -204,7 +211,12 @@ export default {
 			disableAccount2FACode: '',
 			showProfileEditDialog: false,
 			showEnableAccountDialog: false,
-			showDisableAccountDialog: false
+			showDisableAccountDialog: false,
+			showAddPrepaidCreditsDialog: false,
+			showActiveServersDialog: false,
+			showMessage: false,
+			draftInvoice: {},
+			unpaidInvoices: [] | {},
 		};
 	},
 	computed: {
@@ -213,7 +225,7 @@ export default {
 		},
 		user() {
 			return this.$team?.doc?.user_info;
-		}
+		},
 	},
 	resources: {
 		updateProfile() {
@@ -223,46 +235,34 @@ export default {
 				params: {
 					first_name,
 					last_name,
-					email
+					email,
 				},
 				onSuccess() {
 					this.showProfileEditDialog = false;
 					this.notifySuccess();
-				}
+				},
 			};
 		},
 		disableAccount: {
 			url: 'press.api.account.disable_account',
-			onSuccess(data) {
+			onSuccess() {
 				this.showDisableAccountDialog = false;
 
-				if (data === 'Unpaid Invoices') {
-					const finalizeInvoicesDialog = defineAsyncComponent(() =>
-						import('../../billing/FinalizeInvoicesDialog.vue')
-					);
-					renderDialog(h(finalizeInvoicesDialog));
-				} else if (data === 'Active Servers') {
-					const activeServersDialog = defineAsyncComponent(() =>
-						import('../../ActiveServersDialog.vue')
-					);
-					renderDialog(h(activeServersDialog));
-				} else {
-					const ChurnFeedbackDialog = defineAsyncComponent(() =>
-						import('../../ChurnFeedbackDialog.vue')
-					);
+				const ChurnFeedbackDialog = defineAsyncComponent(
+					() => import('../../ChurnFeedbackDialog.vue'),
+				);
 
-					renderDialog(
-						h(ChurnFeedbackDialog, {
-							team: this.$team.doc.name,
-							onUpdated: () => {
-								toast.success('Your feedback was submitted successfully');
-							}
-						})
-					);
-					toast.success('Your account was disabled successfully');
-					this.reloadAccount();
-				}
-			}
+				renderDialog(
+					h(ChurnFeedbackDialog, {
+						team: this.$team.doc.name,
+						onUpdated: () => {
+							toast.success('Your feedback was submitted successfully');
+						},
+					}),
+				);
+				toast.success('Your account was disabled successfully');
+				this.reloadAccount();
+			},
 		},
 		enableAccount: {
 			url: 'press.api.account.enable_account',
@@ -270,8 +270,36 @@ export default {
 				toast.success('Your account was enabled successfully');
 				this.reloadAccount();
 				this.showEnableAccountDialog = false;
-			}
-		}
+			},
+		},
+		upcomingInvoice: {
+			url: 'press.api.billing.upcoming_invoice',
+			auto: true,
+			onSuccess(data) {
+				this.draftInvoice = data.upcoming_invoice;
+			},
+		},
+		unPaidInvoices: {
+			url: 'press.api.billing.get_unpaid_invoices',
+			auto: true,
+			onSuccess(data) {
+				this.unpaidInvoices = data;
+			},
+		},
+		hasActiveServers: {
+			url: 'press.api.account.has_active_servers',
+			auto: true,
+			params: {
+				team: this.$team.doc.name,
+			},
+			onSuccess(data) {
+				if (data) {
+					console.log(data);
+					this.$team.reload();
+					this.showActiveServersDialog = true;
+				}
+			},
+		},
 	},
 	methods: {
 		reloadAccount() {
@@ -284,6 +312,60 @@ export default {
 		notifySuccess() {
 			toast.success('Your profile was updated successfully');
 		},
+		deactivateAccount(disableAccount2FACode) {
+			if (this.draftInvoice) {
+				const finalizeInvoicesDialog = defineAsyncComponent(
+					() => import('../../billing/FinalizeInvoicesDialog.vue'),
+				);
+				renderDialog(h(finalizeInvoicesDialog));
+				return;
+			} else if (this.unpaidInvoices) {
+				if (this.unpaidInvoices.length > 1) {
+					if (this.$team.doc.payment_mode === 'Prepaid Credits') {
+						this.showAddPrepaidCreditsDialog = true;
+					} else {
+						confirmDialog({
+							title: 'Multiple unpaid invoices',
+							message:
+								'You have multiple unpaid invoices. Please pay them from the invoices page',
+							primaryAction: {
+								label: 'Go to invoices',
+								variant: 'solid',
+								onClick: ({ hide }) => {
+									router.push({ name: 'BillingInvoices' });
+									hide();
+								},
+							},
+						});
+					}
+				} else {
+					let invoice = this.unpaidInvoices;
+					if (
+						invoice.stripe_invoice_url &&
+						this.$team.doc.payment_mode === 'Card'
+					) {
+						window.open(
+							`/api/method/press.api.client.run_doc_method?dt=Invoice&dn=${invoice.name}&method=stripe_payment_url`,
+						);
+					} else {
+						this.showAddPrepaidCreditsDialog = true;
+					}
+				}
+				return;
+			}
+
+			// validate if any active servers
+			if (this.showActiveServersDialog) {
+				const activeServersDialog = defineAsyncComponent(
+					() => import('../../ActiveServersDialog.vue'),
+				);
+				renderDialog(h(activeServersDialog));
+				return;
+			}
+			this.$resources.disableAccount.submit({
+				totp_code: disableAccount2FACode,
+			});
+		},
 		confirmPublisherAccount() {
 			confirmDialog({
 				title: 'Become a marketplace app developer?',
@@ -293,29 +375,29 @@ export default {
 					toast.promise(
 						this.$team.setValue.submit(
 							{
-								is_developer: 1
+								is_developer: 1,
 							},
 							{
 								onSuccess: () => {
 									hide();
 									this.$router.push({
-										name: 'Marketplace App List'
+										name: 'Marketplace App List',
 									});
 								},
 								onError(e) {
 									console.error(e);
-								}
-							}
+								},
+							},
 						),
 						{
 							success: 'You can now publish apps to our Marketplace',
 							error: 'Failed to mark you as a developer',
-							loading: 'Making you a developer...'
-						}
+							loading: 'Making you a developer...',
+						},
 					);
-				}
+				},
 			});
-		}
-	}
+		},
+	},
 };
 </script>

--- a/dashboard/src2/components/settings/profile/AccountProfile.vue
+++ b/dashboard/src2/components/settings/profile/AccountProfile.vue
@@ -320,9 +320,9 @@ export default {
 					() => import('../../billing/FinalizeInvoicesDialog.vue'),
 				);
 				renderDialog(h(finalizeInvoicesDialog));
-				return;
 			} else if (this.unpaidInvoices) {
 				if (this.unpaidInvoices.length > 1) {
+					this.showDisableAccountDialog = false;
 					if (this.$team.doc.payment_mode === 'Prepaid Credits') {
 						this.showAddPrepaidCreditsDialog = true;
 					} else {
@@ -369,7 +369,6 @@ export default {
 						});
 					}
 				}
-				return;
 			}
 
 			// validate if any active servers

--- a/dashboard/src2/components/settings/profile/AccountProfile.vue
+++ b/dashboard/src2/components/settings/profile/AccountProfile.vue
@@ -343,16 +343,30 @@ export default {
 				} else {
 					let invoice = this.unpaidInvoices;
 					if (invoice.amount_due > minAmount) {
-						if (
-							invoice.stripe_invoice_url &&
-							this.$team.doc.payment_mode === 'Card'
-						) {
-							window.open(
-								`/api/method/press.api.client.run_doc_method?dt=Invoice&dn=${invoice.name}&method=stripe_payment_url`,
-							);
-						} else {
-							this.showAddPrepaidCreditsDialog = true;
-						}
+						this.showDisableAccountDialog = false;
+						confirmDialog({
+							title: 'Clear Unpaid Invoice',
+							message: `You have an unpaid invoice of ${
+								invoice.currency === 'INR' ? '₹' : '$'
+							} ${invoice.amount_due}. Please clear it before disabling the account.`,
+							primaryAction: {
+								label: 'Settle it now',
+								variant: 'solid',
+								onClick: ({ hide }) => {
+									if (
+										invoice.stripe_invoice_url &&
+										this.$team.doc.payment_mode === 'Card'
+									) {
+										window.open(
+											`/api/method/press.api.client.run_doc_method?dt=Invoice&dn=${invoice.name}&method=stripe_payment_url`,
+										);
+									} else {
+										this.showAddPrepaidCreditsDialog = true;
+									}
+									hide();
+								},
+							},
+						});
 					}
 				}
 				return;

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -26,8 +26,6 @@ from press.press.doctype.team.team import (
 	Team,
 	get_child_team_members,
 	get_team_members,
-	has_active_servers,
-	has_unsettled_invoices,
 )
 from press.utils import get_country_info, get_current_team, is_user_part_of_team
 from press.utils.telemetry import capture
@@ -241,13 +239,13 @@ def disable_account(totp_code: str | None):
 
 	if user != team.user:
 		frappe.throw("Only team owner can disable the account")
-	if has_unsettled_invoices(team.name):
-		return "Unpaid Invoices"
-	if has_active_servers(team.name):
-		return "Active Servers"
 
 	team.disable_account()
-	return None
+
+
+@frappe.whitelist()
+def has_active_servers(team):
+	return frappe.db.exists("Server", {"status": "Active", "team": team})
 
 
 @frappe.whitelist()

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -209,15 +209,10 @@ class Team(Document):
 			self.partner_email = self.user
 
 	def validate_disable(self):
-		if self.has_value_changed("enabled"):
-			has_unpaid_invoices = frappe.get_all(
-				"Invoice",
-				{"team": self.name, "status": ("in", ["Draft", "Unpaid"]), "type": "Subscription"},
+		if self.has_value_changed("enabled") and self.enabled == 0 and has_unsettled_invoices(self.team):
+			frappe.throw(
+				"Cannot disable team with Draft or Unpaid invoices. Please finalize and settle the pending invoices first"
 			)
-			if self.enabled == 0 and has_unpaid_invoices:
-				frappe.throw(
-					"Cannot disable team with Draft or Unpaid invoices. Please finalize and settle the pending invoices first"
-				)
 
 	def validate_billing_team(self):
 		if not (self.billing_team and self.payment_mode == "Paid By Partner"):
@@ -1520,12 +1515,17 @@ def has_unsettled_invoices(team):
 	):
 		return False
 
+	currency = frappe.db.get_value("Team", team, "currency")
+	minimum_amount = 5
+	if currency == "INR":
+		minimum_amount = 450
+
 	data = frappe.get_all(
 		"Invoice",
 		{"team": team, "status": ("in", ("Unpaid", "Draft")), "type": "Subscription"},
 		["sum(amount_due) as amount_due"],
 	)[0]
-	if data.amount_due <= 5:
+	if data.amount_due <= minimum_amount:
 		return False
 	return True
 

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -209,7 +209,7 @@ class Team(Document):
 			self.partner_email = self.user
 
 	def validate_disable(self):
-		if self.has_value_changed("enabled") and self.enabled == 0 and has_unsettled_invoices(self.team):
+		if self.has_value_changed("enabled") and self.enabled == 0 and has_unsettled_invoices(self.name):
 			frappe.throw(
 				"Cannot disable team with Draft or Unpaid invoices. Please finalize and settle the pending invoices first"
 			)

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -1530,10 +1530,6 @@ def has_unsettled_invoices(team):
 	return True
 
 
-def has_active_servers(team):
-	return frappe.db.exists("Server", {"status": "Active", "team": team})
-
-
 def is_us_eu():
 	"""Is the customer from U.S. or European Union"""
 	from press.utils import get_current_team


### PR DESCRIPTION
* Move all the validation to client side
* Finalize only once and redirect them to Invoices page next time
* If payment mode is prepaid credits, allow to refill wallet
* If amount_due <= $5 or equivalent, allow to disable account (skip validation)

#### Scenarios:
- [x] First time user with no Invoice (Trial account)
- [x] User with active invoice (Draft) (Both Card & Prepaid Credits)
- [x] User with Unpaid invoice (Both Card & Prepaid Credits)
- [ ] User with Active Servers
- [ ] User with 2FA enabled