### PR TITLE
fix(banner): Trial banner not loading in product after signup

### DIFF
--- a/press/saas/doctype/product_trial/product_trial.py
+++ b/press/saas/doctype/product_trial/product_trial.py
@@ -119,6 +119,7 @@ class ProductTrial(Document):
 			site._update_configuration(get_plan_config(plan), save=False)
 			site.signup_time = frappe.utils.now()
 			site.generate_saas_communication_secret(create_agent_job=True, save=False)
+			site.plan = plan
 			site.save()  # Save is needed for create_subscription to work TODO: remove this
 			site.reload()
 			self.set_site_domain(site, site_domain)


### PR DESCRIPTION
As subscription creation part was moved to background jobs, plan was not associated with sites. During the landing into product page after sign up process, it causes issue and the banner to upgrade plan is not displayed. Fixing this by adding the plan on the signup flow.