### PR TITLE
fix(login-as-admin): Use host name instead of site name

### DIFF
--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1904,8 +1904,9 @@ class Site(Document, TagHelpers):
 		sid = None
 		if user == "Administrator":
 			password = get_decrypted_password("Site", self.name, "admin_password")
+			host = self.host_name or self.name
 			response = requests.post(
-				f"https://{self.name}/api/method/login",
+				f"https://{host}/api/method/login",
 				data={"usr": user, "pwd": password},
 			)
 			sid = response.cookies.get("sid")


### PR DESCRIPTION
Ref: https://support.frappe.io/helpdesk/tickets/60439

The support team was unable to log in as admin to a self-hosted client’s site because the self.name site domain had expired. The client had been using their primary configured domain to log in for a long time.

CNAME redirects (in this case, self.name -> self.host_name) also do not seem to be working. (Why?)

Also, `host_name` is the address of the site, not `name`. Setting `name` as a fallback.