### PR TITLE
Update billing.py to eliminate endlessly showing loading screen.

### DIFF
--- a/press/utils/billing.py
+++ b/press/utils/billing.py
@@ -3,7 +3,7 @@ import re
 import frappe
 import razorpay
 import stripe
-from frappe.utils import fmt_money
+from frappe.utils import fmt_money, now_datetime
 
 from press.exceptions import CentralServerNotSet, FrappeioServerNotSet
 from press.utils import get_current_team, log_error
@@ -142,7 +142,7 @@ def get_setup_intent(team):
 						"amount_type": "maximum",
 						"amount": 1500000,
 						"currency": currency.lower(),
-						"start_date": int(frappe.utils.get_timestamp()),
+						"start_date": int(frappe.utils.get_timestamp(now_datetime())),
 						"interval": "sporadic",
 						"supported_types": ["india"],
 					},


### PR DESCRIPTION
This PR adds proper start time while adding card details (stripe) to eliminate the endlessly showing loading icon and showing this traceback:
```
Traceback (most recent call last):

  File "apps/frappe/frappe/app.py", line 115, in application

    response = frappe.api.handle(request)

  File "apps/frappe/frappe/api/__init__.py", line 50, in handle

    data = endpoint(**arguments)

  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call

    return frappe.handler.handle()

  File "apps/frappe/frappe/handler.py", line 52, in handle

    data = execute_cmd(cmd)

  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd

    return frappe.call(method, **frappe.form_dict)

  File "apps/frappe/frappe/__init__.py", line 1754, in call

    return fn(*args, **newargs)

  File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper

    return func(*args, **kwargs)

  File "apps/press/press/api/billing.py", line 49, in get_publishable_key_and_setup_intent

    "setup_intent": get_setup_intent(team),

  File "apps/press/press/utils/billing.py", line 145, in get_setup_intent

    "start_date": int(frappe.utils.get_timestamp()),

TypeError: get_timestamp() missing 1 required positional argument: 'date' 
```