### PR TITLE
chore(signup): Honour user signup even if they belong to other team

### DIFF
--- a/press/api/account.py
+++ b/press/api/account.py
@@ -53,7 +53,12 @@ def signup(email: str, product: str | None = None, referrer: str | None = None) 
 
 	account_request = frappe.db.get_value(
 		"Account Request",
-		{"email": email, "referrer_id": referrer, "product_trial": product},
+		{
+			"email": email,
+			"referrer_id": referrer,
+			"product_trial": product,
+			"invited_by": ("is", "not set"),
+		},
 		"name",
 	)
 


### PR DESCRIPTION
Allow user to do proper signup and create their own team even when they belong to a different team as a member.