### PR TITLE
fix(server-plan): Validate active subs before disabling

### DIFF
--- a/press/press/doctype/server_plan/server_plan.py
+++ b/press/press/doctype/server_plan/server_plan.py
@@ -2,6 +2,8 @@
 # For license information, please see license.txt
 from __future__ import annotations
 
+import frappe
+
 from press.press.doctype.site_plan.plan import Plan
 
 
@@ -46,3 +48,15 @@ class ServerPlan(Plan):
 		doc["price_per_day_inr"] = self.get_price_per_day("INR")
 		doc["price_per_day_usd"] = self.get_price_per_day("USD")
 		return doc
+
+	def validate(self):
+		self.validate_active_subscriptions()
+
+	def validate_active_subscriptions(self):
+		old_doc = self.get_doc_before_save()
+		if old_doc and old_doc.enabled and not self.enabled:
+			active_sub_count = frappe.db.count("Subscription", {"enabled": 1, "plan": self.name})
+			if active_sub_count > 0:
+				frappe.throw(
+					f"Cannot disable this plan. This plan is used in {active_sub_count} active subscription(s)."
+				)

--- a/press/press/doctype/server_plan/server_plan.py
+++ b/press/press/doctype/server_plan/server_plan.py
@@ -54,7 +54,7 @@ class ServerPlan(Plan):
 
 	def validate_active_subscriptions(self):
 		old_doc = self.get_doc_before_save()
-		if old_doc and old_doc.enabled and not self.enabled:
+		if old_doc and old_doc.enabled and not self.enabled and not self.legacy_plan:
 			active_sub_count = frappe.db.count("Subscription", {"enabled": 1, "plan": self.name})
 			if active_sub_count > 0:
 				frappe.throw(


### PR DESCRIPTION
Add validations for disabling active plans which are used in any of active subscriptions.

<img width="1758" height="522" alt="Screenshot from 2025-07-18 11-24-25" src="https://github.com/user-attachments/assets/2dd7c877-9c37-47be-8c06-3d5206aeb961" />
