### PR TITLE
fix(notifications): Build failure notification with correct candidate

### DIFF
--- a/press/press/doctype/deploy_candidate/deploy_notifications.py
+++ b/press/press/doctype/deploy_candidate/deploy_notifications.py
@@ -46,7 +46,6 @@ if typing.TYPE_CHECKING:
 	from press.press.doctype.deploy_candidate_app.deploy_candidate_app import (
 		DeployCandidateApp,
 	)
-	from press.press.doctype.deploy_candidate_build.deploy_candidate_build import DeployCandidateBuild
 
 	# TYPE_CHECKING guard for code below cause DeployCandidate
 	# might cause circular import.
@@ -230,7 +229,7 @@ def handlers() -> "list[UserAddressableHandlerTuple]":
 
 
 def create_build_failed_notification(
-	dc: "DeployCandidateBuild",
+	dc: "DeployCandidate",
 	exc: BaseException | None,
 ) -> bool:
 	"""

--- a/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
+++ b/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
@@ -621,7 +621,7 @@ class DeployCandidateBuild(Document):
 			self.candidate._fail_site_group_deploy_if_exists()
 
 		# Do not send a notification if the build is being retried.
-		if not should_retry and create_build_failed_notification(self, exc):
+		if not should_retry and create_build_failed_notification(self.candidate, exc):
 			self.user_addressable_failure = True
 			self.save(ignore_permissions=True)
 			frappe.db.commit()


### PR DESCRIPTION
Build failure notifications failing and deploy candidate build being passed instead of deploy candidate