### PR TITLE
feat: 2fa recovery

### DIFF
--- a/dashboard/src2/components/auth/Configure2FA.vue
+++ b/dashboard/src2/components/auth/Configure2FA.vue
@@ -8,22 +8,6 @@
 			<LoadingText />
 		</div>
 
-		<!-- Show recovery codes if present. -->
-		<div v-else-if="recoveryCodes.length" class="space-y-4">
-			<AlertBanner
-				title="Save these recovery codes in a safe place. You can use them to
-				reset two factor authentication if you lose access to your
-				authenticator app."
-				type="warning"
-			/>
-
-			<div class="rounded border border-gray-200 bg-gray-50 p-4">
-				<div class="text-sm text-gray-700">
-					{{ recoveryCodesStr }}
-				</div>
-			</div>
-		</div>
-
 		<!-- Disable if 2FA is enabled. -->
 		<div
 			v-else-if="is2FAEnabled && $route.name !== 'Enable2FA'"
@@ -135,15 +119,6 @@
 				@click="enable2FA"
 			/>
 
-			<!-- Show recovery codes if present. -->
-			<Button
-				v-else-if="recoveryCodes.length"
-				class="w-full"
-				variant="solid"
-				label="Close"
-				@click="() => $emit('enabled')"
-			/>
-
 			<!-- Disable 2FA if already enabled. -->
 			<Button
 				v-else
@@ -164,13 +139,12 @@ import { toast } from 'vue-sonner';
 import AlertBanner from '../AlertBanner.vue';
 
 export default {
-	emits: ['enabled', 'disabled'],
+	emits: ['enabled', 'disabled', 'update-recovery-codes'],
 	data() {
 		return {
 			qrUrl: '', // not storing as computed property to avoid re-fetching on dialog close
 			totpCode: '',
 			showSetupKey: false,
-			recoveryCodes: [],
 		};
 	},
 	components: {
@@ -187,7 +161,7 @@ export default {
 					loading: 'Enabling 2FA...',
 					success: (recoveryCodes) => {
 						this.totpCode = '';
-						this.recoveryCodes = recoveryCodes;
+						this.$emit('update-recovery-codes', recoveryCodes);
 
 						// avoid flickering of 2FA dialog
 						setTimeout(() => {
@@ -272,9 +246,6 @@ export default {
 		},
 		is2FAEnabled() {
 			return this.$team.doc?.user_info?.is_2fa_enabled;
-		},
-		recoveryCodesStr() {
-			return this.recoveryCodes.reduce((acc, cur) => acc + ' ' + cur, '');
 		},
 	},
 };

--- a/dashboard/src2/components/settings/profile/AccountProfile.vue
+++ b/dashboard/src2/components/settings/profile/AccountProfile.vue
@@ -65,6 +65,14 @@
 				</template>
 			</ListItem>
 			<ListItem
+				title="View Recovery Codes"
+				subtitle="View your two-factor authentication recovery codes"
+			>
+				<template #actions>
+					<Button @click="show2FARecoveryCodesDialog = true"> Show </Button>
+				</template>
+			</ListItem>
+			<ListItem
 				:title="teamEnabled ? 'Disable Account' : 'Enable Account'"
 				:subtitle="
 					teamEnabled
@@ -187,6 +195,7 @@
 		/>
 	</Card>
 	<TFADialog v-model="show2FADialog" />
+	<TFARecoveryCodesDialog v-model="show2FARecoveryCodesDialog" />
 </template>
 
 <script>
@@ -195,6 +204,7 @@ import { defineAsyncComponent, h } from 'vue';
 import FileUploader from '@/components/FileUploader.vue';
 import { confirmDialog, renderDialog } from '../../../utils/components';
 import TFADialog from './TFADialog.vue';
+import TFARecoveryCodesDialog from './TFARecoveryCodesDialog.vue';
 import router from '../../../router';
 import AddPrepaidCreditsDialog from '../../billing/AddPrepaidCreditsDialog.vue';
 
@@ -202,12 +212,14 @@ export default {
 	name: 'AccountProfile',
 	components: {
 		TFADialog,
+		TFARecoveryCodesDialog,
 		FileUploader,
 		AddPrepaidCreditsDialog,
 	},
 	data() {
 		return {
 			show2FADialog: false,
+			show2FARecoveryCodesDialog: false,
 			disableAccount2FACode: '',
 			showProfileEditDialog: false,
 			showEnableAccountDialog: false,
@@ -248,8 +260,8 @@ export default {
 			onSuccess() {
 				this.showDisableAccountDialog = false;
 
-				const ChurnFeedbackDialog = defineAsyncComponent(
-					() => import('../../ChurnFeedbackDialog.vue'),
+				const ChurnFeedbackDialog = defineAsyncComponent(() =>
+					import('../../ChurnFeedbackDialog.vue')
 				);
 
 				renderDialog(
@@ -258,7 +270,7 @@ export default {
 						onUpdated: () => {
 							toast.success('Your feedback was submitted successfully');
 						},
-					}),
+					})
 				);
 				toast.success('Your account was disabled successfully');
 				this.reloadAccount();
@@ -316,8 +328,8 @@ export default {
 			const currency = this.$team.doc.currency;
 			const minAmount = currency === 'INR' ? 410 : 5;
 			if (this.draftInvoice && this.draftInvoice.amount_due > minAmount) {
-				const finalizeInvoicesDialog = defineAsyncComponent(
-					() => import('../../billing/FinalizeInvoicesDialog.vue'),
+				const finalizeInvoicesDialog = defineAsyncComponent(() =>
+					import('../../billing/FinalizeInvoicesDialog.vue')
 				);
 				renderDialog(h(finalizeInvoicesDialog));
 			} else if (this.unpaidInvoices) {
@@ -360,7 +372,7 @@ export default {
 										this.$team.doc.payment_mode === 'Card'
 									) {
 										window.open(
-											`/api/method/press.api.client.run_doc_method?dt=Invoice&dn=${invoice.name}&method=stripe_payment_url`,
+											`/api/method/press.api.client.run_doc_method?dt=Invoice&dn=${invoice.name}&method=stripe_payment_url`
 										);
 									} else {
 										this.showAddPrepaidCreditsDialog = true;
@@ -375,8 +387,8 @@ export default {
 
 			// validate if any active servers
 			if (this.showActiveServersDialog) {
-				const activeServersDialog = defineAsyncComponent(
-					() => import('../../ActiveServersDialog.vue'),
+				const activeServersDialog = defineAsyncComponent(() =>
+					import('../../ActiveServersDialog.vue')
 				);
 				renderDialog(h(activeServersDialog));
 				return;
@@ -406,13 +418,13 @@ export default {
 								onError(e) {
 									console.error(e);
 								},
-							},
+							}
 						),
 						{
 							success: 'You can now publish apps to our Marketplace',
 							error: 'Failed to mark you as a developer',
 							loading: 'Making you a developer...',
-						},
+						}
 					);
 				},
 			});

--- a/dashboard/src2/components/settings/profile/TFADialog.vue
+++ b/dashboard/src2/components/settings/profile/TFADialog.vue
@@ -2,34 +2,50 @@
 	<Dialog
 		v-model="show"
 		:options="{
-			title: is2FAEnabled
-				? 'Disable Two-Factor Authentication'
-				: 'Enable Two-Factor Authentication'
+			title,
 		}"
 	>
 		<template #body-content>
-			<Configure2FA @enabled="closeDialog" @disabled="closeDialog" />
+			<TFARecoveryCodes
+				v-if="is2FAEnabled && recoveryCodes.length"
+				:recoveryCodes="recoveryCodes"
+				@close="closeDialog"
+			/>
+			<Configure2FA
+				v-else
+				@enabled="closeDialog"
+				@disabled="closeDialog"
+				@update-recovery-codes="(codes) => (recoveryCodes = codes)"
+			/>
 		</template>
 	</Dialog>
 </template>
 
 <script>
 import Configure2FA from '../../auth/Configure2FA.vue';
+import TFARecoveryCodes from './TFARecoveryCodes.vue';
 
 export default {
 	props: {
 		modelValue: {
 			type: Boolean,
-			required: true
-		}
+			required: true,
+		},
 	},
 	components: {
-		Configure2FA
+		Configure2FA,
+		TFARecoveryCodes,
+	},
+	data() {
+		return {
+			recoveryCodes: [],
+		};
 	},
 	methods: {
 		closeDialog() {
 			this.show = false;
-		}
+			this.recoveryCodes = [];
+		},
 	},
 	computed: {
 		is2FAEnabled() {
@@ -41,8 +57,17 @@ export default {
 			},
 			set(value) {
 				this.$emit('update:modelValue', value);
+			},
+		},
+		title() {
+			if (this.is2FAEnabled && this.recoveryCodes.length) {
+				return 'Two-Factor Authentication Recovery Codes';
+			} else if (this.is2FAEnabled) {
+				return 'Disable Two-Factor Authentication';
+			} else {
+				return 'Enable Two-Factor Authentication';
 			}
-		}
-	}
+		},
+	},
 };
 </script>

--- a/dashboard/src2/components/settings/profile/TFARecoveryCodes.vue
+++ b/dashboard/src2/components/settings/profile/TFARecoveryCodes.vue
@@ -13,6 +13,15 @@
 			</div>
 		</div>
 
+		<!-- Reset button only shown if withReset prop is true -->
+		<Button
+			v-if="withReset"
+			class="w-full"
+			variant="subtle"
+			label="Reset Recovery Codes"
+			@click="() => $emit('reset')"
+		/>
+
 		<Button
 			class="w-full"
 			variant="solid"
@@ -31,8 +40,12 @@ export default {
 			type: Array,
 			required: true,
 		},
+		withReset: {
+			type: Boolean,
+			default: false,
+		},
 	},
-	emits: ['close'],
+	emits: ['close', 'reset'],
 	components: {
 		AlertBanner,
 	},

--- a/dashboard/src2/components/settings/profile/TFARecoveryCodes.vue
+++ b/dashboard/src2/components/settings/profile/TFARecoveryCodes.vue
@@ -1,0 +1,45 @@
+<template>
+	<div class="space-y-4">
+		<AlertBanner
+			title="Save these recovery codes in a safe place. You can use them to
+				reset two factor authentication if you lose access to your
+				authenticator app."
+			type="warning"
+		/>
+
+		<div class="rounded border border-gray-200 bg-gray-50 p-4">
+			<div class="text-sm text-gray-700">
+				{{ recoveryCodesStr }}
+			</div>
+		</div>
+
+		<Button
+			class="w-full"
+			variant="solid"
+			label="Close"
+			@click="() => $emit('close')"
+		/>
+	</div>
+</template>
+
+<script>
+import AlertBanner from '../../AlertBanner.vue';
+
+export default {
+	props: {
+		recoveryCodes: {
+			type: Array,
+			required: true,
+		},
+	},
+	emits: ['close'],
+	components: {
+		AlertBanner,
+	},
+	computed: {
+		recoveryCodesStr() {
+			return this.recoveryCodes.join('\n');
+		},
+	},
+};
+</script>

--- a/dashboard/src2/components/settings/profile/TFARecoveryCodesDialog.vue
+++ b/dashboard/src2/components/settings/profile/TFARecoveryCodesDialog.vue
@@ -1,0 +1,59 @@
+<template>
+	<Dialog
+		v-model="show"
+		:options="{
+			title: 'Two-Factor Authentication Recovery Codes',
+		}"
+	>
+		<template #body-content>
+			<TFARecoveryCodes :recoveryCodes="recoveryCodes" @close="closeDialog" />
+		</template>
+	</Dialog>
+</template>
+
+<script>
+import TFARecoveryCodes from './TFARecoveryCodes.vue';
+
+export default {
+	props: {
+		modelValue: {
+			type: Boolean,
+			required: true,
+		},
+	},
+	components: {
+		TFARecoveryCodes,
+	},
+	data() {
+		return {
+			recoveryCodes: [],
+		};
+	},
+	resources: {
+		getRecoveryCodes() {
+			return {
+				url: 'press.api.account.get_2fa_recovery_codes',
+				auto: true,
+				onSuccess(codes) {
+					this.recoveryCodes = codes;
+				},
+			};
+		},
+	},
+	methods: {
+		closeDialog() {
+			this.show = false;
+		},
+	},
+	computed: {
+		show: {
+			get() {
+				return this.modelValue;
+			},
+			set(value) {
+				this.$emit('update:modelValue', value);
+			},
+		},
+	},
+};
+</script>

--- a/dashboard/src2/components/settings/profile/TFARecoveryCodesDialog.vue
+++ b/dashboard/src2/components/settings/profile/TFARecoveryCodesDialog.vue
@@ -6,7 +6,12 @@
 		}"
 	>
 		<template #body-content>
-			<TFARecoveryCodes :recoveryCodes="recoveryCodes" @close="closeDialog" />
+			<TFARecoveryCodes
+				:recoveryCodes="recoveryCodes"
+				@close="closeDialog"
+				@reset="() => $resources.resetRecoveryCodes.submit()"
+				with-reset
+			/>
 		</template>
 	</Dialog>
 </template>
@@ -36,6 +41,15 @@ export default {
 				auto: true,
 				onSuccess(codes) {
 					this.recoveryCodes = codes;
+				},
+			};
+		},
+		resetRecoveryCodes() {
+			return {
+				url: 'press.api.account.reset_2fa_recovery_codes',
+				onSuccess(codes) {
+					this.recoveryCodes = codes;
+					this.$toast.success('Recovery codes have been reset.');
 				},
 			};
 		},

--- a/dashboard/src2/pages/LoginSignup.vue
+++ b/dashboard/src2/pages/LoginSignup.vue
@@ -638,7 +638,6 @@ export default {
 				},
 			};
 		},
-		// Todo!
 		recover2FA() {
 			return {
 				url: 'press.api.account.recover_2fa',

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -1331,6 +1331,35 @@ def get_2fa_recovery_codes():
 	return recovery_codes
 
 
+@frappe.whitelist()
+def reset_2fa_recovery_codes():
+	"""Reset the recovery codes for the user."""
+
+	# Check if the user has 2FA enabled.
+	if not frappe.db.exists("User 2FA", frappe.session.user):
+		frappe.throw("2FA is not enabled for this user")
+
+	# Get the User 2FA document.
+	two_fa = frappe.get_doc("User 2FA", frappe.session.user)
+
+	# Clear existing recovery codes.
+	two_fa.recovery_codes = []
+	recovery_codes = [frappe.generate_hash(length=8).upper() for _ in range(8)]
+
+	# Add new recovery codes.
+	for recovery_code in recovery_codes:
+		two_fa.append(
+			"recovery_codes",
+			{"code": recovery_code},
+		)
+
+	# Save the document.
+	two_fa.save()
+
+	# Return the new recovery codes.
+	return recovery_codes
+
+
 # Not available for Telangana, Ladakh, and Other Territory
 STATE_PINCODE_MAPPING = {
 	"Jammu and Kashmir": (180, 194),

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -1256,7 +1256,7 @@ def enable_2fa(totp_code):
 	recovery_codes = [
 		get_decrypted_password("User 2FA Recovery Code", recovery_code.name, "code")
 		for recovery_code in two_fa.recovery_codes
-		if not recovery_code.used_on
+		if not recovery_code.used_at
 	]
 
 	return recovery_codes
@@ -1292,7 +1292,7 @@ def recover_2fa(user: str, recovery_code: str):
 	code = None
 	for code_doc in two_fa.recovery_codes:
 		decrypted_code = get_decrypted_password("User 2FA Recovery Code", code_doc.name, "code")
-		if decrypted_code == recovery_code and not code_doc.used_on:
+		if decrypted_code == recovery_code and not code_doc.used_at:
 			code = code_doc
 			break
 
@@ -1301,7 +1301,7 @@ def recover_2fa(user: str, recovery_code: str):
 		frappe.throw("Invalid or used recovery code")
 
 	# Mark the recovery code as used.
-	code.used_on = frappe.utils.now_datetime()
+	code.used_at = frappe.utils.now_datetime()
 
 	# Disable 2FA and save the document.
 	two_fa.enabled = 0
@@ -1323,7 +1323,7 @@ def get_2fa_recovery_codes():
 	recovery_codes = [
 		get_decrypted_password("User 2FA Recovery Code", recovery_code.name, "code")
 		for recovery_code in two_fa.recovery_codes
-		if not recovery_code.used_on
+		if not recovery_code.used_at
 	]
 
 	# Add a timestamp for when the recovery codes were last viewed.

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -1246,6 +1246,9 @@ def enable_2fa(totp_code):
 				{"code": frappe.generate_hash(length=8).upper()},
 			)
 
+	# Update the last verified time.
+	two_fa.recovery_codes_last_viewed_at = frappe.utils.now_datetime()
+
 	# Save the document.
 	two_fa.save()
 
@@ -1353,7 +1356,8 @@ def reset_2fa_recovery_codes():
 			{"code": recovery_code},
 		)
 
-	# Save the document.
+	# Update time and save the document.
+	two_fa.recovery_codes_last_viewed_at = frappe.utils.now_datetime()
 	two_fa.save()
 
 	# Return the new recovery codes.

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -199,6 +199,7 @@ scheduler_events = {
 		"press.press.doctype.virtual_disk_snapshot.virtual_disk_snapshot.sync_all_snapshots_from_aws",
 		"press.press.doctype.payment_due_extension.payment_due_extension.remove_payment_due_extension",
 		"press.press.doctype.tls_certificate.tls_certificate.notify_custom_tls_renewal",
+		"press.press.doctype.user_2fa.user_2fa.yearly_2fa_recovery_code_reminder",
 	],
 	"hourly": [
 		"press.press.doctype.site.backups.cleanup_local",

--- a/press/press/doctype/user_2fa/user_2fa.json
+++ b/press/press/doctype/user_2fa/user_2fa.json
@@ -9,7 +9,8 @@
   "user",
   "totp_secret",
   "enabled",
-  "last_verified_at"
+  "last_verified_at",
+  "recovery_codes"
  ],
  "fields": [
   {
@@ -34,12 +35,18 @@
    "fieldname": "last_verified_at",
    "fieldtype": "Datetime",
    "label": "Last Verified At"
+  },
+  {
+   "fieldname": "recovery_codes",
+   "fieldtype": "Table",
+   "label": "Recovery Codes",
+   "options": "User 2FA Recovery Code"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-06 21:23:48.649044",
+ "modified": "2025-06-21 13:25:11.061337",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "User 2FA",

--- a/press/press/doctype/user_2fa/user_2fa.json
+++ b/press/press/doctype/user_2fa/user_2fa.json
@@ -10,7 +10,8 @@
   "totp_secret",
   "enabled",
   "last_verified_at",
-  "recovery_codes"
+  "recovery_codes",
+  "recovery_codes_last_viewed_at"
  ],
  "fields": [
   {
@@ -41,12 +42,17 @@
    "fieldtype": "Table",
    "label": "Recovery Codes",
    "options": "User 2FA Recovery Code"
+  },
+  {
+   "fieldname": "recovery_codes_last_viewed_at",
+   "fieldtype": "Datetime",
+   "label": "Recovery Codes Last Viewed At"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-21 13:25:11.061337",
+ "modified": "2025-06-21 16:04:54.476967",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "User 2FA",

--- a/press/press/doctype/user_2fa/user_2fa.py
+++ b/press/press/doctype/user_2fa/user_2fa.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2024, Frappe and contributors
 # For license information, please see license.txt
 
-# import frappe
 from __future__ import annotations
 
+import frappe import frappe.utils
 from frappe.model.document import Document
 
 
@@ -15,6 +15,7 @@ class User2FA(Document):
 
 	if TYPE_CHECKING:
 		from frappe.types import DF
+
 		from press.press.doctype.user_2fa_recovery_code.user_2fa_recovery_code import User2FARecoveryCode
 
 		enabled: DF.Check
@@ -33,3 +34,38 @@ class User2FA(Document):
 		import pyotp
 
 		self.totp_secret = pyotp.random_base32()
+
+
+def yearly_2fa_recovery_code_reminder():
+	"""Check and send yearly recovery code reminders"""
+
+	# Construct dashboard url.
+	dashboard_url = frappe.utils.get_url("/dashboard/settings/profile")
+
+	# Get all users who have not viewed their recovery codes in the last year.
+	users = frappe.get_all(
+		"User 2FA",
+		filters={
+			"recovery_codes_last_viewed_at": [
+				"<=",
+				frappe.utils.add_to_date(frappe.utils.now_datetime(), years=-1),
+			],
+			"user": ["!=", "Administrator"],
+		},
+		pluck="name",
+	)
+
+	for user in users:
+		# Send mail.
+		frappe.sendmail(
+			recipients=[user],
+			subject="Verify Your Recovery Codes",
+			message=f"""
+	           <p>It's been a year since you last reviewed your two-factor authentication recovery codes.</p>
+	           <p>Please verify that you still have access to these codes. They are essential for account recovery if you lose access to your authentication device.</p>
+	           <p><a href="{dashboard_url}">View your recovery codes</a></p>
+	           """,
+		)
+
+		# Update recovery codes last viewed time.
+		frappe.db.set_value("User 2FA", user, "recovery_codes_last_viewed_at", frappe.utils.now_datetime())

--- a/press/press/doctype/user_2fa/user_2fa.py
+++ b/press/press/doctype/user_2fa/user_2fa.py
@@ -15,9 +15,11 @@ class User2FA(Document):
 
 	if TYPE_CHECKING:
 		from frappe.types import DF
+		from press.press.doctype.user_2fa_recovery_code.user_2fa_recovery_code import User2FARecoveryCode
 
 		enabled: DF.Check
 		last_verified_at: DF.Datetime | None
+		recovery_codes: DF.Table[User2FARecoveryCode]
 		totp_secret: DF.Password | None
 		user: DF.Link | None
 	# end: auto-generated types

--- a/press/press/doctype/user_2fa/user_2fa.py
+++ b/press/press/doctype/user_2fa/user_2fa.py
@@ -20,6 +20,7 @@ class User2FA(Document):
 		enabled: DF.Check
 		last_verified_at: DF.Datetime | None
 		recovery_codes: DF.Table[User2FARecoveryCode]
+		recovery_codes_last_viewed_at: DF.Datetime | None
 		totp_secret: DF.Password | None
 		user: DF.Link | None
 	# end: auto-generated types

--- a/press/press/doctype/user_2fa_recovery_code/user_2fa_recovery_code.json
+++ b/press/press/doctype/user_2fa_recovery_code/user_2fa_recovery_code.json
@@ -6,7 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "code",
-  "used_on"
+  "used_at"
  ],
  "fields": [
   {
@@ -17,17 +17,17 @@
    "reqd": 1
   },
   {
-   "fieldname": "used_on",
+   "fieldname": "used_at",
    "fieldtype": "Datetime",
    "in_list_view": 1,
-   "label": "Used On"
+   "label": "Used At"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-06-21 15:16:33.271412",
+ "modified": "2025-06-21 16:20:54.624042",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "User 2FA Recovery Code",

--- a/press/press/doctype/user_2fa_recovery_code/user_2fa_recovery_code.json
+++ b/press/press/doctype/user_2fa_recovery_code/user_2fa_recovery_code.json
@@ -1,0 +1,39 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-06-21 13:22:03.233018",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "code",
+  "used_on"
+ ],
+ "fields": [
+  {
+   "fieldname": "code",
+   "fieldtype": "Password",
+   "in_list_view": 1,
+   "label": "Code",
+   "reqd": 1
+  },
+  {
+   "fieldname": "used_on",
+   "fieldtype": "Datetime",
+   "label": "Used On"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-06-21 13:23:51.519151",
+ "modified_by": "Administrator",
+ "module": "Press",
+ "name": "User 2FA Recovery Code",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/press/press/doctype/user_2fa_recovery_code/user_2fa_recovery_code.json
+++ b/press/press/doctype/user_2fa_recovery_code/user_2fa_recovery_code.json
@@ -19,6 +19,7 @@
   {
    "fieldname": "used_on",
    "fieldtype": "Datetime",
+   "in_list_view": 1,
    "label": "Used On"
   }
  ],
@@ -26,7 +27,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-06-21 13:23:51.519151",
+ "modified": "2025-06-21 15:16:33.271412",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "User 2FA Recovery Code",

--- a/press/press/doctype/user_2fa_recovery_code/user_2fa_recovery_code.py
+++ b/press/press/doctype/user_2fa_recovery_code/user_2fa_recovery_code.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2025, Frappe and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class User2FARecoveryCode(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		code: DF.Password
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		used_on: DF.Datetime | None
+	# end: auto-generated types
+
+	pass

--- a/press/press/doctype/user_2fa_recovery_code/user_2fa_recovery_code.py
+++ b/press/press/doctype/user_2fa_recovery_code/user_2fa_recovery_code.py
@@ -18,7 +18,7 @@ class User2FARecoveryCode(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
-		used_on: DF.Datetime | None
+		used_at: DF.Datetime | None
 	# end: auto-generated types
 
 	pass


### PR DESCRIPTION
This PR adds recovery options for two factor authentication using recovery codes.

Related: https://github.com/frappe/press/issues/2435

- Create recovery codes on enabling 2FA
- View and/or reset recovery codes
- Reset 2FA using one of the recovery codes
- Invalidate a recovery code upon use
- Yearly reminders to view/save recovery codes