### PR TITLE
fix(exception): Inherit a different ancestor

### DIFF
--- a/press/press/doctype/marketplace_app/marketplace_app.py
+++ b/press/press/doctype/marketplace_app/marketplace_app.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 	from press.press.doctype.site.site import Site
 
 
-class VersioningError(frappe.ValidationError): ...
+class VersioningError(Exception): ...
 
 
 class MarketplaceApp(WebsiteGenerator):


### PR DESCRIPTION
BaseException
└── Exception
    ├── frappe.ValidationError
    │   └── Error
    └── VersioningError


In this Error is also suppressed, therefore VersioningError should inherit Exception