### PR TITLE
fix: Server selection when creating site on shared bench

### DIFF
--- a/press/api/tests/test_site.py
+++ b/press/api/tests/test_site.py
@@ -125,7 +125,7 @@ class TestAPISite(FrappeTestCase):
 		frappe.db.set_single_value("Press Settings", "domain", root_domain.name)
 
 		n1_server = create_test_proxy_server(cluster=cluster.name, domain=root_domain.name)
-		f1_server = create_test_server(cluster=cluster.name, proxy_server=n1_server.name)
+		f1_server = create_test_server(cluster=cluster.name, proxy_server=n1_server.name, public=True)
 
 		group = create_test_release_group(
 			[frappe_app, allowed_app, disallowed_app], public=True, frappe_version="Version 15"
@@ -169,7 +169,7 @@ class TestAPISite(FrappeTestCase):
 		frappe.db.set_single_value("Press Settings", "domain", root_domain.name)
 
 		n1_server = create_test_proxy_server(cluster=cluster.name, domain=root_domain.name)
-		f1_server = create_test_server(cluster=cluster.name, proxy_server=n1_server.name)
+		f1_server = create_test_server(cluster=cluster.name, proxy_server=n1_server.name, public=True)
 
 		group = create_test_release_group([frappe_app, another_app], public=True, frappe_version="Version 15")
 		group.append(
@@ -208,9 +208,9 @@ class TestAPISite(FrappeTestCase):
 		frappe_app = create_test_app(name="frappe")
 
 		n1_server = create_test_proxy_server(cluster=cluster.name, domain=root_domain.name)
-		f1_server = create_test_server(cluster=cluster.name, proxy_server=n1_server.name)
+		f1_server = create_test_server(cluster=cluster.name, proxy_server=n1_server.name, public=True)
 		n2_server = create_test_proxy_server(cluster=cluster.name, domain=root_domain.name)
-		f2_server = create_test_server(cluster=cluster.name, proxy_server=n2_server.name)
+		f2_server = create_test_server(cluster=cluster.name, proxy_server=n2_server.name, public=True)
 
 		rg1 = create_test_release_group([frappe_app], public=True, frappe_version="Version 15")
 		rg1.append(
@@ -268,9 +268,9 @@ class TestAPISite(FrappeTestCase):
 		frappe_app = create_test_app(name="frappe")
 
 		n1_server = create_test_proxy_server(cluster=cluster.name, domain=root_domain.name)
-		f1_server = create_test_server(cluster=cluster.name, proxy_server=n1_server.name)
+		f1_server = create_test_server(cluster=cluster.name, proxy_server=n1_server.name, public=True)
 		n2_server = create_test_proxy_server(cluster=cluster.name, domain=root_domain.name)
-		f2_server = create_test_server(cluster=cluster.name, proxy_server=n2_server.name)
+		f2_server = create_test_server(cluster=cluster.name, proxy_server=n2_server.name, public=True)
 
 		rg1 = create_test_release_group([frappe_app], public=True, frappe_version="Version 15")
 		rg1.append(
@@ -678,7 +678,7 @@ insights 0.8.3	    HEAD
 		app2 = create_test_app("erpnext", "ERPNext")
 		group = create_test_release_group([app, app2])
 		plan = create_test_plan("Site")
-		create_test_bench(group=group)
+		create_test_bench(group=group, public_server=True)
 		subdomain = "testsite"
 
 		# frappe.set_user(self.team.user) # can't this due to weird perm error with ignore_perimssions in new site

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -2895,7 +2895,7 @@ class Site(Document, TagHelpers):
 			config["rate_limit"] = {}
 		return config
 
-	def _get_benches_for_(self, proxy_servers, release_group_names=None):
+	def _get_benches_for_(self, proxy_servers, release_group_names=None, host_on_shared_server=False):
 		from pypika.terms import PseudoColumn
 
 		benches = frappe.qb.DocType("Bench")
@@ -2919,6 +2919,9 @@ class Site(Document, TagHelpers):
 			.orderby(benches.creation, order=frappe.qb.desc)
 			.limit(1)
 		)
+		if host_on_shared_server:
+			bench_query = bench_query.where(servers.public == 1)
+
 		if release_group_names:
 			groups = frappe.qb.DocType("Release Group")
 			bench_query = (
@@ -2993,7 +2996,9 @@ class Site(Document, TagHelpers):
 		"""
 
 		release_group_names = []
-		if self.get_plan_name():
+		host_on_shared_server = False
+		plan_name = self.get_plan_name()
+		if plan_name:
 			release_group_names = frappe.db.get_all(
 				"Site Plan Release Group",
 				pluck="release_group",
@@ -3004,10 +3009,12 @@ class Site(Document, TagHelpers):
 				},
 			)
 
-		benches = self._get_benches_for_(
-			proxy_servers,
-			release_group_names,
-		)
+			is_dedicated_server_plan = (
+				frappe.db.get_value("Site Plan", plan_name, "dedicated_server_plan") if plan_name else False
+			)
+			host_on_shared_server = not (self.server and is_dedicated_server_plan)
+
+		benches = self._get_benches_for_(proxy_servers, release_group_names, host_on_shared_server)
 		if len(benches) == 0:
 			frappe.throw(
 				"No bench is available to deploy this site, please deploy a new bench or reach out to us at <a href='https://support.frappe.io'>support.frappe.io</a>"

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -3005,7 +3005,7 @@ class Site(Document, TagHelpers):
 				filters={
 					"parenttype": "Site Plan",
 					"parentfield": "release_groups",
-					"parent": self.get_plan_name(),
+					"parent": plan_name,
 				},
 			)
 

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -454,7 +454,7 @@ class Site(Document, TagHelpers):
 
 	def before_insert(self):
 		if not self.bench and self.group:
-			if self.server and self.team != "Administrator":  # Check to avoid standby sites
+			if self.server and not self.is_standby:
 				self.set_bench_for_server()
 			else:
 				self.set_latest_bench()


### PR DESCRIPTION
- Ensure that when a release group spans both public and dedicated servers, selecting a public (shared) deployment correctly chooses a public server
- Fix issue where a user’s dedicated server was incorrectly selected instead