### PR TITLE
perf(proxy-failover): faster dns record updation

### DIFF
--- a/press/press/doctype/proxy_failover/proxy_failover.py
+++ b/press/press/doctype/proxy_failover/proxy_failover.py
@@ -201,7 +201,8 @@ class ProxyFailover(Document, StepHandler):
 			{"status": ("!=", "Archived"), "server": ("in", servers)},
 			["name", "domain"],
 		)
-		for domain_name, sites in groupby(sites_domains, lambda x: x["domain"]):
+		sorted_sites_domains = sorted(sites_domains, key=lambda x: x["domain"])
+		for domain_name, sites in groupby(sorted_sites_domains, lambda x: x["domain"]):
 			domain = frappe.get_doc("Root Domain", domain_name)
 			domain.update_dns_records_for_sites([site.name for site in sites], self.secondary, batch_size=250)
 
@@ -459,7 +460,8 @@ def reduce_ttl_of_sites(primary_proxy_name, secondary_proxy_name):
 		{"status": ("!=", "Archived"), "server": ("in", servers)},
 		["name", "domain"],
 	)
-	for domain_name, sites in groupby(sites_domains, lambda x: x["domain"]):
+	sorted_sites_domains = sorted(sites_domains, key=lambda x: x["domain"])
+	for domain_name, sites in groupby(sorted_sites_domains, lambda x: x["domain"]):
 		domain = frappe.get_doc("Root Domain", domain_name)
 		domain.update_dns_records_for_sites(
 			[site.name for site in sites], primary_proxy.name, ttl=60, batch_size=250


### PR DESCRIPTION
groupby groups same things which are consecutive in the dataset, if things are sparsely places it will form multiple groups of the same key
This reduces the grouping by sorting things and then passing them to groupby


ideally we shouldn't need to do multiple iterations on the same data set but this is better than the current thing