### PR TITLE
fix(retry): Retry count is increased in a new deploy candidate build

### DIFF
--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -214,6 +214,7 @@ class DeployCandidate(Document):
 		self,
 		run_now: bool = True,
 		scheduled_time: datetime | None = None,
+		retry_count: int = 0,
 	):
 		# Here it's fine to call `self.build_and_deploy()`
 		# Since the doc has not been created yet.
@@ -225,6 +226,7 @@ class DeployCandidate(Document):
 			deploy_after_build=True,
 			status="Scheduled",
 			scheduled_time=scheduled_time or now(),
+			retry_count=retry_count,
 		)
 		deploy_candidate_build.insert()
 		return {"error": False, "name": deploy_candidate_build.name}

--- a/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
+++ b/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
@@ -661,11 +661,17 @@ class DeployCandidateBuild(Document):
 			log_error("Deploy Candidate Build Exception", doc=self)
 
 	def schedule_build_retry(self):
-		self.retry_count += 1
+		"""
+		Fail the current deploy candidate build and create a new deploy candidate build
+		with an increased `retry_count` and a scheduled time.
+		"""
 		minutes = min(5**self.retry_count, 125)
 		scheduled_time = now() + timedelta(minutes=minutes)
-		self.set_status(Status.SCHEDULED)
-		self.candidate.schedule_build_and_deploy(run_now=False, scheduled_time=scheduled_time)
+		self.set_status(Status.FAILURE)
+		# Increase the retry count
+		self.candidate.schedule_build_and_deploy(
+			run_now=False, scheduled_time=scheduled_time, retry_count=self.retry_count + 1
+		)
 
 	@retry(
 		reraise=True,

--- a/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
+++ b/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
@@ -669,9 +669,10 @@ class DeployCandidateBuild(Document):
 		scheduled_time = now() + timedelta(minutes=minutes)
 		self.set_status(Status.FAILURE)
 		# Increase the retry count
-		self.candidate.schedule_build_and_deploy(
-			run_now=False, scheduled_time=scheduled_time, retry_count=self.retry_count + 1
-		)
+		if self.retry_count < 3:
+			self.candidate.schedule_build_and_deploy(
+				run_now=False, scheduled_time=scheduled_time, retry_count=self.retry_count + 1
+			)
 
 	@retry(
 		reraise=True,


### PR DESCRIPTION
- Fail the current build doctype instead of setting it's status to scheduled (leads to race condition scheduling)
- In the new deploy candidate build increase the retry count by one, so that after 3 retries we stop.