### PR TITLE
fix(billing): Updating payment mode if the invoice is in draft state

### DIFF
--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -698,7 +698,7 @@ class Invoice(Document):
 		else:
 			self.billing_email = self.customer_email
 		self.currency = team.currency
-		if not self.payment_mode:
+		if not self.payment_mode or self.status == "Draft":
 			self.payment_mode = team.payment_mode
 		if not self.currency:
 			frappe.throw(f"Cannot create Invoice because Currency is not set in Team {self.team}")


### PR DESCRIPTION
User will be in their old payment mode even if they have changed their payment mode in the mid of month. This will allow user to overwrite their payment mode until it is in draft state. This way invoice will always use the payment mode that the user has set latest.