### PR TITLE
fix(tag): Fetch tag in release event

### DIFF
--- a/press/press/doctype/github_webhook_log/github_webhook_log.py
+++ b/press/press/doctype/github_webhook_log/github_webhook_log.py
@@ -200,12 +200,12 @@ class GitHubWebhookLog(Document):
 		frappe.db.delete(table, filters=(table.creation < (Now() - Interval(days=days))))
 
 
-def set_uninstalled(owner: str, repository: Optional[str] = None):
+def set_uninstalled(owner: str, repository: str | None = None):
 	for name in get_sources(owner, repository):
 		frappe.db.set_value("App Source", name, "uninstalled", True)
 
 
-def get_sources(owner: str, repository: Optional[str] = None) -> "list[str]":
+def get_sources(owner: str, repository: str | None = None) -> "list[str]":
 	filters = {"repository_owner": owner}
 	if repository:
 		filters["repository"] = repository


### PR DESCRIPTION
Fix tag not being fetched in release event; Currently for a release event tag is not set.

Ref: [get-a-release](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-a-release)