### PR TITLE
feat(devtools): Make vue devtools optional by default

### DIFF
--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -6,6 +6,8 @@ import frappeui from 'frappe-ui/vite';
 import pluginRewriteAll from 'vite-plugin-rewrite-all';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import vueDevTools from 'vite-plugin-vue-devtools'
+import dotenv from 'dotenv';
+dotenv.config();
 
 export default defineConfig({
 	plugins: [
@@ -30,7 +32,7 @@ export default defineConfig({
 			applicationKey: 'press-dashboard',
 			authToken: process.env.SENTRY_AUTH_TOKEN,
 		}),
-		vueDevTools(),
+		...(process.env.ENABLE_VUE_DEVTOOLS ? [vueDevTools()] : []),
 	],
 	server: {
 		allowedHosts: true


### PR DESCRIPTION
Vue devtools can be enabled by downloading the Firefox/Chrome Vue.js [devtools extensions](https://devtools.vuejs.org/guide/browser-extension), or creating a `.env` in the `/dashboard` path and then adding the following line to it:

```sh
ENABLE_VUE_DEVTOOLS=true
```