### PR TITLE
refactor(payment-extension): Add status in payment extension

### DIFF
--- a/press/api/billing.py
+++ b/press/api/billing.py
@@ -1117,9 +1117,11 @@ def handle_transaction_result(transaction_response, integration_request):
 
 	result_code = transaction_response.get("ResultCode")
 	status = None
+	current_user = frappe.session.user
 
 	if result_code == 0:
 		try:
+			frappe.set_user("Administrator")  # To create BT and Invoice
 			status = "Completed"
 			create_mpesa_request_log(
 				transaction_response, "Host", "Mpesa Express", integration_request, None, status
@@ -1127,6 +1129,7 @@ def handle_transaction_result(transaction_response, integration_request):
 
 			create_mpesa_payment_record(transaction_response)
 		except Exception as e:
+			frappe.set_user(current_user)  # reset to current user
 			frappe.log_error(f"Mpesa: Transaction failed with error {e}")
 
 	elif result_code == 1037:  # User unreachable (Phone off or timeout)

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -318,7 +318,7 @@ class Invoice(Document):
 					)
 				)
 
-		self.save(ignore_permissions=True)
+		self.save()
 
 		if self.amount_due > 0:
 			if self.payment_mode == "Prepaid Credits":
@@ -946,7 +946,7 @@ class Invoice(Document):
 				{"invoice": self.name, "amount": allocated, "currency": self.currency},
 			)
 			# ignore permissions for BT added via Mpesa
-			doc.save(ignore_permissions=True)
+			doc.save()
 			total_allocated += allocated
 
 		balance_transaction = frappe.get_doc(
@@ -955,7 +955,7 @@ class Invoice(Document):
 			type="Applied To Invoice",
 			amount=total_allocated * -1,
 			invoice=self.name,
-		).insert(ignore_permissions=True)
+		).insert()
 		balance_transaction.submit()
 
 		self.applied_credits = sum(row.amount for row in self.credit_allocations)

--- a/press/press/doctype/payment_due_extension/payment_due_extension.json
+++ b/press/press/doctype/payment_due_extension/payment_due_extension.json
@@ -8,7 +8,8 @@
   "team",
   "extension_date",
   "reason",
-  "amended_from"
+  "amended_from",
+  "status"
  ],
  "fields": [
   {
@@ -18,7 +19,8 @@
    "in_list_view": 1,
    "label": "Team",
    "options": "Team",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "extension_date",
@@ -42,12 +44,20 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "Draft\nActive\nExpired"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-04-14 11:55:56.662380",
+ "modified": "2026-04-21 12:56:37.114551",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Payment Due Extension",
@@ -66,6 +76,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/press/press/doctype/payment_due_extension/payment_due_extension.py
+++ b/press/press/doctype/payment_due_extension/payment_due_extension.py
@@ -18,6 +18,7 @@ class PaymentDueExtension(Document):
 		amended_from: DF.Link | None
 		extension_date: DF.Date
 		reason: DF.SmallText
+		status: DF.Literal["Draft", "Active", "Expired"]
 		team: DF.Link
 	# end: auto-generated types
 
@@ -33,18 +34,19 @@ class PaymentDueExtension(Document):
 			frappe.throw("An active Payment due extension record already exists for this team")
 
 	def on_submit(self):
+		self.status = "Active"
 		frappe.db.set_value("Team", self.team, "extend_payment_due_suspension", 1)
-	
-	def on_cancel(self):
+
+	def expire(self):
+		frappe.db.set_value("Payment Due Extension", self.name, "status", "Expired")
 		frappe.db.set_value("Team", self.team, "extend_payment_due_suspension", 0)
 
 
 def remove_payment_due_extension():
 	extensions = frappe.get_all(
 		"Payment Due Extension",
-		{"docstatus": 1, "extension_date": ("<", frappe.utils.today())},
-		pluck="team",
+		{"docstatus": 1, "extension_date": ("<", frappe.utils.today()), "status": "Active"},
+		pluck="name",
 	)
-	for team in extensions:
-		frappe.db.set_value("Team", team, "extend_payment_due_suspension", 0)
-		frappe.db.commit()
+	for name in extensions:
+		frappe.get_doc("Payment Due Extension", name).expire()


### PR DESCRIPTION
- Instead of cancelling the extension doc, change the
status to expire
- Only filter with Active extension doc