### PR TITLE
fix(signups): Move create subscription part as bg job

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -318,6 +318,7 @@ scheduler_events = {
 			"press.press.doctype.agent_request_failure.agent_request_failure.remove_old_failures",
 			"press.saas.doctype.site_access_token.site_access_token.cleanup_expired_access_tokens",
 			"press.press.doctype.server_snapshot.server_snapshot.sync_ongoing_server_snapshots",
+			"press.press.doctype.site.site.create_subscription_for_trial_sites",
 		],
 		"*/10 * * * *": [
 			"press.saas.doctype.product_trial.product_trial.replenish_standby_sites",

--- a/press/patches.txt
+++ b/press/patches.txt
@@ -147,3 +147,4 @@ press.press.doctype.drip_email.patches.migrate_to_product_trial_field
 press.press.doctype.mpesa_payment_record.patches.add_unique_constraint
 press.press.doctype.user_2fa.patches.generate_recovery_codes
 press.press.doctype.account_request.patches.generate_expiration_time_for_request_key
+press.saas.doctype.product_trial_request.patches.set_subscription_created_flag

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -4412,3 +4412,35 @@ def suspend_sites_exceeding_disk_usage_for_last_7_days():
 			# Check once again and suspend if still exceeds limits
 			site: Site = frappe.get_doc("Site", site.name)
 			site.suspend(reason="Site Usage Exceeds Plan limits", skip_reload=True)
+
+
+def create_subscription_for_trial_sites():
+	# Get sites that are in "Site Created" status and has no entry in "Site Plan Change"
+	# For those sites, invoke "Create Subscription" that puts entry into "Site Plan Change" and "Subscription"
+	active_sites = frappe.db.sql(
+		"""
+		SELECT trial.site, producttrial.trial_plan
+		FROM `tabProduct Trial Request` trial
+		LEFT JOIN `tabSite Plan Change` siteplanchange
+		ON trial.site = siteplanchange.name
+		LEFT JOIN `tabProduct Trial`  producttrial ON trial.product_trial = producttrial.name WHERE trial.is_subscription_created = 0 AND siteplanchange.name is NULL AND trial.status="Site Created" LIMIT 25;
+		""",
+		as_dict=True,
+	)
+	frappe.log(f"Creating subscription for the sites {active_sites}")
+	for trial_site in active_sites:
+		if has_job_timeout_exceeded():
+			return
+		try:
+			site: Site = frappe.get_doc("Site", trial_site.site)
+			site.create_subscription(trial_site.trial_plan)
+			frappe.db.set_value(
+				"Product Trial Request",
+				{"site": trial_site.site},
+				{"is_subscription_created": 1},
+				update_modified=False,
+			)
+			frappe.db.commit()
+		except Exception:
+			frappe.db.rollback()
+			log_error(title="Creating subscription for trial sites", site=trial_site)

--- a/press/saas/doctype/product_trial/product_trial.py
+++ b/press/saas/doctype/product_trial/product_trial.py
@@ -121,7 +121,7 @@ class ProductTrial(Document):
 			site.signup_time = frappe.utils.now()
 			site.generate_saas_communication_secret(create_agent_job=True, save=False)
 			site.save()  # Save is needed for create_subscription to work TODO: remove this
-			site.create_subscription(plan)
+			# site.create_subscription(plan)
 			site.reload()
 			self.set_site_domain(site, site_domain)
 		else:

--- a/press/saas/doctype/product_trial/product_trial.py
+++ b/press/saas/doctype/product_trial/product_trial.py
@@ -121,7 +121,6 @@ class ProductTrial(Document):
 			site.signup_time = frappe.utils.now()
 			site.generate_saas_communication_secret(create_agent_job=True, save=False)
 			site.save()  # Save is needed for create_subscription to work TODO: remove this
-			# site.create_subscription(plan)
 			site.reload()
 			self.set_site_domain(site, site_domain)
 		else:

--- a/press/saas/doctype/product_trial_request/patches/set_subscription_created_flag.py
+++ b/press/saas/doctype/product_trial_request/patches/set_subscription_created_flag.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2025, Frappe and contributors
+# For license information, please see license.txt
+
+import frappe
+
+
+def execute():
+	frappe.db.set_value("Product Trial Request", {"is_subscription_created": 0}, "is_subscription_created", 1)

--- a/press/saas/doctype/product_trial_request/product_trial_request.json
+++ b/press/saas/doctype/product_trial_request/product_trial_request.json
@@ -19,6 +19,7 @@
   "section_break_zlzx",
   "site_creation_started_on",
   "is_standby_site",
+  "is_subscription_created",
   "column_break_bvut",
   "site_creation_completed_on",
   "is_site_accessible",
@@ -137,12 +138,18 @@
    "fieldtype": "Code",
    "label": "Error",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_subscription_created",
+   "fieldtype": "Check",
+   "label": "Is Subscription Created"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-08-25 11:10:51.808901",
+ "modified": "2025-09-22 14:10:22.140755",
  "modified_by": "Administrator",
  "module": "SaaS",
  "name": "Product Trial Request",

--- a/press/saas/doctype/product_trial_request/product_trial_request.py
+++ b/press/saas/doctype/product_trial_request/product_trial_request.py
@@ -38,6 +38,7 @@ class ProductTrialRequest(Document):
 		error: DF.Code | None
 		is_site_accessible: DF.Literal["Not Checked", "Yes", "No"]
 		is_standby_site: DF.Check
+		is_subscription_created: DF.Check
 		product_trial: DF.Link | None
 		site: DF.Link | None
 		site_creation_completed_on: DF.Datetime | None
@@ -243,6 +244,8 @@ class ProductTrialRequest(Document):
 			self.is_standby_site = is_standby_site
 			self.agent_job = agent_job_name
 			self.site = site.name
+			if not is_standby_site:
+				self.is_subscription_created = 1
 			self.save()
 
 			if is_standby_site:


### PR DESCRIPTION
This PR moves the creating subscription process for precreated site from the sign up flow into background job that runs for every 5 mins and take care of it there.