### PR TITLE
fix(tls): Explicitly set region_name and AWS_DEFAULT_REGION

### DIFF
--- a/press/press/doctype/root_domain/root_domain.json
+++ b/press/press/doctype/root_domain/root_domain.json
@@ -13,7 +13,8 @@
   "column_break_4",
   "dns_provider",
   "aws_access_key_id",
-  "aws_secret_access_key"
+  "aws_secret_access_key",
+  "aws_region"
  ],
  "fields": [
   {
@@ -66,6 +67,12 @@
    "fieldname": "enabled",
    "fieldtype": "Check",
    "label": "Enabled"
+  },
+  {
+   "description": "Sets AWS_DEFAULT_REGION environment variable",
+   "fieldname": "aws_region",
+   "fieldtype": "Data",
+   "label": "AWS Region"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -101,7 +108,7 @@
    "link_fieldname": "domain"
   }
  ],
- "modified": "2025-07-07 13:57:57.363562",
+ "modified": "2025-12-09 14:04:47.403558",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Root Domain",
@@ -122,6 +129,7 @@
   }
  ],
  "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/press/press/doctype/root_domain/root_domain.py
+++ b/press/press/doctype/root_domain/root_domain.py
@@ -30,6 +30,7 @@ class RootDomain(Document):
 		from frappe.types import DF
 
 		aws_access_key_id: DF.Data | None
+		aws_region: DF.Data | None
 		aws_secret_access_key: DF.Password | None
 		default_cluster: DF.Link
 		default_proxy_server: DF.Link | None
@@ -78,6 +79,7 @@ class RootDomain(Document):
 				"route53",
 				aws_access_key_id=self.aws_access_key_id,
 				aws_secret_access_key=self.get_password("aws_secret_access_key"),
+				region_name=self.aws_region,
 			)
 		return self._boto3_client
 
@@ -95,6 +97,7 @@ class RootDomain(Document):
 			)
 		except Exception:
 			log_error("Route 53 Pagination Error", domain=self.name)
+		return []
 
 	def delete_dns_records(self, records: list[str]):
 		try:

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -480,6 +480,7 @@ class BaseServer(Document, TagHelpers):
 				"route53",
 				aws_access_key_id=domain.aws_access_key_id,
 				aws_secret_access_key=domain.get_password("aws_secret_access_key"),
+				region_name=domain.aws_region,
 			)
 			zones = client.list_hosted_zones_by_name()["HostedZones"]
 			# list_hosted_zones_by_name returns a lexicographically ordered list of zones

--- a/press/press/doctype/tls_certificate/tls_certificate.py
+++ b/press/press/doctype/tls_certificate/tls_certificate.py
@@ -529,19 +529,21 @@ class LetsEncrypt(BaseCA):
 
 	def _obtain_wildcard(self):
 		domain = frappe.get_doc("Root Domain", self.domain[2:])
-		environment = os.environ
+		environment = os.environ.copy()
 		environment.update(
 			{
 				"AWS_ACCESS_KEY_ID": domain.aws_access_key_id,
 				"AWS_SECRET_ACCESS_KEY": domain.get_password("aws_secret_access_key"),
 			}
 		)
+		if domain.aws_region:
+			environment["AWS_DEFAULT_REGION"] = domain.aws_region
 		self.run(self._certbot_command(), environment=environment)
 
 	def _obtain_naked_with_dns(self):
 		domain = frappe.get_all("Root Domain", pluck="name", limit=1)[0]
 		domain = frappe.get_doc("Root Domain", domain)
-		environment = os.environ
+		environment = os.environ.copy()
 		environment.update(
 			{
 				"AWS_ACCESS_KEY_ID": domain.aws_access_key_id,

--- a/press/utils/dns.py
+++ b/press/utils/dns.py
@@ -62,6 +62,7 @@ def _change_dns_record(method: str, domain: RootDomain, proxy_server: str, recor
 		"route53",
 		aws_access_key_id=domain.aws_access_key_id,
 		aws_secret_access_key=domain.get_password("aws_secret_access_key"),
+		region_name=domain.aws_region,
 	)
 	try:
 		zones = client.list_hosted_zones_by_name()["HostedZones"]


### PR DESCRIPTION
Route53 for AWS China regions is hosted on a different endpoint. We'll likely have to do the same everywhere else.
i.e explicitly use region_name or AWS_DEFAULT_REGION.

Without this, certbot fails with
```
Requesting a certificate for *.frappe.net.cn\nAn error occurred
(InvalidClientTokenId) when calling the ListHostedZones operation:
The security token included in the request is invalid.
```

References:
- https://github.com/certbot/certbot/issues/8548
- https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#:~:text=region%5Fname
- https://cloud.frappe.io/app/error-log/9q0nm2vrb9