### PR TITLE
fix(login): User accepting invite should not get permission error

### DIFF
--- a/press/api/account.py
+++ b/press/api/account.py
@@ -268,16 +268,25 @@ def accept_team_invite(key: str):
 	if not account_request.invited_by:
 		frappe.throw("You are not invited by any team")
 
-	team = account_request.team
-	first_name = account_request.first_name
-	last_name = account_request.last_name
-	email = account_request.email
-	password = None
-	role = account_request.role
-	press_roles = account_request.press_roles
+	if frappe.session.user != account_request.email:
+		frappe.throw("This invite is not for your account")
 
-	team_doc = frappe.get_doc("Team", team)
-	return team_doc.create_user_for_member(first_name, last_name, email, password, role, press_roles)
+	current_user = frappe.session.user
+	try:
+		frappe.set_user("Administrator")
+
+		team = account_request.team
+		first_name = account_request.first_name
+		last_name = account_request.last_name
+		email = account_request.email
+		password = None
+		role = account_request.role
+		press_roles = account_request.press_roles
+
+		team_doc = frappe.get_doc("Team", team)
+		team_doc.create_user_for_member(first_name, last_name, email, password, role, press_roles)
+	finally:
+		frappe.set_user(current_user)
 
 
 @frappe.whitelist(allow_guest=True)


### PR DESCRIPTION
Validate the permission error that user gets when invited to another team