### PR TITLE
fix(backend): Better incident sms format

### DIFF
--- a/press/press/doctype/incident/incident.py
+++ b/press/press/doctype/incident/incident.py
@@ -564,17 +564,10 @@ Likely due to insufficient balance or incorrect credentials""",
 		) and ignore_since < frappe.utils.now_datetime():
 			return
 		domain = frappe.db.get_value("Press Settings", None, "domain")
-		incident_link = f"{domain}{self.get_url()}"
-
-		message_body = f"""New Incident {self.name} Reported
-
-Hosted on: {self.server}
-
-Incident URL: {incident_link}"""
+		incident_link = f"https://{domain}{self.get_url()}"
+		message = f"Incident on server: {self.server}\n\nURL: {incident_link}\n\nID: {self.name}"
 		for human in self.get_humans():
-			self.twilio_client.messages.create(
-				to=human.phone, from_=self.twilio_phone_number, body=message_body
-			)
+			self.twilio_client.messages.create(to=human.phone, from_=self.twilio_phone_number, body=message)
 		self.reload()  # In case the phone call status is modified by the investigator before the sms is sent
 		self.sms_sent = 1
 		self.save()


### PR DESCRIPTION
- Server name on top
- Prefix url with `https://` so it becomes clickable
- Use `\n\n` instead of multiline string