### PR TITLE
fix(search): Layout and platform specific shortcut issue

### DIFF
--- a/dashboard/src/components/navigation/sidebar/SearchItem.vue
+++ b/dashboard/src/components/navigation/sidebar/SearchItem.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import LucideSearch from '~icons/lucide/search';
-import LucideCommand from '~icons/lucide/command';
 import { searchModalOpen } from '@/data/ui';
+import { isMac } from '@/utils/device';
+
+const onMac = isMac();
 </script>
 
 <template>
@@ -10,9 +12,10 @@ import { searchModalOpen } from '@/data/ui';
 		@click="() => (searchModalOpen = true)"
 	>
 		<LucideSearch class="size-4 text-ink-gray-6 mr-1" />
-		<span class="text-left mr-auto"> Search</span>
-
-		<LucideCommand class="size-3.5 text-ink-gray-6" />
-		<span class="text-xs">K</span>
+		<span class="text-left mr-auto">Search</span>
+		<div class="flex items-center">
+			<span v-if="onMac" class="text-xs">⌘+K</span>
+			<span v-else class="text-xs">Ctrl+K</span>
+		</div>
 	</button>
 </template>

--- a/dashboard/src/utils/device.ts
+++ b/dashboard/src/utils/device.ts
@@ -17,3 +17,7 @@ export function getPlatform(): Platform {
 export function isMobile(): boolean {
 	return window.innerWidth < 640;
 }
+
+export function isMac(): boolean {
+	return getPlatform() === 'mac';
+}


### PR DESCRIPTION
* Add isMac utility to detect macOS devices
* Update SearchItem component to display ⌘+K for Mac and Ctrl+K for other platforms
* Command + K makes more sense to me, can be subjective opinion though, have seen both at various places. Framework has "+" so sticking with that.

### Screenshots:

On Mac:

<img width="2284" height="386" alt="CleanShot 2026-04-17 at 16 02 46@2x" src="https://github.com/user-attachments/assets/a3f77b66-e3bd-4b05-be70-cae0c08d2350" />

<br>

On Windows/Linux:

<img width="2064" height="256" alt="CleanShot 2026-04-17 at 16 18 18@2x" src="https://github.com/user-attachments/assets/3b2ff94c-e5f9-44dd-84bb-d37c1189e1a6" />


