### PR TITLE
fix(Proxy Server): Ability to set public and private IP if VM is not defined

### DIFF
--- a/press/press/doctype/proxy_server/proxy_server.js
+++ b/press/press/doctype/proxy_server/proxy_server.js
@@ -125,3 +125,19 @@ frappe.ui.form.on('Proxy Server', {
 		press.set_hostname_abbreviation(frm);
 	},
 });
+
+// Enable manual IP entry for AWS instances
+frappe.ui.form.on('Proxy Server', {
+	refresh: function (frm) {
+		// Enable IP fields for manual entry in case Virtual Machine is not used
+		if (!frm.doc.virtual_machine && frm.doc.provider == "Generic") {
+			frm.set_df_property('ip', 'read_only', 0);
+			frm.set_df_property('private_ip', 'read_only', 0);
+			frm.set_df_property('ip', 'reqd', 1);
+			frm.set_df_property('private_ip', 'reqd', 1);
+
+		}
+
+	}
+
+});

--- a/press/press/doctype/proxy_server/proxy_server.py
+++ b/press/press/doctype/proxy_server/proxy_server.py
@@ -78,6 +78,7 @@ class ProxyServer(BaseServer):
 		super().validate()
 		self.validate_domains()
 		self.validate_proxysql_admin_password()
+		self.validate_ips()
 
 	def validate_domains(self):
 		domains = [row.domain for row in self.domains]
@@ -97,6 +98,13 @@ class ProxyServer(BaseServer):
 	def validate_proxysql_admin_password(self):
 		if not self.proxysql_admin_password:
 			self.proxysql_admin_password = frappe.generate_hash(length=32)
+
+	
+	def validate_ips(self):
+		# If Virtual machine is not available, valid IP addresses of the Proxy server must be entered to continue with the setup. 
+		if not self.virtual_machine and not (self.ip and self.private_ip):
+			frappe.throw("Enter the public and private IP addresses while configuring of the Proxy Server.")
+
 
 	def _setup_server(self):
 		agent_password = self.get_password("agent_password")


### PR DESCRIPTION
While setting up frappe press locally, had created various servers like app,database and proxy on separate AWS EC2 instances.
Using Route53 had added records for the domain purchased on NameCheap.
After following the Local Development Environment setup doc (https://docs.frappe.io/cloud/local-fc-setup), ran into an issue when setting up the Proxy Server for the fist time once Root Domain was added and TLS certificate was generated.
In case of both actions Ping Agent and Setup Server the proxy server was unreachable since the proxy.yml triggered expected public and private IP of the Proxy server instance.
While going through the doctype for the proxy_server, found out that the networking tab and the section for IPs has been put in read only mode and the values are taken from the Virtual Machine configured.
Since being new to this, i was not aware of creation of VM's and needed a way so that the ansible playbook could successfully ssh via IP to my proxy server. 
This prompted me to make changes in the javascript file to enable these filelds in case IP's were not fetched on account of VM not being available and the USER can manually enter his Proxy Machines IP.
After making said changes, the code is working and new proxy server was created successfully.