### PR TITLE
fix(bench): Port offset conflicts

### DIFF
--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -265,7 +265,6 @@ class Bench(Document):
 
 		if self.is_new():
 			self.port_offset = self.get_unused_port_offset()
-			frappe.db.commit()  # Release lock taken above
 
 		config = {
 			"monitor": True,

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -265,7 +265,6 @@ class Bench(Document):
 
 		if self.is_new():
 			self.port_offset = self.get_unused_port_offset()
-			self.save(ignore_version=True)
 			frappe.db.commit()  # Release lock taken above
 
 		config = {


### PR DESCRIPTION
- Multiple benches created in parallel run into same port offsets.
- Need to take a lock for txnA to finish before txnB can take a lock to get unused port.
- Quick commit once the port is assigned to release lock.