### PR TITLE
chore(job): Pass param to backup site job to determine agent_job_timeout

### DIFF
--- a/press/agent.py
+++ b/press/agent.py
@@ -278,7 +278,7 @@ class Agent:
 		assert site.config is not None, "Site config is required to restore site from backup"
 
 		data = {
-			"config": json.loads(site.config),
+			"config": json.loads(site.config) if site.config else {},
 			"apps": apps,
 			"name": site.name,
 			"mariadb_root_password": get_mariadb_root_password(site),
@@ -533,8 +533,10 @@ class Agent:
 	def backup_site(self, site, site_backup: SiteBackup):
 		from press.press.doctype.site_backup.site_backup import get_backup_bucket
 
-		data = {"with_files": site_backup.with_files}
-
+		data = {
+			"with_files": site_backup.with_files,
+			"agent_job_timeout": site.backup_timeout,
+		}
 		if site_backup.offsite:
 			settings = frappe.get_single("Press Settings")
 			backups_path = os.path.join(site.name, str(date.today()))

--- a/press/press/doctype/site/site.json
+++ b/press/press/doctype/site/site.json
@@ -19,6 +19,7 @@
   "cluster",
   "admin_password",
   "additional_system_user_created",
+  "backup_timeout",
   "config_tab",
   "hide_config",
   "host_name",
@@ -742,6 +743,12 @@
    "fieldtype": "Datetime",
    "label": "Creation Failed",
    "read_only": 1
+  },
+  {
+   "default": "18000",
+   "fieldname": "backup_timeout",
+   "fieldtype": "Int",
+   "label": "Backup Timeout"
   }
  ],
  "links": [

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -154,6 +154,7 @@ class Site(Document, TagHelpers):
 		apps: DF.Table[SiteApp]
 		archive_failed: DF.Check
 		auto_update_last_triggered_on: DF.Datetime | None
+		backup_timeout: DF.Int
 		bench: DF.Link
 		cluster: DF.Link
 		communication_infos: DF.Table[CommunicationInfo]


### PR DESCRIPTION
@tanmoysrt Do you think we should give each site backup specific timeout or common backup timeout through configuration in Press Settings? Please do let me know if there are other ways that you think that would fit.