### PR TITLE
chore: add python and node version options for Nightly bench groups

### DIFF
--- a/press/fixtures/bench_dependency.json
+++ b/press/fixtures/bench_dependency.json
@@ -83,7 +83,7 @@
 			{
 				"supported_frappe_version": "Nightly",
 				"version": "24.12.0"
-			},
+			}
 		],
 		"title": "Node Version"
 	},


### PR DESCRIPTION
I always had to select "Use Custom Version" in this popup for Node and Python.

<img width="1507" height="892" alt="image" src="https://github.com/user-attachments/assets/ce4562a3-ba85-486f-922a-16efecafc0d8" />

I think this is the right fix so that the options are populated correctly on the Bench Group's dependency tab?