### PR TITLE
fix(billing): Prevent stripe issue when settling bill using credits

### DIFF
--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -204,9 +204,7 @@ class Invoice(Document):
 
 		elif item.document_type == "Marketplace App":
 			item.document_name = frappe.get_value(item.document_type, item.document_name, "title")
-			item.plan = (
-				f"{currency_symbol}{frappe.get_value('Marketplace App Plan', item.plan, price_field)}"
-			)
+			item.plan = f"{currency_symbol}{frappe.get_value('Marketplace App Plan', item.plan, price_field)}"
 		elif item.document_type == "Site":
 			hostname = frappe.get_value(item.document_type, item.document_name, "host_name")
 			if hostname:


### PR DESCRIPTION
When finalizing invoice using prepaid credits, we are running stripe related checks as the first try of settlement of invoice is made via Card. User face following issue as the invoice is not in correct state to move to void state. Added a check that will fix this issue.

 File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
  File "apps/press/press/press/doctype/invoice/invoice.py", line 1065, in change_stripe_invoice_status
    stripe.Invoice.void_invoice(self.stripe_invoice_id)
  File "env/lib/python3.10/site-packages/stripe/util.py", line 237, in _wrapper
    return class_method(*args, **kwargs)
  File "env/lib/python3.10/site-packages/stripe/api_resources/abstract/custom_method.py", line 23, in custom_method_request
    return cls._static_request(http_verb, url, **params)
  File "env/lib/python3.10/site-packages/stripe/api_resources/abstract/api_resource.py", line 64, in _static_request
    response, api_key = requestor.request(method_, url_, params, headers)
  File "env/lib/python3.10/site-packages/stripe/api_requestor.py", line 122, in request
    resp = self.interpret_response(rbody, rcode, rheaders)
  File "env/lib/python3.10/site-packages/stripe/api_requestor.py", line 373, in interpret_response
    self.handle_error_response(rbody, rcode, resp.data, rheaders)
  File "env/lib/python3.10/site-packages/stripe/api_requestor.py", line 152, in handle_error_response
    raise err
stripe.error.InvalidRequestError: Request: You can only pass in open invoices. This invoice isn't open.