### PR TITLE
fix(release-pipeline): Get latest retried build with the same platform

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -780,7 +780,7 @@
         "ndarray",
         "mult",
         "ruleid",
-        "chatwoot"
+        "chatwoot",
         "ssti"
     ]
 }

--- a/press/press/doctype/release_pipeline/release_pipeline.json
+++ b/press/press/doctype/release_pipeline/release_pipeline.json
@@ -22,6 +22,7 @@
   {
    "fieldname": "release_group",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Release Group",
    "options": "Release Group",
    "read_only": 1,
@@ -31,6 +32,7 @@
    "default": "Pending",
    "fieldname": "status",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Status",
    "options": "Pending\nRunning\nPartial Success\nSuccess\nFailure\nRetrying"
   }
@@ -38,7 +40,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-09 15:10:24.783344",
+ "modified": "2026-04-22 15:25:16.828078",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Release Pipeline",

--- a/press/press/doctype/release_pipeline/release_pipeline.py
+++ b/press/press/doctype/release_pipeline/release_pipeline.py
@@ -168,7 +168,12 @@ class ReleasePipeline(WorkflowBuilder):
 			"Press Workflow", {"linked_doctype": "Release Pipeline", "linked_docname": self.name}, "name"
 		)
 
-	@task
+	@staticmethod
+	def _get_task_execution_queue() -> str:
+		"""Determine the appropriate queue for task execution based on the release group."""
+		return "default" if frappe.conf.developer_mode else "build"
+
+	@task(queue=_get_task_execution_queue())
 	def validate_app_hashes(self, apps: list[dict[str, str]]):
 		"""Validate App Hashes"""
 		from press.api.bench import validate_app_hashes as app_hash_validation
@@ -177,17 +182,17 @@ class ReleasePipeline(WorkflowBuilder):
 
 		self.update_pipeline_status("Running")  # Mark the pipeline as running!
 
-	@task
+	@task(queue=_get_task_execution_queue())
 	def validate_server_storages(self):
 		"""Validate server storage for all servers in the release group."""
 		self.release_group_doc.check_app_server_storage()
 
-	@task
+	@task(queue=_get_task_execution_queue())
 	def validate_auto_scales_on_servers(self):
 		"""Validate no server in release group is autoscaled."""
 		self.release_group_doc.check_auto_scales()
 
-	@task
+	@task(queue=_get_task_execution_queue())
 	def create_deploy_candidate(
 		self,
 		apps: list[dict[str, str]],
@@ -206,7 +211,7 @@ class ReleasePipeline(WorkflowBuilder):
 			create_build=create_deploy,
 		)
 
-	@task
+	@task(queue=_get_task_execution_queue())
 	def initiate_pre_build_validations(self, deploy_candidate: str) -> str:
 		"""Start the deploy candidate build process which will run the pre-build validations."""
 		candidate: DeployCandidate = frappe.get_doc("Deploy Candidate", deploy_candidate)
@@ -268,7 +273,7 @@ class ReleasePipeline(WorkflowBuilder):
 
 		return retried_build or deploy_candidate_build
 
-	@task
+	@task(queue=_get_task_execution_queue())
 	def monitor_pre_build_validation(self, deploy_candidate_build: str):
 		"""Monitors the Deploy Candidate Build until the remote build job is created."""
 		deploy_candidate_build_status = frappe.db.get_value(
@@ -288,7 +293,7 @@ class ReleasePipeline(WorkflowBuilder):
 			message=f"Waiting for remote build job to be enqueued for Deploy Candidate Build {deploy_candidate_build}",
 		)
 
-	@task
+	@task(queue=_get_task_execution_queue())
 	def monitor_build_success(self, deploy_candidate_build: str):
 		"""Monitor build till terminal state."""
 		deploy_candidate_build = self._get_latest_retried_build(deploy_candidate_build)
@@ -426,7 +431,7 @@ class ReleasePipeline(WorkflowBuilder):
 		deploy_candidate.save()
 		release_group_doc.save()
 
-	@task
+	@task(queue=_get_task_execution_queue())
 	def run_pre_release_checks(self, apps: list[dict[str, str]]):
 		"""Groups all early-exit validation logic."""
 		try:
@@ -436,7 +441,7 @@ class ReleasePipeline(WorkflowBuilder):
 		except (frappe.ValidationError, InsufficientSpaceOnServer) as e:
 			raise ReleasePipelineFailure(str(e)) from e
 
-	@task
+	@task(queue=_get_task_execution_queue())
 	def add_implicit_app_dependencies(self, deploy_candidate: str):
 		"""Add any implicit dependencies for the apps being deployed."""
 		deploy_candidate_doc: DeployCandidate = frappe.get_doc(
@@ -451,7 +456,7 @@ class ReleasePipeline(WorkflowBuilder):
 				dependant_app_versions=dependant_app_versions["frappe_dependencies"],
 			)
 
-	@task
+	@task(queue=_get_task_execution_queue())
 	def auto_update_bench_dependency_versions(self, deploy_candidate: str):
 		"""Auto update the versions of the dependencies depending on app requirements.
 		Currently only supports python version upgrades
@@ -472,7 +477,7 @@ class ReleasePipeline(WorkflowBuilder):
 			self.release_group_doc.name, required_python_versions
 		)
 
-	@task
+	@task(queue=_get_task_execution_queue())
 	def prepare_deployment(self, apps, sites, run_will_fail_check) -> tuple[str, str]:
 		"""Creates the candidate and returns the primary build name."""
 		try:
@@ -490,7 +495,7 @@ class ReleasePipeline(WorkflowBuilder):
 		except frappe.ValidationError as e:
 			raise ReleasePipelineFailure(f"Failed to prepare deployment: {e!s}") from e
 
-	@task
+	@task(queue=_get_task_execution_queue())
 	def orchestrate_build_monitoring(self, deploy_candidate: str, primary_build: str):
 		"""Monitors primary and, if necessary, secondary builds."""
 		# Monitor Primary
@@ -514,7 +519,7 @@ class ReleasePipeline(WorkflowBuilder):
 			# If we were in retrying status, it means builds have succeeded after retries, we can move back to running status
 			self.update_pipeline_status("Running")
 
-	@task
+	@task(queue=_get_task_execution_queue())
 	def monitor_bench_creation(self, deploy_candidate_build: str):
 		"""Monitor new bench creation accounting for any failures and retries."""
 		candidate = frappe.db.get_value("Deploy Candidate Build", deploy_candidate_build, "deploy_candidate")

--- a/press/press/doctype/release_pipeline/release_pipeline.py
+++ b/press/press/doctype/release_pipeline/release_pipeline.py
@@ -19,7 +19,6 @@ from press.press.doctype.app.app import (
 )
 from press.press.doctype.bench_update.bench_update import get_bench_update
 from press.workflow_engine.doctype.press_workflow.decorators import flow, task
-from press.workflow_engine.doctype.press_workflow.exceptions import PressWorkflowTaskEnqueued
 from press.workflow_engine.doctype.press_workflow.workflow_builder import WorkflowBuilder
 
 if typing.TYPE_CHECKING:
@@ -164,15 +163,9 @@ class ReleasePipeline(WorkflowBuilder):
 		return frappe.get_doc("Release Group", self.release_group)
 
 	@cached_property
-	def workflow_name(self) -> str:
+	def current_workflow(self) -> str:
 		return frappe.db.get_value(
 			"Press Workflow", {"linked_doctype": "Release Pipeline", "linked_docname": self.name}, "name"
-		)
-
-	def get_task_name(self, func):
-		"""Get task name for the given function"""
-		return frappe.db.get_value(
-			"Press Workflow Task", {"method_name": func.__name__, "workflow": self.workflow_name}, "name"
 		)
 
 	@task
@@ -245,10 +238,8 @@ class ReleasePipeline(WorkflowBuilder):
 
 		if deploy_candidate_build_doc.should_build_retry(exc=None, job=agent_job):
 			self.update_pipeline_status("Retrying")
-			raise PressWorkflowTaskEnqueued(
-				f"Build {deploy_candidate_build} has scheduled retries. Waiting for retries to complete.",
-				self.workflow_name,
-				self.get_task_name(self.monitor_pre_build_validation),
+			self.defer_current_task(
+				message=f"Build {deploy_candidate_build} has scheduled retries. Waiting for retries to complete."
 			)
 
 	def _get_latest_retried_build(self, deploy_candidate_build: str) -> str:
@@ -280,7 +271,6 @@ class ReleasePipeline(WorkflowBuilder):
 	@task
 	def monitor_pre_build_validation(self, deploy_candidate_build: str):
 		"""Monitors the Deploy Candidate Build until the remote build job is created."""
-		task_name = self.get_task_name(self.monitor_pre_build_validation)
 		deploy_candidate_build_status = frappe.db.get_value(
 			"Deploy Candidate Build", deploy_candidate_build, "status"
 		)
@@ -294,10 +284,8 @@ class ReleasePipeline(WorkflowBuilder):
 				"Please check the build logs for more details."
 			)
 
-		raise PressWorkflowTaskEnqueued(
-			f"Waiting for remote build job to be enqueued for Deploy Candidate Build {deploy_candidate_build}",
-			self.workflow_name,
-			task_name,
+		self.defer_current_task(
+			message=f"Waiting for remote build job to be enqueued for Deploy Candidate Build {deploy_candidate_build}",
 		)
 
 	@task
@@ -318,10 +306,8 @@ class ReleasePipeline(WorkflowBuilder):
 				f"Remote build failed for Deploy Candidate Build {deploy_candidate_build}. Please check the build logs for more details."
 			)
 
-		raise PressWorkflowTaskEnqueued(
-			f"Waiting for build to complete for Deploy Candidate Build {deploy_candidate_build}",
-			self.workflow_name,
-			self.get_task_name(self.monitor_build_success),
+		self.defer_current_task(
+			message=f"Waiting for build to complete for Deploy Candidate Build {deploy_candidate_build}",
 		)
 
 	def _is_active_bench_work_in_progress(self, builds: list[str]) -> bool:
@@ -517,10 +503,8 @@ class ReleasePipeline(WorkflowBuilder):
 
 			if not secondary_build:
 				# Wait for sometime for the secondary build to be created in case of any delays in build scheduling
-				raise PressWorkflowTaskEnqueued(
-					f"Waiting for secondary build creation for {deploy_candidate}",
-					self.workflow_name,
-					self.get_task_name(self.monitor_build_success),
+				self.defer_current_task(
+					message=f"Waiting for secondary build creation for Deploy Candidate {deploy_candidate}",
 				)
 
 			self.monitor_pre_build_validation(secondary_build)
@@ -542,10 +526,8 @@ class ReleasePipeline(WorkflowBuilder):
 
 		# This should take care of the retries as well.
 		if self._is_active_bench_work_in_progress(builds):
-			raise PressWorkflowTaskEnqueued(
-				"Benches in progress, Waiting...",
-				self.workflow_name,
-				self.get_task_name(self.monitor_bench_creation),
+			self.defer_current_task(
+				message=f"Waiting for bench creation to complete for Deploy Candidate Build(s) {builds}",
 			)
 
 		# Just another safety lock to ensure no early failures occur
@@ -553,10 +535,8 @@ class ReleasePipeline(WorkflowBuilder):
 		in_transition = [status for status in statues if status in BENCH_TRANSITION_STATES]
 
 		if in_transition:
-			raise PressWorkflowTaskEnqueued(
-				"Benches are in transition states...",
-				self.workflow_name,
-				self.get_task_name(self.monitor_bench_creation),
+			self.defer_current_task(
+				message=f"Benches are still in transition states for Deploy Candidate Build(s) {builds}.",
 			)
 
 		self._finalize_pipeline_status(builds=builds, expected_count=expected)
@@ -587,7 +567,7 @@ class ReleasePipeline(WorkflowBuilder):
 		if self.status != "Failure":
 			return
 
-		workflow = frappe.get_doc("Press Workflow", self.workflow_name)
+		workflow = frappe.get_doc("Press Workflow", self.current_workflow)
 		failure_summary = self.get_failure_summary(workflow)
 
 		if not failure_summary:
@@ -636,6 +616,6 @@ class ReleasePipeline(WorkflowBuilder):
 			# Just in case, make sure that we mark the pipeline as failed and notify the frontend to stop listening for deploy updates
 			self.update_pipeline_status("Failure")
 
-		workflow_status = frappe.db.get_value("Press Workflow", self.workflow_name, "status")
+		workflow_status = frappe.db.get_value("Press Workflow", self.current_workflow, "status")
 		if workflow_status == "Failure":
 			self.update_pipeline_status("Failure")

--- a/press/press/doctype/release_pipeline/release_pipeline.py
+++ b/press/press/doctype/release_pipeline/release_pipeline.py
@@ -252,10 +252,15 @@ class ReleasePipeline(WorkflowBuilder):
 			)
 
 	def _get_latest_retried_build(self, deploy_candidate_build: str) -> str:
-		"""In case there are retries for the build, get the latest retried build to monitor."""
-		deploy_candidate = frappe.db.get_value(
-			"Deploy Candidate Build", deploy_candidate_build, "deploy_candidate"
+		"""In case there are retries for the build, get the latest retried build with same platform to monitor."""
+		deploy_info = frappe.db.get_value(
+			"Deploy Candidate Build", deploy_candidate_build, ["deploy_candidate", "platform"]
 		)
+
+		if deploy_info is None:
+			raise ReleasePipelineFailure(f"Deploy Candidate Build {deploy_candidate_build} not found.")
+
+		deploy_candidate, platform = deploy_info
 
 		# Get the latest **retried** build
 		retried_build = frappe.db.get_value(
@@ -264,6 +269,7 @@ class ReleasePipeline(WorkflowBuilder):
 				"group": self.release_group,
 				"deploy_candidate": deploy_candidate,
 				"name": ("!=", deploy_candidate_build),
+				"platform": platform,
 			},
 			"name",
 			order_by="creation desc",

--- a/press/workflow_engine/doctype/press_workflow/press_workflow.json
+++ b/press/workflow_engine/doctype/press_workflow/press_workflow.json
@@ -217,7 +217,7 @@
    "link_fieldname": "workflow"
   }
  ],
- "modified": "2026-03-11 00:51:08.486677",
+ "modified": "2026-04-22 00:01:07.425649",
  "modified_by": "Administrator",
  "module": "Workflow Engine",
  "name": "Press Workflow",
@@ -233,6 +233,28 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Press Member",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Press Admin",
    "share": 1,
    "write": 1
   }

--- a/press/workflow_engine/doctype/press_workflow/press_workflow.py
+++ b/press/workflow_engine/doctype/press_workflow/press_workflow.py
@@ -38,12 +38,8 @@ class PressWorkflow(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		from press.workflow_engine.doctype.press_workflow_kv.press_workflow_kv import (
-			PressWorkflowKV,
-		)
-		from press.workflow_engine.doctype.press_workflow_step.press_workflow_step import (
-			PressWorkflowStep,
-		)
+		from press.workflow_engine.doctype.press_workflow_kv.press_workflow_kv import PressWorkflowKV
+		from press.workflow_engine.doctype.press_workflow_step.press_workflow_step import PressWorkflowStep
 
 		args: DF.Link | None
 		duration: DF.Duration | None

--- a/press/workflow_engine/doctype/press_workflow/workflow_builder.py
+++ b/press/workflow_engine/doctype/press_workflow/workflow_builder.py
@@ -189,3 +189,17 @@ class WorkflowBuilder(Document):
 			if self.kv_store_type != "in_memory":
 				self.kv_store_type = "in_memory"
 				self.kv_store_reference = None
+
+	def defer_current_task(self, message: str = "User has requested to defer the task later.") -> None:
+		if not self.flags.in_press_workflow_execution:
+			return
+
+		assert self.workflow_name is not None, "Workflow name must be set to defer current task"
+
+		raise PressWorkflowTaskEnqueued(
+			message,
+			self.workflow_name,
+			self.flags.current_press_workflow_task
+			if hasattr(self.flags, "current_press_workflow_task")
+			else None,
+		)

--- a/press/workflow_engine/doctype/press_workflow_object/press_workflow_object.json
+++ b/press/workflow_engine/doctype/press_workflow_object/press_workflow_object.json
@@ -54,7 +54,7 @@
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2026-03-03 21:32:26.447603",
+ "modified": "2026-04-22 00:01:32.067496",
  "modified_by": "Administrator",
  "module": "Workflow Engine",
  "name": "Press Workflow Object",
@@ -70,6 +70,28 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Press Member",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Press Admin",
    "share": 1,
    "write": 1
   }

--- a/press/workflow_engine/doctype/press_workflow_task/press_workflow_task.json
+++ b/press/workflow_engine/doctype/press_workflow_task/press_workflow_task.json
@@ -179,7 +179,7 @@
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2026-04-14 16:25:01.842528",
+ "modified": "2026-04-22 00:01:50.295095",
  "modified_by": "Administrator",
  "module": "Workflow Engine",
  "name": "Press Workflow Task",
@@ -195,6 +195,28 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Press Member",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Press Admin",
    "share": 1,
    "write": 1
   }

--- a/press/workflow_engine/doctype/press_workflow_test/press_workflow_test.json
+++ b/press/workflow_engine/doctype/press_workflow_test/press_workflow_test.json
@@ -52,7 +52,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-03-11 22:19:13.824971",
+ "modified": "2026-04-22 00:02:29.087766",
  "modified_by": "Administrator",
  "module": "Workflow Engine",
  "name": "Press Workflow Test",
@@ -68,6 +68,28 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Press Admin",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Press Member",
    "share": 1,
    "write": 1
   }


### PR DESCRIPTION
- Get the latest required build of the same platform.
(Might require composite indexing)
- Explicitly use the `build` queue in production.
- More permissions to `Press Workflow`