### PR TITLE
fix(signup):  Fix login timeout fallback logic

### DIFF
--- a/dashboard/src/pages/signup/LoginToSite.vue
+++ b/dashboard/src/pages/signup/LoginToSite.vue
@@ -172,7 +172,7 @@ export default {
 							};
 						},
 						onSuccess: (data) => {
-							if (data.status === 'Site Created') {
+							if (data.current_step === 'Site Created') {
 								return this.loginToSite();
 							}
 

--- a/press/saas/doctype/product_trial_request/product_trial_request.py
+++ b/press/saas/doctype/product_trial_request/product_trial_request.py
@@ -284,7 +284,7 @@ class ProductTrialRequest(Document):
 		)
 		if status == "Success":
 			if self.status == "Site Created":
-				return {"progress": 100}
+				return {"progress": 100, "current_step": self.status}
 			if self.status == "Adding Domain":
 				return {"progress": 90, "current_step": self.status}
 			return {"progress": 80, "current_step": self.status}


### PR DESCRIPTION
Resolve an infinite loading state during login when the WebSocket connection fails.

The initial socket failure correctly triggered the fallback mechanism, but the fallback code itself contained a bug that prevented the login process from completing. This patch corrects the logic in the fallback handler to ensure login proceeds using the alternative HTTP polling method.

The websocket is not pushing updated status as its broken. The get_progress function, which can ensure login using the polling method doesn't have "status" in the JSON response. As status is not sent in response, the page shows "Logging in" message for very longtime without any sign of moving to product setup