### PR TITLE
feat(deploy): Image in registry check

### DIFF
--- a/press/exceptions.py
+++ b/press/exceptions.py
@@ -25,6 +25,10 @@ class InsufficientSpaceOnServer(ValidationError):
 	pass
 
 
+class ImageNotFoundInRegistry(ValidationError):
+	pass
+
+
 class VolumeResizeLimitError(ValidationError):
 	pass
 

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -21,7 +21,7 @@ from frappe.utils.caching import redis_cache
 
 from press.agent import Agent
 from press.api.client import dashboard_whitelist
-from press.exceptions import InsufficientSpaceOnServer, VolumeResizeLimitError
+from press.exceptions import ImageNotFoundInRegistry, InsufficientSpaceOnServer, VolumeResizeLimitError
 from press.overrides import get_permission_query_conditions_for_doctype
 from press.press.doctype.app.app import new_app
 from press.press.doctype.app_source.app_source import AppSource, create_app_source
@@ -1370,6 +1370,11 @@ class ReleaseGroup(Document, TagHelpers):
 
 	@frappe.whitelist()
 	def add_server(self, server: str, deploy=False, force_new_build: bool = False):
+		"""
+		Add a server to the release group in case last successful deploy candidate exists
+		create a deploy check if the image has not been pruned from the registry in case of
+		missing image create new build.
+		"""
 		if not deploy:
 			return None
 
@@ -1380,7 +1385,9 @@ class ReleaseGroup(Document, TagHelpers):
 
 		if not last_successful_deploy_candidate_build or force_new_build:
 			# No build of this platform is available creating new build
-			last_candidate_build = self.get_last_successful_candidate_build()
+			last_candidate_build = (
+				self.get_last_successful_candidate_build()
+			)  # Checking for any platform build
 
 			if not last_candidate_build:
 				frappe.throw("No build present for this release group", frappe.ValidationError)
@@ -1397,7 +1404,13 @@ class ReleaseGroup(Document, TagHelpers):
 		self.append("servers", {"server": server, "default": False})
 		self.save()
 
-		return last_successful_deploy_candidate_build._create_deploy([server])
+		try:
+			return last_successful_deploy_candidate_build._create_deploy(
+				[server],
+				check_image_exists=True,
+			)
+		except ImageNotFoundInRegistry:
+			self.add_server(server=server, deploy=True, force_new_build=True)
 
 	@frappe.whitelist()
 	def change_server(self, server: str):


### PR DESCRIPTION
When adding new server to bench group, we fetch the image form the last successful deploy candidate build, however it's possible that the image has been pruned from the registry in that case we need to trigger a new deploy.