### PR TITLE
fix(object-list): Remove border-t for load more

### DIFF
--- a/dashboard/src/components/ObjectList.vue
+++ b/dashboard/src/components/ObjectList.vue
@@ -136,8 +136,7 @@
 			<div
 				class="p-2 text-right"
 				:class="{
-					'border-t bg-white bottom-0 sticky':
-						$list?.next && $list?.hasNextPage,
+					'bg-white bottom-0 sticky': $list?.next && $list?.hasNextPage,
 				}"
 				v-if="$list"
 			>

--- a/dashboard/src/components/group/BenchDependencies.vue
+++ b/dashboard/src/components/group/BenchDependencies.vue
@@ -141,7 +141,7 @@ const columns = computed(() => [
 		<div
 			class="p-2 text-right"
 			:class="{
-				'border-t bg-white bottom-0 sticky':
+				'bg-white bottom-0 sticky':
 					dependencyListResource?.next && dependencyListResource?.hasNextPage,
 			}"
 			v-if="dependencyListResource"


### PR DESCRIPTION
# 1

Removing the top border of "Load more" btn's parent container.

<img width="1440" height="815" alt="Screenshot 2026-04-13 at 10 18 34 PM" src="https://github.com/user-attachments/assets/7129392b-9ae2-4b2f-ad2c-987ddafa3af1" />
