### PR TITLE
fix(site-creation): Add check to pick server with bench > 0

### DIFF
--- a/press/saas/doctype/product_trial/product_trial.py
+++ b/press/saas/doctype/product_trial/product_trial.py
@@ -389,6 +389,7 @@ class ProductTrial(Document):
 
 		ReleaseGroupServer = frappe.qb.DocType("Release Group Server")
 		Server = frappe.qb.DocType("Server")
+		Bench = frappe.qb.DocType("Bench")
 
 		servers = (
 			frappe.qb.from_(ReleaseGroupServer)
@@ -397,6 +398,11 @@ class ProductTrial(Document):
 			.join(Server)
 			.on(Server.name == ReleaseGroupServer.server)
 			.where(Server.cluster == cluster)
+			.where(
+				frappe.qb.exists(
+					frappe.qb.from_(Bench).select(Bench.name).where(Bench.server == ReleaseGroupServer.server)
+				)
+			)
 			.run(pluck="server")
 		)
 


### PR DESCRIPTION
This PR solves the issue where we may pick up server with no bench and use that server to create site in the pre-creation process.