### PR TITLE
feat: Add Ubuntu 24.04 / Python 3.12 compatibility

### DIFF
--- a/press/playbooks/roles/filebeat/tasks/main.yml
+++ b/press/playbooks/roles/filebeat/tasks/main.yml
@@ -17,15 +17,26 @@
   retries: 5
   delay: 120
 
-- name: Add Elasticsearch Repository Key
-  apt_key:
-    url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
-    state: present
+- name: Check if Elasticsearch GPG Key Exists
+  stat:
+    path: /usr/share/keyrings/elasticsearch.gpg
+  register: elasticsearch_gpg_key
 
-- name: Add Elasticsearch Repository
-  apt_repository:
-    repo: deb https://artifacts.elastic.co/packages/7.x/apt stable main
-    state: present
+- name: Add Elasticsearch Repository Key (Modern)
+  shell: curl -fsSL https://artifacts.elastic.co/GPG-KEY-elasticsearch | gpg --dearmor -o /usr/share/keyrings/elasticsearch.gpg
+  when: not elasticsearch_gpg_key.stat.exists
+
+- name: Add Elasticsearch Repository (Modern)
+  copy:
+    content: "deb [signed-by=/usr/share/keyrings/elasticsearch.gpg] https://artifacts.elastic.co/packages/7.x/apt stable main"
+    dest: /etc/apt/sources.list.d/elastic-7.x.list
+  register: elastic_repo
+
+- name: Update APT Cache for Elasticsearch
+  apt:
+    update_cache: yes
+  when: elastic_repo.changed
+  ignore_errors: yes
 
 - name: Remove new Elasticsearch Repository
   apt_repository:

--- a/press/playbooks/roles/nginx/tasks/main.yml
+++ b/press/playbooks/roles/nginx/tasks/main.yml
@@ -8,19 +8,26 @@
       - libpcre3-dev
     state: present
 
+- name: Check if NGINX GPG Key Exists
+  stat:
+    path: /usr/share/keyrings/nginx-archive-keyring.gpg
+  register: nginx_gpg_key
+
+- name: Add NGINX Repository Key (Modern)
+  shell: curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/share/keyrings/nginx-archive-keyring.gpg
+  when: not nginx_gpg_key.stat.exists
+
 - name: Setup NGINX Source Repository
   copy:
-    content: "deb-src http://nginx.org/packages/mainline/ubuntu/ {{ ansible_distribution_release }} nginx"
+    content: "deb-src [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] http://nginx.org/packages/mainline/ubuntu/ {{ ansible_distribution_release }} nginx"
     dest: /etc/apt/sources.list.d/nginx.list
-
-- name: Add NGINX Repository Key
-  apt_key:
-    url: https://nginx.org/keys/nginx_signing.key
-    state: present
+  register: nginx_repo
 
 - name: Update APT Cache
   apt:
     update_cache: yes
+  when: nginx_repo.changed
+  ignore_errors: yes
 
 - name: Install NGINX Build Dependencies
   apt:

--- a/press/playbooks/roles/node_exporter/tasks/main.yml
+++ b/press/playbooks/roles/node_exporter/tasks/main.yml
@@ -1,9 +1,15 @@
 ---
+- name: Check if Node Exporter is installed
+  stat:
+    path: /opt/node_exporter/node_exporter
+  register: node_exporter_binary
+
 - name: Create Node Exporter Directory
   file:
     path: /opt/node_exporter
     state: directory
     mode: 0755
+  when: not node_exporter_binary.stat.exists
 
 - name: Set Architecture
   set_fact:
@@ -14,6 +20,7 @@
     src: "https://github.com/prometheus/node_exporter/releases/download/v1.8.2/node_exporter-1.8.2.linux-{{ arch }}.tar.gz"
     dest: /tmp
     remote_src: yes
+  when: not node_exporter_binary.stat.exists
 
 - name: Copy Node Exporter Binary
   copy:
@@ -23,6 +30,7 @@
     mode: 0755
     owner: root
     group: root
+  when: not node_exporter_binary.stat.exists
 
 - name: Create Node Exporter Systemd Service File
   template:

--- a/press/runner.py
+++ b/press/runner.py
@@ -63,8 +63,11 @@ class AnsibleCallback(CallbackBase):
 		self.update_task("Success", result)
 		self.process_task_success(result)
 
-	def v2_runner_on_failed(self, result, *args, **kwargs):
-		self.update_task("Failure", result)
+	def v2_runner_on_failed(self, result, ignore_errors=False, *args, **kwargs):
+		if ignore_errors:
+			self.update_task("Ignored", result)
+		else:
+			self.update_task("Failure", result)
 
 	def v2_runner_on_skipped(self, result):
 		self.update_task("Skipped", result)


### PR DESCRIPTION
## Summary
Add Ubuntu 24.04 / Python 3.12 compatibility for Frappe Press Ansible playbooks and runner.

## Problem
The current Ansible playbooks use the deprecated `apt_key` module which is:
- Deprecated in Ubuntu 22.04+
- Completely broken in Ubuntu 24.04 due to changes in how APT handles GPG keys

Additionally, the Ansible callback incorrectly marks tasks with `ignore_errors: yes` as "Failure" instead of "Ignored", causing plays to show as failed even when they succeed.

## Changes

### 1. NGINX Role (`press/playbooks/roles/nginx/tasks/main.yml`)
- Replace deprecated `apt_key` module with modern GPG keyring approach
- Use `/usr/share/keyrings/nginx-archive-keyring.gpg` for key storage
- Update repository source to use `signed-by` option
- Make APT cache update conditional and add `ignore_errors: yes`

### 2. Filebeat Role (`press/playbooks/roles/filebeat/tasks/main.yml`)
- Replace deprecated `apt_key` module for Elasticsearch repository
- Use `/usr/share/keyrings/elasticsearch.gpg` for key storage
- Use `copy` module instead of `apt_repository` for signed-by support
- Make APT cache update conditional with `ignore_errors: yes`

### 3. Node Exporter Role (`press/playbooks/roles/node_exporter/tasks/main.yml`)
- Add check for existing binary at `/opt/node_exporter/node_exporter`
- Skip download/copy tasks if already installed
- Prevents unnecessary re-downloads on subsequent runs

### 4. Ansible Callback (`press/runner.py`)
- Update `v2_runner_on_failed` to accept `ignore_errors` parameter (passed by Ansible)
- Mark tasks with `ignore_errors: yes` as "Ignored" instead of "Failure"
- Fixes incorrect play status when using `ignore_errors` directive

## Testing
Tested on Ubuntu 24.04 with Python 3.12 and Ansible 7.7.0. All playbooks run successfully with proper status tracking.

## References
- [Ansible apt_key deprecation](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_key_module.html)
- [Ubuntu APT key management changes](https://wiki.debian.org/DebianRepository/UseThirdParty)