### PR TITLE
feat: Provision ARM servers only

### DIFF
--- a/press/api/server.py
+++ b/press/api/server.py
@@ -23,9 +23,6 @@ if TYPE_CHECKING:
 	from press.press.doctype.cluster.cluster import Cluster
 
 
-REGIONS_WITH_ARM_SUPPORT = ["ap-south-1", "eu-central-1"]
-
-
 def poly_get_doc(doctypes, name):
 	for doctype in doctypes:
 		if frappe.db.exists(doctype, name):
@@ -185,9 +182,9 @@ def archive(name):
 @frappe.whitelist()
 def new(server):
 	server_plan_platform = frappe.get_value("Server Plan", server["app_plan"], "platform")
-	cluster_region = frappe.get_value("Cluster", server["cluster"], "region")
+	cluster_has_arm_support = frappe.get_value("Cluster", server["cluster"], "has_arm_support")
 
-	if server_plan_platform == "arm64" and cluster_region not in REGIONS_WITH_ARM_SUPPORT:
+	if server_plan_platform == "arm64" and not cluster_has_arm_support:
 		frappe.throw(f"ARM Instances are currently unavailable in the {server['cluster']} region")
 
 	team = get_current_team(get_doc=True)

--- a/press/api/server.py
+++ b/press/api/server.py
@@ -455,6 +455,9 @@ def options():
 
 @frappe.whitelist()
 def plans(name, cluster=None, platform="x86_64"):
+	if name == "Server":
+		platform = "arm64"
+
 	return Plan.get_plans(
 		doctype="Server Plan",
 		fields=[

--- a/press/press/doctype/cluster/cluster.json
+++ b/press/press/doctype/cluster/cluster.json
@@ -13,6 +13,7 @@
   "public",
   "beta",
   "hybrid",
+  "has_arm_support",
   "column_break_fsht",
   "monitoring_password",
   "image",
@@ -283,6 +284,12 @@
    "fieldtype": "Link",
    "label": "Team",
    "options": "Team"
+  },
+  {
+   "default": "0",
+   "fieldname": "has_arm_support",
+   "fieldtype": "Check",
+   "label": "Has ARM Support"
   }
  ],
  "image_field": "image",
@@ -319,7 +326,7 @@
    "link_fieldname": "document_name"
   }
  ],
- "modified": "2024-09-14 13:52:58.308402",
+ "modified": "2025-06-16 16:47:37.016006",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Cluster",
@@ -339,6 +346,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/press/press/doctype/cluster/cluster.py
+++ b/press/press/doctype/cluster/cluster.py
@@ -59,6 +59,7 @@ class Cluster(Document):
 		cidr_block: DF.Data | None
 		cloud_provider: DF.Literal["AWS EC2", "Generic", "OCI", "Hetzner"]
 		description: DF.Data | None
+		has_arm_support: DF.Check
 		hybrid: DF.Check
 		image: DF.AttachImage | None
 		monitoring_password: DF.Password | None

--- a/press/press/doctype/cluster/cluster.py
+++ b/press/press/doctype/cluster/cluster.py
@@ -764,6 +764,7 @@ class Cluster(Document):
 				"series": series,
 				"disk_size": disk_size,
 				"machine_type": machine_type,
+				"platform": platform,
 				"virtual_machine_image": self.get_available_vmi(series, platform=platform),
 				"team": team,
 			},
@@ -817,6 +818,7 @@ class Cluster(Document):
 				server.database_server = self.database_server
 				server.proxy_server = self.proxy_server
 				server.new_worker_allocation = True
+				server.platform = vm.platform
 			case "Proxy Server":
 				server = vm.create_proxy_server()
 				server.title = f"{title} - Proxy"


### PR DESCRIPTION
- [x] Removed platform constrains on `Server Plan`.
- [x] Restrict ARM server creation where `ARM AMI` is not available.


ARM server creation is limited by the region, til ARM AMI's are available in all supported region.