### PR TITLE
fix(play): Missing `iptables` directory

### DIFF
--- a/press/playbooks/roles/iptables/tasks/main.yml
+++ b/press/playbooks/roles/iptables/tasks/main.yml
@@ -11,5 +11,11 @@
     rule_num: 1
     jump: DROP
 
+- name: Create directory for iptables rules
+  file:
+    path: /etc/iptables
+    state: directory
+    mode: '0755'
+
 - name: Save iptables rules
   shell: iptables-save > /etc/iptables/rules.v4


### PR DESCRIPTION
closes: https://github.com/frappe/press/issues/4858