### PR TITLE
refactor(release-pipeline): Permissions & reliable pipeline status

### DIFF
--- a/press/press/doctype/release_pipeline/release_pipeline.json
+++ b/press/press/doctype/release_pipeline/release_pipeline.json
@@ -7,7 +7,8 @@
  "field_order": [
   "team",
   "release_group",
-  "status"
+  "status",
+  "workflow"
  ],
  "fields": [
   {
@@ -35,12 +36,18 @@
    "in_list_view": 1,
    "label": "Status",
    "options": "Pending\nRunning\nPartial Success\nSuccess\nFailure\nRetrying"
+  },
+  {
+   "fieldname": "workflow",
+   "fieldtype": "Link",
+   "label": "Workflow",
+   "options": "Press Workflow"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-22 15:25:16.828078",
+ "modified": "2026-04-23 23:29:23.698727",
  "modified_by": "Administrator",
  "module": "Press",
  "name": "Release Pipeline",

--- a/press/press/doctype/release_pipeline/release_pipeline.py
+++ b/press/press/doctype/release_pipeline/release_pipeline.py
@@ -142,7 +142,33 @@ class ReleasePipeline(WorkflowBuilder):
 		release_group: DF.Link | None
 		status: DF.Literal["Pending", "Running", "Partial Success", "Success", "Failure", "Retrying"]
 		team: DF.Link
+		workflow: DF.Link | None
 	# end: auto-generated types
+
+	def send_failure_notification(self):
+		workflow = frappe.get_doc("Press Workflow", self.workflow)
+		failure_summary = self.get_failure_summary(workflow)
+
+		if not failure_summary:
+			return  # No failed tasks found, no need to create a notification
+
+		frappe.get_doc(
+			{
+				"doctype": "Press Notification",
+				"title": "Update Failure",
+				"type": "Bench Deploy",
+				"is_actionable": False,
+				"class": "Error",
+				"team": self.team,
+				"document_type": "Release Pipeline",
+				"document_name": self.name,
+				"message": failure_summary,
+			}
+		).insert()
+
+		frappe.publish_realtime(
+			"press_notification", doctype="Press Notification", message={"team": self.team}
+		)
 
 	def update_pipeline_status(
 		self,
@@ -157,6 +183,9 @@ class ReleasePipeline(WorkflowBuilder):
 	):
 		self.status = status
 		self.save()
+
+		if self.status == "Failure":
+			self.send_failure_notification()
 
 	@cached_property
 	def release_group_doc(self) -> "ReleaseGroup":
@@ -564,38 +593,6 @@ class ReleasePipeline(WorkflowBuilder):
 
 		return frappe.db.get_value("Press Workflow Object", workflow_object_name, "summary")
 
-	def on_update(self):
-		"""A few steps have their notifications handled seperately in (ref deploy_notifications.py) skipping them"""
-		if not self.has_value_changed("status"):
-			return
-
-		if self.status != "Failure":
-			return
-
-		workflow = frappe.get_doc("Press Workflow", self.current_workflow)
-		failure_summary = self.get_failure_summary(workflow)
-
-		if not failure_summary:
-			return  # No failed tasks found, no need to create a notification
-
-		frappe.get_doc(
-			{
-				"doctype": "Press Notification",
-				"title": "Update Failure",
-				"type": "Bench Deploy",
-				"is_actionable": False,
-				"class": "Error",
-				"team": self.team,
-				"document_type": "Release Pipeline",
-				"document_name": self.name,
-				"message": failure_summary,
-			}
-		).insert()
-
-		frappe.publish_realtime(
-			"press_notification", doctype="Press Notification", message={"team": self.team}
-		)
-
 	@flow
 	def create_release(
 		self,
@@ -604,6 +601,9 @@ class ReleasePipeline(WorkflowBuilder):
 		run_will_fail_check: bool = False,
 	):
 		"""Orchestrates the release process from validation to bench creation with recursive monitoring and retry handling"""
+		self.workflow = self.current_workflow
+		self.save()
+
 		try:
 			# 1. Validation Phase
 			self.run_pre_release_checks(apps)
@@ -621,6 +621,6 @@ class ReleasePipeline(WorkflowBuilder):
 			# Just in case, make sure that we mark the pipeline as failed and notify the frontend to stop listening for deploy updates
 			self.update_pipeline_status("Failure")
 
-		workflow_status = frappe.db.get_value("Press Workflow", self.current_workflow, "status")
+		workflow_status = frappe.db.get_value("Press Workflow", self.workflow, "status")
 		if workflow_status == "Failure":
 			self.update_pipeline_status("Failure")

--- a/press/press/doctype/release_pipeline/release_pipeline.py
+++ b/press/press/doctype/release_pipeline/release_pipeline.py
@@ -127,7 +127,7 @@ def _resolve_python_version_conflicts_and_update_group(
 		if dependency.dependency == "PYTHON_VERSION":
 			dependency.version = str(highest_compatible_python_version)
 			dependency.is_custom = True
-			dependency.save()
+			dependency.save(ignore_permissions=True)
 
 
 class ReleasePipeline(WorkflowBuilder):
@@ -428,8 +428,8 @@ class ReleasePipeline(WorkflowBuilder):
 			release_group_doc.append("apps", {"app": app, "source": app_source.name})
 
 		# Final save
-		deploy_candidate.save()
-		release_group_doc.save()
+		deploy_candidate.save(ignore_permissions=True)
+		release_group_doc.save(ignore_permissions=True)
 
 	@task(queue=_get_task_execution_queue())
 	def run_pre_release_checks(self, apps: list[dict[str, str]]):

--- a/press/press/doctype/release_pipeline/test_release_pipeline.py
+++ b/press/press/doctype/release_pipeline/test_release_pipeline.py
@@ -147,17 +147,14 @@ class TestReleasePipeline(FrappeTestCase):
 		release_pipeline: ReleasePipeline = frappe.get_last_doc("Release Pipeline")
 		self.assertEqual(release_pipeline.release_group, self.test_release_group.name)
 		self.assertEqual(release_pipeline.team, get_current_team())
-		release_pipeline = frappe.get_doc(
+		workflow_doc = frappe.get_doc(
 			"Press Workflow",
 			{
 				"linked_doctype": "Release Pipeline",
 				"linked_docname": release_pipeline.name,
 			},
 		)
-
-		frappe.get_last_doc(
-			"Press Workflow"
-		)  # To ensure nothing is raised when fetching the workflow created for the release pipeline
+		self.assertEqual(release_pipeline.workflow, workflow_doc.name)
 
 	@patch.object(DeployCandidateBuild, "_upload_build_context", get_mock_context_file)
 	@patch.object(DeployCandidateBuild, "_build", Mock())

--- a/press/workflow_engine/doctype/press_workflow/press_workflow.py
+++ b/press/workflow_engine/doctype/press_workflow/press_workflow.py
@@ -133,7 +133,9 @@ class PressWorkflow(Document):
 				print(self.stdout)
 
 			self.exception = exception
-			self.workflow_traceback = workflow_exception_traceback or self.workflow_traceback
+			self.workflow_traceback = workflow_exception_traceback or getattr(
+				self, "workflow_traceback", None
+			)
 			self.update_skipped_steps_status(save=False)
 			self.save()
 

--- a/press/workflow_engine/doctype/press_workflow_task/press_workflow_task.py
+++ b/press/workflow_engine/doctype/press_workflow_task/press_workflow_task.py
@@ -164,7 +164,7 @@ class PressWorkflowTask(Document):
 			self.output = output
 			self.exception = exception
 			self.stdout = (self.stdout or "") + buffer.getvalue()
-			self.traceback = exception_traceback or self.traceback
+			self.traceback = exception_traceback or getattr(self, "traceback", None)
 
 			if frappe.flags.in_test and self.stdout:
 				print(self.stdout)

--- a/press/workflow_engine/doctype/press_workflow_task/press_workflow_task.py
+++ b/press/workflow_engine/doctype/press_workflow_task/press_workflow_task.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2026, Frappe and contributors
 # For license information, please see license.txt
 
+from __future__ import annotations
+
 import io
-from contextlib import redirect_stdout
+from contextlib import redirect_stdout, suppress
 from typing import TYPE_CHECKING
 
 import frappe
@@ -72,6 +74,13 @@ class PressWorkflowTask(Document):
 				"Failure": "Failure",
 			}.get(self.status, "Pending"),
 		)
+
+	def _mark_reference_doc_as_failed(self, reference_doc: WorkflowBuilder):
+		"""In case the link document has a status field try and mark it as failure to reflect the workflow failure."""
+		with suppress(Exception):  # Try your best but don't fail
+			if hasattr(reference_doc, "status"):
+				reference_doc.status = "Failure"
+				reference_doc.save(ignore_permissions=True)
 
 	def run(self):  # noqa: C901 - Best to keep workflow execution logic in one place
 		assert self.name, "Task must be saved before it can be run"
@@ -165,6 +174,9 @@ class PressWorkflowTask(Document):
 			self.exception = exception
 			self.stdout = (self.stdout or "") + buffer.getvalue()
 			self.traceback = exception_traceback or getattr(self, "traceback", None)
+
+			if self.status == "Failure":
+				self._mark_reference_doc_as_failed(reference_doc)
 
 			if frappe.flags.in_test and self.stdout:
 				print(self.stdout)


### PR DESCRIPTION
- Ignore permissions when updating dependencies on the fly.
- In any `Press Workflow` failure ensure `Release Pipeline` is marked as failed