### PR TITLE
feat(wkhtmltopdf): Add binaries for jammy

### DIFF
--- a/press/docker/Dockerfile
+++ b/press/docker/Dockerfile
@@ -90,35 +90,29 @@ ENV {{ doc.get_dependency_version("wkhtmltopdf", True) }}
 {% if is_arm_build %}
   # ARM setup (0.12.5) & (0.12.6)
   {% if doc.get_dependency_version("wkhtmltopdf") == '0.12.5' %}
-  RUN wget https://github.com/adityahase/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.focal_arm64.deb \
-    && dpkg -i wkhtmltox_0.12.5-1.focal_arm64.deb \
-    && rm wkhtmltox_0.12.5-1.focal_arm64.deb \
+  RUN wget https://github.com/Aradhya-Tripathi/wkhtmltopdf/releases/download/0.12.5-arm/wkhtmltox_0.12.5-1.jammy_arm64.deb \
+    && dpkg -i wkhtmltox_0.12.5-1.jammy_arm64.deb \
+    && rm wkhtmltox_0.12.5-1.jammy_arm64.deb \
     `#stage-pre-wkhtmltopdf`
   {% endif %}
 
   {% if doc.get_dependency_version("wkhtmltopdf") == '0.12.6' %}
   RUN wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_arm64.deb  \
-    && dpkg -i wkhtmltox_0.12.6-1.focal_arm64.deb \
-    && rm wkhtmltox_0.12.6-1.focal_arm64.deb \
+    && dpkg -i wkhtmltox_0.12.6.1-2.jammy_arm64 \
+    && rm wkhtmltox_0.12.6.1-2.jammy_arm64 \
     `#stage-pre-wkhtmltopdf`
   {% endif %}
 {% else %}
   # Intel setup
   {% if doc.get_dependency_version("wkhtmltopdf") == '0.12.6' %}
   RUN wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb  \
-    && dpkg -i wkhtmltox_0.12.6-1.focal_amd64.deb \
-    && rm wkhtmltox_0.12.6-1.focal_amd64.deb \
+    && dpkg -i wkhtmltox_0.12.6.1-2.jammy_amd64.deb \
+    && rm wkhtmltox_0.12.6.1-2.jammy_amd64.deb \
     `#stage-pre-wkhtmltopdf`
   {% elif doc.get_dependency_version("wkhtmltopdf") == '0.12.5' %}
-  RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.focal_amd64.deb \
-    && dpkg -i wkhtmltox_0.12.5-1.focal_amd64.deb \
-    && rm wkhtmltox_0.12.5-1.focal_amd64.deb \
-    `#stage-pre-wkhtmltopdf`
-  {% elif doc.get_dependency_version("wkhtmltopdf") == '0.12.4' %}
-  RUN wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz \
-    && tar -xvf wkhtmltox-0.12.4_linux-generic-amd64.tar.xz \
-    && mv wkhtmltox/bin/wkhtmlto* /usr/local/bin/ \
-    && rm -rf wkhtmltox-0.12.4_linux-generic-amd64.tar.xz wkhtmltox \
+  RUN wget https://github.com/Aradhya-Tripathi/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.jammy_amd64.deb  \
+    && dpkg -i wkhtmltox_0.12.5-1.jammy_amd64.deb \
+    && rm wkhtmltox_0.12.5-1.jammy_amd64.deb \
     `#stage-pre-wkhtmltopdf`
   {% endif %}
 {% endif %}


### PR DESCRIPTION
- Dropped support for `wkhtmltopdf 0.12.4`
- Created builds for arm 0.12.5 Jammy and x86 0.12.5 Jammy