### PR TITLE
chore(bench-groups): Enable to see bench group once got transferred

### DIFF
--- a/press/press/doctype/team_change/team_change.py
+++ b/press/press/doctype/team_change/team_change.py
@@ -56,3 +56,6 @@ class TeamChange(Document):
 
 		if self.document_type == "Release Group" and self.transfer_completed:
 			frappe.db.set_value("Release Group", self.document_name, "team", self.to_team)
+			# Skip onboarding for receiving team so they can access bench groups immediately
+			# Actual resource usage (servers/sites) will still require billing setup
+			frappe.db.set_value("Team", self.to_team, "skip_onboarding", 1)


### PR DESCRIPTION
Currently if user got bench group transferred by creating a new team then they cant see it until they complete the onboarding step. However these users know how bench group and stuff work so they should be able to see bench group without going through onboarding process.