### PR TITLE
fix(signup):adding 2s delay to prevent connection timedout error

### DIFF
--- a/dashboard/src/pages/signup/LoginToSite.vue
+++ b/dashboard/src/pages/signup/LoginToSite.vue
@@ -154,7 +154,11 @@ export default {
 				realtime: true,
 				auto: true,
 				onSuccess(doc) {
-					if (doc.status == 'Site Created') this.loginToSite();
+					if (doc.status == 'Site Created') {
+						setTimeout(() => {
+							this.loginToSite();
+						}, 2000);
+					}
 					else if (
 						doc.status == 'Wait for Site' ||
 						doc.status == 'Prefilling Setup Wizard'
@@ -173,7 +177,10 @@ export default {
 						},
 						onSuccess: (data) => {
 							if (data.current_step === 'Site Created') {
-								return this.loginToSite();
+								setTimeout(() => {
+									this.loginToSite();
+								}, 2000);
+								return;
 							}
 
 							const currentStepMap = {


### PR DESCRIPTION
Some of the sites in Jakarta cluster faced errors that caused ConnectionTimedOut error. The sites are all accessible now, however during the login process, this issue occured. Added a 2 second delay to avoid this issue.

This is a temporary fix and a patchwork done. Increasing the time during the signup process is not a great idea. However to prevent error during the sign up process we are taking up this approach. 