### PR TITLE
feat: Install bench into a virtualenv during init

### DIFF
--- a/press/docker/Dockerfile
+++ b/press/docker/Dockerfile
@@ -212,7 +212,8 @@ RUN wget https://bootstrap.pypa.io/get-pip.py && python${PYTHON_VERSION} get-pip
 {% endif %}
 
 ENV {{ doc.get_dependency_version("bench", True) }}
-RUN --mount=type=cache,target=/home/frappe/.cache,uid=1000,gid=1000 python${PYTHON_VERSION} -m pip install --upgrade frappe-bench==${BENCH_VERSION} `#stage-bench-bench`
+RUN python${PYTHON_VERSION} -m venv /tmp/venv
+RUN --mount=type=cache,target=/home/frappe/.cache,uid=1000,gid=1000 /tmp/venv/bin/python -m `pip install --upgrade frappe-bench==${BENCH_VERSION} `#stage-bench-bench`
 
 RUN --mount=type=cache,target=/home/frappe/.cache,uid=1000,gid=1000 python${PYTHON_VERSION} -m pip install Jinja2~=3.0.3
 RUN --mount=type=cache,target=/home/frappe/.cache,uid=1000,gid=1000 python${PYTHON_VERSION} -m pip install --upgrade setuptools
@@ -230,7 +231,7 @@ ENV {{v.key}} {{ v.value }}
 {% endfor %}
 
 # Install Frappe app
-RUN --mount=type=cache,sharing=locked,target=/home/frappe/.cache,uid=1000,gid=1000 --mount=type=bind,source=apps/frappe,target=/home/frappe/context/apps/frappe bench init --python /usr/bin/python${PYTHON_VERSION} --no-backups --frappe-path file:///home/frappe/context/apps/frappe frappe-bench `#stage-apps-frappe`
+RUN --mount=type=cache,sharing=locked,target=/home/frappe/.cache,uid=1000,gid=1000 --mount=type=bind,source=apps/frappe,target=/home/frappe/context/apps/frappe /tmp/venv/bin/bench init --python /usr/bin/python${PYTHON_VERSION} --no-backups --frappe-path file:///home/frappe/context/apps/frappe frappe-bench `#stage-apps-frappe`
 WORKDIR /home/frappe/frappe-bench
 
 RUN --mount=type=cache,target=/home/frappe/.cache,uid=1000,gid=1000 /home/frappe/frappe-bench/env/bin/pip install pycups==2.0.1
@@ -245,8 +246,8 @@ COPY --chown=frappe:frappe common_site_config.json /home/frappe/frappe-bench/sit
 {% if app.app != "frappe" %}
 
 RUN --mount=type=cache,sharing=locked,target=/home/frappe/.cache,uid=1000,gid=1000 \
-  --mount=type=bind,source=apps/{{ app.app }},target=/home/frappe/context/apps/{{ app.app }} \
-  bench get-app file:///home/frappe/context/apps/{{ app.app }} \
+    --mount=type=bind,source=apps/{{ app.app }},target=/home/frappe/context/apps/{{ app.app }} \
+    /tmp/venv/bin/bench get-app file:///home/frappe/context/apps/{{ app.app }} \
     {% if app.use_cached %}
     # Bench get-app flags to use get-app cache
     --cache-key {{ app.hash }} {% if doc.compress_app_cache %}--compress-artifacts{% endif %} \


### PR DESCRIPTION
This makes the resolver fetch the correct version of urllib3 (part of request's dependencies), otherwise it uses an old version from dist-packages, which tries to use `six`, which is not installed.
