### PR TITLE
build: add pkg-config in dockerfile

### DIFF
--- a/press/docker/Dockerfile
+++ b/press/docker/Dockerfile
@@ -15,6 +15,7 @@ RUN --mount=type=cache,target=/var/cache/apt apt-get update \
   git \
   mariadb-client \
   libmariadb-dev \
+  pkg-config \
   pv \
   ntp \
   wget \


### PR DESCRIPTION
Required for building certain packages that depend on env and available libs to compile.
