### PR TITLE
fix(app-release): Only get approved app releases for public app releases

### DIFF
--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -1243,7 +1243,7 @@ class ReleaseGroup(Document, TagHelpers):
 			latest_app_release = None
 			latest_app_releases = find_all(latest_releases, lambda x: x.source == app.source)
 
-			if app.source in only_approved_for_sources:
+			if app.source in get_flattened_app_sources(app_sources=only_approved_for_sources):
 				latest_app_release = find(latest_app_releases, can_use_release)
 				latest_app_releases = find_all(latest_app_releases, can_use_release)
 			else:
@@ -1850,3 +1850,13 @@ def get_restricted_server_names():
 		},
 		distinct=True,
 	)
+
+
+def get_flattened_app_sources(app_sources: list[str | list[str]]) -> list[str]:
+	flattened_sources = []
+	for source in app_sources:
+		if isinstance(source, list):
+			flattened_sources.extend(source)
+		else:
+			flattened_sources.append(source)
+	return flattened_sources


### PR DESCRIPTION
`'b' in ['a', 'b'] != 'b' in ['a', ['b']]`

Therefore currently app release status is rendered meaning less.