### PR TITLE
fix(job): Site creation timeout issue fix

### DIFF
--- a/press/saas/doctype/product_trial/product_trial.py
+++ b/press/saas/doctype/product_trial/product_trial.py
@@ -410,6 +410,7 @@ class ProductTrial(Document):
 		servers = (
 			frappe.qb.from_(ReleaseGroupServer)
 			.select(ReleaseGroupServer.server)
+			.distinct()
 			.where(ReleaseGroupServer.parent == self.release_group)
 			.join(Server)
 			.on(Server.name == ReleaseGroupServer.server)


### PR DESCRIPTION
This issue occurred after joining bench table but not pulling distinct entries and it caused the job to timeout as the server count is equal to bench size.