### PR TITLE
feat(site-action): Don't show cluster migrate option for private bench

### DIFF
--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -4015,7 +4015,7 @@ class Site(Document, TagHelpers):
 				},
 			},
 			"Move Site To Different Region": {
-				"hidden": False,
+				"hidden": not release_group.public,
 				"allow_scheduling": True,
 				"button_label": "Move Site",
 				"options": {


### PR DESCRIPTION
Users on private bench can use `Move Site To Different Server or Bench` option to migrate to new region.
That will help to get rid of multiple steps and also user have the choice to select correct server.

For public bench only, cluster migration makes sense. It will just make it easier for them to make the choice.