### PR TITLE
fix(signup): Show cleaner text in the preview of OTP mail

### DIFF
--- a/press/templates/emails/product_trial_verify_account.txt
+++ b/press/templates/emails/product_trial_verify_account.txt
@@ -1,0 +1,16 @@
+{% if header_content %}
+{{ header_content | striptags | trim }}
+
+{% else %}
+You're almost done!
+Just one quick step left.
+
+{% endif %}
+Verification Code: {{ otp }}
+{% if link %}
+Verification Link: {{ link }}
+{% endif %}
+
+Team Frappe
+
+This email was sent by Frappe Cloud


### PR DESCRIPTION
### Before
<img width="1024" height="43" alt="image" src="https://github.com/user-attachments/assets/ec94bb19-6e94-4f0f-a46a-a403ffd1a548" />


### After
<img width="1644" height="88" alt="image" src="https://github.com/user-attachments/assets/29d9d20b-ab24-44a3-bbfb-271fbb836c52" />
