### PR TITLE
feat: Inspect a request/job by trace ID

### DIFF
--- a/press/press/doctype/inspect_trace_id/inspect_trace_id.js
+++ b/press/press/doctype/inspect_trace_id/inspect_trace_id.js
@@ -1,0 +1,13 @@
+// Copyright (c) 2025, Frappe and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Inspect Trace ID', {
+	refresh(frm) {
+		frm.disable_save();
+	},
+	trace_id(frm) {
+		if (frm.doc.trace_id) {
+			frm.call('fetch');
+		}
+	},
+});

--- a/press/press/doctype/inspect_trace_id/inspect_trace_id.json
+++ b/press/press/doctype/inspect_trace_id/inspect_trace_id.json
@@ -1,0 +1,51 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-05-12 18:24:34.545167",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "trace_id",
+  "data"
+ ],
+ "fields": [
+  {
+   "fieldname": "trace_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Trace ID",
+   "reqd": 1
+  },
+  {
+   "fieldname": "data",
+   "fieldtype": "Code",
+   "label": "Data",
+   "read_only": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "hide_toolbar": 1,
+ "index_web_pages_for_search": 1,
+ "is_virtual": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2025-05-12 18:28:47.694295",
+ "modified_by": "Administrator",
+ "module": "Press",
+ "name": "Inspect Trace ID",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/press/press/doctype/inspect_trace_id/inspect_trace_id.py
+++ b/press/press/doctype/inspect_trace_id/inspect_trace_id.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2025, Frappe and contributors
+# For license information, please see license.txt
+from __future__ import annotations
+
+import frappe
+import requests
+from frappe.model.document import Document
+from frappe.utils import add_to_date, now_datetime
+from frappe.utils.password import get_decrypted_password
+
+from press.utils import convert_user_timezone_to_utc
+
+
+class InspectTraceID(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		data: DF.Code | None
+		trace_id: DF.Data
+	# end: auto-generated types
+
+	def load_from_db(self):
+		frappe.only_for("Desk User")
+
+	@frappe.whitelist()
+	def fetch(self):
+		frappe.only_for("Desk User")
+
+		if not self.trace_id:
+			return
+
+		log_server = frappe.db.get_single_value("Press Settings", "log_server")
+		if not log_server:
+			return
+
+		url = f"https://{log_server}/elasticsearch/filebeat-*/_search"
+		password = get_decrypted_password("Log Server", log_server, "kibana_password")
+
+		start_datetime = convert_user_timezone_to_utc(add_to_date(days=-30))
+		end_datetime = convert_user_timezone_to_utc(now_datetime())
+
+		query = {
+			"query": {
+				"bool": {
+					"filter": [
+						{"match_phrase": {"json.uuid": self.trace_id}},
+						{"range": {"@timestamp": {"gt": start_datetime, "lte": end_datetime}}},
+					],
+				}
+			},
+			"size": 1,
+		}
+
+		response = requests.post(url, json=query, auth=("frappe", password)).json()
+		records = response.get("hits", {}).get("hits", [])
+		self.data = frappe.as_json(records[0] if records else "")
+
+	# Not relevant
+	def db_update(self):
+		raise NotImplementedError
+
+	def delete(self):
+		raise NotImplementedError
+
+	def db_insert(self, *args, **kwargs):
+		raise NotImplementedError
+
+	@staticmethod
+	def get_list(filters=None, page_length=20, **kwargs):
+		pass
+
+	@staticmethod
+	def get_count(filters=None, **kwargs):
+		pass
+
+	@staticmethod
+	def get_stats(**kwargs):
+		pass

--- a/press/press/doctype/inspect_trace_id/test_inspect_trace_id.py
+++ b/press/press/doctype/inspect_trace_id/test_inspect_trace_id.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2025, Frappe and Contributors
+# See license.txt
+
+from frappe.tests import IntegrationTestCase, UnitTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class UnitTestInspectTraceID(UnitTestCase):
+	"""
+	Unit tests for InspectTraceID.
+	Use this class for testing individual functions and methods.
+	"""
+
+	pass
+
+
+class IntegrationTestInspectTraceID(IntegrationTestCase):
+	"""
+	Integration tests for InspectTraceID.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass


### PR DESCRIPTION
A very basic "search request/job log for this trace ID"

Towards https://github.com/frappe/press/issues/2494



![image](https://github.com/user-attachments/assets/36b66421-d022-460d-b758-e723a64cc380)
