### PR TITLE
fix(dependency): Migrate FormControl combobox and form.Button

### DIFF
--- a/dashboard/src/components/LinkControl.vue
+++ b/dashboard/src/components/LinkControl.vue
@@ -7,10 +7,10 @@
 		:modelValue="modelValue"
 		:placeholder="placeholder"
 		@update:query="onQuery"
-		@update:model-value="
+		@update:modelValue="
 			(option) => {
-				if (option?.value) {
-					$emit('update:modelValue', option.value);
+				if (option) {
+					$emit('update:modelValue', option);
 				} else {
 					$emit('update:modelValue', undefined);
 				}

--- a/dashboard/src/pages/LoginSignup.vue
+++ b/dashboard/src/pages/LoginSignup.vue
@@ -143,6 +143,7 @@
 									I remember my password
 								</router-link>
 								<Button
+									type="submit"
 									class="mt-4"
 									:loading="$resources.resetPassword.loading"
 									variant="solid"
@@ -164,7 +165,7 @@
 								/>
 								<!-- OAuth Authentication -->
 								<template v-if="isOauthLogin && !usePassword">
-									<Button class="mt-4" variant="solid">
+									<Button class="mt-4" variant="solid" type="submit">
 										Log in with {{ oauthProviderName }}
 									</Button>
 								</template>
@@ -282,6 +283,7 @@
 									class="mt-4"
 									:loading="$resources.signup.loading"
 									variant="solid"
+									type="submit"
 								>
 									Sign up with email
 								</Button>

--- a/dashboard/src/pages/ResetPassword.vue
+++ b/dashboard/src/pages/ResetPassword.vue
@@ -57,6 +57,7 @@
 					$resources.verify2FA.loading ||
 					$resources.is2FAEnabled.loading
 				"
+				type="submit"
 			>
 				Submit
 			</Button>

--- a/dashboard/src/pages/SetupAccount.vue
+++ b/dashboard/src/pages/SetupAccount.vue
@@ -93,6 +93,7 @@
 								$resources.setupAccount.loading ||
 								$resources.acceptInvite.loading
 							"
+							type="submit"
 						>
 							{{
 								is2FA ? 'Verify' : isInvitation ? 'Accept' : 'Create account'

--- a/dashboard/src/pages/signup/SetupSite.vue
+++ b/dashboard/src/pages/signup/SetupSite.vue
@@ -59,6 +59,7 @@
 						label="Create site"
 						:loading="findingClosestServer || $resources.createSite?.loading"
 						:loadingText="'Creating site...'"
+						type="submit"
 					/>
 				</form>
 			</LoginBox>


### PR DESCRIPTION
Migrate to frappe-ui v0.1.238:
- `@update` event callback parameter changed for FormControl type combobox
- `<Button>` inside `<form>` are no more type="submit" by default