### PR TITLE
chore(signup): Keep phone number field optional

### DIFF
--- a/dashboard/src/pages/SetupAccount.vue
+++ b/dashboard/src/pages/SetupAccount.vue
@@ -84,7 +84,7 @@
 							<FormControl
 								v-if="!isInvitation"
 								type="tel"
-								label="Phone Number"
+								label="Phone Number (Optional)"
 								v-model="phoneNumber"
 								placeholder="9876543210"
 								variant="outline"


### PR DESCRIPTION
Keep phone number optional until we are supporting country code. To prevent damage control until then.