### PR TITLE
fix(billing): Clear cache if the team is trusted via update

### DIFF
--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -567,7 +567,7 @@ class Team(Document):
 		):
 			self.update_billing_details_on_frappeio()
 
-		if self.has_value_changed("is_trusted_team") and self.is_trusted_team:
+		if self.has_value_changed("is_trusted_team"):
 			frappe.cache().hdel("setup_intent", self.name)
 
 	def update_draft_invoice_payment_mode(self):

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -567,6 +567,9 @@ class Team(Document):
 		):
 			self.update_billing_details_on_frappeio()
 
+		if self.has_value_changed("is_trusted_team") and self.is_trusted_team:
+			frappe.cache().hdel("setup_intent", self.name)
+
 	def update_draft_invoice_payment_mode(self):
 		if self.has_value_changed("payment_mode"):
 			draft_invoices = frappe.get_all(


### PR DESCRIPTION
When we update the team as trusted, we are manually clearing the cache. Added change in team doctype, where on_update, if the value has changed, we clear the cache value automatically and user can create new intent