### PR TITLE
fix: Resolve permission issue during Prometheus template validation

### DIFF
--- a/press/playbooks/roles/reconfigure_prometheus/tasks/main.yml
+++ b/press/playbooks/roles/reconfigure_prometheus/tasks/main.yml
@@ -36,12 +36,13 @@
 
 - name: Configure Prometheus
   become: yes
-  become_user: frappe
   template:
     src: ../../prometheus/templates/prometheus.yml
     dest: /home/frappe/prometheus/prometheus.yml
-    force: true
+    owner: frappe
+    group: frappe
     mode: 0600
+    force: true
     validate: "/home/frappe/prometheus/promtool check config %s"
 
 - name: Reload Prometheus Service


### PR DESCRIPTION
Permission Error while validating template 

```
Traceback (most recent call last):\n  File \"/tmp/ansible_ansible.legacy.copy_payload_261j7u1y/ansible_ansible.legacy.copy_payload.zip/ansible/modules/copy.py\", line 653, in main\n  File \"/tmp/ansible_ansible.legacy.copy_payload_261j7u1y/ansible_ansible.legacy.copy_payload.zip/ansible/module_utils/basic.py\", line 1187, in set_mode_if_different\n    os.chmod(b_path, mode)\nPermissionError: [Errno 1] Operation not permitted: b'/var/tmp/ansible-tmp-1765371762.4120207-710025-107816821451108/source'\n
```