### PR TITLE
fix(desk): visit dashboard link for bench doc

### DIFF
--- a/press/press/doctype/bench/bench.js
+++ b/press/press/doctype/bench/bench.js
@@ -14,7 +14,7 @@ frappe.ui.form.on('Bench', {
 
 	refresh: function (frm) {
 		frm.add_web_link(
-			`/dashboard/groups/${frm.doc.group}/versions/${frm.doc.name}`,
+			`/dashboard/benches/${frm.doc.name}`,
 			__('Visit Dashboard'),
 		);
 


### PR DESCRIPTION
Routing was refactored a while ago, but this link wasn't fixed.

<img width="2828" height="1024" alt="CleanShot 2025-10-06 at 11 30 09@2x" src="https://github.com/user-attachments/assets/357aa2a6-338f-498b-a6ae-5a490f6569b4" />
