### PR TITLE
fix(billing): Bug in create_razorpay_order method

### DIFF
--- a/press/api/billing.py
+++ b/press/api/billing.py
@@ -666,7 +666,9 @@ def create_razorpay_order(amount, transaction_type, doc_name=None) -> dict | Non
 		amount += gst_amount
 
 	# normalize type for payment record
-	payment_record_type = "Prepaid Credits" if transaction_type in ["Invoice", "Purchase Plan"] else type
+	payment_record_type = (
+		"Prepaid Credits" if transaction_type in ["Invoice", "Purchase Plan"] else transaction_type
+	)
 
 	amount = round(amount, 2)
 	data = {


### PR DESCRIPTION
- Avoid python 'type' in razorpay payload in place of transaction_type