### PR TITLE
fix(billing): Reload issue when upgrading plan

### DIFF
--- a/dashboard/src/components/ManageSitePlansDialog.vue
+++ b/dashboard/src/components/ManageSitePlansDialog.vue
@@ -221,11 +221,14 @@ export default {
 			);
 		},
 		paymentModeAdded() {
-			this.$team.reload();
 			const mode = this.isAutomatedBilling ? 'Card' : 'Prepaid Credits';
 			this.changePaymentMode.submit(
 				{ mode },
-				{ onSuccess: () => this.changePlan() },
+				{
+					onSuccess: () => {
+						this.$team.reload().then(() => this.changePlan());
+					},
+				},
 			);
 		},
 	},
@@ -242,7 +245,7 @@ export default {
 		},
 		nextButtonLabel() {
 			if (this.showSetupSubscription) {
-				return this.plan ? 'Select Plan' : 'Next';
+				return this.plan ? 'Next' : 'Select Plan';
 			}
 			return this.$site.doc?.current_plan?.is_trial_plan
 				? 'Upgrade Plan'


### PR DESCRIPTION
During plan upgrade, via setup subscription, the plan doesn't change because of timestamp mismatch error. So on payment, setting the payment mode change followed by doctype reload and then initiating the plan change