### PR TITLE
fix(marketplace-report): Group by repo url for fewer iterations

### DIFF
--- a/press/press/report/marketplace_app_repository_visibility/marketplace_app_repository_visibility.py
+++ b/press/press/report/marketplace_app_repository_visibility/marketplace_app_repository_visibility.py
@@ -71,10 +71,7 @@ def execute(filters=None):
 	columns = [
 		{"fieldname": "app_name", "label": "Application Name", "fieldtype": "Data", "width": 200},
 		{"fieldname": "team", "label": "Team", "fieldtype": "Data", "width": 200},
-		{"fieldname": "version", "label": "Version", "fieldtype": "Data", "width": 100},
-		{"fieldname": "source", "label": "Source", "fieldtype": "Data", "width": 100},
 		{"fieldname": "repository_url", "label": "Repository URL", "fieldtype": "Data", "width": 300},
-		{"fieldname": "branch", "label": "Branch", "fieldtype": "Data", "width": 100},
 		{
 			"fieldname": "visibility",
 			"label": "Visibility",
@@ -86,20 +83,22 @@ def execute(filters=None):
 	data = frappe.db.sql(
 		"""
         SELECT
-            ma.name AS app_name,
+			ma.name AS app_name,
 			t.user AS team,
-            mav.version AS version,
-            mav.source AS source,
-            asrc.repository_url AS repository_url,
-            asrc.branch AS branch
-        FROM
-            `tabMarketplace App` ma
-        JOIN
-            `tabMarketplace App Version` mav ON ma.name = mav.parent
-        JOIN
-            `tabApp Source` asrc ON mav.source = asrc.name
+			asrc.repository_url AS repository_url
+		FROM
+			`tabMarketplace App` ma
+		JOIN
+			`tabMarketplace App Version` mav ON ma.name = mav.parent
+		JOIN
+			`tabApp Source` asrc ON mav.source = asrc.name
 		JOIN
 			`tabTeam` t ON ma.team = t.name
+		WHERE
+			asrc.enabled = 1 AND
+			ma.status = 'Published'
+		GROUP BY
+			repository_url
         """,
 		as_dict=True,
 	)

--- a/press/press/report/marketplace_app_repository_visibility/marketplace_app_repository_visibility.py
+++ b/press/press/report/marketplace_app_repository_visibility/marketplace_app_repository_visibility.py
@@ -40,7 +40,7 @@ def send_emails(columns, data):
 
 def check_repository_visibility(repository_url, personal_access_token):
 	try:
-		repo_parts = repository_url.split("github.com/")[1].rstrip(".git").split("/")
+		repo_parts = repository_url.split("github.com/")[1].removesuffix(".git").split("/")
 		owner = repo_parts[0]
 		repo_name = repo_parts[1]
 	except IndexError:

--- a/press/templates/emails/marketplace_app_visibility.html
+++ b/press/templates/emails/marketplace_app_visibility.html
@@ -19,8 +19,6 @@
         <ul>
             <li><strong>App Name:</strong> {{ app_name }}</li>
             <li><strong>Repository URL:</strong> {{ repository_url }}</li>
-            <li><strong>Branch:</strong> {{ branch }}</li>
-            <li><strong>Version:</strong> {{ version }}</li>
         </ul>
 
         <p>We understand that this change might require some adjustments, and we appreciate your prompt attention to
@@ -32,8 +30,7 @@
         <p>Thank you for your understanding and cooperation.</p>
 
         <p>Regards,<br>
-            Arun Mathai<br>
-            Engineer @Frappe Cloud</p>
+            Team Frappe Cloud</p>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Report also filters only published apps and active app sources