### PR TITLE
fix(env-var): Changed deploy candidate env var field from data to text

### DIFF
--- a/press/press/doctype/deploy_candidate_variable/deploy_candidate_variable.json
+++ b/press/press/doctype/deploy_candidate_variable/deploy_candidate_variable.json
@@ -19,7 +19,7 @@
   },
   {
    "fieldname": "value",
-   "fieldtype": "Data",
+   "fieldtype": "Text",
    "in_list_view": 1,
    "label": "Value",
    "reqd": 1
@@ -28,12 +28,13 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-06-13 19:07:58.471385",
+ "modified": "2025-05-11 14:43:27.654938",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Deploy Candidate Variable",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/press/press/doctype/deploy_candidate_variable/deploy_candidate_variable.py
+++ b/press/press/doctype/deploy_candidate_variable/deploy_candidate_variable.py
@@ -18,7 +18,7 @@ class DeployCandidateVariable(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
-		value: DF.Data
+		value: DF.Text
 	# end: auto-generated types
 
 	pass


### PR DESCRIPTION
This is to accommodate large text values/API keys in `Deploy Candidate`