### PR TITLE
fix(vm): OCI VM Syncing

### DIFF
--- a/press/press/doctype/virtual_machine/virtual_machine.py
+++ b/press/press/doctype/virtual_machine/virtual_machine.py
@@ -2156,7 +2156,7 @@ class VirtualMachine(Document):
 
 	def bulk_sync_oci_cluster_in_batch(self, instances: list[frappe._dict]):
 		for instance in instances:
-			machine: VirtualMachine = frappe.get_doc("Virtual Machine", {"instance_id": instance["id"]})
+			machine: VirtualMachine = frappe.get_doc("Virtual Machine", {"instance_id": instance.id})
 			if has_job_timeout_exceeded():
 				return
 			try:


### PR DESCRIPTION
The `instance` is an object created from the oci client. So, it is not subscriptable.