### PR TITLE
feat(dashboard-banners): Add cluster scope to banners

### DIFF
--- a/dashboard/src/components/CustomAlerts.vue
+++ b/dashboard/src/components/CustomAlerts.vue
@@ -127,22 +127,29 @@ export default {
 					this.trimOldDismissedBanners();
 
 					this.localBanners = (
-						this.ctx_type === 'Server'
+						this.ctx_type === 'Cluster'
 							? data.filter(
 									(banner) =>
-										banner.server === this.ctx_name || banner.is_global,
+										banner.cluster === this.ctx_name || banner.is_global,
 								)
-							: this.ctx_type === 'Site'
+							: this.ctx_type === 'Server'
 								? data.filter(
 										(banner) =>
-											banner.site === this.ctx_name || banner.is_global,
+											banner.server === this.ctx_name || banner.is_global,
 									)
-								: this.ctx_type === 'List Page'
+								: this.ctx_type === 'Site'
 									? data.filter(
 											(banner) =>
-												banner.type_of_scope === 'Team' || banner.is_global,
+												banner.site === this.ctx_name || banner.is_global,
 										)
-									: data
+									: this.ctx_type === 'List Page'
+										? data.filter(
+												(banner) =>
+													banner.type_of_scope === 'Team' ||
+													banner.type_of_scope === 'Cluster' ||
+													banner.is_global,
+											)
+										: data
 					).filter((banner) => !(banner.name in this.localDismissedBanners));
 				},
 			};

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -1424,14 +1424,15 @@ def get_user_banners():
 	team = get_current_team()
 
 	# fetch sites + servers for this team
-	site_server_pairs = frappe.get_all(
+	all_sites = frappe.get_all(
 		"Site",
 		filters={"team": team},
-		fields=["name", "server"],
+		fields=["name", "server", "cluster"],
 	)
 
-	sites = list(set([pair["name"] for pair in site_server_pairs]))
-	servers = list(set([pair["server"] for pair in site_server_pairs if pair.get("server")]))
+	sites = list(set([site["name"] for site in all_sites]))
+	servers = list(set([site["server"] for site in all_sites if site.get("server")]))
+	clusters = list(set([site["cluster"] for site in all_sites if site.get("cluster")]))
 
 	DashboardBanner = frappe.qb.DocType("Dashboard Banner")
 	now = frappe.utils.now()
@@ -1452,6 +1453,10 @@ def get_user_banners():
 		.where(
 			(DashboardBanner.is_global == 1)
 			| ((DashboardBanner.type_of_scope == "Site") & (DashboardBanner.site.isin(sites or [""])))
+			| (
+				(DashboardBanner.type_of_scope == "Cluster")
+				& (DashboardBanner.cluster.isin(clusters or [""]))
+			)
 			| ((DashboardBanner.type_of_scope == "Server") & (DashboardBanner.server.isin(servers or [""])))
 			| ((DashboardBanner.type_of_scope == "Team") & (DashboardBanner.team == team))
 		)

--- a/press/press/doctype/dashboard_banner/dashboard_banner.json
+++ b/press/press/doctype/dashboard_banner/dashboard_banner.json
@@ -29,6 +29,7 @@
   "column_break_udzz",
   "type_of_scope",
   "team",
+  "cluster",
   "server",
   "site",
   "dismissals_section",
@@ -90,7 +91,7 @@
   },
   {
    "depends_on": "eval:!doc.is_global && doc.type_of_scope == \"Server\"",
-   "description": "Recipients are users with Sites on this Server",
+   "description": "Recipients are users that own Sites on this Server",
    "fieldname": "server",
    "fieldtype": "Link",
    "label": "Server",
@@ -99,7 +100,7 @@
   },
   {
    "depends_on": "eval:!doc.is_global & doc.type_of_scope == \"Site\"",
-   "description": "Recipients are users with this Site",
+   "description": "Recipients are users that own this Site",
    "fieldname": "site",
    "fieldtype": "Link",
    "label": "Site",
@@ -175,7 +176,7 @@
    "in_standard_filter": 1,
    "label": "Type of scope",
    "mandatory_depends_on": "eval:!doc.is_global",
-   "options": "Team\nServer\nSite"
+   "options": "Team\nCluster\nServer\nSite"
   },
   {
    "fieldname": "column_break_udzz",
@@ -209,11 +210,20 @@
    "label": "Scheduled End Time",
    "mandatory_depends_on": "eval:!!doc.is_scheduled",
    "search_index": 1
+  },
+  {
+   "depends_on": "eval:!doc.is_global & doc.type_of_scope == \"Cluster\"",
+   "description": "Recipients are users that own resources in this cluster",
+   "fieldname": "cluster",
+   "fieldtype": "Link",
+   "label": "Cluster",
+   "mandatory_depends_on": "eval:!doc.is_global && doc.type_of_scope == \"Cluster\"",
+   "options": "Cluster"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-30 20:48:50.537360",
+ "modified": "2025-11-09 23:58:06.299785",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Dashboard Banner",

--- a/press/press/doctype/dashboard_banner/dashboard_banner.py
+++ b/press/press/doctype/dashboard_banner/dashboard_banner.py
@@ -19,6 +19,7 @@ class DashboardBanner(Document):
 
 		action: DF.Data | None
 		action_label: DF.Data | None
+		cluster: DF.Link | None
 		enabled: DF.Check
 		has_action: DF.Check
 		help_url: DF.Data | None
@@ -33,6 +34,6 @@ class DashboardBanner(Document):
 		team: DF.Link | None
 		title: DF.Data | None
 		type: DF.Literal["Info", "Success", "Error", "Warning"]
-		type_of_scope: DF.Literal["Team", "Server", "Site"]
+		type_of_scope: DF.Literal["Team", "Cluster", "Server", "Site"]
 		user_dismissals: DF.Table[DashboardBannerDismissal]
 	# end: auto-generated types


### PR DESCRIPTION
Resolves #3798

Admins can now address users with sites in specific clusters.