### PR TITLE
chore(dependencies): Add semgrep version 1.159.0 to project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "playwright==1.49.1",
     "prometheus-api-client==0.6.0",
     "pydo==0.24.0",
+    "semgrep==1.159.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Semgrep would be needed for the auditor to run the semgrep checks.