### PR TITLE
fix: Using ro to avoid breaking `set_only_once` validation

### DIFF
--- a/press/press/doctype/database_server/database_server.json
+++ b/press/press/doctype/database_server/database_server.json
@@ -114,7 +114,7 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "IP",
-   "set_only_once": 1
+   "read_only": 1
   },
   {
    "fetch_from": "virtual_machine.private_ip_address",
@@ -143,7 +143,7 @@
    "fieldname": "agent_password",
    "fieldtype": "Password",
    "label": "Agent Password",
-   "set_only_once": 1
+   "read_only": 1
   },
   {
    "fieldname": "server_id",

--- a/press/press/doctype/proxy_server/proxy_server.json
+++ b/press/press/doctype/proxy_server/proxy_server.json
@@ -72,14 +72,14 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "IP",
-   "set_only_once": 1
+   "read_only": 1
   },
   {
    "fetch_from": "virtual_machine.private_ip_address",
    "fieldname": "private_ip",
    "fieldtype": "Data",
    "label": "Private IP",
-   "set_only_once": 1
+   "ready_only": 1
   },
   {
    "fieldname": "agent_password",

--- a/press/press/doctype/server/server.json
+++ b/press/press/doctype/server/server.json
@@ -98,7 +98,7 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "IP",
-   "set_only_once": 1
+   "read_only": 1
   },
   {
    "fieldname": "proxy_server",
@@ -116,7 +116,7 @@
    "fieldname": "agent_password",
    "fieldtype": "Password",
    "label": "Agent Password",
-   "set_only_once": 1
+   "read_only": 1
   },
   {
    "collapsible": 1,


### PR DESCRIPTION
The `validate_set_only_once` method breaks `ip` and `agent_password` fields since those fields are at times changed because of some circumstance.