### PR TITLE
fix(notifications): unreadcount & open support access modal instead of navigation

### DIFF
--- a/dashboard/src/App.vue
+++ b/dashboard/src/App.vue
@@ -31,7 +31,10 @@
 				</div>
 			</div>
 		</div>
-		<Toaster position="top-right" />
+		<Toaster
+			position="top-right"
+			:toastOptions="{ class: 'text-sm prose-sm' }"
+		/>
 		<component v-for="dialog in dialogs" :is="dialog" :key="dialog.id" />
 		<SearchModal v-if="searchModalOpen" />
 	</div>

--- a/dashboard/src/components/MobileNav.vue
+++ b/dashboard/src/components/MobileNav.vue
@@ -49,7 +49,7 @@
 				</Button>
 			</DisclosureButton>
 		</div>
-		<DisclosurePanel class="border-b bg-gray-100 p-2">
+		<DisclosurePanel class="border-b bg-gray-100 px-1 py-2">
 			<NavigationItems>
 				<template v-slot="{ navigation }">
 					<template v-for="(item, i) in navigation">

--- a/dashboard/src/components/MobileNav.vue
+++ b/dashboard/src/components/MobileNav.vue
@@ -1,6 +1,6 @@
 <template>
 	<Disclosure as="div" v-slot="{ open }">
-		<div class="flex h-12 items-center border-b px-5">
+		<div class="flex h-12 items-center border-b px-3">
 			<span class="font-semibold">
 				<router-link :to="{ name: 'Site List' }">
 					<img
@@ -49,7 +49,7 @@
 				</Button>
 			</DisclosureButton>
 		</div>
-		<DisclosurePanel class="border-b bg-gray-100 px-5 py-2">
+		<DisclosurePanel class="border-b bg-gray-100 p-2">
 			<NavigationItems>
 				<template v-slot="{ navigation }">
 					<template v-for="(item, i) in navigation">
@@ -57,6 +57,11 @@
 							:key="item.name"
 							:item="item"
 							v-if="item.children"
+						/>
+						<component
+							v-else-if="item.customComponent"
+							:is="item.customComponent"
+							:item="item"
 						/>
 						<MobileNavItem :key="item.name" :item="item" v-else />
 					</template>

--- a/dashboard/src/components/navigation/search/Popup.vue
+++ b/dashboard/src/components/navigation/search/Popup.vue
@@ -46,7 +46,9 @@ const navigationIndex = ref(0);
 const navigateEnter = (close) => {
 	const item = flatList.value[navigationIndex.value];
 	if (item) {
-		router.push(item.route);
+		if (item.route) router.push(item.route);
+		if (item.click) item?.click();
+
 		close();
 	}
 };

--- a/dashboard/src/components/navigation/search/index.ts
+++ b/dashboard/src/components/navigation/search/index.ts
@@ -169,6 +169,25 @@ export const index = computed(() => {
 				},
 			],
 		},
+		Actions: {
+			items: [
+				{
+					name: 'Access Request',
+					icon: LucideKey,
+					click: () => {
+						document
+							.querySelector('button[aria-label="Notifications btn"]')
+							.click();
+						setTimeout(() => {
+							const tab = document.querySelectorAll(
+								'.PopoverContent [role="tab"]',
+							)[1];
+							tab.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+						}, 0);
+					},
+				},
+			],
+		},
 	};
 
 	for (const [key, value] of Object.entries(integrations)) {

--- a/dashboard/src/components/navigation/sidebar/Item.vue
+++ b/dashboard/src/components/navigation/sidebar/Item.vue
@@ -12,7 +12,7 @@ let props = defineProps({
 		:to="item.route"
 		class="flex items-center rounded px-3 py-2 text-ink-gray-6 transition gap-2"
 		:class="[
-			item.isActive ? 'bg-white shadow-sm' : 'hover:bg-gray-100',
+			item.isActive ? 'bg-white shadow-sm' : 'hover:bg-surface-gray-3',
 			item.disabled ? 'pointer-events-none opacity-50' : '',
 			$attrs.class,
 		]"

--- a/dashboard/src/components/navigation/sidebar/NavList.vue
+++ b/dashboard/src/components/navigation/sidebar/NavList.vue
@@ -96,7 +96,6 @@ const navigation = computed(() => {
 		{
 			name: 'Servers',
 			icon: Server,
-			class: 'mt-2',
 			route: onboardingComplete ? '/servers' : '/enable-servers',
 			isActive:
 				['New Server'].includes(routeName) ||

--- a/dashboard/src/components/navigation/sidebar/Notifications.vue
+++ b/dashboard/src/components/navigation/sidebar/Notifications.vue
@@ -202,7 +202,7 @@ const tabs = [
 					<LucideBell class="m-1 size-4 text-ink-gray-6" />
 					<span
 						v-if="unreadNotificationsCount.data > 0"
-						class="size-1.5 bg-blue-400 rounded-full absolute right-0 top-0"
+						class="size-1 bg-surface-blue-3 rounded-full absolute right-0.5 top-0.5"
 					/>
 				</span>
 

--- a/dashboard/src/components/navigation/sidebar/Notifications.vue
+++ b/dashboard/src/components/navigation/sidebar/Notifications.vue
@@ -71,17 +71,27 @@ const markAsRead = (row, togglePopover) => {
 	});
 
 	docres.markNotificationAsRead.submit().then(() => {
-		unreadNotificationsCount.setData((data) => data - 1);
-		if (row.route) {
+		// requests tab needs to show both read/unread
+		// so dont set local state!!!
+		if (row.type !== 'Support Access') {
+			unreadNotificationsCount.setData((data) => data - 1);
+
+			resource.setData((data) => {
+				const newData = data.filter((d) => d.name !== row.name);
+				resource.originalData = newData;
+				return newData;
+			});
+		}
+
+		if (row.type === 'Support Access') {
+			unreadSupportNotificationsCount.setData((data) => data - 1);
+			openSupportAccess(null, row.document_name);
+		}
+
+		if (row.route && row.type !== 'Support Access') {
 			togglePopover();
 			router.push('/' + row.route);
 		}
-	});
-
-	resource.setData((data) => {
-		const newData = data.filter((d) => d.name !== row.name);
-		resource.originalData = newData;
-		return newData;
 	});
 };
 
@@ -105,7 +115,7 @@ const markAllAsRead = (togglePopover) => {
 };
 
 const openSupportAccess = (e, name) => {
-	e.stopPropagation();
+	e?.stopPropagation();
 	renderDialog(
 		h(SupportAccessDialog, {
 			name,
@@ -159,6 +169,7 @@ watch(activeTab, (x) => {
 		//
 	} else if (x == 1) {
 		filters.type = 'Support Access';
+		delete filters.read;
 	} else {
 		filters.read = 'Unread';
 	}

--- a/dashboard/src/components/navigation/sidebar/Notifications.vue
+++ b/dashboard/src/components/navigation/sidebar/Notifications.vue
@@ -186,13 +186,16 @@ const tabs = [
 </script>
 
 <template>
-	<Popover :placement="$isMobile ? 'top-start' : 'right-start'">
+	<Popover
+		:placement="$isMobile ? 'top-start' : 'right-start'"
+		popover-class="fixed -mt-[16%]"
+	>
 		<!-- sidebar item -->
 		<template #target="{ togglePopover }">
 			<button
 				aria-label="Notifications btn"
 				@click="togglePopover"
-				class="flex items-center rounded px-3 py-2 text-ink-gray-6 transition gap-2 hover:bg-surface-gray-3 w-full"
+				class="flex items-center rounded px-2.5 py-1.5 md:px-3 md:py-2 text-ink-gray-6 transition gap-2 hover:bg-surface-gray-3 w-full"
 				:class="[
 					item.disabled ? 'pointer-events-none opacity-50' : '',
 					$attrs.class,
@@ -224,7 +227,7 @@ const tabs = [
 		<!-- floating drawer  -->
 		<template #body="{ togglePopover }">
 			<div
-				class="text-ink-gray-9 bg-white h-screen ml-2 shadow-xl w-[430px] flex flex-col"
+				class="text-ink-gray-9 bg-white h-screen w-screen md:ml-2 shadow-xl md:w-[430px] flex flex-col"
 			>
 				<!-- header -->
 				<div class="text-base flex items-center py-2 pl-4 pr-2 border-b">

--- a/dashboard/src/components/navigation/sidebar/Notifications.vue
+++ b/dashboard/src/components/navigation/sidebar/Notifications.vue
@@ -197,7 +197,14 @@ const tabs = [
 					$attrs.class,
 				]"
 			>
-				<LucideInbox class="m-1 h-4 w-4 text-ink-gray-6" />
+				<span class="flex relative">
+					<LucideBell class="m-1 size-4 text-ink-gray-6" />
+					<span
+						v-if="unreadNotificationsCount.data > 0"
+						class="size-1.5 bg-blue-400 rounded-full absolute right-0 top-0"
+					/>
+				</span>
+
 				<span class="text-sm flex-1 text-left">{{ item.name }}</span>
 
 				<span

--- a/dashboard/src/components/navigation/sidebar/Notifications.vue
+++ b/dashboard/src/components/navigation/sidebar/Notifications.vue
@@ -190,6 +190,7 @@ const tabs = [
 		<!-- sidebar item -->
 		<template #target="{ togglePopover }">
 			<button
+				aria-label="Notifications btn"
 				@click="togglePopover"
 				class="flex items-center rounded px-2 py-1 text-ink-gray-6 transition gap-1 hover:bg-surface-gray-3 w-full"
 				:class="[

--- a/dashboard/src/components/navigation/sidebar/Notifications.vue
+++ b/dashboard/src/components/navigation/sidebar/Notifications.vue
@@ -186,23 +186,23 @@ const tabs = [
 </script>
 
 <template>
-	<Popover placement="right-start">
+	<Popover :placement="$isMobile ? 'top-start' : 'right-start'">
 		<!-- sidebar item -->
 		<template #target="{ togglePopover }">
 			<button
 				aria-label="Notifications btn"
 				@click="togglePopover"
-				class="flex items-center rounded px-2 py-1 text-ink-gray-6 transition gap-1 hover:bg-surface-gray-3 w-full"
+				class="flex items-center rounded px-3 py-2 text-ink-gray-6 transition gap-2 hover:bg-surface-gray-3 w-full"
 				:class="[
 					item.disabled ? 'pointer-events-none opacity-50' : '',
 					$attrs.class,
 				]"
 			>
 				<span class="flex relative">
-					<LucideBell class="m-1 size-4 text-ink-gray-6" />
+					<LucideBell class="size-4 text-ink-gray-6" />
 					<span
 						v-if="unreadNotificationsCount.data > 0"
-						class="size-1 bg-surface-blue-3 rounded-full absolute right-0.5 top-0.5"
+						class="size-1 bg-surface-blue-3 rounded-full absolute right-0 -top-0.5"
 					/>
 				</span>
 

--- a/dashboard/src/components/navigation/sidebar/SearchItem.vue
+++ b/dashboard/src/components/navigation/sidebar/SearchItem.vue
@@ -6,7 +6,7 @@ import { searchModalOpen } from '@/data/ui';
 
 <template>
 	<button
-		class="flex items-center rounded px-3 py-2 text-ink-gray-6 transition gap-2 text-sm w-full mt-1 hover:bg-surface-gray-3"
+		class="flex items-center rounded px-2.5 py-1.5 md:px-3 md:py-2 text-ink-gray-6 transition gap-2 text-sm w-full mt-1 hover:bg-surface-gray-3"
 		@click="() => (searchModalOpen = true)"
 	>
 		<LucideSearch class="size-4 text-ink-gray-6" />

--- a/dashboard/src/components/navigation/sidebar/SearchItem.vue
+++ b/dashboard/src/components/navigation/sidebar/SearchItem.vue
@@ -6,7 +6,7 @@ import { searchModalOpen } from '@/data/ui';
 
 <template>
 	<button
-		class="flex items-center rounded px-2 py-1 text-ink-gray-6 transition gap-1 text-sm w-full"
+		class="flex items-center rounded px-2 py-1 text-ink-gray-6 transition gap-1 text-sm w-full mt-1"
 		@click="() => (searchModalOpen = true)"
 	>
 		<span class="grid h-5 w-6 place-items-center">

--- a/dashboard/src/components/navigation/sidebar/SearchItem.vue
+++ b/dashboard/src/components/navigation/sidebar/SearchItem.vue
@@ -6,12 +6,10 @@ import { searchModalOpen } from '@/data/ui';
 
 <template>
 	<button
-		class="flex items-center rounded px-2 py-1 text-ink-gray-6 transition gap-1 text-sm w-full mt-1 hover:bg-surface-gray-3"
+		class="flex items-center rounded px-3 py-2 text-ink-gray-6 transition gap-2 text-sm w-full mt-1 hover:bg-surface-gray-3"
 		@click="() => (searchModalOpen = true)"
 	>
-		<span class="grid h-5 w-6 place-items-center">
-			<LucideSearch class="size-4 text-ink-gray-6" />
-		</span>
+		<LucideSearch class="size-4 text-ink-gray-6" />
 		<span class="text-left mr-auto"> Search</span>
 
 		<LucideCommand class="size-3.5 text-ink-gray-6" />

--- a/dashboard/src/components/navigation/sidebar/SearchItem.vue
+++ b/dashboard/src/components/navigation/sidebar/SearchItem.vue
@@ -6,7 +6,7 @@ import { searchModalOpen } from '@/data/ui';
 
 <template>
 	<button
-		class="flex items-center rounded px-2 py-1 text-ink-gray-6 transition gap-1 text-sm w-full mt-1"
+		class="flex items-center rounded px-2 py-1 text-ink-gray-6 transition gap-1 text-sm w-full mt-1 hover:bg-surface-gray-3"
 		@click="() => (searchModalOpen = true)"
 	>
 		<span class="grid h-5 w-6 place-items-center">

--- a/dashboard/src/components/navigation/sidebar/Sidebar.vue
+++ b/dashboard/src/components/navigation/sidebar/Sidebar.vue
@@ -23,6 +23,9 @@ const SwitchTeamDialog2 = defineAsyncComponent(
 	() => import('../../SwitchTeamDialog.vue'),
 );
 
+const support = () => {
+	window.open('https://support.frappe.io/helpdesk/my-tickets/new', '_blank');
+};
 const docs = () => {
 	window.open('https://docs.frappe.io/cloud', '_blank');
 };
@@ -104,7 +107,7 @@ const releaseNotes = () => {
 				{
 					label: 'Get Support',
 					icon: LucideSupport,
-					onClick: docs,
+					onClick: support,
 				},
 				{
 					label: 'Share Feedback',

--- a/dashboard/src/data/notifications.js
+++ b/dashboard/src/data/notifications.js
@@ -8,6 +8,7 @@ export const unreadNotificationsCount = createResource({
 
 export const unreadSupportNotificationsCount = createResource({
 	cache: 'Unread Support Notifications Count',
-	url: 'press.api.notifications.get_support_unread_count',
+	url: 'press.api.notifications.get_unread_count',
+	params: { type: 'Support Access' },
 	initialData: 0,
 });

--- a/dashboard/src/pages/devtools/database/BinlogBrowser.vue
+++ b/dashboard/src/pages/devtools/database/BinlogBrowser.vue
@@ -250,7 +250,7 @@
 			class="z-1000 bg-white-overlay-800 absolute inset-0 flex justify-center items-center"
 			v-if="binlog_index_state_loaded && this.$resources?.timeline?.loading"
 		>
-			<div class="flex gap-2 text-base text-gray-800">
+			<div class="flex gap-2 text-base text-gray-800 items-center">
 				<Spinner class="w-4" />
 				Building timeline...
 			</div>


### PR DESCRIPTION
- open support access modal if the notification tile.type == 'Support Access' instead of going to that link 
- Unread dot indicator for notif icon in sidebar

<img width="460" height="378" alt="image" src="https://github.com/user-attachments/assets/b162dfc2-853b-4951-8a10-b6865839b7b1" />

<hr/>

- Open notification panel's request section on search item click

https://github.com/user-attachments/assets/9a928009-22aa-4725-b542-09a437934d06



