### PR TITLE
fix: Wildcard TLS Renewal Retry Irrespective of Server Status

### DIFF
--- a/press/press/doctype/analytics_server/analytics_server.json
+++ b/press/press/doctype/analytics_server/analytics_server.json
@@ -8,6 +8,7 @@
   "status",
   "hostname",
   "domain",
+  "tls_certificate_renewal_failed",
   "column_break_4",
   "provider",
   "virtual_machine",
@@ -244,15 +245,23 @@
    "fieldtype": "Password",
    "label": "Google Client Secret",
    "set_only_once": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "tls_certificate_renewal_failed",
+   "fieldtype": "Check",
+   "label": "TLS Certificate Renewal Failed",
+   "read_only": 1
   }
  ],
+ "grid_page_length": 50,
  "links": [
   {
    "link_doctype": "Ansible Play",
    "link_fieldname": "server"
   }
  ],
- "modified": "2023-12-13 15:09:40.978998",
+ "modified": "2025-09-02 16:43:53.162616",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Analytics Server",
@@ -271,6 +280,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/press/press/doctype/analytics_server/analytics_server.py
+++ b/press/press/doctype/analytics_server/analytics_server.py
@@ -41,6 +41,7 @@ class AnalyticsServer(BaseServer):
 		provider: DF.Literal["Generic", "Scaleway", "AWS EC2", "OCI"]
 		root_public_key: DF.Code | None
 		status: DF.Literal["Pending", "Installing", "Active", "Broken", "Archived"]
+		tls_certificate_renewal_failed: DF.Check
 		virtual_machine: DF.Link | None
 	# end: auto-generated types
 
@@ -66,9 +67,7 @@ class AnalyticsServer(BaseServer):
 
 		log_server = frappe.db.get_single_value("Press Settings", "log_server")
 		if log_server:
-			kibana_password = frappe.get_doc("Log Server", log_server).get_password(
-				"kibana_password"
-			)
+			kibana_password = frappe.get_doc("Log Server", log_server).get_password("kibana_password")
 		else:
 			kibana_password = None
 

--- a/press/press/doctype/database_server/database_server.json
+++ b/press/press/doctype/database_server/database_server.json
@@ -10,6 +10,7 @@
   "hostname_abbreviation",
   "domain",
   "title",
+  "tls_certificate_renewal_failed",
   "column_break_4",
   "cluster",
   "provider",
@@ -652,6 +653,13 @@
    "fieldtype": "Data",
    "label": "GTID Slave Pos",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "tls_certificate_renewal_failed",
+   "fieldtype": "Check",
+   "label": "TLS Certificate Renewal Failed",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
@@ -668,7 +676,7 @@
    "link_fieldname": "database_server"
   }
  ],
- "modified": "2025-08-14 02:08:52.404846",
+ "modified": "2025-09-02 16:43:24.080843",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Database Server",

--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -105,6 +105,7 @@ class DatabaseServer(BaseServer):
 		tags: DF.Table[ResourceTag]
 		team: DF.Link | None
 		title: DF.Data | None
+		tls_certificate_renewal_failed: DF.Check
 		virtual_machine: DF.Link | None
 	# end: auto-generated types
 

--- a/press/press/doctype/log_server/log_server.json
+++ b/press/press/doctype/log_server/log_server.json
@@ -8,6 +8,7 @@
   "status",
   "hostname",
   "domain",
+  "tls_certificate_renewal_failed",
   "column_break_4",
   "cluster",
   "provider",
@@ -203,6 +204,13 @@
    "fieldname": "ssh_port",
    "fieldtype": "Int",
    "label": "SSH Port"
+  },
+  {
+   "default": "0",
+   "fieldname": "tls_certificate_renewal_failed",
+   "fieldtype": "Check",
+   "label": "TLS Certificate Renewal Failed",
+   "read_only": 1
   }
  ],
  "links": [
@@ -211,7 +219,7 @@
    "link_fieldname": "server"
   }
  ],
- "modified": "2025-04-23 15:31:55.323135",
+ "modified": "2025-09-02 16:43:33.847741",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Log Server",

--- a/press/press/doctype/log_server/log_server.py
+++ b/press/press/doctype/log_server/log_server.py
@@ -36,6 +36,7 @@ class LogServer(BaseServer):
 		ssh_port: DF.Int
 		ssh_user: DF.Data | None
 		status: DF.Literal["Pending", "Installing", "Active", "Broken", "Archived"]
+		tls_certificate_renewal_failed: DF.Check
 		virtual_machine: DF.Link | None
 	# end: auto-generated types
 

--- a/press/press/doctype/monitor_server/monitor_server.json
+++ b/press/press/doctype/monitor_server/monitor_server.json
@@ -8,6 +8,7 @@
   "status",
   "hostname",
   "domain",
+  "tls_certificate_renewal_failed",
   "column_break_4",
   "cluster",
   "provider",
@@ -248,6 +249,13 @@
    "fieldname": "webhook_token",
    "fieldtype": "Data",
    "label": "Webhook Token"
+  },
+  {
+   "default": "0",
+   "fieldname": "tls_certificate_renewal_failed",
+   "fieldtype": "Check",
+   "label": "TLS Certificate Renewal Failed",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
@@ -257,7 +265,7 @@
    "link_fieldname": "server"
   }
  ],
- "modified": "2025-08-27 09:40:47.243453",
+ "modified": "2025-09-02 16:43:40.405932",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Monitor Server",

--- a/press/press/doctype/monitor_server/monitor_server.py
+++ b/press/press/doctype/monitor_server/monitor_server.py
@@ -60,6 +60,7 @@ class MonitorServer(BaseServer):
 		ssh_port: DF.Int
 		ssh_user: DF.Data | None
 		status: DF.Literal["Pending", "Installing", "Active", "Broken", "Archived"]
+		tls_certificate_renewal_failed: DF.Check
 		virtual_machine: DF.Link | None
 		webhook_token: DF.Data | None
 	# end: auto-generated types

--- a/press/press/doctype/proxy_server/proxy_server.json
+++ b/press/press/doctype/proxy_server/proxy_server.json
@@ -10,6 +10,7 @@
   "hostname_abbreviation",
   "domain",
   "self_hosted_server_domain",
+  "tls_certificate_renewal_failed",
   "column_break_3",
   "cluster",
   "provider",
@@ -430,10 +431,17 @@
    "fieldname": "halt_agent_jobs",
    "fieldtype": "Check",
    "label": "Halt Agent Jobs"
+  },
+  {
+   "default": "0",
+   "fieldname": "tls_certificate_renewal_failed",
+   "fieldtype": "Check",
+   "label": "TLS Certificate Renewal Failed",
+   "read_only": 1
   }
  ],
  "links": [],
- "modified": "2025-08-14 02:14:31.867455",
+ "modified": "2025-09-02 16:42:27.412427",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Proxy Server",

--- a/press/press/doctype/proxy_server/proxy_server.py
+++ b/press/press/doctype/proxy_server/proxy_server.py
@@ -65,6 +65,7 @@ class ProxyServer(BaseServer):
 		ssh_user: DF.Data | None
 		status: DF.Literal["Pending", "Installing", "Active", "Broken", "Archived"]
 		team: DF.Link | None
+		tls_certificate_renewal_failed: DF.Check
 		virtual_machine: DF.Link | None
 		wireguard_interface_id: DF.Data | None
 		wireguard_network: DF.Data | None

--- a/press/press/doctype/registry_server/registry_server.json
+++ b/press/press/doctype/registry_server/registry_server.json
@@ -8,6 +8,7 @@
   "status",
   "hostname",
   "domain",
+  "tls_certificate_renewal_failed",
   "column_break_4",
   "provider",
   "virtual_machine",
@@ -209,6 +210,13 @@
    "fieldname": "ssh_port",
    "fieldtype": "Int",
    "label": "SSH Port"
+  },
+  {
+   "default": "0",
+   "fieldname": "tls_certificate_renewal_failed",
+   "fieldtype": "Check",
+   "label": "TLS Certificate Renewal Failed",
+   "read_only": 1
   }
  ],
  "links": [
@@ -217,7 +225,7 @@
    "link_fieldname": "server"
   }
  ],
- "modified": "2025-04-23 15:31:31.857916",
+ "modified": "2025-09-02 16:43:47.166808",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Registry Server",

--- a/press/press/doctype/registry_server/registry_server.py
+++ b/press/press/doctype/registry_server/registry_server.py
@@ -39,6 +39,7 @@ class RegistryServer(BaseServer):
 		ssh_port: DF.Int
 		ssh_user: DF.Data | None
 		status: DF.Literal["Pending", "Installing", "Active", "Broken", "Archived"]
+		tls_certificate_renewal_failed: DF.Check
 		virtual_machine: DF.Link | None
 	# end: auto-generated types
 

--- a/press/press/doctype/server/server.json
+++ b/press/press/doctype/server/server.json
@@ -5,12 +5,13 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "title",
   "status",
   "hostname",
   "hostname_abbreviation",
   "domain",
   "self_hosted_server_domain",
-  "title",
+  "tls_certificate_renewal_failed",
   "column_break_4",
   "cluster",
   "provider",
@@ -99,8 +100,7 @@
    "fieldname": "ip",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "IP",
-   "read_only": 1
+   "label": "IP"
   },
   {
    "fieldname": "proxy_server",
@@ -628,10 +628,17 @@
    "fieldname": "enable_logical_replication_during_site_update",
    "fieldtype": "Check",
    "label": "Enable Logical Replication During Site Update"
+  },
+  {
+   "default": "0",
+   "fieldname": "tls_certificate_renewal_failed",
+   "fieldtype": "Check",
+   "label": "TLS Certificate Renewal Failed",
+   "read_only": 1
   }
  ],
  "links": [],
- "modified": "2025-08-21 16:08:03.067516",
+ "modified": "2025-09-02 16:43:19.885050",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Server",

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1950,6 +1950,7 @@ class Server(BaseServer):
 		tags: DF.Table[ResourceTag]
 		team: DF.Link | None
 		title: DF.Data | None
+		tls_certificate_renewal_failed: DF.Check
 		use_agent_job_callbacks: DF.Check
 		use_for_build: DF.Check
 		use_for_new_benches: DF.Check

--- a/press/press/doctype/tls_certificate/tls_certificate.py
+++ b/press/press/doctype/tls_certificate/tls_certificate.py
@@ -9,6 +9,7 @@ import subprocess
 import time
 from contextlib import suppress
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import frappe
 import OpenSSL
@@ -23,6 +24,9 @@ from press.exceptions import (
 from press.overrides import get_permission_query_conditions_for_doctype
 from press.runner import Ansible
 from press.utils import get_current_team, log_error
+
+if TYPE_CHECKING:
+	from press.press.doctype.ansible_play.ansible_play import AnsiblePlay
 
 AUTO_RETRY_LIMIT = 5
 MANUAL_RETRY_LIMIT = 8
@@ -188,14 +192,30 @@ class TLSCertificate(Document):
 
 		for server_doctype in server_doctypes:
 			servers = frappe.get_all(
-				server_doctype, {"status": "Active", "name": ("like", f"%.{self.domain}")}
+				server_doctype,
+				filters={
+					"status": ("not in", ["Archived", "Installing"]),
+					"name": ("like", f"%.{self.domain}"),
+				},
+				fields=["name", "status"],
 			)
 			for server in servers:
-				frappe.enqueue(
-					"press.press.doctype.tls_certificate.tls_certificate.update_server_tls_certifcate",
-					server=frappe.get_doc(server_doctype, server),
-					certificate=self,
-				)
+				if server.status == "Active":
+					frappe.enqueue(
+						"press.press.doctype.tls_certificate.tls_certificate.update_server_tls_certifcate",
+						server=frappe.get_doc(server_doctype, server.name),
+						certificate=self,
+						enqueue_after_commit=True,
+					)
+				else:
+					# If server is not active, mark the tls_certificate_renewal_failed field as True
+					frappe.db.set_value(
+						server_doctype,
+						server.name,
+						"tls_certificate_renewal_failed",
+						1,
+						update_modified=False,
+					)
 
 	@frappe.whitelist()
 	def trigger_site_domain_callback(self):
@@ -387,7 +407,15 @@ def update_server_tls_certifcate(server, certificate):
 				"proxysql_admin_password": proxysql_admin_password,
 			},
 		)
-		ansible.run()
+		play: "AnsiblePlay" = ansible.run()
+		frappe.db.set_value(
+			server.doctype,
+			server.name,
+			"tls_certificate_renewal_failed",
+			play.status != "Success",
+			# to avoid causing TimestampMismatchError in other important tasks
+			update_modified=False,
+		)
 	except Exception:
 		log_error("TLS Setup Exception", server=server.as_dict())
 
@@ -404,16 +432,23 @@ def retrigger_failed_wildcard_tls_callbacks():
 		"Trace Server",
 	]
 	for server_doctype in server_doctypes:
-		servers = frappe.get_all(server_doctype, {"status": "Active"}, pluck="name")
+		servers = frappe.get_all(
+			server_doctype, {"status": "Active"}, fields=["name", "tls_certificate_renewal_failed"]
+		)
 		for server in servers:
-			plays = frappe.get_all(
-				"Ansible Play",
-				{"play": "Setup TLS Certificates", "server": server},
-				pluck="status",
-				limit=1,
-				order_by="creation DESC",
-			)
-			if plays and plays[0] != "Success":
+			previous_attempt_failed = server.tls_certificate_renewal_failed
+			if not previous_attempt_failed:
+				plays = frappe.get_all(
+					"Ansible Play",
+					{"play": "Setup TLS Certificates", "server": server.name},
+					pluck="status",
+					limit=1,
+					order_by="creation DESC",
+				)
+				if plays and plays[0] != "Success":
+					previous_attempt_failed = True
+
+			if previous_attempt_failed:
 				server_doc = frappe.get_doc(server_doctype, server)
 				frappe.enqueue(
 					"press.press.doctype.tls_certificate.tls_certificate.update_server_tls_certifcate",

--- a/press/press/doctype/trace_server/trace_server.json
+++ b/press/press/doctype/trace_server/trace_server.json
@@ -8,6 +8,7 @@
   "status",
   "hostname",
   "domain",
+  "tls_certificate_renewal_failed",
   "column_break_4",
   "provider",
   "virtual_machine",
@@ -259,15 +260,23 @@
   {
    "fieldname": "column_break_33",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "tls_certificate_renewal_failed",
+   "fieldtype": "Check",
+   "label": "TLS Certificate Renewal Failed",
+   "read_only": 1
   }
  ],
+ "grid_page_length": 50,
  "links": [
   {
    "link_doctype": "Ansible Play",
    "link_fieldname": "server"
   }
  ],
- "modified": "2023-12-13 15:09:34.499141",
+ "modified": "2025-09-02 16:44:01.317526",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Trace Server",
@@ -286,6 +295,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/press/press/doctype/trace_server/trace_server.py
+++ b/press/press/doctype/trace_server/trace_server.py
@@ -40,6 +40,7 @@ class TraceServer(BaseServer):
 		sentry_oauth_client_secret: DF.Data | None
 		sentry_oauth_server_url: DF.Data | None
 		status: DF.Literal["Pending", "Installing", "Active", "Broken", "Archived"]
+		tls_certificate_renewal_failed: DF.Check
 		virtual_machine: DF.Link | None
 	# end: auto-generated types
 
@@ -65,9 +66,7 @@ class TraceServer(BaseServer):
 
 		log_server = frappe.db.get_single_value("Press Settings", "log_server")
 		if log_server:
-			kibana_password = frappe.get_doc("Log Server", log_server).get_password(
-				"kibana_password"
-			)
+			kibana_password = frappe.get_doc("Log Server", log_server).get_password("kibana_password")
 		else:
 			kibana_password = None
 
@@ -115,9 +114,7 @@ class TraceServer(BaseServer):
 	def upgrade_server(self):
 		self.status = "Installing"
 		self.save()
-		frappe.enqueue_doc(
-			self.doctype, self.name, "_upgrade_server", queue="long", timeout=2400
-		)
+		frappe.enqueue_doc(self.doctype, self.name, "_upgrade_server", queue="long", timeout=2400)
 
 	def _upgrade_server(self):
 		try:


### PR DESCRIPTION
Fixes https://github.com/frappe/press/issues/3164

Instead of relying on `Ansible Play` status, manage TLS Renewal failure in a flag in server doctypes.

After TLS Certificate Renewal,
- If `Server` is `Active`, trigger immediate tls certificate update
- Else, just mark the flag `tls_certificate_renewal_failed` on server doctype. BG Job will retry the renewal later.