### PR TITLE
chore: Remove non-exist build column's linking

### DIFF
--- a/press/press/doctype/deploy_candidate_build/deploy_candidate_build.json
+++ b/press/press/doctype/deploy_candidate_build/deploy_candidate_build.json
@@ -302,15 +302,11 @@
    "link_fieldname": "document_name"
   },
   {
-   "link_doctype": "Deploy",
-   "link_fieldname": "build"
-  },
-  {
    "link_doctype": "Bench",
    "link_fieldname": "build"
   }
  ],
- "modified": "2025-05-27 23:08:21.433327",
+ "modified": "2025-06-18 15:04:51.144067",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Deploy Candidate Build",


### PR DESCRIPTION
The build field (column in the DB) was removed some time ago in the commit https://github.com/frappe/press/commit/46dfda5385cd3d5c7e3761711c85df744bf40b60. But it always had the linking to build field inside "Deploy Candidate Build" doctype leading to weird `tabDeploy.build column not found` kind of errors. 