### PR TITLE
fix(dashboard): Add get_user_banners to allowed paths

### DIFF
--- a/press/auth.py
+++ b/press/auth.py
@@ -32,6 +32,7 @@ ALLOWED_PATHS = [
 	"/api/method/ping",
 	"/api/method/login",
 	"/api/method/logout",
+	"/api/method/press.press.doctype.dashboard_banner.dashboard_banner.get_user_banners",
 	"/api/method/press.press.doctype.razorpay_webhook_log.razorpay_webhook_log.razorpay_webhook_handler",
 	"/api/method/press.press.doctype.razorpay_webhook_log.razorpay_webhook_log.razorpay_authorized_payment_handler",
 	"/api/method/press.press.doctype.stripe_webhook_log.stripe_webhook_log.stripe_webhook_handler",


### PR DESCRIPTION
This is a pretty big issue actually: 

The front-end sends the request, it fails with a 401 error by the back-end. The back-end CLEARS the cookies via the headers of the failed request. The subsequent check in the router `document.cookie.includes('user_id')` fails, this means the user is not considered to be logged in when navigating to a new route. Thus the login popup is shown even though the user is logged in.