### PR TITLE
perf: Move long running jobs to small jobs with batch

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -224,6 +224,7 @@ scheduler_events = {
 		"press.press.doctype.add_on_storage_log.add_on_storage_log.send_disk_extention_notification",
 		"press.press.doctype.server_snapshot_recovery.server_snapshot_recovery.expire_backups",
 		"press.press.doctype.server_snapshot.server_snapshot.expire_snapshots",
+		"press.saas.doctype.product_trial.product_trial.sync_product_site_users",
 	],
 	"hourly_long": [
 		"press.press.doctype.release_group.release_group.prune_servers_without_sites",
@@ -244,7 +245,6 @@ scheduler_events = {
 		"press.press.doctype.virtual_disk_snapshot.virtual_disk_snapshot.delete_expired_snapshots",
 		"press.press.doctype.app_release.app_release.cleanup_unused_releases",
 		"press.press.doctype.press_webhook.press_webhook.auto_disable_high_delivery_failure_webhooks",
-		"press.saas.doctype.product_trial.product_trial.sync_product_site_users",
 	],
 	"all": [
 		"press.auth.flush",

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -233,7 +233,6 @@ scheduler_events = {
 		"press.press.doctype.usage_record.usage_record.link_unlinked_usage_records",
 		"press.press.doctype.bench.bench.sync_benches",
 		"press.press.doctype.invoice.invoice.finalize_draft_invoices",
-		"press.press.doctype.app.app.poll_new_releases",
 		"press.press.doctype.agent_job.agent_job.fail_old_jobs",
 		"press.press.doctype.press_job.press_job.fail_stuck_press_jobs",
 		"press.press.doctype.site_update.site_update.mark_stuck_updates_as_fatal",
@@ -311,6 +310,7 @@ scheduler_events = {
 			"press.press.doctype.drip_email.drip_email.send_welcome_email",
 			"press.press.doctype.site_update.site_update.run_scheduled_updates",
 			"press.press.doctype.virtual_machine.virtual_machine.snapshot_aws_servers",
+			"press.press.doctype.app.app.poll_new_releases",
 		],
 		"* * * * *": [
 			"press.press.doctype.virtual_disk_snapshot.virtual_disk_snapshot.sync_physical_backup_snapshots",

--- a/press/press/doctype/app/app.py
+++ b/press/press/doctype/app/app.py
@@ -1,13 +1,13 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019, Frappe and contributors
 # For license information, please see license.txt
 
 
 import typing
 
-import rq
 import frappe
+import rq
 from frappe.model.document import Document
+
 from press.utils.jobs import has_job_timeout_exceeded
 
 if typing.TYPE_CHECKING:
@@ -38,7 +38,7 @@ class App(Document):
 		url: DF.Data | None
 	# end: auto-generated types
 
-	dashboard_fields = ["title"]
+	dashboard_fields = ("title",)
 
 	def add_source(
 		self,
@@ -90,7 +90,8 @@ def poll_new_releases():
 	for source in frappe.get_all(
 		"App Source",
 		{"enabled": True, "last_github_poll_failed": False},
-		order_by="last_synced",
+		order_by="last_synced asc",
+		limit=300,
 	):
 		if has_job_timeout_exceeded():
 			return

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -35,6 +35,7 @@ from press.utils import (
 	log_error,
 	parse_supervisor_status,
 )
+from press.utils.jobs import has_job_timeout_exceeded
 from press.utils.webhook import create_webhook_event
 
 if TYPE_CHECKING:
@@ -537,8 +538,23 @@ class Bench(Document):
 		data = agent.get_sites_analytics(self)
 		if not data:
 			return
+		items = data.items()
+		# Split into chunk, so that bg job ends faster
+		chunk_size = 20
+		for i in range(0, len(items), chunk_size):
+			frappe.enqueue_doc(
+				"Bench",
+				self.name,
+				"_process_sync_product_site_user_data",
+				enqueue_after_commit=True,
+				data=dict(items=items[i : i + chunk_size]),
+			)
+
+	def _process_sync_product_site_user_data(self, data: dict):
 		for site, analytics in data.items():
 			if not frappe.db.exists("Site", site):
+				return
+			if has_job_timeout_exceeded():
 				return
 			try:
 				frappe.get_doc("Site", site).sync_users_to_product_site(analytics)

--- a/press/saas/doctype/product_trial/product_trial.py
+++ b/press/saas/doctype/product_trial/product_trial.py
@@ -526,34 +526,16 @@ def sync_product_site_users():
 	product_benches = frappe.get_all(
 		"Bench", {"group": ("in", product_groups), "status": "Active"}, pluck="name"
 	)
-	frappe.enqueue(
-		"press.saas.doctype.product_trial.product_trial._sync_product_site_users",
-		queue="short",
-		product_benches=product_benches,
-		job_id="sync_product_site_users",
-		deduplicate=True,
-		enqueue_after_commit=True,
-	)
-	frappe.db.commit()
-
-
-def _sync_product_site_users(product_benches):
 	for bench_name in product_benches:
-		bench = frappe.get_doc("Bench", bench_name)
-		# Skip syncing analytics for benches that have been archived (after the job was enqueued)
-		if bench.status != "Active":
-			return
-		try:
-			bench.sync_product_site_users()
-			frappe.db.commit()
-		except Exception:
-			log_error(
-				"Bench Analytics Sync Error",
-				bench=bench.name,
-				reference_doctype="Bench",
-				reference_name=bench.name,
-			)
-			frappe.db.rollback()
+		frappe.enqueue_doc(
+			"Bench",
+			bench_name,
+			"sync_product_site_users",
+			queue="sync",
+			job_id=f"sync_product_site_users||{bench_name}",
+			deduplicate=True,
+			enqueue_after_commit=True,
+		)
 
 
 def send_suspend_mail(site: str, product: str) -> None:


### PR DESCRIPTION
There are certain hourly jobs, which do some syncing / polling in a loop. That causes two issues -

- Sometimes the job consume too much memory, as it's fetching data of all benches [?].
- Most importantly, it block worker restart while deploying some changes. And we had to force stop those.

Also, move small batch jobs to `sync` queue. We don't restart this custom queue frequently. So that will not block deployment