### PR TITLE
chore(aws): Allow skipping rightsize on EBS volumes

### DIFF
--- a/press/press/doctype/virtual_machine/virtual_machine.js
+++ b/press/press/doctype/virtual_machine/virtual_machine.js
@@ -115,7 +115,7 @@ frappe.ui.form.on('Virtual Machine', {
 				__('Resize'),
 				'resize',
 				frm.doc.status == 'Stopped' ||
-					(frm.doc.cloud_provider == 'OCI' && frm.doc.status != 'Draft'),
+				(frm.doc.cloud_provider == 'OCI' && frm.doc.status != 'Draft'),
 			],
 		].forEach(([label, method, condition]) => {
 			if (typeof condition === 'undefined' || condition) {
@@ -380,6 +380,10 @@ frappe.ui.form.on('Virtual Machine', {
 });
 
 frappe.ui.form.on('Virtual Machine Volume', {
+	toggle_rightsize(frm, cdt, cdn) {
+		frappe.model.set_value(cdt, cdn, 'skip_rightsize', !frm.selected_doc.skip_rightsize);
+		frm.save();
+	},
 	detach(frm, cdt, cdn) {
 		let row = frm.selected_doc;
 		frappe.confirm(

--- a/press/press/doctype/virtual_machine_volume/virtual_machine_volume.json
+++ b/press/press/doctype/virtual_machine_volume/virtual_machine_volume.json
@@ -15,6 +15,8 @@
   "last_updated_at",
   "section_break_frlu",
   "device",
+  "toggle_rightsize",
+  "skip_rightsize",
   "column_break_buwy",
   "detach",
   "delete_volume",
@@ -109,12 +111,25 @@
    "fieldname": "update_ebs_performance",
    "fieldtype": "Button",
    "label": "Update EBS Performance"
+  },
+  {
+   "fieldname": "toggle_rightsize",
+   "fieldtype": "Button",
+   "label": "Toggle Rightsize"
+  },
+  {
+   "default": "0",
+   "fieldname": "skip_rightsize",
+   "fieldtype": "Check",
+   "label": "Skip Rightsize",
+   "read_only_depends_on": "eval: false",
+   "search_index": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-10-16 13:11:45.102040",
+ "modified": "2026-01-21 15:47:37.821650",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Virtual Machine Volume",
@@ -122,6 +137,7 @@
  "owner": "Administrator",
  "permissions": [],
  "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/press/press/doctype/virtual_machine_volume/virtual_machine_volume.py
+++ b/press/press/doctype/virtual_machine_volume/virtual_machine_volume.py
@@ -24,6 +24,7 @@ class VirtualMachineVolume(Document):
 		parentfield: DF.Data
 		parenttype: DF.Data
 		size: DF.Int
+		skip_rightsize: DF.Check
 		throughput: DF.Int
 		volume_id: DF.Data | None
 		volume_type: DF.Literal["gp3", "gp2"]

--- a/press/press/report/aws_rightsizing_recommendation/aws_rightsizing_recommendation.py
+++ b/press/press/report/aws_rightsizing_recommendation/aws_rightsizing_recommendation.py
@@ -69,7 +69,7 @@ def get_data(resource_type, action_type):  # noqa: C901
 				)
 			elif resource_type == "Virtual Machine Volume":
 				virtual_machine = frappe.get_all(
-					resource_type, {"volume_id": row["resourceId"]}, pluck="parent"
+					resource_type, {"volume_id": row["resourceId"], "skip_rightsize": False}, pluck="parent"
 				)
 
 			if not virtual_machine:


### PR DESCRIPTION
Volumes marked with skip_rightsize won't be rightsized