### PR TITLE
fix(minor): Stop agent job on primary after switching to primary when scaling down

### DIFF
--- a/press/press/doctype/auto_scale_record/auto_scale_record.py
+++ b/press/press/doctype/auto_scale_record/auto_scale_record.py
@@ -120,10 +120,10 @@ class AutoScaleRecord(Document, AutoScaleStepFailureHandler, StepHandler):
 				[
 					# There could be jobs running on both primary and secondary
 					self.mark_start_time,
-					self.stop_all_agent_jobs_on_primary,
 					self.stop_all_agent_jobs_on_secondary,
 					self.switch_to_primary,
 					self.wait_for_primary_switch,
+					self.stop_all_agent_jobs_on_primary,
 					self.setup_primary_upstream,
 					self.wait_for_primary_upstream_setup,
 					self.initiate_secondary_shutdown,


### PR DESCRIPTION
we seem to stop agent jobs and then send an agent job in primary (`switch_to_primary`) - did this work?

how? https://cloud.frappe.io/app/auto-scale-record/9g7s4mib8h

bruh: https://github.com/frappe/press/blob/develop/press/press/doctype/agent_job/agent_job.py#L41