### PR TITLE
fix(dashboard-banners): Fix cluster scope permission issue

### DIFF
--- a/press/api/account.py
+++ b/press/api/account.py
@@ -1490,7 +1490,7 @@ def dismiss_banner(banner_name):
 				"parent": banner_name,
 			},
 		)
-		banner.save()
+		banner.save(ignore_permissions=True)
 		return True
 	return False
 

--- a/press/press/doctype/dashboard_banner/dashboard_banner.json
+++ b/press/press/doctype/dashboard_banner/dashboard_banner.json
@@ -223,7 +223,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-11-10 17:51:41.601766",
+ "modified": "2025-11-10 19:56:16.568267",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Dashboard Banner",
@@ -237,30 +237,6 @@
    "print": 1,
    "read": 1,
    "role": "System Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Press Admin",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Press Member",
    "share": 1,
    "write": 1
   }


### PR DESCRIPTION
This is a workaround to prevent the cluster scoped banners' dismissal permission issue where the dismissal was failing for unprivileged Press Admin users but succeeding for System Managers. Need to investigate this further.