### PR TITLE
fix: Periodically cleanup ansible tmp files

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -200,6 +200,7 @@ scheduler_events = {
 		"press.press.doctype.site.backups.schedule_for_sites_with_backup_time",
 		"press.press.doctype.tls_certificate.tls_certificate.renew_tls_certificates",
 		"press.saas.doctype.product_trial_request.product_trial_request.expire_long_pending_trial_requests",
+		"press.overrides.cleanup_ansible_tmp_files",
 	],
 	"hourly_long": [
 		"press.press.doctype.release_group.release_group.prune_servers_without_sites",

--- a/press/infrastructure/doctype/ssh_access_audit/ssh_access_audit.py
+++ b/press/infrastructure/doctype/ssh_access_audit/ssh_access_audit.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import json
-import shutil
 from functools import cached_property
 
 import frappe
@@ -281,8 +280,6 @@ class AnsibleAdHoc:
 		finally:
 			tqm.cleanup()
 			self.loader.cleanup_all_tmp_files()
-
-		shutil.rmtree(constants.DEFAULT_LOCAL_TMP, True)
 
 		return list(self.callback.hosts.values())
 

--- a/press/overrides.py
+++ b/press/overrides.py
@@ -5,7 +5,6 @@
 from functools import partial
 
 import frappe
-from ansible.utils.path import cleanup_tmp_file
 from frappe.core.doctype.user.user import User
 from frappe.handler import is_whitelisted
 from frappe.utils import cint
@@ -105,12 +104,23 @@ def before_request():
 
 
 def cleanup_ansible_tmp_files():
-	if hasattr(constants, "DEFAULT_LOCAL_TMP"):
-		cleanup_tmp_file(constants.DEFAULT_LOCAL_TMP)
+	import pathlib
+	import shutil
+	import time
 
+	if not hasattr(constants, "DEFAULT_LOCAL_TMP"):
+		return
 
-def after_job():
-	cleanup_ansible_tmp_files()
+	threshold = time.time() - 60 * 60  # >One hour old
+
+	temp_dir = pathlib.Path(constants.DEFAULT_LOCAL_TMP).parent
+	ansible_dir = pathlib.Path.home() / ".ansible"
+	# Avoid clearing unknown directories
+	assert temp_dir.is_relative_to(ansible_dir) and temp_dir != ansible_dir
+
+	for folder in temp_dir.iterdir():
+		if folder.is_dir() and folder.stat().st_mtime < threshold:
+			shutil.rmtree(folder)
 
 
 def update_website_context(context):

--- a/press/press/doctype/ansible_console/ansible_console.py
+++ b/press/press/doctype/ansible_console/ansible_console.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import json
-import shutil
 
 import frappe
 from ansible import constants, context
@@ -178,8 +177,6 @@ class AnsibleAdHoc:
 		finally:
 			tqm.cleanup()
 			self.loader.cleanup_all_tmp_files()
-
-		shutil.rmtree(constants.DEFAULT_LOCAL_TMP, True)
 
 		self.callback.publish_update()
 		return list(self.callback.hosts.values())


### PR DESCRIPTION
extends https://github.com/frappe/press/pull/2559
alternate to https://github.com/frappe/press/commit/d90dfb50eba4bea18c54ea6f4372f22d1928b310

- Ansible creates tmp files while running plays
- The files are usually deleted but tmp directories in which the file got
  created is often left out, so that slowly grows (not THAT fast afaik)

This new job clears all directories older than 1 hour, every hour. This
avoids problem with racey deletes or creating a new tmp file in 
directory that got erased by us in previous jobs.

Things to review:
- threshold logic
- "growth rate" - if it's too high then frequency might not be enough. 
   I am only seeing few MBs of growth so eh. 
- is it safe to remove ? 