### PR TITLE
fix(release-group): Redis password backward compatibility

### DIFF
--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -598,12 +598,17 @@ class ReleaseGroup(Document, TagHelpers):
 		return required_arm_build, required_intel_build
 
 	def get_redis_password(self) -> str:
-		"""Get redis password create and update password if not present"""
+		"""Get redis password create and update password if not present
+		Ignore validation while setting redis password to allow older RGs
+		to be password protected.
+		"""
 		try:
 			return self.get_password("redis_password")
-		except frappe.AuthenticationError:
+		except (frappe.AuthenticationError, frappe.ValidationError):
 			self.redis_password = frappe.generate_hash(length=32)
-			self.save(ignore_permissions=True)
+			self.flags.ignore_validate = 1
+			self._save_passwords()
+			self.save()
 			return self.get_password("redis_password")
 
 	@frappe.whitelist()


### PR DESCRIPTION
Older release groups don't have compatible apps, allow them to set a password as well.