### PR TITLE
fix(billing): Removing monthly recurring frequency

### DIFF
--- a/press/press/doctype/razorpay_mandate/razorpay_mandate.py
+++ b/press/press/doctype/razorpay_mandate/razorpay_mandate.py
@@ -278,10 +278,7 @@ def create_razorpay_mandate(
 				"token": {
 					# "auth_type":"netbanking",
 					"max_amount": max_amount * 100,  # Send amount in paisa
-					"frequency": "monthly",
 					"expire_at": expire_by_timestamp,
-					"recurring_value": 28,
-					"recurring_type": "before",
 				},
 			}
 		)


### PR DESCRIPTION
This will allow the order to be as presented and not restrict ourself to do a frequency of monthly. However from Frappe press end we wont run it more than once in a month and we will retry after waiting for around 48 hours to initiate another debit process. 