### PR TITLE
fix: replace deep imports from frappe-ui

### DIFF
--- a/dashboard/src2/components/ChurnFeedbackDialog.vue
+++ b/dashboard/src2/components/ChurnFeedbackDialog.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script>
-import FormControl from 'frappe-ui/src/components/FormControl.vue';
+import { FormControl } from 'frappe-ui';
 import StarRatingInput from '../../src/components/StarRatingInput.vue';
 import { DashboardError } from '../utils/error';
 

--- a/dashboard/src2/components/billing/AddExchangeRate.vue
+++ b/dashboard/src2/components/billing/AddExchangeRate.vue
@@ -48,8 +48,7 @@
 
 <script>
 import { toast } from 'vue-sonner';
-import FormControl from 'frappe-ui/src/components/FormControl.vue';
-import ErrorMessage from 'frappe-ui/src/components/ErrorMessage.vue';
+import { FormControl, ErrorMessage } from 'frappe-ui';
 
 export default {
 	name: 'AddExchangeRate',

--- a/dashboard/src2/objects/bench.ts
+++ b/dashboard/src2/objects/bench.ts
@@ -1,4 +1,4 @@
-import Tooltip from 'frappe-ui/src/components/Tooltip/Tooltip.vue';
+import { Tooltip } from 'frappe-ui';
 import LucideAppWindow from '~icons/lucide/app-window';
 import type { VNode } from 'vue';
 import { defineAsyncComponent, h } from 'vue';


### PR DESCRIPTION
Replacing deep imports from frappe-ui with imports from the entry file.
`import component from "frappe-ui/src/components/component.vue"` → `import { component } from "frappe-ui"`

This will break whenever frappe-ui is upgraded with this change: https://github.com/frappe/frappe-ui/pull/308
In general, its better to avoid deep imports to avoid breakage from changes in library's folder structure.