### PR TITLE
feat: Rolling Snapshot for Physical Backup

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -267,7 +267,6 @@ scheduler_events = {
 			"press.press.doctype.mariadb_stalk.mariadb_stalk.fetch_stalks",
 			"press.press.doctype.database_server.database_server.monitor_disk_performance",
 			"press.press.doctype.virtual_machine.virtual_machine.rolling_snapshot_database_server_virtual_machines",
-			"press.press.doctype.virtual_disk_snapshot.virtual_disk_snapshot.sync_rolling_snapshots",
 		],
 		"*/5 * * * *": [
 			"press.press.doctype.version_upgrade.version_upgrade.update_from_site_update",
@@ -284,6 +283,7 @@ scheduler_events = {
 		"*/10 * * * *": [
 			"press.saas.doctype.product_trial.product_trial.replenish_standby_sites",
 			"press.press.doctype.site.saas_pool.create",
+			"press.press.doctype.virtual_disk_snapshot.virtual_disk_snapshot.sync_rolling_snapshots",
 		],
 		"*/30 * * * *": [
 			"press.press.doctype.site_update.scheduled_auto_updates.trigger",

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -266,6 +266,8 @@ scheduler_events = {
 			"press.press.doctype.virtual_machine.virtual_machine.sync_virtual_machines",
 			"press.press.doctype.mariadb_stalk.mariadb_stalk.fetch_stalks",
 			"press.press.doctype.database_server.database_server.monitor_disk_performance",
+			"press.press.doctype.virtual_machine.virtual_machine.rolling_snapshot_database_server_virtual_machines",
+			"press.press.doctype.virtual_disk_snapshot.virtual_disk_snapshot.sync_rolling_snapshots",
 		],
 		"*/5 * * * *": [
 			"press.press.doctype.version_upgrade.version_upgrade.update_from_site_update",

--- a/press/press/doctype/virtual_disk_snapshot/virtual_disk_snapshot.json
+++ b/press/press/doctype/virtual_disk_snapshot/virtual_disk_snapshot.json
@@ -122,7 +122,8 @@
    "fieldname": "volume_id",
    "fieldtype": "Data",
    "label": "Volume ID",
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "duration",
@@ -159,7 +160,7 @@
    "link_fieldname": "database_snapshot"
   }
  ],
- "modified": "2025-03-27 00:10:35.681800",
+ "modified": "2025-03-27 01:35:12.859467",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Virtual Disk Snapshot",

--- a/press/press/doctype/virtual_disk_snapshot/virtual_disk_snapshot.json
+++ b/press/press/doctype/virtual_disk_snapshot/virtual_disk_snapshot.json
@@ -21,7 +21,10 @@
   "duration",
   "section_break_12",
   "mariadb_root_password",
-  "physical_backup"
+  "snapshot_purpose_section",
+  "physical_backup",
+  "column_break_xgrp",
+  "rolling_snapshot"
  ],
  "fields": [
   {
@@ -132,6 +135,21 @@
    "fieldname": "physical_backup",
    "fieldtype": "Check",
    "label": "Physical Backup"
+  },
+  {
+   "fieldname": "snapshot_purpose_section",
+   "fieldtype": "Section Break",
+   "label": "Snapshot Purpose"
+  },
+  {
+   "fieldname": "column_break_xgrp",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "rolling_snapshot",
+   "fieldtype": "Check",
+   "label": "Rolling Snapshot"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -141,7 +159,7 @@
    "link_fieldname": "database_snapshot"
   }
  ],
- "modified": "2025-03-15 16:12:58.373642",
+ "modified": "2025-03-27 00:10:35.681800",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Virtual Disk Snapshot",

--- a/press/press/doctype/virtual_disk_snapshot/virtual_disk_snapshot.py
+++ b/press/press/doctype/virtual_disk_snapshot/virtual_disk_snapshot.py
@@ -6,6 +6,7 @@ import boto3
 import frappe
 import frappe.utils
 import pytz
+import rq
 from botocore.exceptions import ClientError
 from frappe.model.document import Document
 from oci.core import BlockstorageClient
@@ -222,6 +223,8 @@ def sync_snapshots():
 		try:
 			frappe.get_doc("Virtual Disk Snapshot", snapshot.name).sync()
 			frappe.db.commit()
+		except rq.timeouts.JobTimeoutException:
+			return
 		except Exception:
 			frappe.db.rollback()
 			log_error(title="Virtual Disk Snapshot Sync Error", virtual_snapshot=snapshot.name)
@@ -237,6 +240,8 @@ def sync_rolling_snapshots():
 		try:
 			frappe.get_doc("Virtual Disk Snapshot", snapshot.name).sync()
 			frappe.db.commit()
+		except rq.timeouts.JobTimeoutException:
+			return
 		except Exception:
 			frappe.db.rollback()
 			log_error(title="Virtual Disk Rolling Snapshot Sync Error", virtual_snapshot=snapshot.name)
@@ -255,6 +260,8 @@ def sync_physical_backup_snapshots():
 		try:
 			frappe.get_doc("Virtual Disk Snapshot", snapshot.name).sync()
 			frappe.db.commit()
+		except rq.timeouts.JobTimeoutException:
+			return
 		except Exception:
 			frappe.db.rollback()
 			log_error(

--- a/press/press/doctype/virtual_disk_snapshot/virtual_disk_snapshot.py
+++ b/press/press/doctype/virtual_disk_snapshot/virtual_disk_snapshot.py
@@ -85,6 +85,7 @@ class VirtualDiskSnapshot(Document):
 						"volume_id": self.volume_id,
 						"name": ["!=", self.name],
 						"creation": ["<", self.creation],
+						"status": ["in", ("Pending", "Completed")],
 					},
 					pluck="name",
 				)

--- a/press/press/doctype/virtual_disk_snapshot/virtual_disk_snapshot.py
+++ b/press/press/doctype/virtual_disk_snapshot/virtual_disk_snapshot.py
@@ -67,12 +67,13 @@ class VirtualDiskSnapshot(Document):
 			)
 			self.save(ignore_version=True)
 
-			# Trigger execution of restoration
-			physical_restore_name = frappe.db.exists(
-				"Physical Backup Restoration", {"disk_snapshot": self.name, "status": "Running"}
-			)
-			if physical_restore_name:
-				frappe.get_doc("Physical Backup Restoration", physical_restore_name).next()
+			if self.physical_backup:
+				# Trigger execution of restoration
+				physical_restore_name = frappe.db.exists(
+					"Physical Backup Restoration", {"disk_snapshot": self.name, "status": "Running"}
+				)
+				if physical_restore_name:
+					frappe.get_doc("Physical Backup Restoration", physical_restore_name).next()
 
 	@frappe.whitelist()
 	def sync(self):

--- a/press/press/doctype/virtual_disk_snapshot/virtual_disk_snapshot.py
+++ b/press/press/doctype/virtual_disk_snapshot/virtual_disk_snapshot.py
@@ -10,8 +10,8 @@ from botocore.exceptions import ClientError
 from frappe.model.document import Document
 from oci.core import BlockstorageClient
 
-from press.press.utils.jobs import has_job_timeout_exceeded
 from press.utils import log_error
+from press.utils.jobs import has_job_timeout_exceeded
 
 
 class VirtualDiskSnapshot(Document):

--- a/press/press/doctype/virtual_machine/virtual_machine.py
+++ b/press/press/doctype/virtual_machine/virtual_machine.py
@@ -1456,9 +1456,14 @@ def rolling_snapshot_database_server_virtual_machines():
 		frappe.get_all("Virtual Machine", {"skip_automated_snapshot": 1}, pluck="name")
 	)
 
+	start_time = time.time()
 	for virtual_machine_name in virtual_machines:
 		if has_job_timeout_exceeded():
 			return
+
+		# Don't spend more than 10 minutes in snapshotting
+		if time.time() - start_time > 900:
+			break
 
 		if virtual_machine_name in ignorable_virtual_machines:
 			continue


### PR DESCRIPTION
Fixes #2558
Fixes #2557

- Exclude temporary volumes from snapshotting
- Keep snapshot of server in last 2 hour for faser snapshotting in physical backup
  - Calling it `Rolling Snapshot`
  - We will only delete old rolling snapshot, once the new one become available, else we can't get benefit from old one. 