### PR TITLE
feat(monitoring): Add feature flag to disable monitoring

### DIFF
--- a/dashboard/src/components/AlertBanner.vue
+++ b/dashboard/src/components/AlertBanner.vue
@@ -46,6 +46,7 @@ const colors = {
 	success: 'green',
 	error: 'red',
 	warning: 'amber',
+	general: 'gray',
 };
 
 export default {

--- a/dashboard/src/components/SiteOverview.vue
+++ b/dashboard/src/components/SiteOverview.vue
@@ -66,8 +66,23 @@
 			</Button>
 		</AlertBanner>
 
+		<AlertBanner
+			v-if="$site.doc.is_monitoring_disabled && $site.doc.status !== 'Archived'"
+			class="col-span-1 lg:col-span-2"
+			title="Site monitoring is disabled, which means we won’t be able to notify you of any downtime. Please re-enable monitoring at your earliest convenience."
+			:id="$site.name"
+			type="warning"
+		>
+			<Button
+				class="ml-auto"
+				variant="outline"
+				@click="showEnableMonitoringDialog"
+			>
+				Actions
+			</Button>
+		</AlertBanner>
 		<DismissableBanner
-			v-if="$site.doc.eol_versions.includes($site.doc.version)"
+			v-else-if="$site.doc.eol_versions.includes($site.doc.version)"
 			class="col-span-1 lg:col-span-2"
 			title="Your site is on an End of Life version. Upgrade to the latest version to get support, latest features and security updates."
 			:id="`${$site.name}-eol`"
@@ -350,6 +365,12 @@ export default {
 				() => import('../components/ManageSitePlansDialog.vue'),
 			);
 			renderDialog(h(SitePlansDialog, { site: this.site }));
+		},
+		showEnableMonitoringDialog() {
+			let SiteEnableMonitoringDialog = defineAsyncComponent(
+				() => import('./site/SiteEnableMonitoringDialog.vue'),
+			);
+			renderDialog(h(SiteEnableMonitoringDialog, { site: this.site }));
 		},
 		formatBytes(v) {
 			return this.$format.bytes(v, 2, 2);

--- a/dashboard/src/components/site/SiteEnableMonitoringDialog.vue
+++ b/dashboard/src/components/site/SiteEnableMonitoringDialog.vue
@@ -1,0 +1,141 @@
+<template>
+	<Dialog
+		:options="{
+			title: 'Monitoring & Alerts are Disabled',
+			size: '2xl',
+		}"
+		v-model="showDialog"
+	>
+		<template #body-content>
+			<div
+				v-if="$resources.siteResource.loading"
+				class="flex w-full items-center justify-center gap-2 py-20 text-gray-700"
+			>
+				<Spinner class="w-4" /> Loading data...
+			</div>
+			<div v-else-if="siteDoc?.is_monitoring_disabled" class="w-full">
+				<p class="mb-2 text-gray-800 text-base font-medium">
+					Cause of disabling monitoring :
+				</p>
+				<div
+					class="rounded border bg-gray-50 p-2 text-base font-normalprose prose-sm space-y-2 whitespace-break-spaces w-ful"
+				>
+					{{ siteDoc.reason_for_disabling_monitoring || 'Unknown Reason' }}
+				</div>
+
+				<!-- Result -->
+				<div
+					v-if="enabledMonitoring === false"
+					class="flex flex-col gap-2 mt-4 w-full"
+				>
+					<AlertBanner
+						type="error"
+						:showIcon="true"
+						title="Failed to enable monitoring"
+					/>
+					<p class="mt-1 text-gray-800 text-base font-medium">Reason -</p>
+					<div
+						class="rounded border bg-gray-50 p-2 text-base font-normalprose prose-sm space-y-2 whitespace-break-spaces w-full"
+						style="line-height: inherit"
+					>
+						{{ reasonForFailureInEnablingMonitoring }}
+					</div>
+					<p class="mt-1 text-gray-800 text-base font-medium">
+						Possible Solution -
+					</p>
+					<div
+						class="rounded border bg-gray-50 p-2 text-base font-normalprose prose-sm space-y-2 whitespace-break-spaces w-full"
+						style="line-height: inherit"
+					>
+						{{ solutionToResolveIssue }}
+					</div>
+				</div>
+
+				<Button
+					variant="solid"
+					class="w-full mt-4"
+					:loading="$resources.enableMonitoring?.loading"
+					@click="$resources.enableMonitoring?.submit"
+				>
+					Check & Enable Monitoring
+				</Button>
+			</div>
+			<div v-else>
+				Monitoring is enabled already. No action is required from your end.
+			</div>
+		</template>
+	</Dialog>
+</template>
+<script>
+import AlertBanner from '../AlertBanner.vue';
+import { toast } from 'vue-sonner';
+
+export default {
+	name: 'SiteEnableMonitoringDialog',
+	props: {
+		site: {
+			type: String,
+			required: true,
+		},
+	},
+	components: {
+		AlertBanner,
+	},
+	data() {
+		return {
+			showDialog: true,
+			enabledMonitoring: null,
+			reasonForFailureInEnablingMonitoring: '',
+			solutionToResolveIssue: '',
+		};
+	},
+	resources: {
+		siteResource() {
+			return {
+				type: 'document',
+				doctype: 'Site',
+				name: this.site,
+				auto: true,
+			};
+		},
+		enableMonitoring() {
+			return {
+				url: 'press.api.client.run_doc_method',
+				makeParams() {
+					return {
+						dt: 'Site',
+						dn: this.site,
+						method: 'enable_monitoring',
+					};
+				},
+				auto: false,
+				onSuccess: (e) => {
+					if (e?.message) {
+						this.enabledMonitoring = e?.message?.enabled ?? null;
+						this.reasonForFailureInEnablingMonitoring =
+							e?.message?.reason ?? '';
+						this.solutionToResolveIssue = e?.message?.solution ?? '';
+
+						if (this.enabledMonitoring) {
+							toast.success('Monitoring enabled successfully');
+							this.hide();
+						} else {
+							toast.error('Failed to enable monitoring');
+						}
+					}
+				},
+			};
+		},
+	},
+	computed: {
+		siteDoc() {
+			return this.$resources?.siteResource?.doc ?? {};
+		},
+	},
+	methods: {
+		hide() {
+			this.showDialog = false;
+		},
+	},
+};
+</script>

--- a/dashboard/src/objects/site.js
+++ b/dashboard/src/objects/site.js
@@ -81,6 +81,7 @@ export default {
 			'cluster.title as cluster_title',
 			'trial_end_date',
 			'creation',
+			'is_monitoring_disabled',
 		],
 		orderBy: 'creation desc',
 		searchField: 'host_name',
@@ -1603,6 +1604,21 @@ export default {
 							name: 'Site Detail Updates',
 							params: { name: site.name },
 						});
+					},
+				},
+				{
+					label: 'Enable Monitoring',
+					slots: {
+						prefix: icon('activity'),
+					},
+					condition: () => site.doc?.is_monitoring_disabled,
+					onClick() {
+						let SiteEnableMonitoringDialog = defineAsyncComponent(
+							() => import('../components/site/SiteEnableMonitoringDialog.vue'),
+						);
+						renderDialog(
+							h(SiteEnableMonitoringDialog, { site: site.doc?.name }),
+						);
 					},
 				},
 				{

--- a/press/press/doctype/database_server/database_server.json
+++ b/press/press/doctype/database_server/database_server.json
@@ -27,6 +27,7 @@
   "is_server_renamed",
   "is_server_prepared",
   "is_for_recovery",
+  "is_monitoring_disabled",
   "billing_section",
   "team",
   "column_break_11",
@@ -673,11 +674,18 @@
    "label": "Communication Info",
    "options": "Communication Info"
   },
-  { 
+  {
    "fieldname": "bastion_server",
    "fieldtype": "Link",
    "label": "Bastion Server",
    "options": "Bastion Server"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_monitoring_disabled",
+   "fieldtype": "Check",
+   "label": "Is Monitoring Disabled",
+   "search_index": 1
   }
  ],
  "grid_page_length": 50,
@@ -694,7 +702,7 @@
    "link_fieldname": "database_server"
   }
  ],
- "modified": "2025-09-25 15:33:11.744857",
+ "modified": "2025-10-06 17:08:00.975558",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Database Server",

--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -66,6 +66,7 @@ class DatabaseServer(BaseServer):
 		hostname_abbreviation: DF.Data | None
 		ip: DF.Data | None
 		is_for_recovery: DF.Check
+		is_monitoring_disabled: DF.Check
 		is_performance_schema_enabled: DF.Check
 		is_primary: DF.Check
 		is_replication_setup: DF.Check

--- a/press/press/doctype/server/server.json
+++ b/press/press/doctype/server/server.json
@@ -30,6 +30,7 @@
   "halt_agent_jobs",
   "stop_deployments",
   "is_for_recovery",
+  "is_monitoring_disabled",
   "billing_section",
   "team",
   "plan",
@@ -663,10 +664,17 @@
    "fieldtype": "Link",
    "label": "Bastion Server",
    "options": "Bastion Server"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_monitoring_disabled",
+   "fieldtype": "Check",
+   "label": "Is Monitoring Disabled",
+   "search_index": 1
   }
  ],
  "links": [],
- "modified": "2025-09-26 18:12:36.754235",
+ "modified": "2025-10-06 17:08:11.706019",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Server",

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1993,6 +1993,7 @@ class Server(BaseServer):
 		ipv6: DF.Data | None
 		is_for_recovery: DF.Check
 		is_managed_database: DF.Check
+		is_monitoring_disabled: DF.Check
 		is_primary: DF.Check
 		is_pyspy_setup: DF.Check
 		is_replication_setup: DF.Check

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -85,6 +85,7 @@ class BaseServer(Document, TagHelpers):
 		"auto_add_storage_min",
 		"auto_add_storage_max",
 		"auto_increase_storage",
+		"is_monitoring_disabled",
 	)
 
 	@staticmethod

--- a/press/press/doctype/site/site.js
+++ b/press/press/doctype/site/site.js
@@ -82,6 +82,39 @@ frappe.ui.form.on('Site', {
 			);
 		}
 
+		if (!site.is_monitoring_disabled) {
+			frm.add_custom_button(
+				__('Disable Monitoring'),
+				() => {
+					frappe.prompt(
+						{
+							fieldtype: 'Data',
+							label: 'Reason',
+							fieldname: 'reason',
+							reqd: 1,
+						},
+						({ reason }) => {
+							frm
+								.call('disable_monitoring', {
+									reason,
+								})
+								.then((r) => frm.refresh());
+						},
+						__('Provide Reason'),
+					);
+				},
+				__('Actions'),
+			);
+		} else {
+			frm.add_custom_button(
+				__('Enable Monitoring'),
+				() => {
+					frappe.msgprint('Go to Dashboard to re-enable monitoring.');
+				},
+				__('Actions'),
+			);
+		}
+
 		[
 			[__('Backup'), 'backup'],
 			[__('Physical Backup'), 'physical_backup'],

--- a/press/press/doctype/site/site.json
+++ b/press/press/doctype/site/site.json
@@ -18,6 +18,7 @@
   "cluster",
   "admin_password",
   "additional_system_user_created",
+  "is_monitoring_disabled",
   "config_tab",
   "hide_config",
   "host_name",
@@ -713,6 +714,13 @@
    "fieldtype": "Table",
    "label": "Communication Infos",
    "options": "Communication Info"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_monitoring_disabled",
+   "fieldtype": "Check",
+   "label": "Is Monitoring Disabled",
+   "search_index": 1
   }
  ],
  "links": [
@@ -792,7 +800,7 @@
    "link_fieldname": "site"
   }
  ],
- "modified": "2025-09-26 17:32:30.628404",
+ "modified": "2025-10-06 18:36:56.940236",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site",

--- a/press/press/doctype/site/site.json
+++ b/press/press/doctype/site/site.json
@@ -18,7 +18,6 @@
   "cluster",
   "admin_password",
   "additional_system_user_created",
-  "is_monitoring_disabled",
   "config_tab",
   "hide_config",
   "host_name",
@@ -74,6 +73,9 @@
   "tab_break_46",
   "notifications_section",
   "communication_infos",
+  "monitoring_section",
+  "is_monitoring_disabled",
+  "reason_for_disabling_monitoring",
   "auto_updates_section",
   "skip_auto_updates",
   "only_update_at_specified_time",
@@ -720,7 +722,19 @@
    "fieldname": "is_monitoring_disabled",
    "fieldtype": "Check",
    "label": "Is Monitoring Disabled",
+   "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "monitoring_section",
+   "fieldtype": "Section Break",
+   "label": "Monitoring"
+  },
+  {
+   "fieldname": "reason_for_disabling_monitoring",
+   "fieldtype": "Data",
+   "label": "Reason for Disabling Monitoring",
+   "read_only": 1
   }
  ],
  "links": [
@@ -800,7 +814,7 @@
    "link_fieldname": "site"
   }
  ],
- "modified": "2025-10-06 18:36:56.940236",
+ "modified": "2025-10-07 19:14:24.341019",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site",

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -159,6 +159,7 @@ class Site(Document, TagHelpers):
 		hybrid_for: DF.Link | None
 		hybrid_saas_pool: DF.Link | None
 		is_erpnext_setup: DF.Check
+		is_monitoring_disabled: DF.Check
 		is_standby: DF.Check
 		last_site_usage_warning_mail_sent_on: DF.Datetime | None
 		logical_backup_times: DF.Table[SiteBackupTime]

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -63,7 +63,7 @@ from frappe.utils.password import get_decrypted_password
 
 from press.agent import Agent, AgentRequestSkippedException
 from press.api.client import dashboard_whitelist
-from press.api.site import check_dns, get_updates_between_current_and_next_apps
+from press.api.site import check_dns, check_dns_cname_a, get_updates_between_current_and_next_apps
 from press.overrides import get_permission_query_conditions_for_doctype
 from press.press.doctype.marketplace_app.marketplace_app import (
 	get_plans_for_app,
@@ -166,6 +166,7 @@ class Site(Document, TagHelpers):
 		only_update_at_specified_time: DF.Check
 		physical_backup_times: DF.Table[SiteBackupTime]
 		plan: DF.Link | None
+		reason_for_disabling_monitoring: DF.Data | None
 		remote_config_file: DF.Link | None
 		remote_database_file: DF.Link | None
 		remote_private_file: DF.Link | None
@@ -239,6 +240,8 @@ class Site(Document, TagHelpers):
 		"account_request",
 		"allow_physical_backup_by_user",
 		"site_usage_exceeded",
+		"is_monitoring_disabled",
+		"reason_for_disabling_monitoring",
 	)
 
 	@staticmethod
@@ -2214,6 +2217,118 @@ class Site(Document, TagHelpers):
 			if subscription:
 				subscription.team = self.team
 				subscription.save(ignore_permissions=True)
+
+	@frappe.whitelist()
+	def disable_monitoring(self, reason=None):
+		if self.is_monitoring_disabled:
+			return
+
+		self.is_monitoring_disabled = True
+		if not reason:
+			reason = f"Monitoring disabled by user ({frappe.session.user})"
+		self.reason_for_disabling_monitoring = reason
+		self.save()
+
+		log_site_activity(
+			self.name, "Disable Monitoring And Alerts", reason=self.reason_for_disabling_monitoring
+		)
+		frappe.msgprint("Monitoring has been disabled")
+
+	@dashboard_whitelist()
+	def enable_monitoring(self):  # noqa: C901
+		if not self.is_monitoring_disabled:
+			frappe.throw("Monitoring is already enabled")
+
+		if self.status != "Active":
+			frappe.throw("Make sure site is Active before trying to enable monitoring")
+
+		# Check ping before enabling monitoring
+		result = {"enabled": False, "reason": "", "solution": ""}
+
+		# First validate DNS records
+		dns_result = check_dns_cname_a(self.name, self.host_name, throw_error=False)
+		if not dns_result.get("valid"):
+			msg = f"DNS record of {self.host_name} are not pointing correctly\n"
+			msg += f"  Type: {dns_result.get('exc_type')}\n"
+			msg += f"  Details: {dns_result.get('exc_message')}\n"
+
+			dns_record_exists = dns_result.get("A", {}).get("exists") or dns_result.get("CNAME", {}).get(
+				"exists"
+			)
+			if dns_record_exists:
+				msg += "Current DNS Records:\n"
+				if dns_result.get("A", {}).get("exists"):
+					msg += f"  A: {', '.join(dns_result.get('A').get('answer'))}\n"
+
+				if dns_result.get("CNAME", {}).get("exists"):
+					msg += f"  CNAME: {', '.join(dns_result.get('CNAME').get('answer'))}\n"
+			else:
+				msg += f"No Correct DNS records found for {self.host_name}\n"
+
+			solution = "Required DNS Records:\n"
+			solution += f"  A record with value {self.inbound_ip}\n"
+			solution += f"  Or, CNAME record with value {self.name}\n"
+			solution += (
+				"Please check with your Domain Registrar / DNS provider to add the required records.\n"
+			)
+
+			result.update(
+				{
+					"enabled": False,
+					"reason": msg,
+					"solution": solution,
+				}
+			)
+			return result
+
+		# Send ping request
+		try:
+			resp = requests.get(f"https://{self.host_name}/api/method/ping", timeout=5, verify=True)
+			is_pingable = resp.status_code == 200
+			if not is_pingable:
+				result.update(
+					{
+						"enabled": False,
+						"reason": f"Site not pingable, status code: {resp.status_code}",
+						"solution": "Please ensure site is up and try again. If you are still facing issues, please contact support.",
+					}
+				)
+				return result
+		except requests.exceptions.SSLError:
+			result.update(
+				{
+					"enabled": False,
+					"reason": "SSL Certificate Error",
+					"solution": f"Try removing and adding {self.host_name} domain again. If you are still facing issues, please contact support.",
+				}
+			)
+			return result
+		except requests.exceptions.Timeout as e:
+			result.update(
+				{
+					"enabled": False,
+					"reason": f"Timeout Error\n: {e}",
+					"solution": "Please ensure site is up and try again. If you are still facing issues, please contact support.",
+				}
+			)
+			return result
+
+		log_site_activity(self.name, "Enable Monitoring And Alerts")
+
+		self.is_monitoring_disabled = False
+		self.reason_for_disabling_monitoring = ""
+		self.save()
+		result["enabled"] = True
+		return result
+
+	def is_site_pingable(self):
+		try:
+			response = self.ping()
+			if response.status_code == requests.codes.ok:
+				return True
+		except Exception:
+			return False
+		return False
 
 	def enable_subscription(self):
 		subscription = self.subscription

--- a/press/press/doctype/site_activity/site_activity.json
+++ b/press/press/doctype/site_activity/site_activity.json
@@ -29,7 +29,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Action",
-   "options": "Activate Site\nAdd Domain\nArchive\nBackup\nCreate\nClear Cache\nDeactivate Site\nInstall App\nLogin as Administrator\nMigrate\nReinstall\nRestore\nSuspend Site\nUninstall App\nUnsuspend Site\nUpdate\nUpdate Configuration\nDrop Offsite Backups\nDrop Physical Backups\nEnable Database Access\nDisable Database Access\nCreate Database User\nRemove Database User\nModify Database User Permissions",
+   "options": "Activate Site\nAdd Domain\nArchive\nBackup\nCreate\nClear Cache\nDeactivate Site\nInstall App\nLogin as Administrator\nMigrate\nReinstall\nRestore\nSuspend Site\nUninstall App\nUnsuspend Site\nUpdate\nUpdate Configuration\nDrop Offsite Backups\nDrop Physical Backups\nEnable Database Access\nDisable Database Access\nCreate Database User\nRemove Database User\nModify Database User Permissions\nDisable Monitoring And Alerts\nEnable Monitoring And Alerts",
    "read_only": 1,
    "reqd": 1,
    "search_index": 1
@@ -54,9 +54,10 @@
    "options": "Agent Job"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-11-26 11:53:47.035359",
+ "modified": "2025-10-07 19:31:49.273641",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Site Activity",
@@ -83,6 +84,7 @@
    "role": "Press Member"
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/press/press/doctype/site_activity/site_activity.py
+++ b/press/press/doctype/site_activity/site_activity.py
@@ -36,11 +36,14 @@ class SiteActivity(Document):
 			"Update",
 			"Update Configuration",
 			"Drop Offsite Backups",
+			"Drop Physical Backups",
 			"Enable Database Access",
 			"Disable Database Access",
 			"Create Database User",
 			"Remove Database User",
 			"Modify Database User Permissions",
+			"Disable Monitoring And Alerts",
+			"Enable Monitoring And Alerts",
 		]
 		job: DF.Link | None
 		reason: DF.SmallText | None
@@ -59,6 +62,18 @@ class SiteActivity(Document):
 					subject="Administrator login to your site",
 					template="admin_login",
 					args={"site": self.site, "user": self.owner, "reason": self.reason},
+					reference_doctype=self.doctype,
+					reference_name=self.name,
+				)
+
+		if self.action == "Disable Monitoring And Alerts" and self.reason:
+			recipients = get_communication_info("Email", "Site Activity", "Site", self.site)
+			if recipients:
+				frappe.sendmail(
+					recipients=recipients,
+					subject="Site Monitoring Disabled",
+					template="disabled_site_monitoring",
+					args={"site": self.site, "reason": self.reason},
 					reference_doctype=self.doctype,
 					reference_name=self.name,
 				)

--- a/press/templates/emails/disabled_site_monitoring.html
+++ b/press/templates/emails/disabled_site_monitoring.html
@@ -1,0 +1,27 @@
+{% extends "templates/emails/base.html" %} {% block content %}
+<td class="text-base leading-6 text-gray-900">
+	<div class="p-8 bg-white">
+		<div class="from-markdown">
+			Hey there,
+			<p>
+				Monitoring & alerting mechanism has been disabled for your site
+				<strong>{{site}}</strong>.
+                Reason for disabling monitoring:
+			</p>
+			<blockquote>{{reason}}</blockquote>
+			<p>
+				Please re-enable monitoring from dashboard to receive alerts.<br>
+                Check the documentation
+				<a
+					href="https://docs.frappecloud.com/user-guide/sites/monitoring-and-alerts"
+					target="_blank"
+					>here</a
+				> for the guide. If you need any assistance, please raise a ticket on
+				<a href="https://frappecloud.com/support" target="_blank"
+					>frappecloud.com/support</a
+				>.
+			</p>
+		</div>
+	</div>
+</td>
+{% endblock %}

--- a/press/templates/emails/disabled_site_monitoring.html
+++ b/press/templates/emails/disabled_site_monitoring.html
@@ -13,7 +13,7 @@
 				Please re-enable monitoring from dashboard to receive alerts.<br>
                 Check the documentation
 				<a
-					href="https://docs.frappecloud.com/user-guide/sites/monitoring-and-alerts"
+					href="https://docs.frappe.io/cloud/sites/monitoring#monitoring-disabled"
 					target="_blank"
 					>here</a
 				> for the guide. If you need any assistance, please raise a ticket on


### PR DESCRIPTION
Fixes https://github.com/frappe/press/issues/3397

User can self-fix the issue and enable monitoring back - 

<img width="1700" height="364" alt="image" src="https://github.com/user-attachments/assets/8a2d2e0d-0daf-4b68-abf7-86e11942bfb7" />


<img width="672" height="554" alt="image" src="https://github.com/user-attachments/assets/53c9f3dc-651d-41d0-a8c9-b69920d61e2f" />


**Log activities in `Site Activity`  -** 

<img width="1700" height="403" alt="image" src="https://github.com/user-attachments/assets/ee763f88-d5db-4c14-ae7f-b899b3ecee7a" />

**User will receive a mail regarding the same -**
<img width="662" height="504" alt="image" src="https://github.com/user-attachments/assets/d9ad4a86-b8fa-4d10-92b3-bc4c19204119" />

