### PR TITLE
fix: change text on sign-up flow to make sense

### DIFF
--- a/dashboard/src/pages/signup/AppSelector.vue
+++ b/dashboard/src/pages/signup/AppSelector.vue
@@ -10,7 +10,7 @@
 	>
 		<LoginBox
 			title="Select an app to get started"
-			subtitle="Select the app you need to configure them effortlessly"
+			subtitle="Select the app you want to install on your site."
 		>
 			<div v-if="$resources.availableApps.loading">
 				<div class="flex h-40 justify-center">


### PR DESCRIPTION
<img width="489" height="686" alt="Screenshot 2026-01-24 at 7 31 41 PM" src="https://github.com/user-attachments/assets/18515b78-00dc-48cf-8e61-422b17858b33" />


"Select the app you need to configure them effortlessly" does not make any sense. Changed it to "Select the app you want to install on your site."

