### PR TITLE
fix(date-time-control): Add missing top margin for date

### DIFF
--- a/dashboard/src/components/DateTimeControl.vue
+++ b/dashboard/src/components/DateTimeControl.vue
@@ -2,6 +2,7 @@
 	<div class="flex items-center space-x-1">
 		<FormControl
 			class="flex-[4]"
+			:class="label ? 'mt-5' : ''"
 			:label="hideLabel ? '' : label ? label : 'Date'"
 			type="select"
 			variant="outline"


### PR DESCRIPTION
Fixes this:
<img width="711" height="430" alt="Screenshot 2026-03-07 at 1 30 45 PM" src="https://github.com/user-attachments/assets/dfeb0982-6c5d-4a01-919d-9ea5a7f03ed4" />
