### PR TITLE
fix(timestamp-error): Remove explicit candidate save

### DIFF
--- a/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
+++ b/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
@@ -807,7 +807,6 @@ class DeployCandidateBuild(Document):
 		have been cloned.
 		"""
 		self.candidate._update_packages(pmf)
-		self.candidate.save(ignore_permissions=True, ignore_version=True)
 
 		# Set props used when generating the Dockerfile
 		self.candidate._set_additional_packages()


### PR DESCRIPTION
This save was added to ensure user private/public keys and certificate was saved, however `generate_user_keys` explicitly calls save on deploy candidate