### PR TITLE
Remove use of RSA for cert_authority and use proper permission for root CA

### DIFF
--- a/press/press/doctype/certificate_authority/certificate_authority.py
+++ b/press/press/doctype/certificate_authority/certificate_authority.py
@@ -84,7 +84,7 @@ class CertificateAuthority(Document):
 			f" {self.openssl_config_file} -key {self.private_key_file} -out"
 			f" {self.certificate_file}"
 		)
-		os.chmod(self.certificate_file, 444)
+		os.chmod(self.certificate_file, 400)
 
 	def generate_certificate_signing_request(self):
 		self.run(

--- a/press/press/doctype/certificate_authority/certificate_authority.py
+++ b/press/press/doctype/certificate_authority/certificate_authority.py
@@ -36,7 +36,7 @@ class CertificateAuthority(Document):
 		organization: DF.Data
 		organizational_unit: DF.Data
 		parent_authority: DF.Link | None
-		rsa_key_size: DF.Literal["2048", "3072", "4096"]
+		# rsa_key_size: DF.Literal["2048", "3072", "4096"]
 		validity_days: DF.Int
 	# end: auto-generated types
 
@@ -75,7 +75,7 @@ class CertificateAuthority(Document):
 		return subprocess.check_output(shlex.split(command)).decode()
 
 	def generate_private_key(self):
-		self.run(f"openssl genrsa -out {self.private_key_file} {self.rsa_key_size}")
+		self.run(f"openssl genpkey --algorithm ED25519 {self.private_key_file}")
 		os.chmod(self.private_key_file, 400)
 
 	def generate_root_certificate(self):


### PR DESCRIPTION
This PR removes the use of RSA algorithm for generating TLS Certificate. RSA is still used in many other places like while generating TLS Certificate for Root Domain. Might remove it from there too, but in a different PR as there the RSA algorithm is used like a spider web and might break "somethings". hence, giving it a though before pushing.

And, along with it, previously the root_certiifcate_authority permission was (kind of) insecure, as it was letting the user, group and owner with `ro` access. Owner is fine, but group and user do not need to see root certificate. 