### PR TITLE
fix: Site plan change

### DIFF
--- a/dashboard/src/components/ManageSitePlansDialog.vue
+++ b/dashboard/src/components/ManageSitePlansDialog.vue
@@ -26,7 +26,7 @@
 					v-model="plan"
 					:isPrivateBenchSite="!$site.doc.group_public"
 					:isDedicatedServerSite="$site.doc.is_dedicated_server"
-					:selectedProvider="$site.doc.server_provider"
+					:selectedProvider="$site.doc.plan_provider"
 				/>
 				<div class="mt-4 text-xs text-gray-700">
 					<div

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -346,6 +346,10 @@ class Site(Document, TagHelpers):
 		doc.server_team = server.team
 		doc.server_title = server.title
 		doc.server_provider = server.provider
+		doc.plan_provider = server.provider
+		if not frappe.db.exists("Cloud Provider", server.provider):
+			# fallback for unlisted providers (Scaleway, Generic) to show available plans
+			doc.plan_provider = "AWS EC2"
 		doc.inbound_ip = self.inbound_ip
 		doc.is_dedicated_server = is_dedicated_server(self.server)
 		doc.suspension_reason = (


### PR DESCRIPTION
Set fallback cloud provider if site provider isn't listed in the Cloud Provider doctype