### PR TITLE
fix(cpu-progress): fallback to zero to prevent negative metrics in da…

### DIFF
--- a/dashboard/src/components/server/ServerOverview.vue
+++ b/dashboard/src/components/server/ServerOverview.vue
@@ -460,11 +460,11 @@ export default {
 				{
 					label: 'CPU',
 					type: 'progress',
-					progress_value: currentUsage.vcpu ? currentUsage.vcpu * 100 : 0,
+					progress_value: currentUsage.vcpu
+						? Math.max(0, currentUsage.vcpu * 100)
+						: 0,
 					value: currentPlan
-						? `${((currentUsage.vcpu || 0) * 100).toFixed(
-								2,
-							)}% of ${currentPlan.vcpu} ${this.$format.plural(
+						? `${(Math.max(0, currentUsage.vcpu || 0) * 100).toFixed(2)}% of ${currentPlan.vcpu} ${this.$format.plural(
 								currentPlan.vcpu,
 								'vCPU',
 								'vCPUs',


### PR DESCRIPTION

closes #6053


The negative number comes from the backend's api response, the dashboard is just showing it. So add 0 as fallback to prevent negative metrics at all costs