### PR TITLE
feat(cluster): Add elastic ip integration to ec2 servers (#3288)

### DIFF
--- a/press/fixtures/press_job_type.json
+++ b/press/fixtures/press_job_type.json
@@ -439,7 +439,7 @@
   "callback_script": "server = frappe.get_doc(doc.server_type, doc.server)\n\nif doc.server_type in [\"Server\", \"Database Server\"] and server.is_for_recovery:\n    filter_field = \"app_server\" if doc.server_type == \"Server\" else \"database_server\"\n    recovery_record_name = frappe.db.get_value(\"Server Snapshot Recovery\", {filter_field: doc.server}, \"name\")\n    if recovery_record_name:\n        recovery_record = frappe.get_doc(\"Server Snapshot Recovery\", recovery_record_name, for_update=True)\n    \n        if doc.status == \"Success\":\n            if doc.server_type == \"Server\":\n                recovery_record.is_app_server_ready = True\n            else:\n                recovery_record.is_database_server_ready = True\n            recovery_record.save()\n        else:\n            recovery_record.mark_server_provisioning_as_failed()\n            \nif doc.server_type in [\"Server\", \"Database Server\"] and \"logical_replication_backup\" in arguments:\n    if doc.status == \"Success\":\n        frappe.get_doc(\"Logical Replication Backup\", arguments.get(\"logical_replication_backup\")).next()\n    if doc.status == \"Failure\":\n        frappe.get_doc(\"Logical Replication Backup\", arguments.get(\"logical_replication_backup\")).fail()",
   "docstatus": 0,
   "doctype": "Press Job Type",
-  "modified": "2025-09-18 16:55:27.959089",
+  "modified": "2025-09-18 18:40:28.380844",
   "name": "Create Server",
   "steps": [
    {
@@ -448,7 +448,7 @@
     "wait_until_true": 0
    },
    {
-    "script": "machine = frappe.get_doc(\"Virtual Machine\", doc.virtual_machine)\ntry:\n    # Usually machine sync never fails\n    # It can fail weirdly due to TimestampMismatchError or lock timeout\n    # Don't fail this whole thing just because of that\n    # Ignore the errors of sync and keep retrying\n    machine.sync()\nexcept (frappe.QueryDeadlockError, frappe.QueryTimeoutError, frappe.exceptions.TimestampMismatchError):\n    pass\nresult = (machine.status == \"Running\", False)\n",
+    "script": "machine = frappe.get_doc(\"Virtual Machine\", doc.virtual_machine)\ntry:\n    # Usually machine sync never fails\n    # It can fail weirdly due to TimestampMismatchError or lock timeout\n    # Don't fail this whole thing just because of that\n    # Ignore the errors of sync and keep retrying\n    machine.sync()\n\nexcept (frappe.QueryDeadlockError, frappe.QueryTimeoutError, frappe.TimestampMismatchError):\n    result = (False, False)\nelse:\n    result = (machine.status == \"Running\", False)\n",
     "step_name": "Wait for Server to start",
     "wait_until_true": 1
    },
@@ -463,7 +463,7 @@
     "wait_until_true": 1
    },
    {
-    "script": "try:\n    vm = frappe.get_doc(\"Virtual Machine\", doc.virtual_machine)\n    vm.sync()\n    if len(vm.volumes) > 0:\n        result = (True, False)\n    else:\n        result = (False, False)\nexcept (frappe.QueryDeadlockError, frappe.QueryTimeoutError, frappe.exceptions.TimestampMismatchError):\n    result = (False, False)\nexcept Exception as e:\n    raise e",
+    "script": "try:\n    vm = frappe.get_doc(\"Virtual Machine\", doc.virtual_machine)\n    vm.sync()\n    if len(vm.volumes) > 0:\n        result = (True, False)\n    else:\n        result = (False, False)\nexcept (frappe.QueryDeadlockError, frappe.QueryTimeoutError, frappe.TimestampMismatchError):\n    result = (False, False)\nexcept Exception as e:\n    raise e",
     "step_name": "Sync Default Volumes",
     "wait_until_true": 1
    },

--- a/press/fixtures/press_job_type.json
+++ b/press/fixtures/press_job_type.json
@@ -439,7 +439,7 @@
   "callback_script": "server = frappe.get_doc(doc.server_type, doc.server)\n\nif doc.server_type in [\"Server\", \"Database Server\"] and server.is_for_recovery:\n    filter_field = \"app_server\" if doc.server_type == \"Server\" else \"database_server\"\n    recovery_record_name = frappe.db.get_value(\"Server Snapshot Recovery\", {filter_field: doc.server}, \"name\")\n    if recovery_record_name:\n        recovery_record = frappe.get_doc(\"Server Snapshot Recovery\", recovery_record_name, for_update=True)\n    \n        if doc.status == \"Success\":\n            if doc.server_type == \"Server\":\n                recovery_record.is_app_server_ready = True\n            else:\n                recovery_record.is_database_server_ready = True\n            recovery_record.save()\n        else:\n            recovery_record.mark_server_provisioning_as_failed()\n            \nif doc.server_type in [\"Server\", \"Database Server\"] and \"logical_replication_backup\" in arguments:\n    if doc.status == \"Success\":\n        frappe.get_doc(\"Logical Replication Backup\", arguments.get(\"logical_replication_backup\")).next()\n    if doc.status == \"Failure\":\n        frappe.get_doc(\"Logical Replication Backup\", arguments.get(\"logical_replication_backup\")).fail()",
   "docstatus": 0,
   "doctype": "Press Job Type",
-  "modified": "2025-09-08 11:44:21.210336",
+  "modified": "2025-09-18 16:55:27.959089",
   "name": "Create Server",
   "steps": [
    {
@@ -448,7 +448,7 @@
     "wait_until_true": 0
    },
    {
-    "script": "machine = frappe.get_doc(\"Virtual Machine\", doc.virtual_machine)\ntry:\n    # Usually machine sync never fails\n    # It can fail weirdly due to TimestampMismatchError or lock timeout\n    # Don't fail this whole thing just because of that\n    # Ignore the errors of sync and keep retrying\n    machine.sync()\nexcept:\n    pass\nresult = (machine.status == \"Running\", False)\n",
+    "script": "machine = frappe.get_doc(\"Virtual Machine\", doc.virtual_machine)\ntry:\n    # Usually machine sync never fails\n    # It can fail weirdly due to TimestampMismatchError or lock timeout\n    # Don't fail this whole thing just because of that\n    # Ignore the errors of sync and keep retrying\n    machine.sync()\nexcept (frappe.QueryDeadlockError, frappe.QueryTimeoutError, frappe.exceptions.TimestampMismatchError):\n    pass\nresult = (machine.status == \"Running\", False)\n",
     "step_name": "Wait for Server to start",
     "wait_until_true": 1
    },

--- a/press/press/doctype/press_job_step/press_job_step.py
+++ b/press/press/doctype/press_job_step/press_job_step.py
@@ -2,10 +2,14 @@
 # For license information, please see license.txt
 
 import json
+from typing import TYPE_CHECKING
 
 import frappe
 from frappe.model.document import Document
 from frappe.utils.safe_exec import safe_exec
+
+if TYPE_CHECKING:
+	from press.press.doctype.press_job.press_job import PressJob
 
 
 class PressJobStep(Document):
@@ -41,7 +45,7 @@ class PressJobStep(Document):
 			{"parent": self.job_type, "step_name": self.step_name},
 			"script",
 		)
-		job = frappe.get_doc("Press Job", self.job)
+		job: PressJob = frappe.get_doc("Press Job", self.job)
 		arguments = json.loads(job.arguments)
 		try:
 			local = {"arguments": frappe._dict(arguments), "result": None, "doc": job}
@@ -72,6 +76,8 @@ class PressJobStep(Document):
 		except Exception:
 			self.status = "Failure"
 			self.traceback = frappe.get_traceback(with_context=True)
+			if frappe.flags.in_test:
+				raise
 
 		self.end = frappe.utils.now_datetime()
 		self.duration = (self.end - self.start).total_seconds()

--- a/press/press/doctype/server/server.js
+++ b/press/press/doctype/server/server.js
@@ -65,6 +65,12 @@ frappe.ui.form.on('Server', {
 				frm.doc.is_server_setup,
 			],
 			[
+				__('Get AWS Static IP'),
+				'get_aws_static_ip',
+				false,
+				frm.doc.provider === 'AWS EC2',
+			],
+			[
 				__('Setup PySpy'),
 				'setup_pyspy',
 				false,

--- a/press/press/doctype/server/server.json
+++ b/press/press/doctype/server/server.json
@@ -26,7 +26,6 @@
   "public",
   "column_break_laiq",
   "use_agent_job_callbacks",
-  "is_static_ip_setup",
   "is_pyspy_setup",
   "halt_agent_jobs",
   "stop_deployments",
@@ -40,6 +39,7 @@
   "auto_increase_storage",
   "networking_section",
   "ip",
+  "is_static_ip",
   "ipv6",
   "column_break_3",
   "private_ip",
@@ -639,14 +639,14 @@
   },
   {
    "default": "0",
-   "fieldname": "is_static_ip_setup",
+   "fieldname": "is_static_ip",
    "fieldtype": "Check",
-   "label": "Is Static IP Setup",
+   "label": "Is Static IP",
    "read_only": 1
   }
  ],
  "links": [],
- "modified": "2025-09-17 22:55:23.023365",
+ "modified": "2025-09-18 13:45:30.860124",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Server",

--- a/press/press/doctype/server/server.json
+++ b/press/press/doctype/server/server.json
@@ -26,6 +26,7 @@
   "public",
   "column_break_laiq",
   "use_agent_job_callbacks",
+  "is_static_ip_setup",
   "is_pyspy_setup",
   "halt_agent_jobs",
   "stop_deployments",
@@ -624,7 +625,6 @@
    "fieldtype": "Check",
    "label": "Enable Logical Replication During Site Update"
   },
-
   {
    "fieldname": "ignore_incidents_till",
    "fieldtype": "Datetime",
@@ -636,10 +636,17 @@
    "fieldtype": "Check",
    "label": "TLS Certificate Renewal Failed",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_static_ip_setup",
+   "fieldtype": "Check",
+   "label": "Is Static IP Setup",
+   "read_only": 1
   }
  ],
  "links": [],
- "modified": "2025-09-09 10:34:01.505133",
+ "modified": "2025-09-17 22:55:23.023365",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Server",

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1909,6 +1909,7 @@ class Server(BaseServer):
 
 	if TYPE_CHECKING:
 		from frappe.types import DF
+
 		from press.press.doctype.resource_tag.resource_tag import ResourceTag
 		from press.press.doctype.server_mount.server_mount import ServerMount
 

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1909,7 +1909,6 @@ class Server(BaseServer):
 
 	if TYPE_CHECKING:
 		from frappe.types import DF
-
 		from press.press.doctype.resource_tag.resource_tag import ResourceTag
 		from press.press.doctype.server_mount.server_mount import ServerMount
 
@@ -1942,7 +1941,7 @@ class Server(BaseServer):
 		is_server_setup: DF.Check
 		is_standalone: DF.Check
 		is_standalone_setup: DF.Check
-		is_static_ip_setup: DF.Check
+		is_static_ip: DF.Check
 		is_upstream_setup: DF.Check
 		keep_files_on_server_in_offsite_backup: DF.Check
 		managed_database_service: DF.Link | None
@@ -2377,58 +2376,40 @@ class Server(BaseServer):
 
 	@frappe.whitelist()
 	def get_aws_static_ip(self):
-		try:
-			vm_doc = frappe.get_doc("Virtual Machine", self.virtual_machine)
+		vm_doc = frappe.get_doc("Virtual Machine", self.virtual_machine)
 
-			if vm_doc.cloud_provider != "AWS EC2":
-				frappe.throw("Failed to proceed as VM is not AWS EC2")
+		if vm_doc.cloud_provider != "AWS EC2":
+			frappe.throw("Failed to proceed as VM is not AWS EC2")
 
-			print(f"[AWS] Starting static IP allocation for VM {self.virtual_machine}")
+		cluster_doc = frappe.get_doc("Cluster", self.cluster)
+		region_name = cluster_doc.region
+		aws_access_key_id = cluster_doc.aws_access_key_id
+		aws_secret_access_key = get_decrypted_password(
+			"Cluster", self.cluster, fieldname="aws_secret_access_key", raise_exception=False
+		)
 
-			cluster_doc = frappe.get_doc("Cluster", self.cluster)
-			print(f"[AWS] Using Cluster: {cluster_doc.name}, Region: {cluster_doc.region}")
+		instance_id = vm_doc.instance_id
 
-			region_name = cluster_doc.region
-			aws_access_key_id = cluster_doc.aws_access_key_id
-			aws_secret_access_key = get_decrypted_password(
-				"Cluster", self.cluster, fieldname="aws_secret_access_key", raise_exception=False
-			)
+		# Initialize EC2 client
+		ec2_client = boto3.client(
+			"ec2",
+			aws_access_key_id=aws_access_key_id,
+			aws_secret_access_key=aws_secret_access_key,
+			region_name=region_name,
+		)
 
-			instance_id = vm_doc.instance_id
-			print(f"[AWS] Target Instance ID: {instance_id}")
+		# Allocate new Elastic IP
+		allocation = ec2_client.allocate_address(Domain="vpc")
+		allocation_id = allocation["AllocationId"]
+		public_ip = allocation["PublicIp"]
 
-			# Initialize EC2 client
-			ec2_client = boto3.client(
-				"ec2",
-				aws_access_key_id=aws_access_key_id,
-				aws_secret_access_key=aws_secret_access_key,
-				region_name=region_name,
-			)
-			print("[AWS] EC2 client initialized successfully")
+		# Associate with instance
+		ec2_client.associate_address(InstanceId=instance_id, AllocationId=allocation_id)
 
-			# Allocate new Elastic IP
-			allocation = ec2_client.allocate_address(Domain="vpc")
-			allocation_id = allocation["AllocationId"]
-			public_ip = allocation["PublicIp"]
-			print(f"[AWS] Allocated Elastic IP: {public_ip} (AllocationId: {allocation_id})")
+		# Trigger VM sync
+		vm_doc.sync()
 
-			# Associate with instance
-			ec2_client.associate_address(InstanceId=instance_id, AllocationId=allocation_id)
-			print(f"[AWS] Associated Elastic IP {public_ip} with Instance {instance_id}")
-
-			# Trigger VM sync
-			vm_doc.sync()
-			print(f"[AWS] Cluster {cluster_doc.name} synced after IP allocation")
-
-			return f"Static IP {public_ip} alloted to the VM (Allocation ID: {allocation_id})"
-
-		except Exception as e:
-			frappe.log_error(
-				message=f"Failed to allocate static IP to EC2 instance {getattr(self, 'virtual_machine', None)}\n{frappe.get_traceback()}",
-				title="AWS Elastic IP Allocation Failed",
-			)
-			print(f"[AWS] Exception occurred: {e}")
-			raise
+		return f"Static IP {public_ip} alloted to the VM (Allocation ID: {allocation_id})"
 
 	@frappe.whitelist()
 	def setup_replication(self):

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -18,6 +18,7 @@ from frappe import _
 from frappe.core.utils import find, find_all
 from frappe.installer import subprocess
 from frappe.model.document import Document
+from frappe.utils.password import get_decrypted_password
 from frappe.utils.synchronization import filelock
 from frappe.utils.user import is_system_user
 
@@ -1941,6 +1942,7 @@ class Server(BaseServer):
 		is_server_setup: DF.Check
 		is_standalone: DF.Check
 		is_standalone_setup: DF.Check
+		is_static_ip_setup: DF.Check
 		is_upstream_setup: DF.Check
 		keep_files_on_server_in_offsite_backup: DF.Check
 		managed_database_service: DF.Link | None
@@ -2372,6 +2374,61 @@ class Server(BaseServer):
 			self.save()
 		except Exception:
 			log_error("Setup PySpy Exception", server=self.as_dict())
+
+	@frappe.whitelist()
+	def get_aws_static_ip(self):
+		try:
+			vm_doc = frappe.get_doc("Virtual Machine", self.virtual_machine)
+
+			if vm_doc.cloud_provider != "AWS EC2":
+				frappe.throw("Failed to proceed as VM is not AWS EC2")
+
+			print(f"[AWS] Starting static IP allocation for VM {self.virtual_machine}")
+
+			cluster_doc = frappe.get_doc("Cluster", self.cluster)
+			print(f"[AWS] Using Cluster: {cluster_doc.name}, Region: {cluster_doc.region}")
+
+			region_name = cluster_doc.region
+			aws_access_key_id = cluster_doc.aws_access_key_id
+			aws_secret_access_key = get_decrypted_password(
+				"Cluster", self.cluster, fieldname="aws_secret_access_key", raise_exception=False
+			)
+
+			instance_id = vm_doc.instance_id
+			print(f"[AWS] Target Instance ID: {instance_id}")
+
+			# Initialize EC2 client
+			ec2_client = boto3.client(
+				"ec2",
+				aws_access_key_id=aws_access_key_id,
+				aws_secret_access_key=aws_secret_access_key,
+				region_name=region_name,
+			)
+			print("[AWS] EC2 client initialized successfully")
+
+			# Allocate new Elastic IP
+			allocation = ec2_client.allocate_address(Domain="vpc")
+			allocation_id = allocation["AllocationId"]
+			public_ip = allocation["PublicIp"]
+			print(f"[AWS] Allocated Elastic IP: {public_ip} (AllocationId: {allocation_id})")
+
+			# Associate with instance
+			ec2_client.associate_address(InstanceId=instance_id, AllocationId=allocation_id)
+			print(f"[AWS] Associated Elastic IP {public_ip} with Instance {instance_id}")
+
+			# Trigger VM sync
+			vm_doc.sync()
+			print(f"[AWS] Cluster {cluster_doc.name} synced after IP allocation")
+
+			return f"Static IP {public_ip} alloted to the VM (Allocation ID: {allocation_id})"
+
+		except Exception as e:
+			frappe.log_error(
+				message=f"Failed to allocate static IP to EC2 instance {getattr(self, 'virtual_machine', None)}\n{frappe.get_traceback()}",
+				title="AWS Elastic IP Allocation Failed",
+			)
+			print(f"[AWS] Exception occurred: {e}")
+			raise
 
 	@frappe.whitelist()
 	def setup_replication(self):

--- a/press/press/doctype/virtual_machine/virtual_machine.json
+++ b/press/press/doctype/virtual_machine/virtual_machine.json
@@ -413,7 +413,7 @@
    "link_fieldname": "virtual_machine"
   }
  ],
- "modified": "2025-08-31 20:40:23.989997",
+ "modified": "2025-09-18 13:43:23.037735",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Virtual Machine",

--- a/press/press/doctype/virtual_machine/virtual_machine.json
+++ b/press/press/doctype/virtual_machine/virtual_machine.json
@@ -40,6 +40,7 @@
   "subnet_id",
   "private_ip_address",
   "public_ip_address",
+  "is_static_ip",
   "column_break_15",
   "subnet_cidr_block",
   "public_dns_name",
@@ -378,6 +379,13 @@
    "fieldname": "disable_server_snapshot",
    "fieldtype": "Check",
    "label": "Disable Server Snapshot"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_static_ip",
+   "fieldtype": "Check",
+   "label": "Is Static IP",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
@@ -413,7 +421,7 @@
    "link_fieldname": "virtual_machine"
   }
  ],
- "modified": "2025-09-18 13:43:23.037735",
+ "modified": "2025-09-19 11:58:46.269416",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Virtual Machine",

--- a/press/press/doctype/virtual_machine/virtual_machine.py
+++ b/press/press/doctype/virtual_machine/virtual_machine.py
@@ -67,7 +67,10 @@ class VirtualMachine(Document):
 
 	if TYPE_CHECKING:
 		from frappe.types import DF
-		from press.press.doctype.virtual_machine_temporary_volume.virtual_machine_temporary_volume import VirtualMachineTemporaryVolume
+
+		from press.press.doctype.virtual_machine_temporary_volume.virtual_machine_temporary_volume import (
+			VirtualMachineTemporaryVolume,
+		)
 		from press.press.doctype.virtual_machine_volume.virtual_machine_volume import VirtualMachineVolume
 
 		availability_zone: DF.Data
@@ -1075,7 +1078,8 @@ class VirtualMachine(Document):
 				server = server[0]
 				frappe.db.set_value(doctype, server, "ip", self.public_ip_address)
 				frappe.db.set_value(doctype, server, "private_ip", self.private_ip_address)
-				frappe.db.set_value(doctype, server, "is_static_ip", self.is_elastic_ip_aws())
+				if doctype == "Server":
+					frappe.db.set_value(doctype, server, "is_static_ip", self.is_elastic_ip_aws())
 				if doctype in ["Server", "Database Server"]:
 					frappe.db.set_value(doctype, server, "ram", self.ram)
 				if self.public_ip_address and self.has_value_changed("public_ip_address"):

--- a/press/press/doctype/virtual_machine/virtual_machine.py
+++ b/press/press/doctype/virtual_machine/virtual_machine.py
@@ -1056,7 +1056,7 @@ class VirtualMachine(Document):
 			ip_owner_id = instance["NetworkInterfaces"][0]["Association"]["IpOwnerId"]
 
 			return ip_owner_id.lower() != "amazon"
-		except KeyError:
+		except (KeyError, IndexError):
 			return False
 
 	def update_servers(self):

--- a/press/press/doctype/virtual_machine/virtual_machine.py
+++ b/press/press/doctype/virtual_machine/virtual_machine.py
@@ -966,6 +966,14 @@ class VirtualMachine(Document):
 			self.private_dns_name = instance.get("PrivateDnsName")
 			self.platform = instance.get("Architecture", "x86_64")
 
+			# Check if EC2 instance has Elastic IP and update all associated "Server" docs
+			servers = frappe.get_all("Server", filters={"virtual_machine": self.name}, pluck="name")
+			for server_name in servers:
+				server_doc = frappe.get_doc("Server", server_name)
+				server_doc.is_static_ip_setup = 1
+				server_doc.save(ignore_permissions=True)
+			frappe.db.commit()
+
 			attached_volumes = []
 			attached_devices = []
 			for volume_index, volume in enumerate(self.get_volumes(), start=1):  # idx starts from 1


### PR DESCRIPTION
 - Add action to allocate an Elastic IP to an EC2 instance and trigger sync from the associated Virtual Machine
 - Add a step in sync under update_servers to update the new `is_static_ip` read-only field in Server if the returned IP is Elastic