### PR TITLE
fix: remove hardcoded ncdu version that breaks install, 14.1.1-1 not found

### DIFF
--- a/press/playbooks/roles/install_and_setup_ncdu/tasks/main.yml
+++ b/press/playbooks/roles/install_and_setup_ncdu/tasks/main.yml
@@ -3,6 +3,6 @@
   become: yes
   become_user: root
   apt:
-    name: ncdu=1.14.1-1
+    name: ncdu
     state: present
     update_cache: no


### PR DESCRIPTION
fix: remove hardcoded ncdu version that is not available on newer OS