### PR TITLE
chore: clear alertmanager webhook logs

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -415,6 +415,10 @@ page_renderer = ["press.metrics.MetricsRenderer"]
 
 export_python_type_annotations = True
 
+default_log_clearing_doctypes = {
+	"Alertmanager Webhook Log": 60,
+}
+
 
 # These are used for some business logic, they should be manually evicted.
 __persistent_cache_keys = [

--- a/press/patches.txt
+++ b/press/patches.txt
@@ -149,3 +149,4 @@ press.press.doctype.user_2fa.patches.generate_recovery_codes
 press.press.doctype.account_request.patches.generate_expiration_time_for_request_key
 press.saas.doctype.product_trial_request.patches.set_subscription_created_flag
 press.patches.v0_8_0.move_notify_billing_email_of_team_to_child_doc
+press.patches.v0_8_0.clear_alertmanager_webhook_log

--- a/press/patches/v0_8_0/clear_alertmanager_webhook_log.py
+++ b/press/patches/v0_8_0/clear_alertmanager_webhook_log.py
@@ -1,0 +1,8 @@
+from contextlib import suppress
+
+from frappe.core.doctype.log_settings.log_settings import clear_log_table
+
+
+def execute():
+	with suppress(Exception):
+		clear_log_table("Alertmanager Webhook Log", days=60)


### PR DESCRIPTION
should reduce bloat in prod

the controller hook is already there - just need to add an entry in log settings doctype i guess

depends: https://github.com/frappe/frappe/pull/34786