### PR TITLE
fix: Override has_permission and list_query for few doctypes

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -104,6 +104,7 @@ notification_config = "press.notifications.get_notification_config"
 
 permission_query_conditions = {
 	"Site": "press.press.doctype.site.site.get_permission_query_conditions",
+	"Site Backup": ("press.press.doctype.site_backup.site_backup.get_permission_query_conditions"),
 	"Site Domain": ("press.press.doctype.site_domain.site_domain.get_permission_query_conditions"),
 	"TLS Certificate": "press.press.doctype.tls_certificate.tls_certificate.get_permission_query_conditions",
 	"Team": "press.press.doctype.team.team.get_permission_query_conditions",
@@ -125,9 +126,16 @@ permission_query_conditions = {
 	"Press Webhook Log": "press.press.doctype.press_webhook_log.press_webhook_log.get_permission_query_conditions",
 	"SQL Playground Log": "press.press.doctype.sql_playground_log.sql_playground_log.get_permission_query_conditions",
 	"Site Database User": "press.press.doctype.site_database_user.site_database_user.get_permission_query_conditions",
+	"Server Snapshot": (
+		"press.press.doctype.server_snapshot.server_snapshot.get_permission_query_conditions"
+	),
+	"Server Snapshot Recovery": (
+		"press.press.doctype.server_snapshot_recovery.server_snapshot_recovery.get_permission_query_conditions"
+	),
 }
 has_permission = {
 	"Site": "press.overrides.has_permission",
+	"Site Backup": "press.overrides.has_permission",
 	"Site Domain": "press.overrides.has_permission",
 	"TLS Certificate": "press.overrides.has_permission",
 	"Team": "press.press.doctype.team.team.has_permission",

--- a/press/press/doctype/server_snapshot/server_snapshot.py
+++ b/press/press/doctype/server_snapshot/server_snapshot.py
@@ -10,6 +10,7 @@ import frappe
 from frappe.model.document import Document
 
 from press.api.client import dashboard_whitelist
+from press.overrides import get_permission_query_conditions_for_doctype
 
 if TYPE_CHECKING:
 	from press.press.doctype.cluster.cluster import Cluster
@@ -634,6 +635,9 @@ class ServerSnapshot(Document):
 			0,
 			update_modified=True,
 		)
+
+
+get_permission_query_conditions = get_permission_query_conditions_for_doctype("Server Snapshot")
 
 
 def move_pending_snapshots_to_processing():

--- a/press/press/doctype/server_snapshot_recovery/server_snapshot_recovery.py
+++ b/press/press/doctype/server_snapshot_recovery/server_snapshot_recovery.py
@@ -10,6 +10,7 @@ from frappe.utils import add_to_date
 
 from press.agent import Agent
 from press.api.client import dashboard_whitelist
+from press.overrides import get_permission_query_conditions_for_doctype
 from press.press.doctype.agent_job.agent_job import AgentJob
 from press.press.doctype.remote_file.remote_file import delete_remote_backup_objects
 from press.press.doctype.site_backup.site_backup import get_backup_bucket
@@ -430,6 +431,9 @@ class ServerSnapshotRecovery(Document):
 				remote_files.append(site.database_remote_file)
 
 		delete_remote_backup_objects(remote_files)
+
+
+get_permission_query_conditions = get_permission_query_conditions_for_doctype("Server Snapshot Recovery")
 
 
 def resume_warmed_up_restorations():

--- a/press/press/doctype/site_backup/site_backup.py
+++ b/press/press/doctype/site_backup/site_backup.py
@@ -15,6 +15,7 @@ from frappe.model.document import Document
 
 from press.agent import Agent
 from press.exceptions import SiteTooManyPendingBackups
+from press.overrides import get_permission_query_conditions_for_doctype
 from press.press.doctype.ansible_console.ansible_console import AnsibleAdHoc
 
 if TYPE_CHECKING:
@@ -389,6 +390,9 @@ class SiteBackup(Document):
 	@classmethod
 	def file_backup_exists(cls, site: str, day: datetime.date) -> bool:
 		return cls.backup_exists(site, day, {"with_files": True})
+
+
+get_permission_query_conditions = get_permission_query_conditions_for_doctype("Site Backup")
 
 
 class OngoingSnapshotError(Exception):


### PR DESCRIPTION
- Site Backup
- Server Snapshot
- Server Snapshot Recovery

Although user of the team can't perform any action on the doctypes, but it's better to hide from the list as well.