### PR TITLE
fix: resend OTP contains logo alongside email template

### DIFF
--- a/press/press/doctype/account_request/account_request.py
+++ b/press/press/doctype/account_request/account_request.py
@@ -315,6 +315,13 @@ class AccountRequest(Document):
 			"otp": self.otp,
 		}
 
+		if not args.get("image_path"):
+			args.update(
+				{
+					"image_path": "https://github.com/frappe/gameplan/assets/9355208/447035d0-0686-41d2-910a-a3d21928ab94"
+				}
+			)
+
 		frappe.sendmail(
 			recipients=self.email,
 			subject=subject,


### PR DESCRIPTION
## Summary
Fixes an issue where the resend OTP flow sends the default Frappe Cloud email template instead of the product-specific template used during signup.

## Root Cause
The resend verification flow did not pass the product context when generating the email template, causing the system to fall back to the default template.

##Issue reproduction screenshot
1: OTP sent first time:
<img width="771" height="317" alt="image" src="https://github.com/user-attachments/assets/37e50715-5e55-419a-b603-af84fd5e1789" />

2. Resent OTP:

<img width="1045" height="245" alt="image" src="https://github.com/user-attachments/assets/a26bae1b-1a50-4d80-818b-dd291daaf9da" />

## Related
Fixes #3159 