### PR TITLE
fix(drip_email): Logo rendering issue, removing img tag for time being

### DIFF
--- a/press/templates/emails/product_trial_email.html
+++ b/press/templates/emails/product_trial_email.html
@@ -9,7 +9,7 @@
       <table cellpadding="0" cellspacing="0" role="presentation" width="600px">
         <tbody>
           <tr>
-            <td class="py-10 px-8" style="color: #383838;">
+            <td class="pt-6 pb-4 px-8" style="color: #383838;">
               <div class="flex">
                 <span class="font-bold text-xl my-auto">
                   {% if title %}


### PR DESCRIPTION
Removing the Frappe product logos for time being due to rendering issue when logo is passed as inline image.