### PR TITLE
fix(reminder-mail): Stop sending email to disabled account

### DIFF
--- a/press/press/doctype/user_2fa/user_2fa.py
+++ b/press/press/doctype/user_2fa/user_2fa.py
@@ -89,6 +89,7 @@ def yearly_2fa_recovery_code_reminder():
 				"<=",
 				frappe.utils.add_to_date(frappe.utils.now_datetime(), years=-1),
 			],
+			"enabled": 1,
 		},
 		pluck="name",
 	)


### PR DESCRIPTION
This fix will stop sending reminder emails to disabled accounts.