### PR TITLE
chore(registry): Moving out of server scripts

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -203,7 +203,7 @@ scheduler_events = {
 		"press.press.doctype.tls_certificate.tls_certificate.notify_custom_tls_renewal",
 		"press.press.doctype.site.site.suspend_sites_exceeding_disk_usage_for_last_7_days",
 		"press.press.doctype.user_2fa.user_2fa.yearly_2fa_recovery_code_reminder",
-		"press.press.doctype.registry_server.registry_server.prune_registry",
+		"press.press.doctype.registry_server.registry_server.delete_old_images_from_registry",
 	],
 	"hourly": [
 		"press.press.doctype.site.backups.cleanup_local",

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -203,6 +203,7 @@ scheduler_events = {
 		"press.press.doctype.tls_certificate.tls_certificate.notify_custom_tls_renewal",
 		"press.press.doctype.site.site.suspend_sites_exceeding_disk_usage_for_last_7_days",
 		"press.press.doctype.user_2fa.user_2fa.yearly_2fa_recovery_code_reminder",
+		"press.press.doctype.registry_server.registry_server.prune_registry",
 	],
 	"hourly": [
 		"press.press.doctype.site.backups.cleanup_local",

--- a/press/press/doctype/registry_server/registry_server.py
+++ b/press/press/doctype/registry_server/registry_server.py
@@ -116,7 +116,7 @@ class RegistryServer(BaseServer):
 		toggle_builds(False)
 
 
-def prune_registry():  # noqa: C901
+def delete_old_images_from_registry():  # noqa: C901
 	"""Purge registry of older images"""
 	settings = frappe.get_doc("Press Settings", None)
 	registry = settings.docker_registry_url


### PR DESCRIPTION
Deletion of older images is now managed in code instead of being a server script.