### PR TITLE
refactor(release-pipeline): Stop raising and cache empty result when pyproject is not found

### DIFF
--- a/press/api/github.py
+++ b/press/api/github.py
@@ -568,26 +568,37 @@ def _get_pyproject_from_commit(app_source: str, commit: str):
 		frappe.throw("Invalid pyproject.toml file found in the app repository.", frappe.ValidationError)
 
 
-def get_dependant_apps_with_versions(app_source: str, commit: str, cache: bool = True) -> AppDependencyFetch:
-	"""Get a list of apps that are required by the given repository and commit."""
+def get_dependant_apps_with_versions(
+	app_source: str,
+	commit: str,
+	cache: bool = True,
+	raises: bool = True,
+) -> AppDependencyFetch:
+	"""Return app dependencies and Python version for a repository at a given commit."""
 	cache_key = f"app_deps:{app_source}:{commit}"
 
-	if cache:
-		cached_deps = frappe.cache().get_value(cache_key)
-		if cached_deps is not None:
-			return cached_deps
+	if cache and (cached := frappe.cache().get_value(cache_key)) is not None:
+		return cached
 
-	pyproject = _get_pyproject_from_commit(app_source, commit)
-	frappe_dependencies = pyproject.get("tool", {}).get("bench", {}).get("frappe-dependencies", {})
-	# We can safely remove frappe from the dependencies as it will be added by defult.
-	frappe_dependencies.pop("frappe", None)
-	python_version = pyproject.get("project", {}).get("requires-python")
+	try:
+		pyproject = _get_pyproject_from_commit(app_source, commit)
+	except frappe.ValidationError as exc:
+		if raises:
+			raise frappe.ValidationError from exc
 
-	dependency_data = AppDependencyFetch(
-		frappe_dependencies=frappe_dependencies,
-		python_version=python_version,
-	)
+		dependency_data = AppDependencyFetch(
+			frappe_dependencies={},
+			python_version=None,
+		)
+	else:
+		frappe_dependencies = pyproject.get("tool", {}).get("bench", {}).get("frappe-dependencies", {}).copy()
+		frappe_dependencies.pop("frappe", None)  # Get rid of this
 
+		dependency_data = AppDependencyFetch(
+			frappe_dependencies=frappe_dependencies,
+			python_version=pyproject.get("project", {}).get("requires-python"),
+		)
+
+	# In case of failrues as well we want to cache the result to avoid hitting GitHub
 	frappe.cache().set_value(cache_key, dependency_data, expires_in_sec=60 * 60)
-
 	return dependency_data

--- a/press/api/github.py
+++ b/press/api/github.py
@@ -596,6 +596,6 @@ def get_dependant_apps_with_versions(
 			python_version=pyproject.get("project", {}).get("requires-python"),
 		)
 
-	# In case of failrues as well we want to cache the result to avoid hitting GitHub
+	# In case of failures as well we want to cache the result to avoid hitting GitHub
 	frappe.cache().set_value(cache_key, dependency_data, expires_in_sec=60 * 60)
 	return dependency_data

--- a/press/api/github.py
+++ b/press/api/github.py
@@ -586,10 +586,7 @@ def get_dependant_apps_with_versions(
 		if raises:
 			raise frappe.ValidationError from exc
 
-		dependency_data = AppDependencyFetch(
-			frappe_dependencies={},
-			python_version=None,
-		)
+		dependency_data = AppDependencyFetch(frappe_dependencies={}, python_version=None)
 	else:
 		frappe_dependencies = pyproject.get("tool", {}).get("bench", {}).get("frappe-dependencies", {}).copy()
 		frappe_dependencies.pop("frappe", None)  # Get rid of this

--- a/press/press/doctype/release_pipeline/release_pipeline.py
+++ b/press/press/doctype/release_pipeline/release_pipeline.py
@@ -449,7 +449,7 @@ class ReleasePipeline(WorkflowBuilder):
 		)
 		for app in deploy_candidate_doc.apps:
 			dependant_app_versions = get_dependant_apps_with_versions(
-				app_source=app.source, commit=app.hash, cache=True
+				app_source=app.source, commit=app.hash, cache=True, raises=False
 			)
 			self._add_app_to_group_and_candidate(
 				deploy_candidate_doc,
@@ -469,7 +469,7 @@ class ReleasePipeline(WorkflowBuilder):
 		for app in deploy_candidate_doc.apps:
 			# Should use the cache from the previous task
 			dependant_app_versions = get_dependant_apps_with_versions(
-				app_source=app.source, commit=app.hash, cache=True
+				app_source=app.source, commit=app.hash, cache=True, raises=False
 			)
 			required_python_versions[app.app] = dependant_app_versions["python_version"]
 

--- a/press/press/doctype/release_pipeline/test_release_pipeline.py
+++ b/press/press/doctype/release_pipeline/test_release_pipeline.py
@@ -46,6 +46,10 @@ def mock_bench_monitoring(*args, **kwargs):
 	return
 
 
+def get_failure_pyproject_file(*args, **kwargs):
+	frappe.throw("No pyroject found or something went wrong with github", frappe.ValidationError)
+
+
 def get_mock_pyproject_file(*args, **kwargs):
 	return tomli.loads("""[project]
 		name = "helpdesk"
@@ -258,6 +262,19 @@ class TestReleasePipeline(FrappeTestCase):
 				"telephony": None,  # Some apps might not give their python version requirements.
 			},
 		)
+
+	def test_no_failure_on_fetching_non_existent_pyproject_file(self):
+		# This can happen when fetching pyproject for apps that are not part of the release but are dependencies of apps in the release
+		with patch("press.api.github._get_pyproject_from_commit", get_failure_pyproject_file):
+			dependent_apps = get_dependant_apps_with_versions("some_source", "some_commit", raises=False)
+			self.assertEqual(dependent_apps["frappe_dependencies"], {})
+			self.assertEqual(dependent_apps["python_version"], None)
+
+		with (
+			patch("press.api.github._get_pyproject_from_commit", get_failure_pyproject_file),
+			self.assertRaises(frappe.ValidationError),
+		):
+			get_dependant_apps_with_versions("some_source", "some_commit", raises=True)
 
 	@patch("press.api.github._get_pyproject_from_commit", get_mock_pyproject_file)
 	def test_implicit_dependency_source_addition(self):

--- a/press/press/doctype/release_pipeline/test_release_pipeline.py
+++ b/press/press/doctype/release_pipeline/test_release_pipeline.py
@@ -47,7 +47,7 @@ def mock_bench_monitoring(*args, **kwargs):
 
 
 def get_failure_pyproject_file(*args, **kwargs):
-	frappe.throw("No pyroject found or something went wrong with github", frappe.ValidationError)
+	frappe.throw("No pyproject found or something went wrong with github", frappe.ValidationError)
 
 
 def get_mock_pyproject_file(*args, **kwargs):
@@ -274,7 +274,7 @@ class TestReleasePipeline(FrappeTestCase):
 			patch("press.api.github._get_pyproject_from_commit", get_failure_pyproject_file),
 			self.assertRaises(frappe.ValidationError),
 		):
-			get_dependant_apps_with_versions("some_source", "some_commit", raises=True)
+			get_dependant_apps_with_versions("some_source", "some_commit", raises=True, cache=False)
 
 	@patch("press.api.github._get_pyproject_from_commit", get_mock_pyproject_file)
 	def test_implicit_dependency_source_addition(self):


### PR DESCRIPTION
Generally people don't add a `pyproject.toml` to their custom apps we can't fail every deploy because of it.

- Stop raising in case we don't find `pyproject.toml`
- Cache empty result for the commit in that case.

