### PR TITLE
feat(binlog): Manage & Upload binlogs to s3

### DIFF
--- a/press/fixtures/agent_job_type.json
+++ b/press/fixtures/agent_job_type.json
@@ -1781,6 +1781,21 @@
    }
   ]
  },
+  {
+  "disabled_auto_retry": 1,
+  "docstatus": 0,
+  "doctype": "Agent Job Type",
+  "max_retry_count": 3,
+  "modified": "2025-05-19 15:37:53.073108",
+  "name": "Upload Binlogs To S3",
+  "request_method": "POST",
+  "request_path": "/database/binlogs/upload",
+  "steps": [
+   {
+    "step_name": "Upload Binlogs To S3"
+   }
+  ]
+ },
  {
   "disabled_auto_retry": 1,
   "docstatus": 0,

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -179,6 +179,9 @@ scheduler_events = {
 		"press.press.doctype.log_counter.log_counter.record_counts",
 		"press.press.doctype.incident.incident.notify_ignored_servers",
 		"press.press.doctype.database_server.database_server.unindex_mariadb_binlogs",
+		"press.press.doctype.database_server.database_server.remove_uploaded_binlogs_from_disk",
+		"press.press.doctype.database_server.database_server.remove_uploaded_binlogs_from_s3",
+		"press.press.doctype.mariadb_binlog.mariadb_binlog.cleanup_old_records",
 	],
 	"daily_long": [
 		"press.press.audit.check_bench_fields",

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -182,6 +182,7 @@ scheduler_events = {
 		"press.press.doctype.database_server.database_server.remove_uploaded_binlogs_from_disk",
 		"press.press.doctype.database_server.database_server.remove_uploaded_binlogs_from_s3",
 		"press.press.doctype.mariadb_binlog.mariadb_binlog.cleanup_old_records",
+		"press.press.doctype.database_server.database_server.delete_mariadb_binlog_for_archived_servers",
 	],
 	"daily_long": [
 		"press.press.audit.check_bench_fields",

--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -967,6 +967,9 @@ def process_job_updates(job_name: str, response_data: dict | None = None):  # no
 			process_remove_binlogs_from_indexer_agent_job_update,
 		)
 		from press.press.doctype.deploy_candidate_build.deploy_candidate_build import DeployCandidateBuild
+		from press.press.doctype.mariadb_binlog.mariadb_binlog import (
+			process_upload_binlogs_to_s3_job_update,
+		)
 		from press.press.doctype.physical_backup_restoration.physical_backup_restoration import (
 			process_job_update as process_physical_backup_restoration_job_update,
 		)
@@ -1114,6 +1117,8 @@ def process_job_updates(job_name: str, response_data: dict | None = None):  # no
 			process_add_binlogs_to_indexer_agent_job_update(job)
 		elif job.job_type == "Remove Binlogs From Indexer":
 			process_remove_binlogs_from_indexer_agent_job_update(job)
+		elif job.job_type == "Upload Binlogs To S3":
+			process_upload_binlogs_to_s3_job_update(job)
 
 		# send failure notification if job failed
 		if job.status == "Failure":

--- a/press/press/doctype/database_server/database_server.json
+++ b/press/press/doctype/database_server/database_server.json
@@ -84,7 +84,9 @@
   "column_break_objb",
   "stalk_interval",
   "stalk_cycles",
-  "stalk_sleep"
+  "stalk_sleep",
+  "section_break_imng",
+  "binlog_retention_days"
  ],
  "fields": [
   {
@@ -571,6 +573,16 @@
   {
    "fieldname": "column_break_qsqm",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_imng",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "14",
+   "fieldname": "binlog_retention_days",
+   "fieldtype": "Int",
+   "label": "Binlog Retention (days)"
   }
  ],
  "grid_page_length": 50,
@@ -587,7 +599,7 @@
    "link_fieldname": "database_server"
   }
  ],
- "modified": "2025-05-08 19:03:14.840782",
+ "modified": "2025-05-19 18:09:30.538442",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Database Server",

--- a/press/press/doctype/database_server/database_server.json
+++ b/press/press/doctype/database_server/database_server.json
@@ -86,7 +86,8 @@
   "stalk_cycles",
   "stalk_sleep",
   "section_break_imng",
-  "binlog_retention_days"
+  "binlog_retention_days",
+  "binlogs_removed"
  ],
  "fields": [
   {
@@ -583,6 +584,13 @@
    "fieldname": "binlog_retention_days",
    "fieldtype": "Int",
    "label": "Binlog Retention (days)"
+  },
+  {
+   "default": "0",
+   "fieldname": "binlogs_removed",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Binlogs Removed"
   }
  ],
  "grid_page_length": 50,
@@ -599,7 +607,7 @@
    "link_fieldname": "database_server"
   }
  ],
- "modified": "2025-05-19 18:09:30.538442",
+ "modified": "2025-05-19 18:45:32.246644",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Database Server",

--- a/press/press/doctype/mariadb_binlog/mariadb_binlog.js
+++ b/press/press/doctype/mariadb_binlog/mariadb_binlog.js
@@ -1,8 +1,19 @@
 // Copyright (c) 2025, Frappe and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("MariaDB Binlog", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on('MariaDB Binlog', {
+	refresh(frm) {
+		[[__('Download in Server'), 'download_binlog', frm.doc.uploaded]].forEach(
+			([label, method, condition]) => {
+				if (typeof condition === 'undefined' || condition) {
+					frm.add_custom_button(label, () => {
+						frappe.confirm(
+							`Are you sure you want to ${label.toLowerCase()} this site?`,
+							() => frm.call(method).then((r) => frm.refresh()),
+						);
+					});
+				}
+			},
+		);
+	},
+});

--- a/press/press/doctype/mariadb_binlog/mariadb_binlog.json
+++ b/press/press/doctype/mariadb_binlog/mariadb_binlog.json
@@ -11,6 +11,9 @@
   "current",
   "indexed",
   "purged_from_disk",
+  "column_break_wwgs",
+  "uploaded",
+  "remote_file",
   "section_break_zpmy",
   "size_mb",
   "column_break_botn",
@@ -22,6 +25,7 @@
    "fieldname": "indexed",
    "fieldtype": "Check",
    "label": "Indexed",
+   "read_only": 1,
    "search_index": 1
   },
   {
@@ -55,6 +59,7 @@
    "fieldname": "purged_from_disk",
    "fieldtype": "Check",
    "label": "Purged from Disk",
+   "read_only": 1,
    "search_index": 1
   },
   {
@@ -68,6 +73,7 @@
    "fieldname": "current",
    "fieldtype": "Check",
    "label": "Current",
+   "read_only": 1,
    "search_index": 1
   },
   {
@@ -82,12 +88,31 @@
   {
    "fieldname": "column_break_botn",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_wwgs",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "uploaded",
+   "fieldtype": "Check",
+   "label": "Uploaded",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.uploaded",
+   "fieldname": "remote_file",
+   "fieldtype": "Link",
+   "label": "Remote File",
+   "options": "Remote File",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-08 19:00:09.853051",
+ "modified": "2025-05-19 16:04:37.248196",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "MariaDB Binlog",

--- a/press/press/doctype/remote_file/remote_file.py
+++ b/press/press/doctype/remote_file/remote_file.py
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
+from __future__ import annotations
 
 import json
 import pprint
@@ -27,9 +27,7 @@ def get_remote_key(file):
 
 
 def poll_file_statuses():
-	aws_access_key = frappe.db.get_single_value(
-		"Press Settings", "offsite_backups_access_key_id"
-	)
+	aws_access_key = frappe.db.get_single_value("Press Settings", "offsite_backups_access_key_id")
 	aws_secret_key = get_decrypted_password(
 		"Press Settings", "Press Settings", "offsite_backups_secret_access_key"
 	)
@@ -44,9 +42,7 @@ def poll_file_statuses():
 		{
 			"name": frappe.db.get_single_value("Press Settings", "remote_uploads_bucket"),
 			"region": default_region,
-			"access_key_id": frappe.db.get_single_value(
-				"Press Settings", "remote_access_key_id"
-			),
+			"access_key_id": frappe.db.get_single_value("Press Settings", "remote_access_key_id"),
 			"secret_access_key": get_decrypted_password(
 				"Press Settings", "Press Settings", "remote_secret_access_key"
 			),
@@ -54,7 +50,6 @@ def poll_file_statuses():
 	]
 
 	for b in frappe.get_all("Backup Bucket", ["bucket_name", "cluster", "region"]):
-
 		buckets.append(
 			{
 				"name": b["bucket_name"],
@@ -128,7 +123,7 @@ def delete_remote_backup_objects(remote_files):
 	"""Delete specified objects identified by keys in the backups bucket."""
 	remote_files = list(set([x for x in remote_files if x]))
 	if not remote_files:
-		return
+		return None
 
 	buckets = {bucket: [] for bucket in frappe.get_all("Backup Bucket", pluck="name")}
 	buckets.update({frappe.db.get_single_value("Press Settings", "aws_s3_bucket"): []})
@@ -143,9 +138,7 @@ def delete_remote_backup_objects(remote_files):
 	]
 
 	delete_s3_files(buckets)
-	frappe.db.set_value(
-		"Remote File", {"name": ("in", remote_files)}, "status", "Unavailable"
-	)
+	frappe.db.set_value("Remote File", {"name": ("in", remote_files)}, "status", "Unavailable")
 
 	return remote_files
 
@@ -174,18 +167,14 @@ class RemoteFile(Document):
 		if not self.bucket:
 			return None
 
-		elif self.bucket == frappe.db.get_single_value(
-			"Press Settings", "remote_uploads_bucket"
-		):
+		if self.bucket == frappe.db.get_single_value("Press Settings", "remote_uploads_bucket"):
 			access_key_id = frappe.db.get_single_value("Press Settings", "remote_access_key_id")
 			secret_access_key = get_decrypted_password(
 				"Press Settings", "Press Settings", "remote_secret_access_key"
 			)
 
 		elif self.bucket:
-			access_key_id = frappe.db.get_single_value(
-				"Press Settings", "offsite_backups_access_key_id"
-			)
+			access_key_id = frappe.db.get_single_value("Press Settings", "offsite_backups_access_key_id")
 			secret_access_key = get_decrypted_password(
 				"Press Settings", "Press Settings", "offsite_backups_secret_access_key"
 			)
@@ -215,12 +204,11 @@ class RemoteFile(Document):
 				return True
 			self.db_set("status", "Unavailable")
 			return False
-		else:
-			try:
-				return self.s3_client.head_object(Bucket=self.bucket, Key=self.file_path)
-			except Exception:
-				self.db_set("status", "Unavailable")
-				return False
+		try:
+			return self.s3_client.head_object(Bucket=self.bucket, Key=self.file_path)
+		except Exception:
+			self.db_set("status", "Unavailable")
+			return False
 
 	@frappe.whitelist()
 	def delete_remote_object(self):
@@ -244,9 +232,9 @@ class RemoteFile(Document):
 	def get_content(self):
 		if self.url:
 			return json.loads(requests.get(self.url).content)
-		else:
-			obj = self.s3_client.get_object(Bucket=self.bucket, Key=self.file_path)
-			return json.loads(obj["Body"].read().decode("utf-8"))
+
+		obj = self.s3_client.get_object(Bucket=self.bucket, Key=self.file_path)
+		return json.loads(obj["Body"].read().decode("utf-8"))
 
 	@property
 	def size(self) -> int:
@@ -257,11 +245,11 @@ class RemoteFile(Document):
 		"""
 		if int(self.file_size or 0):
 			return int(self.file_size or 0)
-		else:
-			response = requests.head(self.url)
-			self.file_size = int(response.headers.get("content-length", 0))
-			self.save()
-			return int(self.file_size)
+
+		response = requests.head(self.url)
+		self.file_size = int(response.headers.get("content-length", 0))
+		self.save()
+		return int(self.file_size)
 
 
 def delete_s3_files(buckets):
@@ -271,7 +259,7 @@ def delete_s3_files(buckets):
 	from press.utils import chunk
 
 	press_settings = frappe.get_single("Press Settings")
-	for bucket_name in buckets.keys():
+	for bucket_name in buckets:
 		s3 = resource(
 			"s3",
 			aws_access_key_id=press_settings.offsite_backups_access_key_id,


### PR DESCRIPTION
Related https://github.com/frappe/press/issues/2566

- [x] Auto upload indexed binlogs (binlogs older than a day)
- [x] Purge more than a days indexed binlogs from disk
- [x] Auto-remove binlogs (older than 7 days) from indexer 
- [x] Remove binlogs from S3 based configurable retention (default 14 days)
- [x] Cleanup docs + delete on server archival
- [x] Option to download binlogs from s3 to disk