### PR TITLE
fix: redirect to /apps if Visit Site is clicked

### DIFF
--- a/dashboard/src/views/bench/BenchSites.vue
+++ b/dashboard/src/views/bench/BenchSites.vue
@@ -359,7 +359,7 @@ export default {
 				{
 					label: 'Visit Site',
 					onClick: () => {
-						window.open(`https://${site.name}`, '_blank');
+						window.open(`https://${site.name}/apps`, '_blank');
 					}
 				},
 				{

--- a/dashboard/src/views/site/Site.vue
+++ b/dashboard/src/views/site/Site.vue
@@ -18,7 +18,7 @@
 							v-if="site?.status === 'Active'"
 							icon-left="external-link"
 							label="Visit Site"
-							:link="`https://${site?.name}`"
+							:link="`https://${site?.name}/apps`"
 						/>
 						<Dropdown :options="siteActions">
 							<template v-slot="{ open }">

--- a/dashboard/src/views/site/Sites.vue
+++ b/dashboard/src/views/site/Sites.vue
@@ -412,7 +412,7 @@ export default {
 				{
 					label: 'Visit Site',
 					onClick: () => {
-						window.open(`https://${site.name}`, '_blank');
+						window.open(`https://${site.name}/apps`, '_blank');
 					}
 				},
 				{

--- a/dashboard/src2/objects/site.js
+++ b/dashboard/src2/objects/site.js
@@ -1592,7 +1592,7 @@ export default {
 					condition: () =>
 						site.doc.status !== 'Archived' && site.doc?.setup_wizard_complete,
 					onClick() {
-						window.open(`https://${site.name}`, '_blank');
+						window.open(`https://${site.name}/apps`, '_blank');
 					},
 				},
 				{

--- a/press/press/doctype/site/site.js
+++ b/press/press/doctype/site/site.js
@@ -30,7 +30,7 @@ frappe.ui.form.on('Site', {
 				</div>
 			</div>`,
 		);
-		frm.add_web_link(`https://${frm.doc.name}`, __('Visit Site'));
+		frm.add_web_link(`https://${frm.doc.name}/apps`, __('Visit Site'));
 		frm.add_web_link(`/dashboard/sites/${frm.doc.name}`, __('Visit Dashboard'));
 
 		let site = frm.get_doc();


### PR DESCRIPTION
Redirect to `https://<sitename>/apps` instead of `https://<sitename` if `Visit Site` button is clicked