### PR TITLE
fix(billing): Fix for missing button to upgrade plan

### DIFF
--- a/dashboard/src/components/ManageSitePlansDialog.vue
+++ b/dashboard/src/components/ManageSitePlansDialog.vue
@@ -246,9 +246,11 @@ export default {
 		},
 		nextButtonLabel() {
 			if (this.showSetupSubscription) {
-				return this.plan
-					? `Select Plan: ${this.planDisplayTitle(this.plan)}`
-					: 'Next';
+				if (this.plan) {
+					const display = this.$format.planDisplay(this.plan, false);
+					return `Select Plan: ${display.title}${display.unit}`;
+				}
+				return 'Next';
 			}
 			return this.$site.doc?.current_plan?.is_trial_plan
 				? 'Upgrade Plan'


### PR DESCRIPTION
Error occuring in prod though its defined as methods. 

ManageSitePlansDialog.vue:26 TypeError: this.planDisplayTitle is not a function
    at Proxy.nextButtonLabel (ManageSitePlansDialog.vue:251:29)