### PR TITLE
fix(version-upgrade): Correct date time comparison in Version Upgrade dialog

### DIFF
--- a/dashboard/src/components/site/SiteVersionUpgradeDialog.vue
+++ b/dashboard/src/components/site/SiteVersionUpgradeDialog.vue
@@ -312,6 +312,11 @@ import { getCachedDocumentResource, LoadingIndicator } from 'frappe-ui';
 import { toast } from 'vue-sonner';
 import AlertBanner from '../AlertBanner.vue';
 import DateTimePicker from 'frappe-ui/src/components/DatePicker/DateTimePicker.vue';
+import dayjs from '../../utils/dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+
+const PICKER_DATETIME_FORMAT = 'YYYY-MM-DD h:mm a';
+const IST_TIMEZONE = 'Asia/Calcutta';
 
 export default {
 	name: 'SiteVersionUpgradeDialog',
@@ -364,13 +369,21 @@ export default {
 			}
 			return '';
 		},
-		datetimeInIST() {
+		parsedTargetDateTime() {
 			if (!this.targetDateTime) return null;
-			const datetimeInIST = this.$dayjs(this.targetDateTime).format(
-				'YYYY-MM-DDTHH:mm',
-			);
 
-			return datetimeInIST;
+			const localTimezone = dayjs.tz.guess();
+			return dayjs.tz(
+				this.targetDateTime,
+				PICKER_DATETIME_FORMAT,
+				localTimezone,
+			);
+		},
+		datetimeInIST() {
+			if (!this.parsedTargetDateTime) return null;
+			return this.parsedTargetDateTime
+				.tz(IST_TIMEZONE)
+				.format('YYYY-MM-DDTHH:mm');
 		},
 		errorMessage() {
 			return (
@@ -396,22 +409,24 @@ export default {
 		isScheduleTimeValid() {
 			// Atleast 30 mins from now for deploying bench
 			if (!this.targetDateTime) return true;
+
 			if (!this.existingBenchGroup) {
-				const scheduledTime = this.targetDateTime.$d
-					? this.$dayjs(this.targetDateTime.$d)
-					: this.$dayjs(this.targetDateTime);
-				const minimumTime = this.$dayjs().add(30, 'minute');
-				return scheduledTime.isAfter(minimumTime);
+				const localTimezone = dayjs.tz.guess();
+				const minimumTime = dayjs().tz(localTimezone).add(30, 'minute');
+				return this.parsedTargetDateTime.isAfter(minimumTime);
 			}
+
 			return true;
 		},
+
 		disableButton() {
 			if (!this.newReleaseGroupTitle || !this.hasValidCustomAppSources) {
 				return true;
 			}
-			if (this.targetDateTime && !this.isScheduleTimeValid) {
-				return true;
+			if (!this.targetDateTime) {
+				return false;
 			}
+			return !this.isScheduleTimeValid;
 		},
 	},
 	resources: {

--- a/dashboard/src/components/site/SiteVersionUpgradeDialog.vue
+++ b/dashboard/src/components/site/SiteVersionUpgradeDialog.vue
@@ -313,7 +313,6 @@ import { toast } from 'vue-sonner';
 import AlertBanner from '../AlertBanner.vue';
 import DateTimePicker from 'frappe-ui/src/components/DatePicker/DateTimePicker.vue';
 import dayjs from '../../utils/dayjs';
-import customParseFormat from 'dayjs/plugin/customParseFormat';
 
 const PICKER_DATETIME_FORMAT = 'YYYY-MM-DD h:mm a';
 const IST_TIMEZONE = 'Asia/Calcutta';


### PR DESCRIPTION
- In case where bench creaiton is required for upgrading site, scheduled time for upgrade has to be at least 30 minites from now
- However, string input emitted by DateTimePicker was interpreted as UTC instead of user's local timezone, hence the above comparison fails

### Before:
<img width="500" height="800" alt="Before" src="https://github.com/user-attachments/assets/077ccaf6-bedf-4d10-8f96-16d4c82f024f" />

### After:
<img width="500" height="800" alt="after" src="https://github.com/user-attachments/assets/5fdab655-a895-486e-8bda-fc73b77da34e" />


