### PR TITLE
Closes: #2656

### DIFF
--- a/press/api/account.py
+++ b/press/api/account.py
@@ -897,24 +897,25 @@ def redirect_to(location):
 	)
 
 
-def get_frappe_io_auth_url() -> str | None:
-	"""Get auth url for oauth login with frappe.io."""
-
-	try:
-		provider = frappe.get_last_doc(
-			"Social Login Key", filters={"enable_social_login": 1, "provider_name": "Frappe"}
-		)
-	except DoesNotExistError:
-		return None
-
-	if (
-		provider.base_url
-		and provider.client_id
-		and get_oauth_keys(provider.name)
-		and provider.get_password("client_secret")
-	):
-		return get_oauth2_authorize_url(provider.name, redirect_to="")
-	return None
+def get_frappe_io_auth_url() -> str:
+    """Get auth URL for OAuth login with frappe.io, with a fallback to '/'."""
+    try:
+        provider = frappe.get_last_doc(
+            "Social Login Key", filters={"enable_social_login": 1, "provider_name": "Frappe"}
+        )
+        if (
+            provider.base_url
+            and provider.client_id
+            and get_oauth_keys(provider.name)
+            and provider.get_password("client_secret")
+        ):
+            return get_oauth2_authorize_url(provider.name, redirect_to="")
+    except Exception as e:
+        # Log the error for debugging purposes
+        frappe.log_error(message=str(e), title="Failed to get Frappe OAuth URL")
+    
+    # Fallback to root URL if any error occurs
+    return "/"
 
 
 @frappe.whitelist()

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -69,7 +69,7 @@ website_route_rules = [
 ]
 
 website_redirects = [
-	{"source": "/dashboard/f-login", "target": get_frappe_io_auth_url() or "/"},
+	{"source": "/dashboard/f-login", "target": get_frappe_io_auth_url()},
 	{
 		"source": "/suspended-site",
 		"target": "/api/method/press.api.handle_suspended_site_redirection",


### PR DESCRIPTION
Fixes: https://github.com/frappe/press/issues/2656

This PR refactors the `get_frappe_io_auth_url` function to ensure safe execution during import-time and background job contexts.

---

### What's changed

- Replaces the fragile `DoesNotExistError` catch with a broad `try/except` block.
- Ensures that the function **always returns a string**, falling back to `'/'` on failure.
- Adds error logging with `frappe.log_error(...)` to aid in debugging misconfigured or missing OAuth setups.
- Prevents import-time exceptions in contexts where `frappe.local.site` is not bound (e.g., `bench version`, workers, CLI commands).

---

### Why this matters

Previously, if `get_frappe_io_auth_url()` was imported at the module level (e.g., in `hooks.py`) and the site context wasn’t initialized (common in CLI/worker contexts), it would raise a `RuntimeError: object is not bound`.  
This broke background jobs and even basic commands like `bench version`.

---

### Benefits

- Safer execution across all environments (runtime, background, import).
- Better user experience (no crashing `bench` commands).
- Debugging support via error logging.
- Makes the function side-effect free and safe for lazy usage in templates or routes.