### PR TITLE
feat(server): Allow removing swap

### DIFF
--- a/press/playbooks/reset_swap.yml
+++ b/press/playbooks/reset_swap.yml
@@ -1,0 +1,9 @@
+---
+- name: Reset Swap
+  hosts: all
+  become: yes
+  become_user: root
+  gather_facts: no
+  roles:
+    - role: remove_swap
+    - role: swap

--- a/press/playbooks/roles/remove_swap/tasks/main.yml
+++ b/press/playbooks/roles/remove_swap/tasks/main.yml
@@ -1,0 +1,21 @@
+- name: Disable Swap
+  command: swapoff -av
+  async: 600
+  poll: 5
+
+- name: Remove Swap from fstab
+  mount:
+    name: none
+    src: /{{ item }}
+    fstype: swap
+    opts: sw
+    passno: 0
+    dump: 0
+    state: absent
+  ignore_errors: yes
+  loop: '{{ swap_files_to_remove }}'
+
+- name: Remove Swap Files
+  command: rm /{{ item }}
+  ignore_errors: yes
+  loop: '{{ swap_files_to_remove }}'

--- a/press/playbooks/roles/swap/tasks/main.yml
+++ b/press/playbooks/roles/swap/tasks/main.yml
@@ -8,9 +8,11 @@
     path: '/{{ swap_file }}'
   register: stat_result
   failed_when: 'stat_result.stat.exists'
+  when: swap_size | int > 0
 
 - name: Create Swap file
   command: fallocate -l {{ swap_size }}G /{{ swap_file }}
+  when: swap_size | int > 0
 
 - name: Change Swap file permissions
   file:
@@ -18,12 +20,11 @@
     owner: root
     group: root
     mode: 0600
+  when: swap_size | int > 0
 
 - name: Make Swap
   command: mkswap /{{ swap_file }}
-
-- name: Enable Swap
-  command: swapon /{{ swap_file }}
+  when: swap_size | int > 0
 
 - name: Add Swap to fstab
   mount:
@@ -34,3 +35,7 @@
     passno: 0
     dump: 0
     state: present
+  when: swap_size | int > 0
+
+- name: Enable Swap
+  command: swapon -av

--- a/press/press/doctype/server/server.js
+++ b/press/press/doctype/server/server.js
@@ -239,8 +239,8 @@ frappe.ui.form.on('Server', {
 						fields: [
 							{
 								fieldtype: 'Int',
-								label: __('Swap Size'),
-								description: __('Size in GB'),
+								label: __('Swap Size (GB)'),
+								description: __('Add additional swap'),
 								fieldname: 'swap_size',
 								default: 4,
 							},
@@ -249,6 +249,34 @@ frappe.ui.form.on('Server', {
 
 					dialog.set_primary_action(__('Increase Swap'), (args) => {
 						frm.call('increase_swap', args).then(() => {
+							dialog.hide();
+							frm.refresh();
+						});
+					});
+					dialog.show();
+				},
+				__('Actions'),
+			);
+			frm.add_custom_button(
+				__('Reset Swap'),
+				() => {
+					const dialog = new frappe.ui.Dialog({
+						title: __('Swap Size'),
+						fields: [
+							{
+								fieldtype: 'Int',
+								label: __('Swap Size (GB)'),
+								description: __(
+									'This will reset swap space to specified size. 0 or empty to remove all.',
+								),
+								fieldname: 'swap_size',
+								default: 1,
+							},
+						],
+					});
+
+					dialog.set_primary_action(__('Reset Swap'), (args) => {
+						frm.call('reset_swap', args).then(() => {
 							dialog.hide();
 							frm.refresh();
 						});

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -861,16 +861,6 @@ class BaseServer(Document, TagHelpers):
 			**{"swap_size": swap_size},
 		)
 
-	def add_glass_file(self):
-		frappe.enqueue_doc(self.doctype, self.name, "_add_glass_file")
-
-	def _add_glass_file(self):
-		try:
-			ansible = Ansible(playbook="glass_file.yml", server=self)
-			ansible.run()
-		except Exception:
-			log_error("Add Glass File Exception", doc=self)
-
 	def _increase_swap(self, swap_size=4):
 		"""Increase swap by size defined in playbook"""
 		from press.api.server import calculate_swap
@@ -890,6 +880,52 @@ class BaseServer(Document, TagHelpers):
 			ansible.run()
 		except Exception:
 			log_error("Increase swap exception", doc=self)
+
+	@frappe.whitelist()
+	def reset_swap(self, swap_size=0):
+		"""
+		swap_size: size of swap to be created (in addition to swap.default of 1024)
+		"""
+		frappe.enqueue_doc(
+			self.doctype,
+			self.name,
+			"_reset_swap",
+			queue="long",
+			timeout=1200,
+			**{"swap_size": swap_size},
+		)
+
+	def _reset_swap(self, swap_size=1):
+		"""Reset swap by removing existing swap files and creating new swap"""
+		from press.api.server import calculate_swap
+
+		existing_swap_size = calculate_swap(self.name).get("swap", 0)
+		# list of swap files to remove assuming minimum swap size of 1 GB to be safe. Wrong names are handled in playbook
+		swap_files_to_remove = ["swap.default", "swap"]
+		swap_files_to_remove += ["swap" + str(i) for i in range(1, int(existing_swap_size))]
+		try:
+			ansible = Ansible(
+				playbook="reset_swap.yml",
+				server=self,
+				variables={
+					"swap_size": swap_size,
+					"swap_file": "swap",
+					"swap_files_to_remove": swap_files_to_remove,
+				},
+			)
+			ansible.run()
+		except Exception:
+			log_error("Reset swap exception", doc=self)
+
+	def add_glass_file(self):
+		frappe.enqueue_doc(self.doctype, self.name, "_add_glass_file")
+
+	def _add_glass_file(self):
+		try:
+			ansible = Ansible(playbook="glass_file.yml", server=self)
+			ansible.run()
+		except Exception:
+			log_error("Add Glass File Exception", doc=self)
 
 	@frappe.whitelist()
 	def setup_mysqldump(self):

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -882,7 +882,7 @@ class BaseServer(Document, TagHelpers):
 			log_error("Increase swap exception", doc=self)
 
 	@frappe.whitelist()
-	def reset_swap(self, swap_size=0):
+	def reset_swap(self, swap_size=1):
 		"""
 		swap_size: size of swap to be created (in addition to swap.default of 1024)
 		"""


### PR DESCRIPTION
We can now reset swap to desired number (including 0). Increase swap functionality is
kept, just in case for now.

Can be a reaction to swap full when it is 8 GB or above to avoid
suffering
