### PR TITLE
fix(billing): Include payment id in failure case for tracking

### DIFF
--- a/press/api/billing.py
+++ b/press/api/billing.py
@@ -984,6 +984,7 @@ def handle_razorpay_payment_failed(response):
 		for_update=True,
 	)
 
+	payment_record.payment_id = response["error"]["metadata"].get("payment_id")
 	payment_record.status = "Failed"
 	payment_record.failure_reason = response["error"]["description"]
 	payment_record.save(ignore_permissions=True)


### PR DESCRIPTION
In case of failure in payment, we are not persisting the payment_id that will help us to track with Razorpay team. While we can figure out from Razorpay dashboard its like touching nose around the head.