### PR TITLE
fix(site-migration): Add space validation for taking backup

### DIFF
--- a/press/agent.py
+++ b/press/agent.py
@@ -159,7 +159,7 @@ class Agent:
 		)
 
 	def restore_site(self, site: "Site", skip_failing_patches=False):
-		site.check_enough_space_on_server()
+		site.check_space_on_server_for_restore()
 		apps = [app.app for app in site.apps]
 		public_link, private_link, database_link = None, None, None
 		if site.remote_database_file:
@@ -246,7 +246,7 @@ class Agent:
 		)
 
 	def new_site_from_backup(self, site: "Site", skip_failing_patches=False):
-		site.check_enough_space_on_server()
+		site.check_space_on_server_for_restore()
 		apps = [app.app for app in site.apps]
 
 		def sanitized_site_config(site):

--- a/press/api/site.py
+++ b/press/api/site.py
@@ -1612,10 +1612,10 @@ def validate_restoration_space_requirements(
 	server: Server = frappe.get_cached_doc("Server", site.server)
 	database_server: DatabaseServer = frappe.get_cached_doc("Database Server", server.database_server)
 
-	required_space_on_app_server = site.space_required_for_restoration_on_app_server(
+	required_space_on_app_server = site.get_restore_space_required_on_app(
 		db_file_size=db_file_size, public_file_size=public_file_size, private_file_size=private_file_size
 	)
-	required_space_on_db_server = site.space_required_for_restoration_on_db_server(db_file_size=db_file_size)
+	required_space_on_db_server = site.get_restore_space_required_on_db(db_file_size=db_file_size)
 
 	free_space_on_app_server = server.free_space(server.guess_data_disk_mountpoint())
 	free_space_on_db_server = database_server.free_space(database_server.guess_data_disk_mountpoint())

--- a/press/press/doctype/site_migration/site_migration.py
+++ b/press/press/doctype/site_migration/site_migration.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 import frappe
@@ -90,18 +91,35 @@ class SiteMigration(Document):
 		if frappe.db.get_value("Bench", self.destination_bench, "status", for_update=True) != "Active":
 			frappe.throw("Destination bench does not exist")
 
+	@cached_property
+	def last_backup(self) -> SiteBackup | None:
+		return frappe.get_last_doc(
+			"Site Backup",
+			{
+				"site": self.site,
+				"with_files": True,
+				"offsite": True,
+				"status": "Success",
+				"files_availability": "Available",
+			},
+		)
+
+	def check_enough_space_on_source_server(self):
+		# server needs to have enough space to create backup
+		try:
+			backup = self.last_backup
+		except frappe.DoesNotExistError:
+			pass
+		else:
+			site: "Site" = frappe.get_doc("Site", self.site)
+			site.remote_database_file = backup.remote_database_file
+			site.remote_public_file = backup.remote_public_file
+			site.remote_private_file = backup.remote_private_file
+			site.check_space_on_server_for_backup()
+
 	def check_enough_space_on_destination_server(self):
 		try:
-			backup: SiteBackup = frappe.get_last_doc(  # approximation with last backup
-				"Site Backup",
-				{
-					"site": self.site,
-					"with_files": True,
-					"offsite": True,
-					"status": "Success",
-					"files_availability": "Available",
-				},
-			)
+			backup = self.last_backup
 		except frappe.DoesNotExistError:
 			pass
 		else:
@@ -110,7 +128,7 @@ class SiteMigration(Document):
 			site.remote_database_file = backup.remote_database_file
 			site.remote_public_file = backup.remote_public_file
 			site.remote_private_file = backup.remote_private_file
-			site.check_enough_space_on_server()
+			site.check_space_on_server_for_restore()
 
 	def after_insert(self):
 		self.set_migration_type()


### PR DESCRIPTION
When migrating servers from Scaleway, large sites may not have enough
space for backup. Avoid that in advance.
