### PR TITLE
fix(monitor): Selectively monitor uptime metrics

### DIFF
--- a/press/press/doctype/monitor_server/monitor_server.json
+++ b/press/press/doctype/monitor_server/monitor_server.json
@@ -39,7 +39,8 @@
   "monitoring_password",
   "webhook_token",
   "column_break_nzet",
-  "prometheus_data_directory"
+  "prometheus_data_directory",
+  "only_monitor_uptime_metrics"
  ],
  "fields": [
   {
@@ -256,6 +257,12 @@
    "fieldtype": "Check",
    "label": "TLS Certificate Renewal Failed",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "only_monitor_uptime_metrics",
+   "fieldtype": "Check",
+   "label": "Only Monitor Uptime Metrics"
   }
  ],
  "grid_page_length": 50,
@@ -265,7 +272,7 @@
    "link_fieldname": "server"
   }
  ],
- "modified": "2025-09-02 16:43:40.405932",
+ "modified": "2025-11-17 21:10:06.147734",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Monitor Server",

--- a/press/press/doctype/monitor_server/monitor_server.py
+++ b/press/press/doctype/monitor_server/monitor_server.py
@@ -53,6 +53,7 @@ class MonitorServer(BaseServer):
 		is_server_setup: DF.Check
 		monitoring_password: DF.Password | None
 		node_exporter_dashboard_path: DF.Data | None
+		only_monitor_uptime_metrics: DF.Check
 		private_ip: DF.Data
 		private_mac_address: DF.Data | None
 		private_vlan_id: DF.Data | None


### PR DESCRIPTION
We want to use some servers to monitor the site, server, and domain uptime.

Other metrics (nginx VTS, cadvisor) take up a lot of memory and space on the monitor server.