### PR TITLE
fix(ui): Update switch team dialog

### DIFF
--- a/dashboard/src/components/SwitchTeamDialog.vue
+++ b/dashboard/src/components/SwitchTeamDialog.vue
@@ -21,10 +21,11 @@
 			</div>
 			<div class="mt-3">
 				<TextInput
+					v-if="sortedTeams.length > 5"
 					size="sm"
-					variant="subtle"
-					placeholder="Search team.."
-					v-model="teamSearch"
+					placeholder="Search"
+					:debounce="500"
+					v-model="searchQuery"
 				/>
 			</div>
 			<div class="-mb-3 mt-3 divide-y">
@@ -96,10 +97,10 @@ export default {
 			});
 		},
 		filteredTeams() {
-			if (!this.teamSearch.trim()) {
+			if (!this.searchQuery.trim()) {
 				return this.sortedTeams;
 			}
-			const query = this.teamSearch.toLowerCase();
+			const query = this.searchQuery.toLowerCase();
 			return this.sortedTeams.filter(
 				(team) =>
 					team.user.toLowerCase().includes(query) ||
@@ -110,7 +111,7 @@ export default {
 	data() {
 		return {
 			selectedTeam: null,
-			teamSearch: '',
+			searchQuery: '',
 		};
 	},
 	methods: {


### PR DESCRIPTION
- List valid teams in alphabetical order
- Display a search field if more than 5 teams are listed

**before:**
<img width="671" height="392" alt="Screenshot 2025-11-21 at 3 18 38 PM" src="https://github.com/user-attachments/assets/514fffc6-4737-47d1-b092-9d831d9e6518" />


**After:**
<img width="586" height="409" alt="Screenshot 2025-11-21 at 3 17 32 PM" src="https://github.com/user-attachments/assets/aec84622-ce92-4c59-9cf1-5125a2c3fcc4" />

Search using team user or id
<img width="648" height="304" alt="Screenshot 2025-11-21 at 3 17 39 PM" src="https://github.com/user-attachments/assets/7be4f12c-abdb-47c6-b8da-90d4482ddc3a" />

fix #3252 