### PR TITLE
perf(job): Makes query on press job step faster

### DIFF
--- a/press/press/doctype/press_job_step/press_job_step.py
+++ b/press/press/doctype/press_job_step/press_job_step.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2022, Frappe and contributors
 # For license information, please see license.txt
+from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING
@@ -87,3 +88,7 @@ class PressJobStep(Document):
 			job.fail(local["arguments"])
 		else:
 			job.next(local["arguments"])
+
+
+def on_doctype_update():
+	frappe.db.add_index("Press Job Step", ["job", "status"])


### PR DESCRIPTION
def job(job) in site.py relies on job and def fail(self, arguments=None) in press_job.py will use this index. This is analysed as two of the top 5 queries and adding this index will fix both of them