### PR TITLE
fix(bench): Prevent dropping benches with recent fatal site update

### DIFF
--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -19,11 +19,11 @@ jobs:
       - name: Run Commitlint
         id: commitlint
         run: npx commitlint --edit pr-title.txt > commitlint_output.txt 2>&1
-        if: always()
+        if: github.event.pull_request.user.login != 'mergify[bot]'
       - name: Run CSpell
         id: cspell
         run: npx cspell --config .cspell.json pr-title.txt > cspell_output.txt 2>&1
-        if: always()
+        if: github.event.pull_request.user.login != 'mergify[bot]'
       - name: Delete Old Bot Comments
         if: always()
         env:
@@ -37,7 +37,7 @@ jobs:
             gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X DELETE
           done
       - name: Post PR Comment
-        if: always()
+        if: github.event.pull_request.user.login != 'mergify[bot]'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/dashboard/src/components/server/ServerCharts.vue
+++ b/dashboard/src/components/server/ServerCharts.vue
@@ -591,7 +591,7 @@ export default {
 		},
 		backgroundJobCountBySiteData() {
 			return {
-				url: 'press.api.server.get_background_jobs_by_site',
+				url: 'press.api.server.get_background_job_by_site',
 				params: {
 					name: this.chosenServer,
 					query: 'count',
@@ -604,7 +604,7 @@ export default {
 		},
 		backgroundJobDurationBySiteData() {
 			return {
-				url: 'press.api.server.get_background_jobs_by_site',
+				url: 'press.api.server.get_background_job_by_site',
 				params: {
 					name: this.chosenServer,
 					query: 'duration',

--- a/dashboard/src/components/server/ServerCharts.vue
+++ b/dashboard/src/components/server/ServerCharts.vue
@@ -185,6 +185,42 @@
 			<AnalyticsCard
 				v-if="isServerType('Application Server')"
 				class="sm:col-span-2"
+				title="Background job frequency by site"
+			>
+				<BarChart
+					title="Background job frequency by site"
+					:key="backgroundJobCountBySiteData"
+					:data="backgroundJobCountBySiteData"
+					unit="jobs"
+					:chartTheme="chartColors"
+					:loading="$resources.backgroundJobCountBySiteData.loading"
+					:error="$resources.backgroundJobCountBySiteData.error"
+					:showCard="false"
+					class="h-[15.55rem] p-2 pb-3"
+				/>
+			</AnalyticsCard>
+
+			<AnalyticsCard
+				v-if="isServerType('Application Server')"
+				class="sm:col-span-2"
+				title="Slowest background jobs by site"
+			>
+				<BarChart
+					title="Slowest background jobs by site"
+					:key="backgroundJobDurationBySiteData"
+					:data="backgroundJobDurationBySiteData"
+					unit="seconds"
+					:chartTheme="chartColors"
+					:loading="$resources.backgroundJobDurationBySiteData.loading"
+					:error="$resources.backgroundJobDurationBySiteData.error"
+					:showCard="false"
+					class="h-[15.55rem] p-2 pb-3"
+				/>
+			</AnalyticsCard>
+
+			<AnalyticsCard
+				v-if="isServerType('Application Server')"
+				class="sm:col-span-2"
 				title="Slowest request by site"
 			>
 				<BarChart
@@ -543,6 +579,32 @@ export default {
 		requestDurationBySite() {
 			return {
 				url: 'press.api.server.get_request_by_site',
+				params: {
+					name: this.chosenServer,
+					query: 'duration',
+					timezone: this.localTimezone,
+					duration: this.duration,
+				},
+				auto:
+					this.showAdvancedAnalytics && this.isServerType('Application Server'),
+			};
+		},
+		backgroundJobCountBySiteData() {
+			return {
+				url: 'press.api.server.get_background_jobs_by_site',
+				params: {
+					name: this.chosenServer,
+					query: 'count',
+					timezone: this.localTimezone,
+					duration: this.duration,
+				},
+				auto:
+					this.showAdvancedAnalytics && this.isServerType('Application Server'),
+			};
+		},
+		backgroundJobDurationBySiteData() {
+			return {
+				url: 'press.api.server.get_background_jobs_by_site',
 				params: {
 					name: this.chosenServer,
 					query: 'duration',

--- a/dashboard/src/objects/server.js
+++ b/dashboard/src/objects/server.js
@@ -202,6 +202,33 @@ export default {
 							},
 						},
 						{
+							label: 'View DB in Desk',
+							icon: icon('external-link'),
+							condition: () => $team.doc?.is_desk_user,
+							onClick() {
+								window.open(
+									`${window.location.protocol}//${
+										window.location.host
+									}/app/database-server/${server.doc.database_server}`,
+									'_blank',
+								);
+							},
+						},
+						{
+							label: 'View Replication DB in Desk',
+							icon: icon('external-link'),
+							condition: () =>
+								$team.doc?.is_desk_user && server.doc.replication_server,
+							onClick() {
+								window.open(
+									`${window.location.protocol}//${
+										window.location.host
+									}/app/database-server/${server.doc.replication_server}`,
+									'_blank',
+								);
+							},
+						},
+						{
 							label: 'Visit Server',
 							icon: icon('external-link'),
 							condition: () =>

--- a/press/api/analytics.py
+++ b/press/api/analytics.py
@@ -666,8 +666,8 @@ def get_advanced_analytics(name, timezone, duration="7d", max_no_of_paths=MAX_NO
 		name, "duration", timezone, timespan, timegrain, ResourceType.SITE, max_no_of_paths
 	)
 
-	background_job_duration_by_method = get_background_job_by_method(
-		name, "duration", timezone, timespan, timegrain, max_no_of_paths
+	background_job_duration_by_method = get_background_job_by_(
+		name, "duration", timezone, timespan, timegrain, ResourceType.SITE, max_no_of_paths
 	)
 
 	return (
@@ -682,12 +682,12 @@ def get_advanced_analytics(name, timezone, duration="7d", max_no_of_paths=MAX_NO
 			"request_count_by_ip": get_nginx_request_by_(
 				name, "count", timezone, timespan, timegrain, max_no_of_paths
 			),
-			"background_job_count_by_method": get_background_job_by_method(
-				name, "count", timezone, timespan, timegrain, max_no_of_paths
+			"background_job_count_by_method": get_background_job_by_(
+				name, "count", timezone, timespan, timegrain, ResourceType.SITE, max_no_of_paths
 			),
 			"background_job_duration_by_method": background_job_duration_by_method,
-			"average_background_job_duration_by_method": get_background_job_by_method(
-				name, "average_duration", timezone, timespan, timegrain, max_no_of_paths
+			"average_background_job_duration_by_method": get_background_job_by_(
+				name, "average_duration", timezone, timespan, timegrain, ResourceType.SITE, max_no_of_paths
 			),
 			"job_count": [{"value": r.count, "date": r.date} for r in job_data],
 			"job_cpu_time": [{"value": r.duration, "date": r.date} for r in job_data],
@@ -835,9 +835,17 @@ def get_nginx_request_by_(
 
 
 @redis_cache(ttl=10 * 60)
-def get_background_job_by_method(site, agg_type, timezone, timespan, timegrain, max_no_of_paths):
+def get_background_job_by_(
+	site,
+	agg_type,
+	timezone,
+	timespan,
+	timegrain,
+	resource_type=ResourceType.SITE,
+	max_no_of_paths=MAX_NO_OF_PATHS,
+):
 	return BackgroundJobGroupByChart(
-		site, agg_type, timezone, timespan, timegrain, ResourceType.SITE, max_no_of_paths
+		site, agg_type, timezone, timespan, timegrain, resource_type, max_no_of_paths
 	).run()
 
 

--- a/press/api/server.py
+++ b/press/api/server.py
@@ -420,6 +420,17 @@ def get_request_by_site(name, query, timezone, duration):
 @frappe.whitelist()
 @protected(["Server", "Database Server"])
 @redis_cache(ttl=10 * 60)
+def get_background_job_by_site(name, query, timezone, duration):
+	from press.api.analytics import ResourceType, get_background_job_by_
+
+	timespan, timegrain = get_timespan_timegrain(duration)
+
+	return get_background_job_by_(name, query, timezone, timespan, timegrain, ResourceType.SERVER)
+
+
+@frappe.whitelist()
+@protected(["Server", "Database Server"])
+@redis_cache(ttl=10 * 60)
 def get_slow_logs_by_site(name, query, timezone, duration, normalize=False):
 	from press.api.analytics import ResourceType, get_slow_logs
 

--- a/press/playbooks/install_cadvisor.yml
+++ b/press/playbooks/install_cadvisor.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install cAdvisor (ARM)
+- name: Install cAdvisor
   hosts: all
   become: yes
   become_user: root

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -31,7 +31,6 @@ from press.utils import (
 	SupervisorProcess,
 	flatten,
 	get_datetime,
-	is_in_test_environment,
 	log_error,
 	parse_supervisor_status,
 )
@@ -1243,9 +1242,9 @@ def try_archive(bench: str):
 		Bench("Bench", bench).archive()
 		frappe.db.commit()
 		return True
-	except ArchiveBenchError as e:
-		if is_in_test_environment():
-			print(f"Bench Archival Error: {e}")
+	except ArchiveBenchError:
+		if frappe.flags.in_test:
+			raise
 
 		frappe.db.rollback()
 		return False

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -44,6 +44,8 @@ if TYPE_CHECKING:
 TRANSITORY_STATES = ["Pending", "Installing"]
 FINAL_STATES = ["Active", "Broken", "Archived"]
 
+EMPTY_BENCH_COURTESY_DAYS = 3
+
 MAX_GUNICORN_WORKERS = 36
 MIN_GUNICORN_WORKERS = 2
 MAX_BACKGROUND_WORKERS = 8
@@ -190,7 +192,7 @@ class Bench(Document):
 
 	@staticmethod
 	def with_sites(name: str):
-		bench = frappe.get_doc("Bench", name)
+		bench = Bench("Bench", name)
 		sites = frappe.get_all("Site", filters={"bench": name}, pluck="name")
 		bench.sites = [frappe.get_doc("Site", s) for s in sites]
 
@@ -865,7 +867,7 @@ class Bench(Document):
 
 	@staticmethod
 	def process_update_inplace(job: "AgentJob"):
-		bench: "Bench" = frappe.get_doc("Bench", job.bench)
+		bench: "Bench" = Bench("Bench", job.bench)
 		bench._process_update_inplace(job)
 		bench.save()
 
@@ -925,7 +927,7 @@ class Bench(Document):
 
 	@staticmethod
 	def process_recover_update_inplace(job: "AgentJob"):
-		bench: "Bench" = frappe.get_doc("Bench", job.bench)
+		bench: "Bench" = Bench("Bench", job.bench)
 		bench._process_recover_update_inplace(job)
 		bench.save()
 
@@ -994,31 +996,37 @@ class Bench(Document):
 		if frappe.db.exists(
 			"Agent Job", {"bench": self.name, "status": ("in", ["Running", "Pending", "Undelivered"])}
 		):
-			frappe.throw("Cannot archive bench because of on-going jobs.", ArchiveBenchError)
+			frappe.throw("Cannot archive bench because of ongoing jobs.", ArchiveBenchError)
 
-	def check_active_site_updates(self):
+	def check_ongoing_site_updates(self):
 		frappe.db.commit()
-		if frappe.get_all(
-			"Site Update",
-			{
-				"status": ("in", ["Pending", "Running", "Failure", "Recovering", "Scheduled"]),
-			},
-			or_filters={
-				"source_bench": self.name,
-				"destination_bench": self.name,
-			},
-			limit=1,
-			ignore_ifnull=True,
-			order_by="destination_bench",
-		):
-			frappe.throw("Cannot archive due ongoing active site update.", ArchiveBenchError)
+		site_updates = frappe.qb.DocType("Site Update")
+		ongoing_site_updates = (
+			frappe.qb.from_(site_updates)
+			.select(site_updates.name)
+			.where((site_updates.source_bench == self.name) | (site_updates.destination_bench == self.name))
+			.where(
+				(site_updates.status.isin(["Pending", "Running", "Failure", "Recovering", "Scheduled"]))
+				| (
+					(site_updates.status == "Fatal")
+					& (
+						site_updates.creation
+						> frappe.utils.add_to_date(None, days=-EMPTY_BENCH_COURTESY_DAYS)
+					)
+				)
+			)
+			.limit(1)
+		).run()
+		# TODO: add test for this new case
+		if ongoing_site_updates:
+			frappe.throw("Cannot archive due ongoing site update.", ArchiveBenchError)
 
 	def check_unarchived_sites(self):
 		frappe.db.commit()
 		if frappe.db.exists("Site", {"bench": self.name, "status": ("!=", "Archived")}):
 			frappe.throw("Cannot archive bench due to unarchived sites on bench.", ArchiveBenchError)
 
-	def is_reset_bench(self):
+	def check_bench_resetting(self):
 		if self.resetting_bench:
 			frappe.throw("Cannot archive bench due to ongoing in-place updates.", ArchiveBenchError)
 
@@ -1029,11 +1037,11 @@ class Bench(Document):
 			frappe.throw("Cannot archive as previous archive failed in the last 24 hours.", ArchiveBenchError)
 
 	def ready_to_archive(self):
-		self.is_reset_bench()
+		self.check_bench_resetting()
 		self.check_last_archive()
-		self.check_archive_jobs()  # already being archived
+		self.check_archive_jobs()
 		self.check_ongoing_jobs()
-		self.check_active_site_updates()
+		self.check_ongoing_site_updates()
 		self.check_unarchived_sites()
 		if get_scheduled_version_upgrades(self):
 			frappe.throw("Cannot archive bench due to ongoing scheduled version upgrades", ArchiveBenchError)
@@ -1110,7 +1118,7 @@ def archive_staging_sites():
 
 
 def process_new_bench_job_update(job):
-	bench = frappe.get_doc("Bench", job.bench)
+	bench = Bench("Bench", job.bench)
 
 	updated_status = {
 		"Pending": "Pending",
@@ -1143,7 +1151,7 @@ def process_new_bench_job_update(job):
 		return
 
 	StagingSite.create_if_needed(bench)
-	bench = frappe.get_doc("Bench", job.bench)
+	bench = Bench("Bench", job.bench)
 	frappe.enqueue(
 		"press.press.doctype.bench.bench.archive_obsolete_benches",
 		enqueue_after_commit=True,
@@ -1170,7 +1178,7 @@ def process_new_bench_job_update(job):
 
 
 def process_archive_bench_job_update(job):
-	bench = frappe.get_doc("Bench", job.bench)
+	bench = Bench("Bench", job.bench)
 
 	updated_status = {
 		"Pending": "Pending",
@@ -1189,7 +1197,7 @@ def process_archive_bench_job_update(job):
 		frappe.db.set_value("Bench", job.bench, "status", updated_status)
 		is_ssh_proxy_setup = frappe.db.get_value("Bench", job.bench, "is_ssh_proxy_setup")
 		if updated_status == "Archived" and is_ssh_proxy_setup:
-			frappe.get_doc("Bench", job.bench).remove_ssh_user()
+			Bench("Bench", job.bench).remove_ssh_user()
 
 		if bench.team != "Administrator":
 			bench.status = updated_status  # just to ensure the status got changed in webhook payload, reload_doc is costly here
@@ -1232,7 +1240,7 @@ def get_unfinished_site_migrations(bench: dict):
 
 def try_archive(bench: str):
 	try:
-		frappe.get_doc("Bench", bench).archive()
+		Bench("Bench", bench).archive()
 		frappe.db.commit()
 		return True
 	except ArchiveBenchError as e:
@@ -1287,9 +1295,11 @@ def archive_obsolete_benches(group: str | None = None, server: str | None = None
 
 def archive_obsolete_benches_for_server(benches: Iterable[dict]):
 	for bench in benches:
-		# If the bench is a private one and has been created more than 3 days ago,
+		# If the bench is a private one and has been created more than EMPTY_BENCH_COURTESY_DAYS ago,
 		# then we can attempt to archive it.
-		if not (bench.public or bench.central_bench) and bench.creation < frappe.utils.add_days(None, -3):
+		if not (bench.public or bench.central_bench) and bench.creation < frappe.utils.add_days(
+			None, -EMPTY_BENCH_COURTESY_DAYS
+		):
 			try_archive(bench.name)
 			continue
 
@@ -1369,7 +1379,7 @@ def sync_analytics():
 
 
 def sync_bench_analytics(name):
-	bench = frappe.get_doc("Bench", name)
+	bench = Bench("Bench", name)
 	# Skip syncing analytics for benches that have been archived (after the job was enqueued)
 	if bench.status != "Active":
 		return

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -1016,9 +1016,8 @@ class Bench(Document):
 			)
 			.limit(1)
 		).run()
-		# TODO: add test for this new case
 		if ongoing_site_updates:
-			frappe.throw("Cannot archive due ongoing site update.", ArchiveBenchError)
+			frappe.throw("Cannot archive due to ongoing site update.", ArchiveBenchError)
 
 	def check_unarchived_sites(self):
 		frappe.db.commit()
@@ -1242,9 +1241,9 @@ def try_archive(bench: str):
 		Bench("Bench", bench).archive()
 		frappe.db.commit()
 		return True
-	except ArchiveBenchError:
+	except ArchiveBenchError as e:
 		if frappe.flags.in_test:
-			raise
+			print(f"Bench Archival Error: {e}")
 
 		frappe.db.rollback()
 		return False

--- a/press/press/doctype/bench/test_bench.py
+++ b/press/press/doctype/bench/test_bench.py
@@ -14,6 +14,8 @@ from press.exceptions import ArchiveBenchError
 from press.press.doctype.agent_job.agent_job import AgentJob, poll_pending_jobs
 from press.press.doctype.agent_job.test_agent_job import fake_agent_job
 from press.press.doctype.app.test_app import create_test_app
+from press.press.doctype.app_release.test_app_release import create_test_app_release
+from press.press.doctype.app_source.test_app_source import create_test_app_source
 from press.press.doctype.bench.bench import (
 	MAX_BACKGROUND_WORKERS,
 	MAX_GUNICORN_WORKERS,
@@ -32,6 +34,7 @@ from press.press.doctype.release_group.test_release_group import (
 from press.press.doctype.server.server import Server, scale_workers
 from press.press.doctype.site.test_site import create_test_bench, create_test_site
 from press.press.doctype.site_plan.test_site_plan import create_test_plan
+from press.press.doctype.site_update.test_site_update import create_test_site_update
 from press.press.doctype.subscription.test_subscription import create_test_subscription
 from press.press.doctype.version_upgrade.test_version_upgrade import (
 	create_test_version_upgrade,
@@ -465,6 +468,31 @@ class TestArchiveObsoleteBenches(FrappeTestCase):
 			poll_pending_jobs()
 		benches_after = frappe.db.count("Bench", {"status": "Active"})
 		self.assertEqual(benches_after, benches_before)
+
+	@patch("press.press.doctype.bench.bench.frappe.enqueue", new=foreground_enqueue)
+	def test_if_fatal_site_update_with_source_bench_blocks_archival(self):
+		version = "Version 15"
+		app = create_test_app()
+		app_source = create_test_app_source(version=version, app=app)
+		group = create_test_release_group([app], frappe_version=version)
+
+		with fake_agent_job("New Bench", "Success"):
+			bench1 = create_test_bench(group=group)
+			poll_pending_jobs()
+
+		site = create_test_site(bench=bench1.name, fake_agent_jobs=True)
+		create_test_app_release(
+			app_source=app_source
+		)  # creates pull type release diff only but args are same
+
+		with fake_agent_job("New Bench", "Success"):
+			bench2 = create_test_bench(group=group, server=bench1.server)
+			poll_pending_jobs()
+
+		create_test_deploy_candidate_differences(bench2.candidate)  # for site update to be available
+
+		create_test_site_update(site.name, site.group, "Fatal")
+		archive_obsolete_benches()
 
 	@patch(
 		"press.press.doctype.bench.bench.archive_obsolete_benches_for_server",

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1848,13 +1848,14 @@ node_filesystem_avail_bytes{{instance="{self.name}", mountpoint="{mountpoint}"}}
 		except Exception:
 			log_error("Sever File Copy Exception", server=self.as_dict())
 
-	def install_cadvisor_arm(self):
-		frappe.enqueue_doc(self.doctype, self.name, "_install_cadvisor_arm")
+	@frappe.whitelist()
+	def install_cadvisor(self):
+		frappe.enqueue_doc(self.doctype, self.name, "_install_cadvisor")
 
-	def _install_cadvisor_arm(self):
+	def _install_cadvisor(self):
 		try:
 			ansible = Ansible(
-				playbook="install_cadvisor_arm.yml",
+				playbook="install_cadvisor.yml",
 				server=self,
 				user=self._ssh_user(),
 				port=self._ssh_port(),
@@ -1886,8 +1887,7 @@ node_filesystem_avail_bytes{{instance="{self.name}", mountpoint="{mountpoint}"}}
 			if self.has_data_volume:
 				self.setup_archived_folder()
 
-			if self.platform == "arm64":
-				self.install_cadvisor_arm()
+			self.install_cadvisor()
 
 		if self.doctype == "Database Server":
 			self.adjust_memory_config()

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1430,7 +1430,7 @@ class BaseServer(Document, TagHelpers):
 		)
 
 		if not benches:
-			frappe.throw(f"No active benches found on <a href='/app/server/{self.name}'> Server")
+			frappe.throw(f"No active benches found on <a href='/app/server/{self.name}'>Server</a>")
 
 		for bench in benches:
 			raw_bench_version = self._get_dependency_version(bench["candidate"], "BENCH_VERSION")

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -112,6 +112,7 @@ DOCTYPE_SERVER_TYPE_MAP = {
 }
 
 ARCHIVE_AFTER_SUSPEND_DAYS = 21
+PRIVATE_BENCH_DOC = "https://docs.frappe.io/cloud/sites/move-site-to-private-bench"
 
 
 class Site(Document, TagHelpers):
@@ -477,9 +478,10 @@ class Site(Document, TagHelpers):
 		if not (1 <= self.update_on_day_of_month <= 31):
 			frappe.throw("Day of the month must be between 1 and 31 (included)!")
 		# If site is on public bench, don't allow to disable auto updates
-		is_group_public = frappe.get_cached_value("Release Group", self.group, "public")
-		if self.skip_auto_updates and is_group_public:
-			frappe.throw("Auto updates can't be disabled for sites on public benches!")
+		if self.skip_auto_updates and self.is_group_public:
+			frappe.throw(
+				f'Auto updates can\'t be disabled for sites on public benches! Please move to a <a class="underline" href="{PRIVATE_BENCH_DOC}">private bench</a>.'
+			)
 
 	def validate_site_plan(self):  # noqa: C901
 		if hasattr(self, "subscription_plan") and self.subscription_plan:
@@ -711,6 +713,10 @@ class Site(Document, TagHelpers):
 			if key_type == "Number":
 				key_value = int(row.value) if isinstance(row.value, float | int) else json.loads(row.value)
 			elif key_type == "Boolean":
+				if row.key == "server_script_enabled" and self.is_group_public:
+					frappe.throw(
+						f'You <a class="underline" href="https://docs.frappe.io/cloud/enable-server-script">cannot enable server scripts</a> on public benches. Please move to a <a class="underline" href="{PRIVATE_BENCH_DOC}">private bench</a>.'
+					)
 				key_value = (
 					row.value if isinstance(row.value, bool) else bool(sbool(json.loads(cstr(row.value))))
 				)
@@ -3044,10 +3050,12 @@ class Site(Document, TagHelpers):
 		agent = Agent(self.server)
 		agent.run_after_migrate_steps(self)
 
+	@cached_property
+	def is_group_public(self):
+		return bool(frappe.get_cached_value("Release Group", self.group, "public"))
+
 	@frappe.whitelist()
 	def get_actions(self):
-		is_group_public = frappe.get_cached_value("Release Group", self.group, "public")
-
 		actions = [
 			{
 				"action": "Activate site",
@@ -3101,7 +3109,7 @@ class Site(Document, TagHelpers):
 				"description": "Move your site to a different server",
 				"button_label": "Change",
 				"doc_method": "change_server",
-				"condition": self.status in ["Active", "Broken", "Inactive"] and not is_group_public,
+				"condition": self.status in ["Active", "Broken", "Inactive"] and not self.is_group_public,
 			},
 			{
 				"action": "Clear cache",

--- a/press/press/doctype/site_database_user/site_database_user.py
+++ b/press/press/doctype/site_database_user/site_database_user.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from collections import Counter
+from typing import TYPE_CHECKING
 
 import frappe
 import frappe.utils
@@ -15,6 +16,9 @@ from press.agent import Agent
 from press.api.client import dashboard_whitelist
 from press.overrides import get_permission_query_conditions_for_doctype
 from press.press.doctype.site_activity.site_activity import log_site_activity
+
+if TYPE_CHECKING:
+	from press.press.doctype.site.site import Site
 
 
 class SiteDatabaseUser(Document):
@@ -74,7 +78,7 @@ class SiteDatabaseUser(Document):
 			)
 
 	def before_insert(self):
-		site = frappe.get_doc("Site", self.site)
+		site: Site = frappe.get_doc("Site", self.site)
 		if not site.has_permission():
 			frappe.throw("You don't have permission to create database user")
 		if not frappe.db.get_value("Site Plan", site.plan, "database_access"):

--- a/press/utils/__init__.py
+++ b/press/utils/__init__.py
@@ -1003,9 +1003,3 @@ def get_nearest_cluster():
 			nearest_cluster = cluster_name
 
 	return nearest_cluster
-
-
-def is_in_test_environment():
-	if not hasattr(frappe.local, "in_test"):
-		return False
-	return frappe.local.in_test


### PR DESCRIPTION
- **fix(bench): Keep benches included in fatal site updates for some time**

- **fix(server): Setup cadvisor for all servers**

  - Need it for setting housekeeping_interval to 10s by default
  - Also rename the playbook and fn as the playbook works for x86 already

- **feat(server): Add charts for background jobs by site**
  High cpu can also be caused by them

- **fix(cluster): Get public x86 images for new cluster**

- **test(bench): Test for fatal site update blocking archival**
  - Also remove unnecessary util
  - Also raise error on archival instead of print
