### PR TITLE
fix(sitelogs-page): set icon proper size for lucideIcon

### DIFF
--- a/dashboard/src/components/site/SiteLogs.vue
+++ b/dashboard/src/components/site/SiteLogs.vue
@@ -92,7 +92,7 @@ export default {
 					actions: () => [
 						{
 							slots: {
-								prefix: () => h(LucideSparkleIcon),
+								prefix: () => h(LucideSparkleIcon, { class: 'size-4' }),
 							},
 							label: 'View in Log Browser',
 							onClick: () => {
@@ -210,7 +210,7 @@ export default {
 					actions: () => [
 						{
 							slots: {
-								prefix: () => h(LucideSparkleIcon),
+								prefix: () => h(LucideSparkleIcon, { class: 'size-4' }),
 							},
 							label: 'View in Log Browser',
 							onClick: () => {


### PR DESCRIPTION
### Before 

<img width="986" height="344" alt="image" src="https://github.com/user-attachments/assets/39d9c394-3140-4499-bbb7-df95ed2a8c87" />



### After: 

<img width="926" height="458" alt="image" src="https://github.com/user-attachments/assets/0ea24337-a8b4-4583-bf99-492074ae4bc9" />
