### PR TITLE
chore(registry): Fallback implementations

### DIFF
--- a/press/agent.py
+++ b/press/agent.py
@@ -60,7 +60,7 @@ class Agent:
 			as_dict=True,
 		)
 		cluster = frappe.db.get_value(self.server_type, self.server, "cluster")
-		registry_url = frappe.db.get_value("Cluster", cluster, "repository")
+		registry_url = frappe.db.get_value("Cluster", cluster, "repository") or settings.docker_registry_url
 
 		data = {
 			"name": bench.name,

--- a/press/playbooks/roles/registry/files/registry-config.yml.j2
+++ b/press/playbooks/roles/registry/files/registry-config.yml.j2
@@ -3,7 +3,7 @@ log:
   fields:
     service: registry
 
-{% if (is_disk_storage | string == '1') %}
+{% if (is_mirror | string == '1') %}
 storage:
   cache:
     blobdescriptor: inmemory
@@ -28,7 +28,7 @@ health:
 
 {% if (is_mirror | string == '1') %}
 proxy:
-  remoteurl: https://registry.frappe.cloud/production
+  remoteurl: {{ proxy_pass }}
   username: {{ username }}
   password: {{ password }}
   ttl: 168h

--- a/press/playbooks/roles/registry/tasks/main.yml
+++ b/press/playbooks/roles/registry/tasks/main.yml
@@ -32,7 +32,7 @@
     is_mirror: "{{ is_mirror }}"
     username: "{{ registry_username }}"
     password: "{{ registry_password }}"
-    is_disk_storage: "{{ is_disk_storage }}"
+    proxy_pass: "{{ proxy_pass }}"
 
 
 - name: Copy docker compose file

--- a/press/press/doctype/cluster/cluster.json
+++ b/press/press/doctype/cluster/cluster.json
@@ -299,7 +299,6 @@
    "label": "Docker"
   },
   {
-   "default": "registry.frappe.cloud",
    "fieldname": "repository",
    "fieldtype": "Data",
    "label": "Repository"
@@ -339,7 +338,7 @@
    "link_fieldname": "document_name"
   }
  ],
- "modified": "2025-09-19 11:47:53.571766",
+ "modified": "2025-09-19 16:27:01.820199",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Cluster",

--- a/press/press/doctype/deploy/deploy.py
+++ b/press/press/doctype/deploy/deploy.py
@@ -63,20 +63,22 @@ class Deploy(Document):
 			for v in group.mounts
 		]
 		for bench in self.benches:
+			image = build.docker_image
 			server_platform = frappe.get_value("Server", bench.server, "platform")
 			build = self._get_build_for_bench(server_platform)
 			cluster = frappe.get_value("Server", bench.server, "cluster")
-			docker_repository = frappe.get_value("Cluster", cluster, "repository")
-			hub_registry_url = frappe.db.get_value("Press Settings", None, "docker_registry_url")
-			image = build.docker_image
-			new_image = image.replace(hub_registry_url, docker_repository)
+			cluster_docker_repository = frappe.db.get_value("Cluster", cluster, "repository")
+
+			if cluster_docker_repository:
+				hub_registry_url = frappe.db.get_value("Press Settings", None, "docker_registry_url")
+				image = image.replace(hub_registry_url, cluster_docker_repository)
 
 			new = frappe.get_doc(
 				{
 					"doctype": "Bench",
 					"server": bench.server,
 					"build": build.name,
-					"docker_image": new_image,
+					"docker_image": image,
 					"group": self.group,
 					"candidate": self.candidate,
 					"workers": 1,

--- a/press/press/doctype/registry_server/registry_server.js
+++ b/press/press/doctype/registry_server/registry_server.js
@@ -97,6 +97,12 @@ frappe.ui.form.on('Registry Server', {
 									fieldname: 'private_ip',
 									reqd: 1,
 								},
+								{
+									fieldname: 'Data',
+									label: 'Proxy Pass',
+									fieldname: 'proxy_pass',
+									reqd: 1,
+								},
 							],
 							({
 								hostname,
@@ -104,6 +110,7 @@ frappe.ui.form.on('Registry Server', {
 								container_registry_config_path,
 								public_ip,
 								private_ip,
+								proxy_pass,
 							}) => {
 								frm
 									.call(method, {
@@ -112,6 +119,7 @@ frappe.ui.form.on('Registry Server', {
 										container_registry_config_path,
 										public_ip,
 										private_ip,
+										proxy_pass,
 									})
 									.then((r) => frm.refresh());
 							},

--- a/press/press/doctype/registry_server/registry_server.json
+++ b/press/press/doctype/registry_server/registry_server.json
@@ -41,7 +41,7 @@
   "region_endpoint",
   "region",
   "bucket_name",
-  "is_disk_storage"
+  "proxy_pass"
  ],
  "fields": [
   {
@@ -263,10 +263,9 @@
    "label": "Bucket Name"
   },
   {
-   "default": "0",
-   "fieldname": "is_disk_storage",
-   "fieldtype": "Check",
-   "label": "Is Disk Storage"
+   "fieldname": "proxy_pass",
+   "fieldtype": "Data",
+   "label": "Proxy Pass"
   }
  ],
  "links": [
@@ -275,7 +274,7 @@
    "link_fieldname": "server"
   }
  ],
- "modified": "2025-09-18 23:10:19.218423",
+ "modified": "2025-09-19 16:11:40.237095",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Registry Server",

--- a/press/press/doctype/registry_server/registry_server.py
+++ b/press/press/doctype/registry_server/registry_server.py
@@ -30,7 +30,6 @@ class RegistryServer(BaseServer):
 		frappe_user_password: DF.Password | None
 		hostname: DF.Data
 		ip: DF.Data
-		is_disk_storage: DF.Check
 		is_mirror: DF.Check
 		is_server_setup: DF.Check
 		monitoring_password: DF.Password | None
@@ -38,6 +37,7 @@ class RegistryServer(BaseServer):
 		private_mac_address: DF.Data | None
 		private_vlan_id: DF.Data | None
 		provider: DF.Literal["Generic", "Scaleway", "AWS EC2", "OCI"]
+		proxy_pass: DF.Data | None
 		region: DF.Data | None
 		region_endpoint: DF.Data | None
 		registry_password: DF.Password | None
@@ -96,12 +96,12 @@ class RegistryServer(BaseServer):
 			"certificate_intermediate_chain": certificate.intermediate_chain,
 			"container_registry_config_path": self.container_registry_config_path,
 			"registry_url": f"https://{self.name}",
-			"is_disk_storage": self.is_disk_storage,
 			"access_key": access_key,
 			"secret_key": secret_key,
 			"region_endpoint": self.region_endpoint,
 			"region": self.region,
 			"bucket_name": self.bucket_name,
+			"proxy_pass": self.proxy_pass,
 		}
 		try:
 			ansible = Ansible(
@@ -152,7 +152,9 @@ class RegistryServer(BaseServer):
 		container_registry_config_path: str,
 		public_ip: str,
 		private_ip: str,
+		proxy_pass: str,
 	):
+		"""Create a registry mirror"""
 		registry: RegistryServer = frappe.get_doc(
 			{
 				"doctype": "Registry Server",
@@ -165,6 +167,7 @@ class RegistryServer(BaseServer):
 				"provider": "Generic",
 				"registry_username": self.registry_username,
 				"registry_password": self.get_password("registry_password"),
+				"proxy_pass": proxy_pass,
 			}
 		)
 		registry.insert()


### PR DESCRIPTION
- Make upstream dynamic in mirror
- Don't rely on is_disk_storage just use mirror boolean.
- Add fallback docker registry from press settings in case cluster does not have a registry