### PR TITLE
fix(signup): Issue in gameplan signup due to sync user

### DIFF
--- a/press/saas/doctype/product_trial_request/product_trial_request.py
+++ b/press/saas/doctype/product_trial_request/product_trial_request.py
@@ -157,7 +157,11 @@ class ProductTrialRequest(Document):
 					try:
 						site.create_sync_user_webhook()
 					except Exception:
-						log_error("Sync User Webhook Creation Failed", site=self.site)
+						log_error(
+							title="Sync User Webhook Creation Failed",
+							reference_doctype=self.doctype,
+							reference_name=self.name,
+						)
 
 	@frappe.whitelist()
 	def get_setup_wizard_payload(self):


### PR DESCRIPTION
Signups are failing for gameplan in prod due to 404 site not accessible error during sync user part.