### PR TITLE
fix(dependency): Rearrange component stacking context

### DIFF
--- a/dashboard/src/App.vue
+++ b/dashboard/src/App.vue
@@ -8,7 +8,7 @@
 				>
 					<AppSidebar v-if="$session.user" />
 				</div>
-				<div class="w-full overflow-auto" id="scrollContainer">
+				<div class="w-full overflow-auto z-0" id="scrollContainer">
 					<MobileNav
 						v-if="!isSignupFlow && $isMobile && !isHideSidebar && $session.user"
 					/>

--- a/dashboard/src/components/devtools/database/BinlogResultTable.vue
+++ b/dashboard/src/components/devtools/database/BinlogResultTable.vue
@@ -212,7 +212,7 @@ watch(
 					'h-80': !props.data?.length,
 				}"
 			>
-				<thead class="sticky top-0 bg-gray-50">
+				<thead class="sticky top-0 z-10 bg-gray-50">
 					<tr
 						v-for="headerGroup in table.getHeaderGroups()"
 						:key="headerGroup.id"

--- a/dashboard/src/components/devtools/database/SQLResultTable.vue
+++ b/dashboard/src/components/devtools/database/SQLResultTable.vue
@@ -185,7 +185,7 @@ const downloadCSV = async () => {
 				v-if="props?.columns?.length || props.data?.length"
 				class="border-separate border-spacing-0"
 			>
-				<thead class="sticky top-0 bg-gray-50">
+				<thead class="sticky top-0 z-10 bg-gray-50">
 					<tr
 						v-for="headerGroup in table.getHeaderGroups()"
 						:key="headerGroup.id"

--- a/dashboard/src/pages/Billing.vue
+++ b/dashboard/src/pages/Billing.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="sticky top-0 shrink-0">
+	<div class="sticky top-0 z-10 shrink-0">
 		<Header>
 			<FBreadcrumbs
 				:items="[{ label: 'Billing', route: { name: 'Billing' } }]"

--- a/dashboard/src/pages/DetailPage.vue
+++ b/dashboard/src/pages/DetailPage.vue
@@ -1,5 +1,5 @@
 <template>
-	<Header class="sticky top-0 bg-white">
+	<Header class="sticky top-0 z-10 bg-white">
 		<div class="w-full sm:flex sm:justify-between sm:items-center">
 			<div class="flex items-center space-x-2">
 				<FBreadcrumbs :items="breadcrumbs" />

--- a/dashboard/src/pages/Home.vue
+++ b/dashboard/src/pages/Home.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="sticky top-0 shrink-0">
+	<div class="sticky top-0 z-10 shrink-0">
 		<Header>
 			<Breadcrumbs :items="[{ label: 'Home', route: { name: 'Home' } }]" />
 			<Dropdown

--- a/dashboard/src/pages/NewReleaseGroup.vue
+++ b/dashboard/src/pages/NewReleaseGroup.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="sticky top-0 shrink-0">
+	<div class="sticky top-0 z-10 shrink-0">
 		<Header>
 			<Breadcrumbs
 				:items="

--- a/dashboard/src/pages/NewServer.vue
+++ b/dashboard/src/pages/NewServer.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="sticky top-0 shrink-0">
+	<div class="sticky top-0 z-10 shrink-0">
 		<Header>
 			<Breadcrumbs
 				:items="[

--- a/dashboard/src/pages/NewSite.vue
+++ b/dashboard/src/pages/NewSite.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="sticky top-0 shrink-0">
+	<div class="sticky top-0 z-10 shrink-0">
 		<Header>
 			<FBreadcrumbs :items="breadcrumbs" />
 		</Header>

--- a/dashboard/src/pages/PartnerAdmin.vue
+++ b/dashboard/src/pages/PartnerAdmin.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="sticky top-0 shrink-0">
+	<div class="sticky top-0 z-10 shrink-0">
 		<Header>
 			<FBreadcrumbs
 				:items="[{ label: 'Partner Admin', route: '/partner-admin' }]"

--- a/dashboard/src/pages/PartnerLeadDetails.vue
+++ b/dashboard/src/pages/PartnerLeadDetails.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="flex h-full flex-col">
-		<div class="sticky top-0 shrink-0">
+		<div class="sticky top-0 z-10 shrink-0">
 			<Header>
 				<FBreadcrumbs
 					:items="[

--- a/dashboard/src/pages/PartnerNewPayout.vue
+++ b/dashboard/src/pages/PartnerNewPayout.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>
-		<div class="sticky top-0 shrink-0">
+		<div class="sticky top-0 z-10 shrink-0">
 			<Header>
 				<FBreadcrumbs :items="breadcrumbs" />
 			</Header>

--- a/dashboard/src/pages/Partners.vue
+++ b/dashboard/src/pages/Partners.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="flex h-full flex-col">
-		<div class="sticky top-0 shrink-0">
+		<div class="sticky top-0 z-10 shrink-0">
 			<Header>
 				<FBreadcrumbs
 					:items="[{ label: 'Partnership', route: { name: 'Partnership' } }]"

--- a/dashboard/src/pages/Settings.vue
+++ b/dashboard/src/pages/Settings.vue
@@ -1,5 +1,5 @@
 <template>
-	<Header class="sticky top-0 bg-white">
+	<Header class="sticky top-0 z-10 bg-white">
 		<div class="flex items-center space-x-2">
 			<Breadcrumbs :items="[{ label: 'Settings', route: '/settings' }]" />
 		</div>

--- a/dashboard/src/pages/backups/ServerSnapshots.vue
+++ b/dashboard/src/pages/backups/ServerSnapshots.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="flex h-full flex-col">
-		<div class="sticky top-0 shrink-0">
+		<div class="sticky top-0 z-10 shrink-0">
 			<Header>
 				<Breadcrumbs
 					:items="[{ label: 'Server Snapshots', route: '/backups/sites' }]"

--- a/dashboard/src/pages/backups/SiteBackups.vue
+++ b/dashboard/src/pages/backups/SiteBackups.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="flex h-full flex-col">
-		<div class="sticky top-0 shrink-0">
+		<div class="sticky top-0 z-10 shrink-0">
 			<Header>
 				<Breadcrumbs
 					:items="[{ label: 'Site Backups', route: '/backups/sites' }]"

--- a/dashboard/src/pages/devtools/database/BinlogBrowser.vue
+++ b/dashboard/src/pages/devtools/database/BinlogBrowser.vue
@@ -7,7 +7,7 @@
 				!binlog_indexer_enabled,
 		}"
 	>
-		<Header class="sticky top-0 bg-white">
+		<Header class="sticky top-0 z-10 bg-white">
 			<div
 				class="flex w-full flex-col gap-2 md:flex-row md:items-center md:justify-between"
 			>

--- a/dashboard/src/pages/devtools/database/DatabaseAnalyzer.vue
+++ b/dashboard/src/pages/devtools/database/DatabaseAnalyzer.vue
@@ -1,5 +1,5 @@
 <template>
-	<Header class="sticky top-0 bg-white">
+	<Header class="sticky top-0 z-10 bg-white">
 		<div
 			class="flex w-full flex-col gap-2 md:flex-row md:items-center md:justify-between"
 		>

--- a/dashboard/src/pages/devtools/database/DatabaseSQLPlayground.vue
+++ b/dashboard/src/pages/devtools/database/DatabaseSQLPlayground.vue
@@ -1,5 +1,5 @@
 <template>
-	<Header class="sticky top-0 bg-white">
+	<Header class="sticky top-0 z-10 bg-white">
 		<div
 			class="flex w-full flex-col gap-2 md:flex-row md:items-center md:justify-between"
 		>

--- a/dashboard/src/pages/devtools/log-browser/LogViewer.vue
+++ b/dashboard/src/pages/devtools/log-browser/LogViewer.vue
@@ -51,7 +51,7 @@
 							v-if="columns?.length || props.log?.length"
 							class="w-full border-separate border-spacing-0"
 						>
-							<thead class="z-5 sticky top-0 w-full rounded bg-gray-100">
+							<thead class="z-5 sticky top-0 z-10 w-full rounded bg-gray-100">
 								<tr
 									v-for="headerGroup in table.getHeaderGroups()"
 									:key="headerGroup.id"


### PR DESCRIPTION
This prevents header and dialog overlaps. Part of frappe-ui upgrade.