### PR TITLE
chore(project): Replace `cspell` with `typos`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,19 +49,6 @@ repos:
         stages: [commit-msg]
         always_run: true
 
-      - id: cspell-commit-msg
-        name: check commit message spelling
-        entry: npx cspell --config .cspell.json .git/COMMIT_EDITMSG
-        language: system
-        stages: [commit-msg]
-        always_run: true
-
-      - id: cspell-modified-files
-        name: check spelling of files
-        entry: sh -c "npx cspell --no-must-find-files --config .cspell.json `git diff --cached -p --name-status | cut -c3- | tr '\n' ' '`"
-        language: system
-        stages: [pre-commit]
-
       - id: todo-warning
         name: check todos
         entry: .github/hooks/todo-warning.sh
@@ -88,6 +75,13 @@ repos:
             types-pytz~=2025.2,
             types-python-dateutil~=2.9.0,
           ]
+
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.44.0
+    hooks:
+      - id: typos
+        stages: [pre-commit, commit-msg]
+
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:


### PR DESCRIPTION
- https://github.com/crate-ci/typos
- Faster and light weight
- Check and fix typos
- Not as comprehensive as cspell
- Only checks code, unlike cspell