### PR TITLE
fix(hooks): Prevent get_frappe_io_auth_url() from being called during bench version execution

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -1,6 +1,8 @@
 from press.api.account import get_frappe_io_auth_url
+import sys
 
 from . import __version__ as app_version
+
 
 app_name = "press"
 app_title = "Press"
@@ -69,7 +71,7 @@ website_route_rules = [
 ]
 
 website_redirects = [
-	{"source": "/dashboard/f-login", "target": get_frappe_io_auth_url() or "/"},
+	{"source": "/dashboard/f-login", "target": (target := get_frappe_io_auth_url() if not ("frappe" in sys.orig_argv[3] and "version" in sys.orig_argv[4]) else "/")},
 	{
 		"source": "/suspended-site",
 		"target": "/api/method/press.api.handle_suspended_site_redirection",


### PR DESCRIPTION
This PR fixes a runtime error that occurs when executing bench version due to an unguarded call to get_frappe_io_auth_url() inside website_redirects in hooks.py.

When bench version is run, the site context is not initialized, which causes frappe.get_last_doc() (used within get_frappe_io_auth_url) to fail with a RuntimeError: object is not bound.

To address this, the function call is now conditionally executed only if the script is not being invoked with bench version, using sys.orig_argv as a check. If the check fails, a fallback path ("/") is used instead.

This ensures compatibility with CLI commands like bench version while preserving the intended login redirection logic during normal runtime.