### PR TITLE
fix(login): Request key expired signed up user could not login

### DIFF
--- a/press/press/doctype/account_request/account_request.py
+++ b/press/press/doctype/account_request/account_request.py
@@ -153,6 +153,9 @@ class AccountRequest(Document):
 		return False
 
 	def reset_otp(self):
+		if not self.request_key:
+			self.request_key = random_string(32)
+			self.request_key_expiration_time = frappe.utils.add_to_date(minutes=10)
 		self.otp = generate_otp()
 		if frappe.conf.developer_mode and frappe.local.dev_server:
 			self.otp = 111111

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -4435,7 +4435,6 @@ def create_subscription_for_trial_sites():
 		""",
 		as_dict=True,
 	)
-	frappe.log(f"Creating subscription for the sites {active_sites}")
 	for trial_site in active_sites:
 		if has_job_timeout_exceeded():
 			return


### PR DESCRIPTION
This PR fixes the issue that allows the user who signed up for Frappe account, but didn't continue finishing the setup account process and later came back and logged in. The login started to throw permission issue as the account request key got expired and they were struck in that part forever. This fix regenerates the account key if expired and ensures that user can continue setup of the account process