### PR TITLE
feat(auditor): Add more security checks for shell and template injection

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -779,6 +779,7 @@
         "picklable",
         "ndarray",
         "mult",
-        "ruleid"
+        "ruleid",
+        "ssti"
     ]
 }

--- a/press/marketplace/doctype/marketplace_app_audit/checks/semgrep-rules/security/command_execution.py
+++ b/press/marketplace/doctype/marketplace_app_audit/checks/semgrep-rules/security/command_execution.py
@@ -1,0 +1,79 @@
+import os
+import subprocess
+
+import frappe
+
+
+def os_system_example(user_input):
+	# ruleid: frappe-os-command-exec
+	os.system(f"echo {user_input}")
+
+
+def os_popen_example(user_input):
+	# ruleid: frappe-os-command-exec
+	os.popen(user_input)
+
+
+def os_execl_example(user_input):
+	# ruleid: frappe-os-command-exec
+	os.execl(user_input)
+
+
+def os_execle_example(user_input):
+	# ruleid: frappe-os-command-exec
+	os.execle(user_input)
+
+
+def os_execv_example(user_input):
+	# ruleid: frappe-os-command-exec
+	os.execv(user_input)
+
+
+def os_execve_example(user_input):
+	# ruleid: frappe-os-command-exec
+	os.execve(user_input)
+
+
+def os_execvp_example(user_input):
+	# ruleid: frappe-os-command-exec
+	os.execvp(user_input)
+
+
+def os_execvpe_example(user_input):
+	# ruleid: frappe-os-command-exec
+	os.execvpe(user_input)
+
+
+def subprocess_shell_true(user_input):
+	# ruleid: frappe-subprocess-shell-true
+	subprocess.run(f"ls {user_input}", shell=True)
+
+
+def subprocess_popen_shell_true(user_input):
+	# ruleid: frappe-subprocess-shell-true
+	subprocess.Popen(user_input, shell=True)
+
+
+def subprocess_run_list(user_input):
+	# ruleid: frappe-subprocess-exec
+	subprocess.run(["ls", user_input])
+
+
+def subprocess_check_output(user_input):
+	# ruleid: frappe-subprocess-exec
+	subprocess.check_output(["cat", user_input])
+
+
+def frappe_execute_in_shell_example(cmd):
+	# ruleid: frappe-execute-in-shell
+	frappe.utils.execute_in_shell(cmd)
+
+
+def ok_os_path():
+	# ok: frappe-os-command-exec
+	return os.path.join("/tmp", "foo")
+
+
+def ok_os_getenv():
+	# ok: frappe-os-command-exec
+	return os.getenv("FRAPPE_SITE")

--- a/press/marketplace/doctype/marketplace_app_audit/checks/semgrep-rules/security/command_execution.yml
+++ b/press/marketplace/doctype/marketplace_app_audit/checks/semgrep-rules/security/command_execution.yml
@@ -1,0 +1,107 @@
+rules:
+- id: frappe-os-command-exec
+  patterns:
+  - pattern-either:
+    - pattern: os.system(...)
+    - pattern: os.popen(...)
+    - pattern: os.execl(...)
+    - pattern: os.execle(...)
+    - pattern: os.execv(...)
+    - pattern: os.execve(...)
+    - pattern: os.execvp(...)
+    - pattern: os.execvpe(...)
+  message: |
+    `os.system` / `os.popen` invoke the shell, and os.exec* replace the current process with the command you interpolate. These are classic
+    command-injection sinks. Ensure that arguments are not user-controlled to prevent command injection. This code should be manually audited by review/security team.
+  metadata:
+    marketplace_check_id: security_os_command_exec
+    marketplace_check_name: OS Command Execution
+    marketplace_category: Security
+    remediation: |
+      Replace with `subprocess.run([...], shell=False)` using an argument list, and
+      validate any user-controlled values. This code should be manually audited by review/security team.
+  languages: [python]
+  severity: ERROR
+  paths:
+    exclude:
+      - "**/test_*.py"
+      - "**/tests/**"
+
+- id: frappe-subprocess-shell-true
+  patterns:
+  - pattern-either:
+    - pattern: subprocess.run(..., shell=True, ...)
+    - pattern: subprocess.Popen(..., shell=True, ...)
+    - pattern: subprocess.call(..., shell=True, ...)
+    - pattern: subprocess.check_call(..., shell=True, ...)
+    - pattern: subprocess.check_output(..., shell=True, ...)
+  message: |
+    `subprocess` called with `shell=True`. Any interpolated value becomes a shell
+    injection sink. This code should be manually audited by review/security team.
+  metadata:
+    marketplace_check_id: security_subprocess_shell_true
+    marketplace_check_name: Subprocess With shell=True
+    marketplace_category: Security
+    remediation: |
+      Pass the command as an argument list with `shell=False` (the default):
+      `subprocess.run(["cmd", arg1, arg2])`. If a shell is truly unavoidable, wrap
+      every substituted value with `shlex.quote`.
+  languages: [python]
+  severity: ERROR
+  paths:
+    exclude:
+      - "**/test_*.py"
+      - "**/tests/**"
+
+- id: frappe-subprocess-exec
+  patterns:
+  - pattern-either:
+    - pattern: subprocess.run(...)
+    - pattern: subprocess.Popen(...)
+    - pattern: subprocess.call(...)
+    - pattern: subprocess.check_call(...)
+    - pattern: subprocess.check_output(...)
+  - pattern-not: subprocess.run(..., shell=True, ...)
+  - pattern-not: subprocess.Popen(..., shell=True, ...)
+  - pattern-not: subprocess.call(..., shell=True, ...)
+  - pattern-not: subprocess.check_call(..., shell=True, ...)
+  - pattern-not: subprocess.check_output(..., shell=True, ...)
+  message: |
+    `subprocess` call spawns an external process. Needs to be reviewed by review/security team to confirm
+    arguments are a static list and any interpolated values are validated.
+  metadata:
+    marketplace_check_id: security_subprocess_exec
+    marketplace_check_name: Subprocess Execution
+    marketplace_category: Security
+    remediation: |
+      Needs to be reviewed by review/security team. Keep arguments as a literal list (not a concatenated
+      string) and validate any user-controlled values before interpolation.
+  languages: [python]
+  severity: WARNING
+  paths:
+    exclude:
+      - "**/test_*.py"
+      - "**/tests/**"
+
+- id: frappe-execute-in-shell
+  patterns:
+  - pattern-either:
+    - pattern: frappe.utils.execute_in_shell(...)
+    - pattern: frappe.execute_in_shell(...)
+    - pattern: execute_in_shell(...)
+  message: |
+    `frappe.utils.execute_in_shell` runs the command through `/bin/sh`. Any
+    interpolated value becomes command injection. This code should be manually audited by review/security team.
+  metadata:
+    marketplace_check_id: security_frappe_execute_in_shell
+    marketplace_check_name: Frappe execute_in_shell
+    marketplace_category: Security
+    remediation: |
+      Replace with `subprocess.run([...], shell=False)` using an argument list, and
+      validate any user-controlled values. This code should be manually audited by review/security team.
+  languages: [python]
+  severity: ERROR
+  paths:
+    exclude:
+      - "**/test_*.py"
+      - "**/tests/**"

--- a/press/marketplace/doctype/marketplace_app_audit/checks/semgrep-rules/security/rce.py
+++ b/press/marketplace/doctype/marketplace_app_audit/checks/semgrep-rules/security/rce.py
@@ -1,3 +1,53 @@
-def function_name(input):
+import codeop
+
+import jinja2
+from jinja2 import Environment, Template
+
+
+def eval_example(user_input):
 	# ruleid: frappe-codeinjection-eval
-	eval(input)
+	eval(user_input)
+
+
+def exec_example(user_input):
+	# ruleid: frappe-codeinjection-eval
+	exec(user_input)
+
+
+def compile_example(user_input):
+	# ruleid: frappe-codeinjection-eval
+	compile(user_input, "<string>", "exec")
+
+
+def codeop_example(user_input):
+	# ruleid: frappe-codeinjection-eval
+	codeop.compile_command(user_input)
+
+
+def ssti_example(user_template):
+	import frappe
+
+	# ruleid: frappe-ssti
+	frappe.render_template(user_template, {})
+
+
+def jinja_env_example():
+	# ruleid: frappe-direct-jinja-construction
+	jinja2.Environment(autoescape=False)
+
+
+def jinja_template_example(user_source):
+	# ruleid: frappe-direct-jinja-construction
+	Template(user_source)
+
+
+def jinja_alias_example(user_source):
+	# ruleid: frappe-direct-jinja-construction
+	Environment(autoescape=False)
+
+
+def ok_literal_eval(user_input):
+	import ast
+
+	# ok: frappe-codeinjection-eval
+	return ast.literal_eval(user_input)

--- a/press/marketplace/doctype/marketplace_app_audit/checks/semgrep-rules/security/rce.yml
+++ b/press/marketplace/doctype/marketplace_app_audit/checks/semgrep-rules/security/rce.yml
@@ -6,6 +6,10 @@ rules:
     - pattern: exec(...)
     - pattern: safe_exec(...)
     - pattern: safe_eval(...)
+    - pattern: compile(...)
+    - pattern: codeop.compile_command(...)
+    - pattern: codeop.Compile(...)
+    - pattern: codeop.CommandCompiler(...)
   message: |
     Detected the use of functions that can be  dangerous if used to evaluate
     dynamic content. This code should be manually audited by review/security team.
@@ -21,12 +25,14 @@ rules:
   paths:
     exclude:
       - "**/test_*.py"
+      - "**/tests/**"
 
 - id: frappe-ssti
   patterns:
   - pattern-either:
     - pattern: render_template($ARG, ...)
     - pattern: frappe.render_template($ARG, ...)
+    - pattern: frappe.utils.jinja.render_template($ARG, ...)
   message: |
     Detected the use of render_template, make sure $ARG comes from trusted
     source. This code should be audited by review/security team.
@@ -35,10 +41,42 @@ rules:
     marketplace_check_name: SSTI
     marketplace_category: Security
     remediation: |
-      Detected the use of render_template, make sure $ARG comes from trusted
-      source. This code should be audited by review/security team.
+      Ensure `$ARG` is a hard-coded template path/string defined in the app, not a
+      value from request, DB, or filesystem. If dynamic templates are unavoidable,
+      restrict the source to a trusted directory and reject template names containing
+      `..` or absolute paths.
   languages: [python]
   severity: ERROR
   paths:
     exclude:
       - "**/test_*.py"
+      - "**/tests/**"
+
+- id: frappe-direct-jinja-construction
+  patterns:
+  - pattern-either:
+    - pattern: jinja2.Environment(...)
+    - pattern: jinja2.Template(...)
+    - pattern: jinja.Environment(...)
+    - pattern: jinja.Template(...)
+    - pattern: Environment(autoescape=False, ...)
+    - pattern: Template(...)
+  message: |
+    Direct construction of a Jinja `Environment`/`Template`. Without `autoescape=True`
+    and a constrained loader, user-controlled templates can execute arbitrary Python
+    via template injection.
+  metadata:
+    marketplace_check_id: security_direct_jinja_construction
+    marketplace_check_name: Direct Jinja Construction
+    marketplace_category: Security
+    remediation: |
+      Prefer `frappe.render_template` with a trusted template path. If a custom
+      environment is required, pass `autoescape=True` and a loader restricted to a
+      specific directory (e.g. `FileSystemLoader(trusted_dir)`). Never instantiate
+      `Template(user_input)`.
+  languages: [python]
+  severity: ERROR
+  paths:
+    exclude:
+      - "**/test_*.py"
+      - "**/tests/**"


### PR DESCRIPTION
Added a few more common checks that the Auditor can scan for os, subprocess and jinja templating vulnerabilities.
The only ones which I knew about before were related SSTI (server side template injection).

The os and subprocess command checks were an extension of what the code-screening flags would use to detect. They used to flag all uses of os and subprocess commands, but with semgrep we can be more specific and only flag for specific patterns.

Then I googled, and used AI to know more about potential common vulnerabilities which can occur via these commands, particularly shell injections. Understood a few common patterns and their fixes. Then I tried to translate them into common developer comprehensible words which people can then use to fix.

There are a few other checks which we need to add, have made a note of it. Will keep adding as we go.

Ofc, I am not a security engineer (yet, lol), still learning about these things, but seems fun.