### PR TITLE
feat(registry): Registry mirror

### DIFF
--- a/press/playbooks/roles/registry/files/registry-config.yml.j2
+++ b/press/playbooks/roles/registry/files/registry-config.yml.j2
@@ -1,0 +1,30 @@
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /var/lib/registry
+    maxthreads: 300
+http:
+  addr: :5000
+  headers:
+    X-Content-Type-Options: [nosniff]
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3
+  maintenance:
+    readonly:
+      enabled: true
+
+{% if is_mirror %}
+proxy:
+  remoteurl: https://registry.frappe.cloud/production
+  username: {{ username }}
+  password: {{ password }}
+  ttl: 168h
+{% endif %}

--- a/press/playbooks/roles/registry/files/registry-docker-compose.yml.j2
+++ b/press/playbooks/roles/registry/files/registry-docker-compose.yml.j2
@@ -14,11 +14,11 @@ services:
       - "5001:5001"
     volumes:
       - type: bind
-        source: /mnt/registry_frappe_cloud/data
+        source: {{ docker_data_mountpoint }}
         target: /var/lib/registry
       - type: bind
         source: /home/frappe/registry/config.yml
-        target: {{ registry_config }}
+        target: {{ container_registry_config_path }}
 
   registry-ui:
     image: joxit/docker-registry-ui:latest

--- a/press/playbooks/roles/registry/files/registry-docker-compose.yml.j2
+++ b/press/playbooks/roles/registry/files/registry-docker-compose.yml.j2
@@ -1,0 +1,34 @@
+version: "3.8"
+services:
+  registry:
+    image: registry:latest
+    environment:
+      REGISTRY_STORAGE_DELETE_ENABLED: "true"
+      REGISTRY_LOG_LEVEL: "info"
+      REGISTRY_LOG_ACCESSLOG_DISABLED: "false"
+      REGISTRY_HTTP_DEBUG_ADDR: ":5001"
+      REGISTRY_HTTP_DEBUG_PROMETHEUS_ENABLED: "true"
+      REGISTRY_STORAGE_FILESYSTEM_MAXTHREADS: "300"
+    ports:
+      - "5000:5000"
+      - "5001:5001"
+    volumes:
+      - type: bind
+        source: /mnt/registry_frappe_cloud/data
+        target: /var/lib/registry
+      - type: bind
+        source: /home/frappe/registry/config.yml
+        target: {{ registry_config }}
+
+  registry-ui:
+    image: joxit/docker-registry-ui:latest
+    environment:
+      REGISTRY_TITLE: Frappe Cloud Registry
+      REGISTRY_URL: {{ registry_url }}
+      NGINX_PROXY_PASS_URL: http://registry:5000
+      DELETE_IMAGES: "true"
+      SINGLE_REGISTRY: "true"
+    ports:
+      - "127.0.0.1:6000:80"
+    depends_on:
+      - registry

--- a/press/playbooks/roles/registry/tasks/main.yml
+++ b/press/playbooks/roles/registry/tasks/main.yml
@@ -21,11 +21,34 @@
   shell: docker stop registry; docker rm registry
   ignore_errors: true
 
-- name: Start Docker Registry
-  script: files/registry.sh
+- name: Copy registry config file
+  template:
+    src: files/registry-config.yml.j2
+    dest: /home/frappe/registry/config.yml
+    owner: frappe
+    group: frappe
+    mode: '0644'
+  vars:
+    is_mirror: "{{ is_mirror | bool}}"
+    username: "{{ username }}"
+    password: "{{ password }}"
 
-- name: Start Docker Registry UI
-  script: files/registry-ui.sh
+
+- name: Deploy Docker Compose file
+  template:
+    src: files/registry-docker-compose.yml.j2
+    dest: /home/frappe/registry/docker-compose.yml
+    owner: frappe
+    group: frappe
+    mode: '0644'
+  vars:
+    registry_config: "{{ registry_config }}"
+    registry_url: "http://{{ registry_url }}"
+
+- name: Start Docker registry with docker compose
+  command: docker compose up -d
+  args:
+    chdir: /home/frappe/registry
 
 - name: Setup Registry Authentication
   become: yes

--- a/press/playbooks/roles/registry/tasks/main.yml
+++ b/press/playbooks/roles/registry/tasks/main.yml
@@ -30,8 +30,8 @@
     mode: '0644'
   vars:
     is_mirror: "{{ is_mirror | bool}}"
-    username: "{{ username }}"
-    password: "{{ password }}"
+    username: "{{ registry_username }}"
+    password: "{{ registry_password }}"
 
 
 - name: Deploy Docker Compose file
@@ -42,7 +42,8 @@
     group: frappe
     mode: '0644'
   vars:
-    registry_config: "{{ registry_config }}"
+    docker_data_mountpoint: "{{ docker_data_mountpoint }}"
+    container_registry_config_path: "{{ container_registry_config_path }}"
     registry_url: "http://{{ registry_url }}"
 
 - name: Start Docker registry with docker compose

--- a/press/press/doctype/registry_server/registry_server.js
+++ b/press/press/doctype/registry_server/registry_server.js
@@ -9,6 +9,13 @@ frappe.ui.form.on('Registry Server', {
 			[__('Prepare Server'), 'prepare_server', true, !frm.doc.is_server_setup],
 			[__('Setup Server'), 'setup_server', true, !frm.doc.is_server_setup],
 			[
+				__('Show Registry Password'),
+				'show_registry_password',
+				false,
+				frm.doc.is_server_Setup,
+			],
+			[__('Create Mirror'), 'create_registry_mirror', true, !frm.doc.is_mirror],
+			[
 				__('Update TLS Certificate'),
 				'update_tls_certificate',
 				true,
@@ -22,7 +29,10 @@ frappe.ui.form.on('Registry Server', {
 					(!frm.doc.frappe_public_key || !frm.doc.root_public_key),
 			],
 		].forEach(([label, method, confirm, condition]) => {
-			if (typeof condition === 'undefined' || condition) {
+			if (
+				typeof condition === 'undefined' ||
+				(condition && method != 'create_registry_mirror')
+			) {
 				frm.add_custom_button(
 					label,
 					() => {
@@ -47,6 +57,66 @@ frappe.ui.form.on('Registry Server', {
 								}
 							});
 						}
+					},
+					__('Actions'),
+				);
+			}
+			if (method == 'create_registry_mirror') {
+				frm.add_custom_button(
+					label,
+					() => {
+						frappe.prompt(
+							[
+								{
+									fieldtype: 'Data',
+									label: 'Hostname',
+									fieldname: 'hostname',
+									reqd: 1,
+								},
+								{
+									fieldtype: 'Data',
+									label: 'Mount Point',
+									fieldname: 'docker_data_mountpoint',
+									reqd: 1,
+								},
+								{
+									fieldtype: 'Data',
+									label: 'Container Registry Config Path',
+									fieldname: 'container_registry_config_path',
+									reqd: 1,
+								},
+								{
+									fieldtype: 'Data',
+									label: 'Public IP',
+									fieldname: 'public_ip',
+									reqd: 1,
+								},
+								{
+									fieldtype: 'Data',
+									label: 'Private IP',
+									fieldname: 'private_ip',
+									reqd: 1,
+								},
+							],
+							({
+								hostname,
+								docker_data_mountpoint,
+								container_registry_config_path,
+								public_ip,
+								private_ip,
+							}) => {
+								frm
+									.call(method, {
+										hostname,
+										docker_data_mountpoint,
+										container_registry_config_path,
+										public_ip,
+										private_ip,
+									})
+									.then((r) => frm.refresh());
+							},
+							__('Create Mirror Registry'),
+						);
 					},
 					__('Actions'),
 				);

--- a/press/press/doctype/registry_server/registry_server.json
+++ b/press/press/doctype/registry_server/registry_server.json
@@ -13,6 +13,7 @@
   "provider",
   "virtual_machine",
   "is_server_setup",
+  "is_mirror",
   "networking_section",
   "ip",
   "column_break_9",
@@ -23,8 +24,10 @@
   "agent_password",
   "registry_section",
   "registry_username",
+  "docker_data_mountpoint",
   "column_break_10",
   "registry_password",
+  "container_registry_config_path",
   "ssh_section",
   "ssh_user",
   "ssh_port",
@@ -213,6 +216,22 @@
   },
   {
    "default": "0",
+   "fieldname": "is_mirror",
+   "fieldtype": "Check",
+   "label": "Is Mirror"
+  },
+  {
+   "fieldname": "docker_data_mountpoint",
+   "fieldtype": "Data",
+   "label": "Docker Data Mountpoint"
+  },
+  {
+   "fieldname": "container_registry_config_path",
+   "fieldtype": "Data",
+   "label": "Container Registry Config Path"
+  },
+  {
+   "default": "0",
    "fieldname": "tls_certificate_renewal_failed",
    "fieldtype": "Check",
    "label": "TLS Certificate Renewal Failed",
@@ -225,7 +244,7 @@
    "link_fieldname": "server"
   }
  ],
- "modified": "2025-09-02 16:43:47.166808",
+ "modified": "2025-09-18 14:54:00.130740",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Registry Server",

--- a/press/press/doctype/registry_server/registry_server.py
+++ b/press/press/doctype/registry_server/registry_server.py
@@ -84,7 +84,7 @@ class RegistryServer(BaseServer):
 			"registry_password": self.get_password("registry_password"),
 			"certificate_private_key": certificate.private_key,
 			"certificate_full_chain": certificate.full_chain,
-			"mirror": self.is_mirror,
+			"is_mirror": self.is_mirror,
 			"docker_data_mountpoint": self.docker_data_mountpoint,
 			"certificate_intermediate_chain": certificate.intermediate_chain,
 			"container_registry_config_path": self.container_registry_config_path,


### PR DESCRIPTION
- Add missing configuration files for registry container.
- Allow creating of registries on the fly in different clusters using the base registry.
- Pass mirroring configuration on registry.
