### PR TITLE
fix(uptime-chart): Update promql query to support empty data points

### DIFF
--- a/dashboard/src/components/site/SiteAnalytics.vue
+++ b/dashboard/src/components/site/SiteAnalytics.vue
@@ -97,6 +97,7 @@
 					:timegrain="$resources.analytics?.data?.timegrain"
 					:data="$resources.analytics?.data?.uptime"
 					:loading="$resources.analytics.loading"
+					@datazoom="handleDataZoom"
 					class="h-[15.55rem] p-2 pb-3"
 				/>
 			</AnalyticsCard>

--- a/dashboard/src/components/site/SiteAnalytics.vue
+++ b/dashboard/src/components/site/SiteAnalytics.vue
@@ -93,6 +93,7 @@
 
 			<AnalyticsCard title="Uptime" @share-card="shareDashboard">
 				<SiteUptime
+					:timegrain="$resources.analytics?.data?.timegrain"
 					:data="$resources.analytics?.data?.uptime"
 					:loading="$resources.analytics.loading"
 					class="h-[15.55rem] p-2 pb-3"

--- a/dashboard/src/components/site/SiteAnalytics.vue
+++ b/dashboard/src/components/site/SiteAnalytics.vue
@@ -93,6 +93,7 @@
 
 			<AnalyticsCard title="Uptime" @share-card="shareDashboard">
 				<SiteUptime
+					:site="name"
 					:timegrain="$resources.analytics?.data?.timegrain"
 					:data="$resources.analytics?.data?.uptime"
 					:loading="$resources.analytics.loading"

--- a/dashboard/src/components/site/SiteUptime.vue
+++ b/dashboard/src/components/site/SiteUptime.vue
@@ -19,14 +19,10 @@
 								class="contrast-75 font-bold"
 								:class="hoveringOn.colour || []"
 							>
-								{{
-									(hoveringOn.value * 100).toFixed(
-										hoveringOn.value === 0 || hoveringOn.value === 1 ? 0 : 2,
-									)
-								}}%
+								{{ hoveringOn.percentValue }}%
 							</span>
 							<span class="opacity-30">&#x2022;</span>
-							{{ hoveringOn.prettyDate }}
+							{{ hoveringOn.endDate }}
 						</template>
 					</div>
 					<div class="text-[11px] whitespace-nowrap flex gap-1 items-center">
@@ -72,8 +68,8 @@
 								:style="`width: ${barWidth};`"
 								:class="[
 									'hover:brightness-[110%] border-r border-white',
-									d.value === undefined
-										? 'bg-gray-100'
+									d.value === undefined || d.value < 0
+										? 'bg-gray-300'
 										: d.value === 1
 											? 'bg-green-500'
 											: d.value === 0
@@ -83,7 +79,7 @@
 							>
 								<Tooltip
 									placement="bottom"
-									:text="`${hoveringOn.percentValue}% aggregated for ~${interval} (until ${hoveringOn.prettyDate})`"
+									:text="`${hoveringOn.percentValue}% avg. uptime for ${interval} from ${hoveringOn.startDate} to ${hoveringOn.endDate})`"
 								>
 									<div class="h-full w-full" />
 								</Tooltip>
@@ -130,7 +126,7 @@ import { uuid4 } from '@sentry/core';
 
 export default {
 	name: 'SiteUptime',
-	props: ['data', 'loading'],
+	props: ['data', 'loading', 'timegrain'],
 	components: {
 		Help: icon('help-circle'),
 		Right: icon('arrow-right'),
@@ -146,7 +142,8 @@ export default {
 				key: null, // (== date)
 				value: null,
 				percentValue: null,
-				prettyDate: null,
+				endDate: null,
+				startDate: null,
 				colour: null,
 			},
 			highlightDates: false,
@@ -167,7 +164,11 @@ export default {
 			for (; i < this.filteredData.length; i++) {
 				// there could be empty objects at the end of the array
 				// so we don't have to count them
-				if (typeof this.filteredData[i].value !== 'number') break;
+				if (
+					typeof this.filteredData[i].value !== 'number' ||
+					this.filteredData[i].value === -1
+				)
+					continue;
 
 				total += this.filteredData[i].value;
 			}
@@ -176,18 +177,18 @@ export default {
 			return !isNaN(average) ? `${average}% Overall Uptime` : '';
 		},
 		interval() {
-			if (!this.filteredData || this.filteredData.length < 2) return '';
+			if (
+				!this.filteredData ||
+				typeof this.timegrain != 'number' ||
+				this.filteredData.length < 2
+			)
+				return '';
 
-			const first = dayjs(this.filteredData[0].date);
-			const second = dayjs(this.filteredData[1].date);
-
-			const diffMs = second.diff(first);
-
-			return dayjs.duration(diffMs).humanize();
+			return dayjs.duration(this.timegrain * 1000).humanize();
 		},
 		filteredData() {
 			if (!this.data?.length) return [];
-			const filtered = this.data.filter((obj) => !!obj.value);
+			const filtered = this.data.filter((obj) => typeof obj.value == 'number');
 			this.chunkSize = this.getOptimalChunkSizeFromDataLength(filtered.length);
 			return filtered;
 		},
@@ -228,16 +229,26 @@ export default {
 			return dayjs(date).format('ddd, D MMM YYYY, hh:mm a');
 		},
 		inspectBar({ date, value }) {
-			const prettyDate = this.formatDate(date);
-			const percentValue = (value * 100).toFixed(2);
+			const endDate = this.formatDate(date);
+			const startDate = this.formatDate(new Date(date) - this.timegrain * 1000);
+			const percentValue = value !== -1 ? (value * 100).toFixed(2) : '0.00';
 			const colour =
 				value === 1
 					? 'text-green-500'
-					: value === 0
-						? 'text-red-500'
-						: 'text-yellow-500';
+					: value > 0
+						? 'text-yellow-500'
+						: value === 0
+							? 'text-red-500'
+							: '';
 
-			this.hoveringOn = { key: date, value, percentValue, prettyDate, colour };
+			this.hoveringOn = {
+				key: date,
+				value,
+				percentValue,
+				endDate,
+				startDate,
+				colour,
+			};
 		},
 		getUptimeChunkId(chunkIndex) {
 			return `uptime-${this.carouselId}-${chunkIndex}`;
@@ -246,7 +257,9 @@ export default {
 			this.hoveringOn = {
 				key: null,
 				value: null,
-				prettyDate: null,
+				endDate: null,
+				percentValue: null,
+				startDate: null,
 				colour: null,
 			};
 		},

--- a/dashboard/src/components/site/SiteUptime.vue
+++ b/dashboard/src/components/site/SiteUptime.vue
@@ -68,7 +68,7 @@
 								:style="`width: ${barWidth};`"
 								:class="[
 									'hover:brightness-[110%] border-r border-white',
-									d.value === undefined || d.value < 0
+									Date.parse(d.date) < Date.parse(siteCreation || new Date(0))
 										? 'bg-gray-300'
 										: d.value === 1
 											? 'bg-green-500'
@@ -121,12 +121,12 @@
 <script>
 import dayjs from '../../utils/dayjs';
 import { icon } from '../../utils/components';
-import { Tooltip, debounce } from 'frappe-ui';
+import { Tooltip, debounce, getCachedDocumentResource } from 'frappe-ui';
 import { uuid4 } from '@sentry/core';
 
 export default {
 	name: 'SiteUptime',
-	props: ['data', 'loading', 'timegrain'],
+	props: ['data', 'loading', 'timegrain', 'site'],
 	components: {
 		Help: icon('help-circle'),
 		Right: icon('arrow-right'),
@@ -148,10 +148,12 @@ export default {
 			},
 			highlightDates: false,
 			firstRender: true,
+			siteCreation: null,
 		};
 	},
-	mounted() {
-		setTimeout(() => {}, 2000);
+	created() {
+		const site = getCachedDocumentResource('Site', this.site);
+		this.siteCreation = site?.doc?.creation;
 	},
 	beforeUnmount() {
 		const el = this.$refs.scrollContainer;
@@ -233,13 +235,13 @@ export default {
 			const startDate = this.formatDate(new Date(date) - this.timegrain * 1000);
 			const percentValue = value !== -1 ? (value * 100).toFixed(2) : '0.00';
 			const colour =
-				value === 1
-					? 'text-green-500'
-					: value > 0
-						? 'text-yellow-500'
-						: value === 0
-							? 'text-red-500'
-							: '';
+				Date.parse(date) < Date.parse(this.siteCreation)
+					? ''
+					: value === 1
+						? 'text-green-500'
+						: value > 0
+							? 'text-yellow-500'
+							: 'text-red-500';
 
 			this.hoveringOn = {
 				key: date,

--- a/dashboard/src/components/site/SiteUptime.vue
+++ b/dashboard/src/components/site/SiteUptime.vue
@@ -81,7 +81,12 @@
 									placement="bottom"
 									:text="`${hoveringOn.percentValue}% avg. uptime for ${interval} from ${hoveringOn.startDate} to ${hoveringOn.endDate})`"
 								>
-									<div class="h-full w-full" />
+									<div
+										:data-start-date="hoveringOn.startDate"
+										:data-end-date="hoveringOn.endDate"
+										@click="updateTsFilter"
+										class="h-full w-full"
+									/>
 								</Tooltip>
 							</div>
 						</div>
@@ -121,7 +126,7 @@
 <script>
 import dayjs from '../../utils/dayjs';
 import { icon } from '../../utils/components';
-import { Tooltip, debounce, getCachedDocumentResource } from 'frappe-ui';
+import { Tooltip, getCachedDocumentResource } from 'frappe-ui';
 import { uuid4 } from '@sentry/core';
 
 export default {
@@ -132,6 +137,7 @@ export default {
 		Right: icon('arrow-right'),
 		Left: icon('arrow-left'),
 	},
+	emits: ['datazoom'],
 	data() {
 		return {
 			carouselId: uuid4(),
@@ -227,6 +233,10 @@ export default {
 		},
 	},
 	methods: {
+		updateTsFilter(evt) {
+			const { startDate, endDate } = evt.target.dataset;
+			this.$emit('datazoom', { startDate, endDate });
+		},
 		formatDate(date) {
 			return dayjs(date).format('ddd, D MMM YYYY, hh:mm a');
 		},

--- a/press/api/analytics.py
+++ b/press/api/analytics.py
@@ -927,7 +927,9 @@ def get_uptime(site, timezone, start: datetime, end: datetime, timegrain):
 		) + timedelta(days=1)
 
 	query = {
-		"query": (f'avg_over_time(probe_success{{job="site", instance="{site}"}}[60s]) or on() vector(0)'),
+		"query": (
+			f'avg_over_time(probe_success{{job="site", instance="{site}"}}[{timegrain}s]) or on() vector(0)'
+		),
 		"start": start.timestamp(),
 		"end": end.timestamp(),
 		"step": f"{timegrain}s",

--- a/press/api/analytics.py
+++ b/press/api/analytics.py
@@ -684,6 +684,7 @@ def get(name, timezone, start, end):
 		"request_cpu_time": [{"value": r.duration, "date": r.date} for r in request_data],
 		"uptime": uptime_data,
 		"plan_limit": plan_limit,
+		"timegrain": timegrain,
 	}
 
 
@@ -926,9 +927,7 @@ def get_uptime(site, timezone, start: datetime, end: datetime, timegrain):
 		) + timedelta(days=1)
 
 	query = {
-		"query": (
-			f'sum(sum_over_time(probe_success{{job="site", instance="{site}"}}[{timegrain}s])) by (instance) / sum(count_over_time(probe_success{{job="site", instance="{site}"}}[{timegrain}s])) by (instance)'
-		),
+		"query": (f'avg_over_time(probe_success{{job="site", instance="{site}"}}[60s]) or on() vector(0)'),
 		"start": start.timestamp(),
 		"end": end.timestamp(),
 		"step": f"{timegrain}s",
@@ -939,7 +938,9 @@ def get_uptime(site, timezone, start: datetime, end: datetime, timegrain):
 	buckets = []
 	if not response["data"]["result"]:
 		return []
-	for timestamp, value in response["data"]["result"][0]["values"]:
+	for timestamp, value in sorted(
+		{ts: val for r in response["data"]["result"] for ts, val in r["values"]}.items()
+	):
 		buckets.append(
 			frappe._dict(
 				{


### PR DESCRIPTION
# 1

Data points in site uptime chart before site creation timestamp will now be displayed but grayed out. Previously this was not displayed.

<img width="1064" height="383" alt="Screenshot 2026-04-13 at 11 38 19 AM" src="https://github.com/user-attachments/assets/89217ea5-8c5a-4bc2-ac5f-27940c64c3f5" />

# 2

Enabled datazoom: clicking any bar above will update the global time filter to reflect the time range that bar represents.

# 3

Updated the promql query for uptime. If all uptime data points are missing from Prometheus within a given time-grain interval, the gap will now be filled with zero values represented in red. Previously, such intervals were omitted entirely, which caused abrupt jumps in the visualised data. By filling these gaps with zeroes, the time series becomes continuous and more accurately shows periods of complete downtime:

**Before:**
```py
'sum(sum_over_time(probe_success{{job="site", instance="{site}"}}[{timegrain}s])) by (instance) / sum(count_over_time(probe_success{{job="site", instance="{site}"}}[{timegrain}s])) by (instance)'
```

**After:**
```python
'avg_over_time(probe_success{{job="site", instance="{site}"}}[{timegrain}s]) or on() vector(0)'
```