### PR TITLE
fix(billing): Allow trusted users for frictionless payment

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,4 +13,5 @@ types-python-dateutil~=2.9.0
 types-boto3==1.39.14
 types-jwt==0.1.3
 types-setuptools~=81.0
+types-stripe~=3.5.2
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -47,3 +47,5 @@ ignore_missing_imports = true
 ignore_missing_imports = true
 [mypy-PIL.*]
 ignore_missing_imports = true
+[mypy-razorpay.*]
+ignore_missing_imports = true

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -250,6 +250,7 @@ scheduler_events = {
 		"press.saas.doctype.product_trial.product_trial.sync_product_site_users",
 		"press.press.doctype.database_server.database_server.sync_binlogs_info",
 		"press.press.doctype.team.team.auto_enable_ssh_access_for_7_days_older_teams",
+		# "press.press.doctype.team.team.auto_trust_teams_with_consecutive_paid_invoices",
 	],
 	"hourly_long": [
 		"press.press.doctype.release_group.release_group.prune_servers_without_sites",

--- a/press/press/doctype/team/team.json
+++ b/press/press/doctype/team/team.json
@@ -44,6 +44,7 @@
   "billing_address",
   "free_credits_allocated",
   "upi_autopay_enabled",
+  "is_trusted_team",
   "column_break_12",
   "address_html",
   "section_break_jzok",
@@ -698,6 +699,12 @@
    "fieldname": "upi_autopay_enabled",
    "fieldtype": "Check",
    "label": "UPI Autopay Enabled"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_trusted_team",
+   "fieldtype": "Check",
+   "label": "Is Trusted Team"
   }
  ],
  "grid_page_length": 50,
@@ -763,7 +770,7 @@
    "link_fieldname": "team"
   }
  ],
- "modified": "2026-03-18 15:58:34.156826",
+ "modified": "2026-04-21 15:12:39.866295",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Team",

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -27,6 +27,7 @@ from press.utils.billing import (
 	is_frappe_auth_disabled,
 	process_micro_debit_test_charge,
 )
+from press.utils.jobs import has_job_timeout_exceeded
 from press.utils.telemetry import capture
 
 if TYPE_CHECKING:
@@ -83,6 +84,7 @@ class Team(Document):
 		is_developer: DF.Check
 		is_frappe_compute_internal_user: DF.Check
 		is_saas_user: DF.Check
+		is_trusted_team: DF.Check
 		is_us_eu: DF.Check
 		last_used_team: DF.Link | None
 		monthly_alert_threshold: DF.Currency
@@ -1788,6 +1790,48 @@ def send_budget_alert_email(team_info, invoice):
 	except Exception as e:
 		frappe.log_error(f"Failed to send budget alert email: {team_info['user']}", {e})
 		return False
+
+
+def auto_trust_teams_with_consecutive_paid_invoices():
+	"""Mark teams as trusted if their last 3 subscription invoices are all Paid."""
+	Invoice = frappe.qb.DocType("Invoice")
+	Team = frappe.qb.DocType("Team")
+
+	# Only consider non-trusted teams with at least 3 paid subscription invoices
+	teams_with_paid_invoices = (
+		frappe.qb.from_(Invoice)
+		.join(Team)
+		.on(Invoice.team == Team.name)
+		.select(Invoice.team)
+		.where(Invoice.type == "Subscription")
+		.where(Invoice.status == "Paid")
+		.where(Team.is_trusted_team == 0)
+		.groupby(Invoice.team)
+		.having(Count("*") >= 3)
+	).run(as_dict=True)
+
+	team_names = [t.team for t in teams_with_paid_invoices]
+	if not team_names:
+		return
+
+	trusted_teams = []
+	for team_name in team_names:
+		if has_job_timeout_exceeded():
+			return
+
+		# Fetch last 3 subscription invoices ordered by period_end desc
+		last_3 = frappe.db.get_all(
+			"Invoice",
+			filters={"team": team_name, "type": "Subscription"},
+			fields=["status"],
+			order_by="period_end desc",
+			limit=3,
+		)
+		if len(last_3) == 3 and all(inv.status == "Paid" for inv in last_3):
+			trusted_teams.append(team_name)
+
+	if trusted_teams:
+		frappe.db.set_value("Team", {"name": ("in", trusted_teams)}, "is_trusted_team", 1)
 
 
 def auto_enable_ssh_access_for_7_days_older_teams():

--- a/press/utils/billing.py
+++ b/press/utils/billing.py
@@ -126,9 +126,10 @@ def get_setup_intent(team):
 
 	intent = frappe.cache().hget("setup_intent", team)
 	if not intent:
-		data = frappe.db.get_value("Team", team, ["stripe_customer_id", "currency"])
+		data = frappe.db.get_value("Team", team, ["stripe_customer_id", "currency", "is_trusted_team"])
 		customer_id = data[0]
 		currency = data[1]
+		is_trusted_team = data[2]
 		stripe = get_stripe()
 		hash = random_string(10)
 		intent = stripe.SetupIntent.create(
@@ -136,7 +137,7 @@ def get_setup_intent(team):
 			payment_method_types=["card"],
 			payment_method_options={
 				"card": {
-					"request_three_d_secure": "automatic",
+					"request_three_d_secure": "any" if is_trusted_team else "automatic",
 					"mandate_options": {
 						"reference": f"Mandate-team:{team}-{hash}",
 						"amount_type": "maximum",


### PR DESCRIPTION
This will allow the trusted users to skip auth from stripe side and go through frictionless payment process.
Verified and tested this changes locally.