### PR TITLE
fix(server-plan): Show legacy in case of current legacy and intel

### DIFF
--- a/press/api/server.py
+++ b/press/api/server.py
@@ -762,7 +762,7 @@ def secondary_server_plans(
 
 @frappe.whitelist()
 def plans(name, cluster=None, platform=None, resource_name=None, cpu_and_memory_only_resize=False):  # noqa C901
-	filters = {"server_type": name}
+	filters = {"server_type": name, "legacy_plan": False}
 
 	if cluster:
 		filters.update({"cluster": cluster})
@@ -772,7 +772,13 @@ def plans(name, cluster=None, platform=None, resource_name=None, cpu_and_memory_
 	if platform:
 		filters.update({"platform": platform})
 
-	filters.update({"legacy_plan": False})
+	if resource_name:
+		current_plan = frappe.db.get_value(name, resource_name, "plan")
+		if current_plan:
+			legacy_plan, platform = frappe.db.get_value(
+				"Server Plan", current_plan, ["legacy_plan", "platform"]
+			)
+			filters.update({"legacy_plan": legacy_plan if platform == "x86_64" else False})
 
 	current_root_disk_size = None
 	if resource_name:


### PR DESCRIPTION
Show legacy plan if the current plan is legacy and on intel.
This means that we are no longer showing intel plans in that region, however server in the region must be able to change plans.