### PR TITLE
fix(dependency): Migrate FormControl.combobox implementations

### DIFF
--- a/dashboard/src/components/AddTagDialog.vue
+++ b/dashboard/src/components/AddTagDialog.vue
@@ -20,8 +20,11 @@
 				v-if="selectedTag?.value !== '__new__'"
 				label="Select tag"
 				type="combobox"
-				v-model="selectedTag"
 				:options="tagOptions"
+				:modelValue="selectedTag?.value"
+				@update:modelValue="
+					selectedTag = tagOptions.find((option) => option.value === $event)
+				"
 			/>
 			<FormControl
 				v-if="selectedTag?.value === '__new__'"

--- a/dashboard/src/components/ConfigEditorDialog.vue
+++ b/dashboard/src/components/ConfigEditorDialog.vue
@@ -20,7 +20,12 @@
 						type="combobox"
 						label="Config Name"
 						:options="keyOptions"
-						v-model="selectedConfig"
+						:modelValue="selectedConfig?.value"
+						@update:modelValue="
+							selectedConfig = keyOptions.find(
+								(option) => option.value === $event,
+							)
+						"
 					/>
 					<div
 						v-if="

--- a/dashboard/src/components/GitHubAppSelector.vue
+++ b/dashboard/src/components/GitHubAppSelector.vue
@@ -30,7 +30,12 @@
 					image: i.image,
 				}))
 			"
-			v-model="selectedGithubUser"
+			:modelValue="selectedGithubUser?.value"
+			@update:modelValue="
+				selectedGithubUser = options.installations.find(
+					(option) => option.id === $event,
+				)
+			"
 		>
 			<template #prefix>
 				<img
@@ -68,7 +73,12 @@
 					value: r.name,
 				}))
 			"
-			v-model="selectedGithubRepository"
+			:modelValue="selectedGithubRepository?.value"
+			@update:modelValue="
+				selectedGithubRepository = (selectedGithubUserData.repos || []).find(
+					(option) => option.name === $event,
+				)
+			"
 		>
 			<template #prefix>
 				<FeatherIcon name="book" class="mr-2 h-4 w-4" />

--- a/dashboard/src/components/LinkControl.vue
+++ b/dashboard/src/components/LinkControl.vue
@@ -8,9 +8,9 @@
 		:placeholder="placeholder"
 		@update:query="onQuery"
 		@update:modelValue="
-			(option) => {
-				if (option) {
-					$emit('update:modelValue', option);
+			(optionValue) => {
+				if (optionValue) {
+					$emit('update:modelValue', optionValue);
 				} else {
 					$emit('update:modelValue', undefined);
 				}

--- a/dashboard/src/components/NewAppDialog.vue
+++ b/dashboard/src/components/NewAppDialog.vue
@@ -53,7 +53,12 @@
 									v-else
 									type="combobox"
 									:options="branchOptions"
-									v-model="selectedBranch"
+									:modelValue="selectedBranch?.value"
+									@update:modelValue="
+										selectedBranch = branchOptions.find(
+											(option) => option.value === $event,
+										)
+									"
 								>
 									<template v-slot:target="{ togglePopover }">
 										<Button

--- a/dashboard/src/components/devtools/database/DatabaseTableSchemaDialog.vue
+++ b/dashboard/src/components/devtools/database/DatabaseTableSchemaDialog.vue
@@ -12,7 +12,12 @@
 					class="w-full"
 					type="combobox"
 					:options="autocompleteOptions"
-					v-model="selectedSchema"
+					:modelValue="selectedSchema?.value"
+					@update:modelValue="
+						selectedSchema = autocompleteOptions.find(
+							(option) => option.value === $event,
+						)
+					"
 				/>
 				<Button
 					icon="copy"

--- a/dashboard/src/components/group/AddRegionDialog.vue
+++ b/dashboard/src/components/group/AddRegionDialog.vue
@@ -31,7 +31,12 @@
 					type="combobox"
 					label="Choose Region"
 					:options="regionOptions"
-					v-model="selectedRegion"
+					:modelValue="selectedRegion?.value"
+					@update:modelValue="
+						selectedRegion = regionOptions.find(
+							(option) => option.value === $event,
+						)
+					"
 				>
 					<template #prefix>
 						<img :src="selectedRegion?.image" class="mr-2 h-4" />

--- a/dashboard/src/components/settings/InviteTeamMemberDialog.vue
+++ b/dashboard/src/components/settings/InviteTeamMemberDialog.vue
@@ -24,7 +24,12 @@
 						type="combobox"
 						label="Select Roles"
 						:options="roleOptions"
-						v-model="selectedRole"
+						:modelValue="selectedRole?.value"
+						@update:modelValue="
+							selectedRole = roleOptions.find(
+								(option) => option.value === $event,
+							)
+						"
 					/>
 					<Button
 						label="Add"

--- a/dashboard/src/components/settings/RoleConfigureDialog.vue
+++ b/dashboard/src/components/settings/RoleConfigureDialog.vue
@@ -32,7 +32,12 @@
 								<FormControl
 									type="combobox"
 									:options="autoCompleteList"
-									v-model="member"
+									:modelValue="member?.value"
+									@update:modelValue="
+										member = autoCompleteList.find(
+											(option) => option.value === $event,
+										)
+									"
 									placeholder="Select a member to add"
 								/>
 							</div>

--- a/dashboard/src/components/site/SelectSiteForRestore.vue
+++ b/dashboard/src/components/site/SelectSiteForRestore.vue
@@ -24,7 +24,17 @@
 				label="Select the site where you want to restore the backup"
 				class="mt-4"
 				type="combobox"
-				v-model="selectedSite"
+				:modelValue="selectedSite?.value"
+				@update:modelValue="
+					selectedSite = ($resources.sites.data || [])
+						.map((site) => {
+							return {
+								label: site.host_name || site.name,
+								value: site.name,
+							};
+						})
+						.find((option) => option.value === $event)
+				"
 				:options="
 					($resources.sites.data || []).map((site) => {
 						return {

--- a/dashboard/src/components/site/SiteChangeGroupDialog.vue
+++ b/dashboard/src/components/site/SiteChangeGroupDialog.vue
@@ -46,7 +46,16 @@
 							value: group.name,
 						}))
 					"
-					v-model="targetGroup"
+					:modelValue="targetGroup?.value"
+					@update:modelValue="
+						targetGroup = $resources.changeGroupOptions.data
+							.map((group) => ({
+								label: group.title || group.name,
+								description: group.name,
+								value: group.name,
+							}))
+							.find((option) => option.value === $event)
+					"
 				/>
 				<FormControl
 					label="Skip failing patches if any"

--- a/dashboard/src/components/site/SiteChangeRegionDialog.vue
+++ b/dashboard/src/components/site/SiteChangeRegionDialog.vue
@@ -25,7 +25,12 @@
 					variant="outline"
 					type="combobox"
 					label="Choose Region"
-					v-model="selectedRegion"
+					:modelValue="selectedRegion?.value"
+					@update:modelValue="
+						selectedRegion = $resources.changeRegionOptions.data.regions.find(
+							(option) => option.value === $event,
+						)
+					"
 					:options="
 						$resources.changeRegionOptions.data.regions.map((r) => ({
 							label: r.title || r.name,

--- a/dashboard/src/pages/InstallApp.vue
+++ b/dashboard/src/pages/InstallApp.vue
@@ -57,7 +57,12 @@
 											value: b.name,
 										}))
 									"
-									v-model="selectedGroup"
+									:modelValue="selectedGroup?.value"
+									@update:modelValue="
+										selectedGroup = options.private_groups.find(
+											(option) => option.value === $event,
+										)
+									"
 								/>
 							</div>
 						</div>

--- a/dashboard/src/pages/NewSite.vue
+++ b/dashboard/src/pages/NewSite.vue
@@ -44,7 +44,12 @@
 					variant="outline"
 					:class="{ 'pointer-events-none opacity-50': !showLocalisationOption }"
 					label="Select Country"
-					v-model="selectedLocalisationCountry"
+					:modelValue="selectedLocalisationCountry?.value"
+					@update:modelValue="
+						selectedLocalisationCountry = localisationAppCountries.find(
+							(option) => option.value === $event,
+						)
+					"
 					type="combobox"
 					:options="localisationAppCountries"
 				/>


### PR DESCRIPTION
This is a second attempt at combobox migrations. `v-model` of FormControl.combobox during backbinding now sets the optionValue instead of the option object in case of `:options` being object of type `Array<{ label: string; value: string }>`.