### PR TITLE
feat(deploy): Add validating state to deploys

### DIFF
--- a/dashboard/src/components/group/UpdateReleaseGroupDialog.vue
+++ b/dashboard/src/components/group/UpdateReleaseGroupDialog.vue
@@ -548,6 +548,7 @@ export default {
 					}
 				},
 				onSuccess(candidate) {
+					// Backward compatibility in case we switch to the older deploy flow which returns a candidate
 					if (candidate) {
 						this.$router.push({
 							name: 'Deploy Candidate',

--- a/dashboard/src/objects/group.js
+++ b/dashboard/src/objects/group.js
@@ -1,4 +1,4 @@
-import { LoadingIndicator, Tooltip } from 'frappe-ui';
+import { LoadingIndicator, Tooltip, frappeRequest } from 'frappe-ui';
 import { defineAsyncComponent, h } from 'vue';
 import { toast } from 'vue-sonner';
 import LucideAppWindow from '~icons/lucide/app-window';
@@ -15,6 +15,49 @@ import { getToastErrorMessage } from '../utils/toast';
 import { getJobsTab } from './common/jobs';
 import { getPatchesTab } from './common/patches';
 import { tagTab } from './common/tags';
+
+const pollingGroups = new Set();
+
+function pollReleasePipelineValidationStatus(group) {
+	if (pollingGroups.has(group.doc.name)) return; // already polling
+	if (!group.doc.deploy_information.has_running_release_pipeline) return;
+	if (group.doc.deploy_information.deploy_in_progress) return;
+
+	pollingGroups.add(group.doc.name);
+
+	console.log(
+		'POLLING FOR VALIDATION STATUS!',
+		group.doc.deploy_information.has_running_release_pipeline,
+		group.doc.deploy_information.deploy_in_progress,
+	);
+
+	function poll() {
+		frappeRequest({
+			url: 'press.api.bench.is_deploy_validating',
+			params: { name: group.name },
+		})
+			.then((result) => {
+				console.log(result);
+				if (!group.doc.deploy_information.has_running_release_pipeline) {
+					pollingGroups.delete(group.doc.name);
+					return;
+				}
+
+				if (result) {
+					setTimeout(poll, 2000);
+				} else {
+					group.doc.deploy_information.has_running_release_pipeline = false;
+					group.doc.deploy_information.deploy_in_progress = true;
+					pollingGroups.delete(group.doc.name);
+				}
+			})
+			.catch(() => {
+				pollingGroups.delete(group.doc.name);
+			});
+	}
+
+	poll();
+}
 
 export default {
 	doctype: 'Release Group',
@@ -876,6 +919,11 @@ export default {
 			let { documentResource: group } = context;
 			let team = getTeam();
 
+			if (group.doc?.deploy_information?.has_running_release_pipeline) {
+				console.log('coming from here');
+				pollReleasePipelineValidationStatus(group);
+			}
+
 			return [
 				{
 					label: 'Impersonate Group Owner',
@@ -922,27 +970,7 @@ export default {
 											name: candidate,
 										};
 									}
-									// Listen for the background task to signal deploy is actually running
-									function handleUpdate({
-										status,
-										group: benchGroup,
-										deploy_candidate_build: candidate,
-									}) {
-										if (benchGroup !== group.name) return;
-
-										if (status === 'deploy-in-progress') {
-											group.doc.deploy_information.deploy_in_progress = true;
-											group.doc.deploy_information.last_deploy = {
-												name: candidate,
-											};
-										} else if (status === 'failure') {
-											group.doc.deploy_information.deploy_in_progress = false;
-										}
-
-										$socket.off('release_pipeline_update', handleUpdate);
-									}
-
-									$socket.on('release_pipeline_update', handleUpdate);
+									pollReleasePipelineValidationStatus(group);
 								},
 							}),
 						);

--- a/dashboard/src/objects/group.js
+++ b/dashboard/src/objects/group.js
@@ -21,33 +21,35 @@ const pollingGroups = new Set();
 function pollReleasePipelineValidationStatus(group) {
 	if (pollingGroups.has(group.doc.name)) return; // already polling
 	if (!group.doc.deploy_information.has_running_release_pipeline) return;
-	if (group.doc.deploy_information.deploy_in_progress) return;
 
 	pollingGroups.add(group.doc.name);
 
-	console.log(
-		'POLLING FOR VALIDATION STATUS!',
-		group.doc.deploy_information.has_running_release_pipeline,
-		group.doc.deploy_information.deploy_in_progress,
-	);
-
 	function poll() {
 		frappeRequest({
-			url: 'press.api.bench.is_deploy_validating',
+			url: 'press.api.bench.deploy_status',
 			params: { name: group.name },
 		})
-			.then((result) => {
-				console.log(result);
+			.then(({ is_validating, is_deploy_in_progress, candidate }) => {
 				if (!group.doc.deploy_information.has_running_release_pipeline) {
 					pollingGroups.delete(group.doc.name);
 					return;
 				}
 
-				if (result) {
-					setTimeout(poll, 2000);
+				group.doc.deploy_information.deploy_in_progress = Boolean(
+					is_deploy_in_progress,
+				);
+
+				if (candidate) {
+					group.doc.deploy_information.last_deploy = {
+						name: candidate,
+					};
+				}
+
+				if (is_validating) {
+					setTimeout(poll, 2000); // still validating, keep polling
 				} else {
+					// Validation done
 					group.doc.deploy_information.has_running_release_pipeline = false;
-					group.doc.deploy_information.deploy_in_progress = true;
 					pollingGroups.delete(group.doc.name);
 				}
 			})
@@ -919,8 +921,10 @@ export default {
 			let { documentResource: group } = context;
 			let team = getTeam();
 
-			if (group.doc?.deploy_information?.has_running_release_pipeline) {
-				console.log('coming from here');
+			if (
+				group.doc?.deploy_information?.has_running_release_pipeline &&
+				!group.doc?.deploy_information?.deploy_in_progress
+			) {
 				pollReleasePipelineValidationStatus(group);
 			}
 

--- a/dashboard/src/objects/group.js
+++ b/dashboard/src/objects/group.js
@@ -928,14 +928,6 @@ export default {
 										group: benchGroup,
 										deploy_candidate_build: candidate,
 									}) {
-										console.log(
-											'Received update for bench',
-											benchGroup,
-											'with status',
-											status,
-											'and candidate',
-											candidate,
-										);
 										if (benchGroup !== group.name) return;
 
 										if (status === 'deploy-in-progress') {

--- a/dashboard/src/objects/group.js
+++ b/dashboard/src/objects/group.js
@@ -558,6 +558,7 @@ export default {
 													group.doc.deploy_information.last_deploy.name =
 														candidate;
 												}
+												pollReleasePipelineValidationStatus(group);
 											},
 										}),
 									);

--- a/dashboard/src/objects/group.js
+++ b/dashboard/src/objects/group.js
@@ -498,7 +498,9 @@ export default {
 								} else if (group.doc.deploy_information.update_available) {
 									let UpdateReleaseGroupDialog = defineAsyncComponent(
 										() =>
-											import('../components/group/UpdateReleaseGroupDialog.vue'),
+											import(
+												'../components/group/UpdateReleaseGroupDialog.vue'
+											),
 									);
 									renderDialog(
 										h(UpdateReleaseGroupDialog, {
@@ -819,7 +821,9 @@ export default {
 								onClick() {
 									let ConfigEditorDialog = defineAsyncComponent(
 										() =>
-											import('../components/EnvironmentVariableEditorDialog.vue'),
+											import(
+												'../components/EnvironmentVariableEditorDialog.vue'
+											),
 									);
 									renderDialog(
 										h(ConfigEditorDialog, {
@@ -910,14 +914,43 @@ export default {
 								bench: group.name,
 								lastDeploy: group.doc?.deploy_information?.last_deploy,
 								onSuccess(candidate) {
-									// group.doc.deploy_information.has_running_release_pipeline = true;
-									group.doc.deploy_information.deploy_in_progress = true;
+									group.doc.deploy_information.has_running_release_pipeline = true;
 									group.doc.deploy_information.update_available = false;
+
 									if (candidate) {
 										group.doc.deploy_information.last_deploy = {
 											name: candidate,
 										};
 									}
+									// Listen for the background task to signal deploy is actually running
+									function handleUpdate({
+										status,
+										group: benchGroup,
+										deploy_candidate_build: candidate,
+									}) {
+										console.log(
+											'Received update for bench',
+											benchGroup,
+											'with status',
+											status,
+											'and candidate',
+											candidate,
+										);
+										if (benchGroup !== group.name) return;
+
+										if (status === 'deploy-in-progress') {
+											group.doc.deploy_information.deploy_in_progress = true;
+											group.doc.deploy_information.last_deploy = {
+												name: candidate,
+											};
+										} else if (status === 'failure') {
+											group.doc.deploy_information.deploy_in_progress = false;
+										}
+
+										$socket.off('release_pipeline_update', handleUpdate);
+									}
+
+									$socket.on('release_pipeline_update', handleUpdate);
 								},
 							}),
 						);

--- a/press/api/bench.py
+++ b/press/api/bench.py
@@ -19,6 +19,7 @@ from press.press.doctype.app.app import get_app_from_policies
 from press.press.doctype.app_patch.app_patch import create_app_patch
 from press.press.doctype.bench_update.bench_update import get_bench_update
 from press.press.doctype.cluster.cluster import Cluster
+from press.press.doctype.deploy_candidate.deploy_candidate import RESTING_STATES, TRANSITORY_STATES
 from press.press.doctype.deploy_candidate_build.deploy_candidate_build import (
 	fail_and_redeploy as fail_and_redeploy_build,
 )
@@ -1273,21 +1274,60 @@ def search_releases(
 
 @frappe.whitelist()
 @protected("Release Group")
-def is_deploy_validating(name: str) -> bool:
-	"""Check if there is a deploy in validating state for the release group. A deploy is validating if the build doc is not created yet"""
-	release_pipeline = frappe.db.get_value(
-		"Release Pipeline", {"release_group": name, "status": ("in", ["Running", "Pending"])}
+def deploy_status(name: str) -> dict[str, bool | str | None]:
+	"""
+	Determine deployment state for a Release Group.
+
+	States:
+	- validating: pipeline exists, but no deploy candidate yet
+	- deploying: candidate exists and is in progress
+	- idle: no active pipeline or deployment finished
+	"""
+
+	ACTIVE_PIPELINE_STATUSES = ("Running", "Pending")
+
+	def response(is_validating=False, is_deploy_in_progress=False, candidate=None):
+		return {
+			"is_validating": is_validating,
+			"is_deploy_in_progress": is_deploy_in_progress,
+			"candidate": candidate,
+		}
+
+	# 1. Get active pipeline (latest one implicitly via creation filter)
+	pipeline_creation = frappe.db.get_value(
+		"Release Pipeline",
+		{
+			"release_group": name,
+			"status": ["in", ACTIVE_PIPELINE_STATUSES],
+		},
+		"creation",
+		order_by="creation desc",
 	)
 
-	if not release_pipeline:
-		return False
+	if not pipeline_creation:
+		return response()
 
-	newly_created_build = frappe.db.get_value(
+	# 2. Get latest deploy candidate AFTER pipeline start
+	dc = frappe.db.get_value(
 		"Deploy Candidate Build",
-		{"group": name, "status": ("in", ["Pending", "Running", "Scheduled", "Preparing"])},
+		{
+			"group": name,
+			"creation": (">", pipeline_creation),
+		},
+		["name", "status"],
+		order_by="creation desc",
 	)
 
-	if newly_created_build:
-		return False
+	if not dc:
+		return response(is_validating=True)
 
-	return True
+	candidate, status = dc
+
+	# 3. Map status → UI state
+	if status in TRANSITORY_STATES:
+		return response(is_deploy_in_progress=True, candidate=candidate)
+
+	if status in RESTING_STATES:
+		return response()
+
+	return response(is_validating=True)

--- a/press/api/bench.py
+++ b/press/api/bench.py
@@ -1293,7 +1293,6 @@ def deploy_status(name: str) -> dict[str, bool | str | None]:
 			"candidate": candidate,
 		}
 
-	# 1. Get active pipeline (latest one implicitly via creation filter)
 	pipeline_creation = frappe.db.get_value(
 		"Release Pipeline",
 		{
@@ -1301,13 +1300,11 @@ def deploy_status(name: str) -> dict[str, bool | str | None]:
 			"status": ["in", ACTIVE_PIPELINE_STATUSES],
 		},
 		"creation",
-		order_by="creation desc",
 	)
 
 	if not pipeline_creation:
 		return response()
 
-	# 2. Get latest deploy candidate AFTER pipeline start
 	dc = frappe.db.get_value(
 		"Deploy Candidate Build",
 		{
@@ -1315,7 +1312,6 @@ def deploy_status(name: str) -> dict[str, bool | str | None]:
 			"creation": (">", pipeline_creation),
 		},
 		["name", "status"],
-		order_by="creation desc",
 	)
 
 	if not dc:

--- a/press/api/bench.py
+++ b/press/api/bench.py
@@ -1269,3 +1269,25 @@ def search_releases(
 	)
 
 	return q.run(as_dict=1)
+
+
+@frappe.whitelist()
+@protected("Release Group")
+def is_deploy_validating(name: str) -> bool:
+	"""Check if there is a deploy in validating state for the release group. A deploy is validating if the build doc is not created yet"""
+	release_pipeline = frappe.db.get_value(
+		"Release Pipeline", {"release_group": name, "status": ("in", ["Running", "Pending"])}
+	)
+
+	if not release_pipeline:
+		return False
+
+	newly_created_build = frappe.db.get_value(
+		"Deploy Candidate Build",
+		{"group": name, "status": ("in", ["Pending", "Running", "Scheduled", "Preparing"])},
+	)
+
+	if newly_created_build:
+		return False
+
+	return True

--- a/press/press/doctype/release_pipeline/release_pipeline.py
+++ b/press/press/doctype/release_pipeline/release_pipeline.py
@@ -442,6 +442,11 @@ class ReleasePipeline(WorkflowBuilder):
 			self.validate_server_storages()
 			self.validate_auto_scales_on_servers()
 		except (frappe.ValidationError, InsufficientSpaceOnServer) as e:
+			frappe.publish_realtime(
+				"release_pipeline_update",
+				doctype="Release Pipeline",
+				message={"status": "failure", "group": self.release_group},
+			)
 			raise ReleasePipelineFailure(str(e)) from e
 
 	@task
@@ -493,6 +498,17 @@ class ReleasePipeline(WorkflowBuilder):
 			self.add_implicit_app_dependencies(deploy_candidate)
 			self.auto_update_bench_dependency_versions(deploy_candidate)
 			primary_build = self.initiate_pre_build_validations(deploy_candidate)
+
+			frappe.publish_realtime(
+				"release_pipeline_update",
+				doctype="Release Pipeline",
+				message={
+					"status": "deploy-in-progress",
+					"group": self.release_group,
+					"deploy_candidate_build": primary_build,
+				},
+			)
+
 			return deploy_candidate, primary_build
 		except frappe.ValidationError as e:
 			raise ReleasePipelineFailure(f"Failed to prepare deployment: {e!s}") from e

--- a/press/press/doctype/release_pipeline/release_pipeline.py
+++ b/press/press/doctype/release_pipeline/release_pipeline.py
@@ -442,11 +442,6 @@ class ReleasePipeline(WorkflowBuilder):
 			self.validate_server_storages()
 			self.validate_auto_scales_on_servers()
 		except (frappe.ValidationError, InsufficientSpaceOnServer) as e:
-			frappe.publish_realtime(
-				"release_pipeline_update",
-				doctype="Release Pipeline",
-				message={"status": "failure", "group": self.release_group},
-			)
 			raise ReleasePipelineFailure(str(e)) from e
 
 	@task
@@ -642,6 +637,12 @@ class ReleasePipeline(WorkflowBuilder):
 			self.monitor_bench_creation(primary_build)
 
 		except ReleasePipelineFailure:
+			# Just in case, make sure that we mark the pipeline as failed and notify the frontend to stop listening for deploy updates
+			frappe.publish_realtime(
+				"release_pipeline_update",
+				doctype="Release Pipeline",
+				message={"status": "failure", "group": self.release_group},
+			)
 			self.update_pipeline_status("Failure")
 
 		workflow_status = frappe.db.get_value("Press Workflow", self.workflow_name, "status")

--- a/press/press/doctype/release_pipeline/release_pipeline.py
+++ b/press/press/doctype/release_pipeline/release_pipeline.py
@@ -494,16 +494,6 @@ class ReleasePipeline(WorkflowBuilder):
 			self.auto_update_bench_dependency_versions(deploy_candidate)
 			primary_build = self.initiate_pre_build_validations(deploy_candidate)
 
-			frappe.publish_realtime(
-				"release_pipeline_update",
-				doctype="Release Pipeline",
-				message={
-					"status": "deploy-in-progress",
-					"group": self.release_group,
-					"deploy_candidate_build": primary_build,
-				},
-			)
-
 			return deploy_candidate, primary_build
 		except frappe.ValidationError as e:
 			raise ReleasePipelineFailure(f"Failed to prepare deployment: {e!s}") from e
@@ -638,11 +628,6 @@ class ReleasePipeline(WorkflowBuilder):
 
 		except ReleasePipelineFailure:
 			# Just in case, make sure that we mark the pipeline as failed and notify the frontend to stop listening for deploy updates
-			frappe.publish_realtime(
-				"release_pipeline_update",
-				doctype="Release Pipeline",
-				message={"status": "failure", "group": self.release_group},
-			)
 			self.update_pipeline_status("Failure")
 
 		workflow_status = frappe.db.get_value("Press Workflow", self.workflow_name, "status")


### PR DESCRIPTION
Added validation state to deploys.

Transition between validation -> deploy-in-progress is handled via polling
<img width="1185" height="217" alt="Screenshot 2026-04-21 at 1 50 35 PM" src="https://github.com/user-attachments/assets/f18e1c9b-bf54-4650-a921-2a134e8c5045" />
<img width="1173" height="301" alt="Screenshot 2026-04-21 at 1 50 54 PM" src="https://github.com/user-attachments/assets/2b33aa50-249b-43b9-a16e-30c1bf6f75cd" />

