### PR TITLE
refactor(press-job): Trigger scale up only if not already scaled up

### DIFF
--- a/press/fixtures/press_job_type.json
+++ b/press/fixtures/press_job_type.json
@@ -643,7 +643,7 @@
   "name": "Auto Scale Up Application Server",
   "steps": [
    {
-    "script": "server = frappe.get_doc(doc.server_type, doc.server)\n\nif doc.server_type == \"Server\":\n    server.scale_up(is_automatically_triggered=True)",
+    "script": "server = frappe.get_doc(doc.server_type, doc.server)\n\nif doc.server_type == \"Server\" and not server.scaled_up:\n    server.scale_up(is_automatically_triggered=True)",
     "step_name": "Auto Scale Up Application Server",
     "wait_until_true": 0
     }


### PR DESCRIPTION
Doesn't seem nice to `frappe.throw` in a press job silently