### PR TITLE
feat(metric): Update metrics counts to disregard migration builds

### DIFF
--- a/press/press/doctype/build_metric/build_metric_types.py
+++ b/press/press/doctype/build_metric/build_metric_types.py
@@ -60,3 +60,4 @@ class MetricsType(typing.TypedDict):
 	median_upload_context_duration: float
 	median_package_context_duration: float
 	failure_frequency: dict[str, int]
+	build_count_split: dict[str, int]


### PR DESCRIPTION
- Change build metrics to only count `deploy_after_build` flags.
- Show the arm / intel build split.