### PR TITLE
fix: Get datetime format of `last_archive_failure` field in `check_last_archive` method

### DIFF
--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -27,7 +27,7 @@ from press.press.doctype.bench_shell_log.bench_shell_log import (
 )
 from press.press.doctype.site.site import Site
 from press.runner import Ansible
-from press.utils import SupervisorProcess, flatten, log_error, parse_supervisor_status
+from press.utils import SupervisorProcess, flatten, get_datetime, log_error, parse_supervisor_status
 from press.utils.webhook import create_webhook_event
 
 if TYPE_CHECKING:
@@ -1001,7 +1001,7 @@ class Bench(Document):
 			frappe.throw("Cannot archive bench due to ongoing in-place updates.", ArchiveBenchError)
 
 	def check_last_archive(self):
-		if self.last_archive_failure and self.last_archive_failure > frappe.utils.add_to_date(
+		if self.last_archive_failure and get_datetime(self.last_archive_failure) > frappe.utils.add_to_date(
 			None, hours=-24
 		):
 			frappe.throw("Cannot archive as previous archive failed in the last 24 hours.", ArchiveBenchError)


### PR DESCRIPTION
Even if the DB has `datetime(6)` type set for `last_archive_failure`, it gets fatched as `datetime_str` causing the below error. This PR fixes the typeError.

```py
TypeError: '>' not supported between instances of 'str' and 'datetime.datetime'
```