### PR TITLE
feat: variable to identify docker build

### DIFF
--- a/press/docker/Dockerfile
+++ b/press/docker/Dockerfile
@@ -1,6 +1,7 @@
 # syntax = docker/dockerfile:experimental
 FROM ubuntu:20.04
 
+ENV FRAPPE_DOCKER_BUILD True
 ENV LANG C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -281,6 +282,7 @@ RUN mkdir -p {{ m.destination }} && \
   `#stage-mounts-create`
 {% endfor %}
 
+ENV FRAPPE_DOCKER_BUILD=
 ENV FRAPPE_HARD_LINK_ASSETS True
 ENV HISTTIMEFORMAT "%Y-%m-%d %T "
 


### PR DESCRIPTION
This should allow tweaking bench, framework etc when we detect that it's a docker build. 

Examples: 
- https://github.com/frappe/frappe/pull/33051 
- https://github.com/frappe/bench/pull/1642