### PR TITLE
feat(build): Support multiple builds depending on Release Group Server platforms.

### DIFF
--- a/press/press/doctype/deploy/deploy.py
+++ b/press/press/doctype/deploy/deploy.py
@@ -14,6 +14,7 @@ from press.utils import log_error
 
 if typing.TYPE_CHECKING:
 	from press.press.doctype.deploy_candidate.deploy_candidate import DeployCandidate
+	from press.press.doctype.deploy_candidate_build.deploy_candidate_build import DeployCandidateBuild
 
 
 class Deploy(Document):
@@ -41,6 +42,30 @@ class Deploy(Document):
 	def after_insert(self):
 		self.create_benches()
 
+	def _get_build_for_bench(self, server_platform: str) -> str:
+		"Fetch build from deploy candidate depending on the server platform"
+		build_field = {"arm64": "arm_build", "x86_64": "intel_build"}.get(server_platform)
+		return frappe.get_value("Deploy Candidate", self.candidate, build_field)
+
+	def _get_docker_image_for_bench(self, server_platform: str) -> str:
+		"""Fetch docker image for a particular server depending on the server platform"""
+		DeployCandidate: DeployCandidate = frappe.qb.DocType("Deploy Candidate")
+		DeployCandidateBuild: DeployCandidateBuild = frappe.qb.DocType("Deploy Candidate Build")
+
+		build_field = {"arm64": DeployCandidate.arm_build, "x86_64": DeployCandidate.intel_build}.get(
+			server_platform
+		)
+
+		return (
+			frappe.qb.from_(DeployCandidate)
+			.join(DeployCandidateBuild)
+			.on(DeployCandidateBuild.deploy_candidate == DeployCandidate.name)
+			.where(DeployCandidate.name == self.candidate)
+			.where(build_field == DeployCandidateBuild.name)
+			.select(DeployCandidateBuild.docker_image)
+			.run(pluck=True)
+		)[0]
+
 	def create_benches(self):
 		deploy_candidate: DeployCandidate = frappe.get_doc("Deploy Candidate", self.candidate)
 		environment_variables = [
@@ -57,12 +82,14 @@ class Deploy(Document):
 			for v in group.mounts
 		]
 		for bench in self.benches:
-			docker_image = frappe.get_value("Deploy Candidate Build", {"name": self.build}, "docker_image")
+			server_platform = frappe.get_value("Server", bench.server, "platform")
+			build = self._get_build_for_bench(server_platform)
+			docker_image = self._get_docker_image_for_bench(server_platform)
 			new = frappe.get_doc(
 				{
 					"doctype": "Bench",
 					"server": bench.server,
-					"build": self.build,
+					"build": build,
 					"docker_image": docker_image,
 					"group": self.group,
 					"candidate": self.candidate,

--- a/press/press/doctype/deploy_candidate/deploy_candidate.json
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.json
@@ -12,6 +12,11 @@
   "redis_cache_size",
   "use_app_cache",
   "compress_app_cache",
+  "column_break_uyow",
+  "requires_arm_build",
+  "requires_intel_build",
+  "intel_build",
+  "arm_build",
   "column_break_tkdd",
   "merge_all_rq_queues",
   "merge_default_and_short_rq_queues",
@@ -182,6 +187,38 @@
    "fieldname": "redis_cache_size",
    "fieldtype": "Int",
    "label": "Redis Cache Size (MB)"
+  },
+  {
+   "fieldname": "column_break_uyow",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "requires_arm_build",
+   "fieldtype": "Check",
+   "label": "Requires ARM Build",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "requires_intel_build",
+   "fieldtype": "Check",
+   "label": "Requires Intel Build",
+   "read_only": 1
+  },
+  {
+   "fieldname": "intel_build",
+   "fieldtype": "Link",
+   "label": "Intel Build",
+   "options": "Deploy Candidate Build",
+   "read_only": 1
+  },
+  {
+   "fieldname": "arm_build",
+   "fieldtype": "Link",
+   "label": "ARM Build",
+   "options": "Deploy Candidate Build",
+   "read_only": 1
   }
  ],
  "links": [
@@ -198,7 +235,7 @@
    "link_fieldname": "deploy_candidate"
   }
  ],
- "modified": "2025-05-07 20:52:35.176671",
+ "modified": "2025-05-27 22:02:19.465983",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Deploy Candidate",

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -67,16 +67,20 @@ class DeployCandidate(Document):
 		)
 
 		apps: DF.Table[DeployCandidateApp]
+		arm_build: DF.Link | None
 		compress_app_cache: DF.Check
 		dependencies: DF.Table[DeployCandidateDependency]
 		environment_variables: DF.Table[DeployCandidateVariable]
 		group: DF.Link
 		gunicorn_threads_per_worker: DF.Int
+		intel_build: DF.Link | None
 		is_redisearch_enabled: DF.Check
 		merge_all_rq_queues: DF.Check
 		merge_default_and_short_rq_queues: DF.Check
 		packages: DF.Table[DeployCandidatePackage]
 		redis_cache_size: DF.Int
+		requires_arm_build: DF.Check
+		requires_intel_build: DF.Check
 		team: DF.Link
 		use_app_cache: DF.Check
 		use_rq_workerpool: DF.Check
@@ -216,8 +220,6 @@ class DeployCandidate(Document):
 		scheduled_time: datetime | None = None,
 		retry_count: int = 0,
 	):
-		# Here it's fine to call `self.build_and_deploy()`
-		# Since the doc has not been created yet.
 		if run_now and not is_suspended():
 			return {"error": False, "name": self.build_and_deploy()}
 

--- a/press/press/doctype/deploy_candidate/utils.py
+++ b/press/press/doctype/deploy_candidate/utils.py
@@ -153,16 +153,16 @@ def get_build_server(group: str | None = None) -> str | None:
 				if server := get_arm_build_server_with_least_active_builds():
 					return server
 			else:
-				if server := get_x86_build_server_with_least_active_builds():
+				if server := get_intel_build_server_with_least_active_builds():
 					return server
 	else:
-		if server := get_x86_build_server_with_least_active_builds():
+		if server := get_intel_build_server_with_least_active_builds():
 			return server
 
 	return frappe.get_value("Press Settings", None, "build_server")
 
 
-def get_x86_build_server_with_least_active_builds() -> str | None:
+def get_intel_build_server_with_least_active_builds() -> str | None:
 	return get_build_server_with_least_active_builds(platform="x86_64")
 
 

--- a/press/press/doctype/deploy_candidate_build/deploy_candidate_build.js
+++ b/press/press/doctype/deploy_candidate_build/deploy_candidate_build.js
@@ -30,16 +30,7 @@ frappe.ui.form.on('Deploy Candidate Build', {
 				{},
 				'Build',
 			],
-			[
-				__('Create ARM Build'),
-				'create_arm_build',
-				(frm.doc.status === 'Success') & (frm.doc.platform !== 'arm64'),
-				{},
-				'Build',
-			],
-
 			[__('Deploy'), 'deploy', frm.doc.status === 'Success', {}, 'Deploy'],
-
 			[
 				__('Redeploy'),
 				'redeploy',

--- a/press/press/doctype/deploy_candidate_build/deploy_candidate_build.json
+++ b/press/press/doctype/deploy_candidate_build/deploy_candidate_build.json
@@ -11,7 +11,6 @@
   "group",
   "team",
   "platform",
-  "arm_build",
   "column_break_9sga",
   "no_build",
   "no_cache",
@@ -285,13 +284,6 @@
    "fieldname": "run_build",
    "fieldtype": "Check",
    "label": "Run Build"
-  },
-  {
-   "fieldname": "arm_build",
-   "fieldtype": "Link",
-   "label": "Arm Build",
-   "options": "Deploy Candidate Build",
-   "read_only": 1
   }
  ],
  "grid_page_length": 50,
@@ -318,7 +310,7 @@
    "link_fieldname": "build"
   }
  ],
- "modified": "2025-05-08 13:17:34.367411",
+ "modified": "2025-05-27 23:08:21.433327",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Deploy Candidate Build",

--- a/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
+++ b/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
@@ -12,7 +12,6 @@ import shutil
 import tarfile
 import tempfile
 import typing
-from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
 from functools import cached_property
@@ -35,7 +34,9 @@ from press.press.doctype.deploy_candidate.docker_output_parsers import (
 	UploadStepUpdater,
 )
 from press.press.doctype.deploy_candidate.utils import (
+	get_arm_build_server_with_least_active_builds,
 	get_build_server,
+	get_intel_build_server_with_least_active_builds,
 	get_package_manager_files,
 	is_suspended,
 	load_pyproject,
@@ -170,27 +171,27 @@ def get_duration(start_time: datetime, end_time: datetime | None = None):
 	return float(value)
 
 
-@dataclass
-class ARMBuild:
-	deploy_candidate: str
-	build_server: str = field(init=False)
+# @dataclass
+# class ARMBuild:
+# 	deploy_candidate: str
+# 	build_server: str = field(init=False)
 
-	def __post_init__(self):
-		self.build_server = self.get_build_server()
+# 	def __post_init__(self):
+# 		self.build_server = self.get_build_server()
 
-	def create_deploy_candidate_build(self) -> str:
-		deploy_candidate_build: DeployCandidateBuild = frappe.get_doc(
-			{
-				"doctype": "Deploy Candidate Build",
-				"deploy_candidate": self.deploy_candidate,
-				"build_server": self.build_server,
-			}
-		)
-		deploy_candidate_build.insert()
-		return deploy_candidate_build.name
+# 	def create_deploy_candidate_build(self) -> str:
+# 		deploy_candidate_build: DeployCandidateBuild = frappe.get_doc(
+# 			{
+# 				"doctype": "Deploy Candidate Build",
+# 				"deploy_candidate": self.deploy_candidate,
+# 				"build_server": self.build_server,
+# 			}
+# 		)
+# 		deploy_candidate_build.insert()
+# 		return deploy_candidate_build.name
 
-	def get_build_server(self) -> str:
-		return frappe.get_value("Server", {"platform": "arm64", "use_for_build": True}, "name")
+# 	def get_build_server(self) -> str:
+# 		return frappe.get_value("Server", {"platform": "arm64", "use_for_build": True}, "name")
 
 
 class DeployCandidateBuild(Document):
@@ -206,7 +207,6 @@ class DeployCandidateBuild(Document):
 			DeployCandidateBuildStep,
 		)
 
-		arm_build: DF.Link | None
 		build_directory: DF.Data | None
 		build_duration: DF.Time | None
 		build_end: DF.Datetime | None
@@ -763,6 +763,32 @@ class DeployCandidateBuild(Document):
 			case _:
 				raise Exception("unreachable code execution")
 
+	def update_deploy_candidate_with_build(self):
+		"""Update the deploy candidate with the build fields"""
+		candidate_field = "arm_build" if self.platform == "arm64" else "intel_build"
+		setattr(self.candidate, candidate_field, self.name)
+		self.candidate.save()
+
+	def create_new_platform_build_if_required(self):
+		"""Create a platform specefic build if requirement enforced by the deploy candidate"""
+		requires_arm = self.candidate.requires_arm_build and not self.candidate.arm_build
+		requires_intel_build = self.candidate.requires_intel_build and not self.candidate.intel_build
+
+		build_meta = {
+			"doctype": "Deploy Candidate Build",
+			"deploy_candidate": self.candidate,
+			"no_build": self.no_build,
+			"no_cache": self.no_cache,
+			"no_push": self.no_push,
+		}
+
+		if requires_arm:
+			build_meta.update({"platform": "arm64"})
+			frappe.get_doc(build_meta).insert()
+		if requires_intel_build:
+			build_meta.update({"platform": "x86_64"})
+			frappe.get_doc(build_meta).insert()
+
 	@staticmethod
 	def process_run_build(job: AgentJob, response_data: dict | None):
 		request_data = json.loads(job.request_data)
@@ -771,13 +797,9 @@ class DeployCandidateBuild(Document):
 		)
 		build._process_run_build(job, request_data, response_data)
 
-		allow_automatic_arm_build: bool = frappe.get_cached_doc("Press Settings").allow_automatic_arm_build
-		if not allow_automatic_arm_build:
-			return
-
-		if should_create_arm_build(build):
-			arm_build_name = build.create_arm_build()
-			build.db_set("arm_build", arm_build_name, commit=True)
+		if build.status == Status.SUCCESS.value:
+			build.update_deploy_candidate_with_build()
+			build.create_new_platform_build_if_required()
 
 	def _process_run_build(
 		self,
@@ -1031,12 +1053,28 @@ class DeployCandidateBuild(Document):
 	def get_platform(self) -> str:
 		return frappe.get_value("Server", self.build_server, "platform")
 
+	def _select_build_server(self):
+		"""Select build server based on platform or group"""
+		match self.platform:
+			case "arm64":
+				return get_arm_build_server_with_least_active_builds()
+			case "x86_64":
+				return get_intel_build_server_with_least_active_builds()
+			case _:
+				# Case where no platform is set?
+				# The first build that occurs will be based on the platform of first
+				# Server listed in the Release Group Server List
+				# Then if anyother builds are required their platform will be passed in.
+				return get_build_server(self.group)
+
 	def set_platform(self):
-		self.platform = self.get_platform() or "x86_64"
+		# If no platform is set we set the platform based on the build server
+		if not self.platform:
+			self.platform = self.get_platform() or "x86_64"
 
 	def set_build_server(self):
 		if not self.build_server:
-			self.build_server = get_build_server(self.group)
+			self.build_server = self._select_build_server()
 
 		if self.build_server:
 			self.set_platform()
@@ -1055,22 +1093,6 @@ class DeployCandidateBuild(Document):
 			"Please wait for build to succeed or fail before retrying."
 		)
 		return False
-
-	@frappe.whitelist()
-	def create_arm_build(self, set_arm_build_name: bool = False) -> str:
-		if not should_create_arm_build(self):
-			frappe.throw("Can not create arm build for this build", frappe.ValidationError)
-
-		arm_build = ARMBuild(self.deploy_candidate)
-		arm_build_name = arm_build.create_deploy_candidate_build()
-
-		# In case this is triggered from actions and allow arm build is unset
-		# Process job will early exit, skipping build.db_set("arm_build", arm_build_name, commit=True)
-		allow_automatic_arm_build: bool = frappe.get_cached_doc("Press Settings").allow_automatic_arm_build
-		if not allow_automatic_arm_build or set_arm_build_name:
-			self.db_set("arm_build", arm_build_name, commit=True)
-
-		return arm_build_name
 
 	def pre_build(self, **kwargs):
 		self.reset_build_state()

--- a/press/press/doctype/press_settings/press_settings.json
+++ b/press/press/doctype/press_settings/press_settings.json
@@ -87,7 +87,6 @@
   "build_directory",
   "build_server",
   "minimum_rebuild_memory",
-  "allow_automatic_arm_build",
   "column_break_66",
   "code_server",
   "code_server_password",
@@ -1441,12 +1440,6 @@
    "label": "Servers Using Alternative HTTP Port For Communication"
   },
   {
-   "default": "0",
-   "fieldname": "allow_automatic_arm_build",
-   "fieldtype": "Check",
-   "label": "Allow Automatic ARM Build"
-  },
-  {
    "description": "Add value in percent (%). e.g. 10",
    "fieldname": "npo_discount",
    "fieldtype": "Float",
@@ -1455,7 +1448,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2025-05-20 13:05:30.783898",
+ "modified": "2025-05-28 10:07:18.507316",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Press Settings",

--- a/press/press/doctype/press_settings/press_settings.py
+++ b/press/press/doctype/press_settings/press_settings.py
@@ -29,7 +29,6 @@ class PressSettings(Document):
 		agent_github_access_token: DF.Data | None
 		agent_repository_owner: DF.Data | None
 		agent_sentry_dsn: DF.Data | None
-		allow_automatic_arm_build: DF.Check
 		app_include_script: DF.Data | None
 		auto_update_queue_size: DF.Int
 		aws_access_key_id: DF.Data | None


### PR DESCRIPTION
## Context

We need to allow builds for multiple platforms, since there can be cases post the migration where Release Group Servers have different platforms.

Therefore a single build will not be sufficient in this case.

## What's changed
This pull request allows builds on different server platforms incase there is a platform mismatch on Release Group Server.

- [ ] Allow build on intel servers.
- [ ] Allow build on arm servers.
- [ ] Remove unessesary parallel arm builds.
- [ ] Only build on different platforms when required.
- [ ] Figure out Build and Docker Image for bench when deploying.