### PR TITLE
fix(billing): Setup intent frictionless for trusted user in micro debit

### DIFF
--- a/press/api/billing.py
+++ b/press/api/billing.py
@@ -271,6 +271,11 @@ def create_payment_intent_for_micro_debit():
 		metadata={
 			"payment_for": "micro_debit_test_charge",
 		},
+		payment_method_options={
+			"card": {
+				"request_three_d_secure": "any" if team.is_trusted_team else "automatic",
+			}
+		},
 	)
 	return {"client_secret": intent["client_secret"]}
 
@@ -300,6 +305,11 @@ def create_payment_intent_for_buying_credits(amount):
 		customer=team.stripe_customer_id,
 		description="Prepaid Credits",
 		metadata=metadata,
+		payment_method_options={
+			"card": {
+				"request_three_d_secure": "any" if team.is_trusted_team else "automatic",
+			}
+		},
 	)
 	return {
 		"client_secret": intent["client_secret"],

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -1806,6 +1806,7 @@ def auto_trust_teams_with_consecutive_paid_invoices():
 		.where(Invoice.type == "Subscription")
 		.where(Invoice.status == "Paid")
 		.where(Team.is_trusted_team == 0)
+		.where(Team.enabled == 1)
 		.groupby(Invoice.team)
 		.having(Count("*") >= 3)
 	).run(as_dict=True)


### PR DESCRIPTION
While trusted user is allowed for frictionless 3DS part in setting intent, i missed to set it during payment intent for micro debit charges. This micro debit charge also has to explicitly pass the frictionless payment mode, otherwise the payment intent will be still struck. I have added the trusted and enabled team verification to pass this frictionless 3DS option.