### PR TITLE
ci: Bump up node to v20

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -154,7 +154,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           check-latest: true
 
       - name: Cache apt


### PR DESCRIPTION
build was failing due to node https://github.com/frappe/press/actions/runs/22099615153/job/63865646534?pr=5141