### PR TITLE
fix(billing): Add support for invoice.paid endpoint

### DIFF
--- a/press/press/doctype/invoice/stripe_webhook_handler.py
+++ b/press/press/doctype/invoice/stripe_webhook_handler.py
@@ -9,6 +9,7 @@ EVENT_TYPE_MAP = {
 	"invoice.finalized": "Finalized",
 	"invoice.payment_succeeded": "Succeeded",
 	"invoice.payment_failed": "Failed",
+	"invoice.paid": "Succeeded",
 }
 
 DISPUTE_EVENT_TYPE_MAP = {
@@ -62,7 +63,7 @@ class StripeWebhookHandler:
 
 		event_type = self.webhook_log.event_type
 		payment_status = "Unpaid"
-		if event_type == "invoice.payment_succeeded" or (
+		if event_type in ["invoice.payment_succeeded", "invoice.paid"] or (
 			event_type == "invoice.finalized" and stripe_invoice["status"] == "paid"
 		):
 			payment_status = "Paid"

--- a/press/press/doctype/press_settings/press_settings.py
+++ b/press/press/doctype/press_settings/press_settings.py
@@ -236,6 +236,7 @@ class PressSettings(Document):
 				"payment_method.attached",
 				"invoice.payment_action_required",
 				"invoice.payment_succeeded",
+				"invoice.paid",
 				"invoice.payment_failed",
 				"invoice.finalized",
 				"mandate.updated",


### PR DESCRIPTION
For few invoices, Stripe has failed to trigger invoice.payment_succeeded endpoint on which the original invoice settlement logic relied on. However, invoice.paid endpoint is triggered on all payments and more reliable.