### PR TITLE
fix(ssh-keys): Pass build dir to generate_ssh_keys

### DIFF
--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -270,7 +270,7 @@ class DeployCandidate(Document):
 			stdout=subprocess.PIPE,
 			stderr=subprocess.STDOUT,
 			env=environment,
-			cwd=directory or self.build_directory,
+			cwd=directory,
 			universal_newlines=True,
 		)
 		yield from process.stdout
@@ -279,13 +279,13 @@ class DeployCandidate(Document):
 		if return_code:
 			raise subprocess.CalledProcessError(return_code, command)
 
-	def generate_ssh_keys(self):
+	def generate_ssh_keys(self, build_directory: str):
 		ca = frappe.db.get_single_value("Press Settings", "ssh_certificate_authority")
 		if not ca:
 			return
 
 		ca = frappe.get_doc("SSH Certificate Authority", ca)
-		ssh_directory = os.path.join(self.build_directory, "config", "ssh")
+		ssh_directory = os.path.join(build_directory, "config", "ssh")
 
 		self.generate_host_keys(ca, ssh_directory)
 		self.generate_user_keys(ca, ssh_directory)

--- a/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
+++ b/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
@@ -802,7 +802,7 @@ class DeployCandidateBuild(Document):
 			self._generate_config_from_template(config_template)
 
 		self._generate_apps_txt()
-		self.candidate.generate_ssh_keys()
+		self.candidate.generate_ssh_keys(self.build_directory)
 
 	def _prepare_build(self):
 		if not self.no_cache:


### PR DESCRIPTION
Generating ssh keys from deploy candidate; fixed missing build dir error.