### PR TITLE
fix(site): Selectively rollback failed Site.archive iterations

### DIFF
--- a/press/press/doctype/site/archive.py
+++ b/press/press/doctype/site/archive.py
@@ -50,8 +50,12 @@ def archive_suspended_trial_sites():
 				site: Site = frappe.get_doc("Site", site.name, for_update=True)
 				site.archive(reason="Archive suspended trial site")
 				archived_now = archived_now + 1
+				frappe.db.commit()
 		except Exception:
 			log_error("Suspended Site Archive Error")
+			# Without the rollback the transaction will be implicitly committed
+			# So we selectively commit and rollback
+			frappe.db.rollback()
 
 
 def delete_offsite_backups_for_archived_sites():


### PR DESCRIPTION
AgentJob.enqueue_http_request creates a background job with enqueue_after_commit.

If the transaction is later committed then the enqueue_after_commit job still runs.

Since the Agent Job wasn't inserted. The jobs that shouldn't have been scheduled now fail with
```python
frappe.exceptions.DoesNotExistError: Agent Job abcdef not found
```