### PR TITLE
fix(account-request): Save the country info from signup

### DIFF
--- a/press/api/account.py
+++ b/press/api/account.py
@@ -213,6 +213,7 @@ def setup_account(  # noqa: C901
 
 	# pass lead to local partner if consent given
 	account_request.agreed_to_partner_consent = share_details_consent
+	account_request.country = country
 	account_request.save()
 
 	team = account_request.team


### PR DESCRIPTION
fix #5145 
This might be needed for users who signup from X but wants things from Y.