### PR TITLE
chore(site): Allow update config for broken site

### DIFF
--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -2304,7 +2304,7 @@ class Site(Document, TagHelpers):
 			)
 
 	@dashboard_whitelist()
-	@site_action(["Active"])
+	@site_action(["Active", "Broken"])
 	def update_config(self, config=None):
 		"""Updates site.configuration, meant for dashboard and API users"""
 		if config is None:


### PR DESCRIPTION
This will allow to update config and wont cause issue in restoring sites if it broke because of config issues. cc: @balamurali27 