### PR TITLE
fix(server): Only update virtual machine name if virtual machine is set

### DIFF
--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -538,11 +538,21 @@ class BaseServer(Document, TagHelpers):
 	def _set_hostname_abbreviation(self):
 		self.hostname_abbreviation = get_hostname_abbreviation(self.hostname)
 
+	def update_vm_if_present(self):
+		if not self.virtual_machine:
+			frappe.logger().debug(
+				f"Skipping VM update for {self.doctype} {self.name}: virtual_machine not set"
+			)
+			return
+
+		self.update_virtual_machine_name()
+
 	def after_insert(self):
 		if self.ip:
 			if self.doctype not in ["Database Server", "Server", "Proxy Server"] or not self.is_self_hosted:
 				self.create_dns_record()
-				self.update_virtual_machine_name()
+				self.update_vm_if_present()
+
 		elif (
 			self.private_ip
 			and self.doctype in ["Server", "Database Server"]
@@ -550,7 +560,7 @@ class BaseServer(Document, TagHelpers):
 			and not frappe.flags.in_test
 		):
 			self.create_dns_record()
-			self.update_virtual_machine_name()
+			self.update_vm_if_present()
 
 	@frappe.whitelist()
 	def create_dns_record(self):

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1185,7 +1185,7 @@ class BaseServer(Document, TagHelpers):
 
 	def update_virtual_machine_name(self):
 		if not self.virtual_machine:
-			return
+			return None
 		virtual_machine = frappe.get_doc("Virtual Machine", self.virtual_machine)
 		return virtual_machine.update_name_tag(self.name)
 

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -538,20 +538,11 @@ class BaseServer(Document, TagHelpers):
 	def _set_hostname_abbreviation(self):
 		self.hostname_abbreviation = get_hostname_abbreviation(self.hostname)
 
-	def update_vm_if_present(self):
-		if not self.virtual_machine:
-			frappe.logger().debug(
-				f"Skipping VM update for {self.doctype} {self.name}: virtual_machine not set"
-			)
-			return
-
-		self.update_virtual_machine_name()
-
 	def after_insert(self):
 		if self.ip:
 			if self.doctype not in ["Database Server", "Server", "Proxy Server"] or not self.is_self_hosted:
 				self.create_dns_record()
-				self.update_vm_if_present()
+				self.update_virtual_machine_name()
 
 		elif (
 			self.private_ip
@@ -560,7 +551,7 @@ class BaseServer(Document, TagHelpers):
 			and not frappe.flags.in_test
 		):
 			self.create_dns_record()
-			self.update_vm_if_present()
+			self.update_virtual_machine_name()
 
 	@frappe.whitelist()
 	def create_dns_record(self):
@@ -1193,6 +1184,8 @@ class BaseServer(Document, TagHelpers):
 		return find(machine.volumes, lambda v: v.device == "/dev/sda1")
 
 	def update_virtual_machine_name(self):
+		if not self.virtual_machine:
+			return
 		virtual_machine = frappe.get_doc("Virtual Machine", self.virtual_machine)
 		return virtual_machine.update_name_tag(self.name)
 


### PR DESCRIPTION
**Problem**

`update_virtual_machine_name()` was called unconditionally in `after_insert`, even when `virtual_machine` is not set (optional field).

This caused errors like:
"Virtual Machine None not found"

**Solution**

Guarded the call to `update_virtual_machine_name()` to run only when `virtual_machine` is present.

**Result**

Prevents invalid calls and avoids misleading errors when Virtual Machine is not provided.