### PR TITLE
fix(bench-group-deploy): Let users select app commit during initial deployment

### DIFF
--- a/dashboard/src/components/group/UpdateReleaseGroupDialog.vue
+++ b/dashboard/src/components/group/UpdateReleaseGroupDialog.vue
@@ -3,7 +3,7 @@
 		v-model="show"
 		:options="{
 			size: '4xl',
-			title: 'Update Bench Group',
+			title: lastDeploy ? 'Update Bench Group' : 'Deploy Bench Group',
 		}"
 	>
 		<template #body-content>
@@ -17,7 +17,9 @@
 			<div class="space-y-4">
 				<!-- Select Apps Step -->
 				<div v-if="step === 'select-apps'">
-					<h2 class="mb-4 text-lg font-medium">Select apps to update</h2>
+					<h2 class="mb-4 text-lg font-medium">
+						{{ lastDeploy ? 'Select apps to update' : 'Select apps to deploy' }}
+					</h2>
 					<GenericList
 						class="max-h-[500px]"
 						v-if="benchDocResource.doc.deploy_information.update_available"
@@ -131,7 +133,7 @@ import AlertBanner from '../AlertBanner.vue';
 
 export default {
 	name: 'UpdateReleaseGroupDialog',
-	props: ['bench'],
+	props: ['bench', 'lastDeploy'],
 	components: {
 		GenericList,
 		CommitChooser,
@@ -153,6 +155,14 @@ export default {
 	mounted() {
 		if (this.hasUpdateAvailable) {
 			this.step = 'select-apps';
+			if (!this.lastDeploy) {
+				// Preselect all updatable apps for first time deploys
+				this.handleAppSelection(
+					this.benchDocResource.doc?.deploy_information?.apps?.map(
+						(app) => app.name,
+					) || [],
+				);
+			}
 		} else if (this.hasRemovedApps) {
 			this.step = 'removed-apps';
 		} else {
@@ -168,7 +178,7 @@ export default {
 
 			return {
 				data: appData,
-				selectable: true,
+				selectable: !!this.lastDeploy,
 				columns: [
 					{
 						label: 'App',
@@ -401,6 +411,10 @@ export default {
 			return this.hasUpdateAvailable || this.step === 'restrict-build';
 		},
 		canShowNext() {
+			if (this.step === 'select-apps' && !this.lastDeploy) {
+				return false;
+			}
+
 			if (this.step === 'restrict-build') {
 				return false;
 			}
@@ -415,6 +429,10 @@ export default {
 			return !this.canShowNext;
 		},
 		deployLabel() {
+			if (!this.lastDeploy) {
+				return 'Deploy now';
+			}
+
 			if (this.selectedSites.length === 0) {
 				return 'Skip and Deploy';
 			}
@@ -595,6 +613,11 @@ export default {
 			).next_release;
 		},
 		updateBench() {
+			if (this.selectedApps.length === 0 && !this.lastDeploy) {
+				this.errorMessage = 'Please select an app to proceed';
+				return;
+			}
+
 			if (this.restrictMessage && !this.ignoreWillFailCheck) {
 				this.errorMessage =
 					'Please check the <b>I understand</b> box to proceed';

--- a/dashboard/src/objects/group.js
+++ b/dashboard/src/objects/group.js
@@ -976,44 +976,23 @@ export default {
 						group.doc.deploy_information.update_available &&
 						['Awaiting Deploy', 'Active'].includes(group.doc.status),
 					onClick() {
-						if (group.doc?.deploy_information?.last_deploy) {
-							let UpdateReleaseGroupDialog = defineAsyncComponent(
-								() =>
-									import('../components/group/UpdateReleaseGroupDialog.vue'),
-							);
-							renderDialog(
-								h(UpdateReleaseGroupDialog, {
-									bench: group.name,
-									onSuccess(candidate) {
-										group.doc.deploy_information.deploy_in_progress = true;
-										if (candidate) {
-											group.doc.deploy_information.last_deploy.name = candidate;
-										}
-									},
-								}),
-							);
-						} else {
-							confirmDialog({
-								title: 'Deploy',
-								message: "Let's deploy now?",
-								onSuccess({ hide }) {
-									toast.promise(
-										group.initialDeploy.submit(null, {
-											onSuccess: () => {
-												group.reload();
-												hide();
-											},
-										}),
-										{
-											success: 'Deploy scheduled successfully',
-											error: (e) =>
-												getToastErrorMessage(e, 'Failed to schedule deploy'),
-											loading: 'Scheduling deploy...',
-										},
-									);
+						let UpdateReleaseGroupDialog = defineAsyncComponent(
+							() => import('../components/group/UpdateReleaseGroupDialog.vue'),
+						);
+						renderDialog(
+							h(UpdateReleaseGroupDialog, {
+								bench: group.name,
+								lastDeploy: group.doc?.deploy_information?.last_deploy,
+								onSuccess(candidate) {
+									group.doc.deploy_information.deploy_in_progress = true;
+									if (candidate) {
+										group.doc.deploy_information.last_deploy = {
+											name: candidate,
+										};
+									}
 								},
-							});
-						}
+							}),
+						);
 					},
 				},
 				{


### PR DESCRIPTION
Resolves #3443 

This functionality previously existed but was replaced to improve the user experience. I’ve reintroduced the best parts by allowing users to choose the exact commit ID to deploy, while keeping things simple by removing the site selection step. These changes apply only to first-time deployments, the experience for subsequent deployments remains unchanged.

In the new flow, checkboxes are no longer visible. All staged apps are automatically selected when the dialog loads. The site selection step has been omitted because a site cannot be added to a bench group unless it has already been deployed.

# Before

https://github.com/user-attachments/assets/4ac006dd-1f3f-4f0c-84d3-1e40b4cea7cf

# After

https://github.com/user-attachments/assets/a37c68e2-ca35-4120-9f14-a82c879ee3f2

