### PR TITLE
fix(agent-job): Select jobs to fail randomly

### DIFF
--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -644,6 +644,7 @@ def fail_old_jobs():
 		},
 		"name",
 		limit=100,
+		order_by="RAND()",
 		pluck=True,
 	)
 	update_status(failed_jobs, "Failure")
@@ -657,6 +658,7 @@ def fail_old_jobs():
 		},
 		"name",
 		limit=100,
+		order_by="RAND()",
 		pluck=True,
 	)
 


### PR DESCRIPTION
Broken sites can halt the process of failing jobs. This is mostly
outside of our control as users have freedom.

Docs can also get locked randomly during other ops.
