### PR TITLE
chore: preset country code in razorpay modal

### DIFF
--- a/dashboard/src/components/BuyPrepaidCreditsRazorpay.vue
+++ b/dashboard/src/components/BuyPrepaidCreditsRazorpay.vue
@@ -103,12 +103,35 @@ export default {
 				},
 			};
 		},
+		countriesWithIsd() {
+			return {
+				url: 'press.api.account.get_countries_with_isd_codes',
+				auto: true,
+			};
+		},
 	},
 	methods: {
 		buyCreditsWithRazorpay() {
 			this.$resources.createRazorpayOrder.submit();
 		},
+		getTeamCallingCode() {
+			const countries = this.$resources.countriesWithIsd?.data || [];
+			const teamCountry = this.$team.doc.country;
+			if (!teamCountry || countries.length === 0) {
+				return null;
+			}
+			const match = countries.find((country) => country.name === teamCountry);
+			if (!match?.isd) {
+				return null;
+			}
+			const isd = String(match.isd).trim();
+			if (!isd) {
+				return null;
+			}
+			return isd.startsWith('+') ? isd : `+${isd}`;
+		},
 		processOrder(data) {
+			const callingCode = this.getTeamCallingCode();
 			const options = {
 				key: data.key_id,
 				order_id: data.order_id,
@@ -116,6 +139,7 @@ export default {
 				image: '/assets/press/images/frappe-cloud-logo.png',
 				prefill: {
 					email: this.$team.doc.user,
+					...(callingCode ? { contact: callingCode } : {}),
 				},
 				handler: this.handlePaymentSuccess,
 				theme: { color: '#171717' },

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -453,6 +453,7 @@ def validate_request_key(key, timezone=None):
 	return None
 
 
+@frappe.whitelist()
 def get_countries_with_isd_codes():
 	"""Get list of countries with their ISD codes from Frappe's country_info."""
 	import phonenumbers


### PR DESCRIPTION
#### Description

Passes contact code value to Razorpay modal so it's not preset to India ( +91 ) regardless of user's country.

#### Resolutions 

- https://github.com/frappe/press/issues/5776