### PR TITLE
fix(ui): Add class to LucideSparkleIcon prefix for consistent styling

### DIFF
--- a/dashboard/src/components/group/BenchLogsDialog.vue
+++ b/dashboard/src/components/group/BenchLogsDialog.vue
@@ -126,7 +126,7 @@ const listOptions = ref({
 	actions: () => [
 		{
 			slots: {
-				prefix: () => h(LucideSparkleIcon),
+				prefix: () => h(LucideSparkleIcon, { class: 'h-4 w-4' }),
 			},
 			label: 'View in Log Browser',
 			onClick: () => {


### PR DESCRIPTION
### Screenshot
<img width="2310" height="572" alt="CleanShot 2026-03-13 at 12 40 19@2x" src="https://github.com/user-attachments/assets/6dd71dcd-88a4-40d1-ae9d-ded356abd4f3" />
