### PR TITLE
chore: Update mergify config to disable back porting to master

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -41,10 +41,3 @@ pull_request_rules:
           - master
         assignees:
           - "{{ author }}"
-  - name: Label PRs targeting develop with 'backport-master'
-    conditions:
-      - base=develop
-    actions:
-      label:
-        add:
-          - backport-master


### PR DESCRIPTION
This change has been made by @saurabh6790 from the Mergify workflow automation editor.