### PR TITLE
fix(snapshot): Ignore errors while deleting locked snapshots

### DIFF
--- a/press/press/doctype/virtual_disk_snapshot/virtual_disk_snapshot.py
+++ b/press/press/doctype/virtual_disk_snapshot/virtual_disk_snapshot.py
@@ -380,6 +380,8 @@ def delete_old_snapshots():
 		try:
 			frappe.get_doc("Virtual Disk Snapshot", snapshot).delete_snapshot()
 			frappe.db.commit()
+		except (SnapshotLockedError, SnapshotInUseError):
+			pass
 		except Exception:
 			log_error("Virtual Disk Snapshot Delete Error", snapshot=snapshot)
 			frappe.db.rollback()


### PR DESCRIPTION
Reference: https://sentry.frappe.cloud/organizations/frappe/issues/406

Note: Started failing after https://github.com/frappe/press/pull/3881