### PR TITLE
perf: Add innodb_stats_persistent_sample_pages to mariadb variables

### DIFF
--- a/press/fixtures/mariadb_variable.json
+++ b/press/fixtures/mariadb_variable.json
@@ -606,5 +606,19 @@
   "set_on_new_servers": 0,
   "skippable": 0,
   "title": null
+ },
+ {
+  "configurable_by_user": 0,
+  "datatype": "Str",
+  "default_value": "256",
+  "doc_section": "innodb",
+  "docstatus": 0,
+  "doctype": "MariaDB Variable",
+  "dynamic": 1,
+  "modified": "2025-04-14 16:31:30.382561",
+  "name": "innodb_stats_persistent_sample_pages",
+  "set_on_new_servers": 1,
+  "skippable": 0,
+  "title": null
  }
 ]


### PR DESCRIPTION
https://mariadb.com/kb/en/innodb-system-variables/#innodb_stats_persistent_sample_pages

20 is way too low, we can easily 10x this and it will barely have any
real cost for us. So 10x-ing this for now.

ref: https://www.percona.com/blog/correcting-mysql-inaccurate-table-statistics-for-better-execution-plan/

We also need to upgrade to 11.x someday soon... when 11.8 is stable.
