### PR TITLE
fix(rq): Alert when we find a zombie RQ job

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -313,6 +313,7 @@ scheduler_events = {
 			"press.press.doctype.site_update.site_update.run_scheduled_updates",
 			"press.press.doctype.virtual_machine.virtual_machine.snapshot_aws_servers",
 			"press.press.doctype.app.app.poll_new_releases",
+			"press.utils.jobs.alert_on_zombie_rq_jobs",
 		],
 		"* * * * *": [
 			"press.press.doctype.virtual_disk_snapshot.virtual_disk_snapshot.sync_physical_backup_snapshots",

--- a/press/utils/jobs.py
+++ b/press/utils/jobs.py
@@ -1,12 +1,18 @@
-from typing import Any, Generator, Optional
+import json
 import signal
+from collections.abc import Generator
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
 
 import frappe
 from frappe.core.doctype.rq_job.rq_job import fetch_job_ids
 from frappe.utils.background_jobs import get_queues, get_redis_conn
-from redis import Redis
 from rq.command import send_stop_job_command
 from rq.job import Job, JobStatus, NoSuchJobError, get_current_job
+from rq.queue import Queue
+
+if TYPE_CHECKING:
+	from redis import Redis
 
 
 def stop_background_job(job: Job):
@@ -23,7 +29,7 @@ def get_background_jobs(
 	doctype: str,
 	name: str,
 	status: list[str] | None = None,
-	connection: "Optional[Redis]" = None,
+	connection: "Redis | None" = None,
 ) -> Generator[Job, Any, None]:
 	"""
 	Returns background jobs for a `doc` created using the `run_doc_method`
@@ -45,7 +51,7 @@ def get_background_jobs(
 
 def get_job_ids(
 	status: str | list[str],
-	connection: "Optional[Redis]" = None,
+	connection: "Redis | None" = None,
 ) -> Generator[str, Any, None]:
 	if isinstance(status, str):
 		status = [status]
@@ -60,8 +66,7 @@ def get_job_ids(
 			except ValueError:
 				return
 
-			for jid in job_ids:
-				yield jid
+			yield from job_ids
 
 
 def does_job_belong_to_doc(job: Job, doctype: str, name: str) -> bool:
@@ -69,9 +74,7 @@ def does_job_belong_to_doc(job: Job, doctype: str, name: str) -> bool:
 	if site and site != frappe.local.site:
 		return False
 
-	job_name = (
-		job.kwargs.get("job_type") or job.kwargs.get("job_name") or job.kwargs.get("method")
-	)
+	job_name = job.kwargs.get("job_type") or job.kwargs.get("job_name") or job.kwargs.get("method")
 	if job_name != "frappe.utils.background_jobs.run_doc_method":
 		return False
 
@@ -91,3 +94,23 @@ def has_job_timeout_exceeded() -> bool:
 	# getitimer returns the time left for this timer
 	# 0.0 means the timer is expired
 	return bool(get_current_job()) and (signal.getitimer(signal.ITIMER_REAL)[0] <= 0)
+
+
+def alert_on_zombie_rq_jobs() -> None:
+	from press.telegram_utils import Telegram
+
+	connection = get_redis_conn()
+
+	threshold = datetime.now() - timedelta(minutes=2)
+	for id in connection.keys("rq:job:*"):
+		id = id.decode().split(":", 2)[-1]
+		try:
+			job = Job.fetch(id, connection=connection)
+			queue = Queue(job.origin, connection=connection)
+			position = queue.get_job_position(job.id)
+			if job.enqueued_at < threshold and job.get_status() == JobStatus.QUEUED and position is None:
+				serialized = json.dumps(vars(job), default=str, indent=2, sort_keys=True)
+				message = f"""*Stuck Job Detected in RQ Queue* \n\n```JSON\n{serialized}```\n\n@adityahase @balamurali27 @tanmoysrt"""
+				Telegram("Errors").send(message)
+		except Exception:
+			pass


### PR DESCRIPTION
Sometimes, deduplicated jobs aren't added to the queue. So no workers consume the job. But Job.fetch returns a valid job. So deduplicate doesn't add another job to the queue.

We noticed this with randomly stuck Agent job updates (poll_pending_jobs_server), for a specific server.

Cancelling the job removes the job from the redis hash.

I suspect that the process gets terminated between hset and rpush https://github.com/rq/rq/blob/dc79d62a93f452005bb720b7938278e9b09296cf/rq/queue.py#L1170 https://github.com/rq/rq/blob/dc79d62a93f452005bb720b7938278e9b09296cf/rq/queue.py#L1174

Something like the following should solve the problem
```python
pipeline = connection.pipeline()
q.enqueue_call(...., pipeline=pipeline)
pipeline.execute()
```