### PR TITLE
refactor(release-pipeline): Ignore permissions from pipeline & better modifications

### DIFF
--- a/press/press/doctype/bench_update/bench_update.py
+++ b/press/press/doctype/bench_update/bench_update.py
@@ -89,7 +89,7 @@ class BenchUpdate(Document):
 		run_will_fail_check=False,
 		validate_pre_candidate_checks: bool = True,
 		create_build: bool = True,
-		ignore_permissions_check: bool = False,
+		ignore_permissions: bool = False,
 	) -> str:
 		"""Creates and returns candidate name or build name depending on the point of invocation."""
 		rg: ReleaseGroup = frappe.get_doc("Release Group", self.group)
@@ -97,7 +97,7 @@ class BenchUpdate(Document):
 			apps_to_update=self.apps,
 			run_will_fail_check=run_will_fail_check,
 			validate_pre_candidate_checks=validate_pre_candidate_checks,
-			ignore_permissions_check=ignore_permissions_check,
+			ignore_permissions=ignore_permissions,
 		)
 
 		self.candidate = candidate.name
@@ -112,7 +112,7 @@ class BenchUpdate(Document):
 			# In case we are not scheduling build from here (eg. new build flow) return candidate name here
 			return candidate.name
 
-		deploy = candidate.schedule_build_and_deploy(ignore_permissions_check=ignore_permissions_check)
+		deploy = candidate.schedule_build_and_deploy(ignore_permissions=ignore_permissions)
 
 		return deploy["name"]
 
@@ -181,12 +181,12 @@ def get_bench_update(
 	apps: list,
 	sites: list | None = None,
 	is_inplace_update: bool = False,
-	ignore_permissions_check: bool = False,
+	ignore_permissions: bool = False,
 ) -> BenchUpdate:
 	if sites is None:
 		sites = []
 
-	if not ignore_permissions_check:
+	if not ignore_permissions:
 		current_team = get_current_team()
 		rg_team = frappe.db.get_value("Release Group", name, "team")
 

--- a/press/press/doctype/bench_update/bench_update.py
+++ b/press/press/doctype/bench_update/bench_update.py
@@ -89,6 +89,7 @@ class BenchUpdate(Document):
 		run_will_fail_check=False,
 		validate_pre_candidate_checks: bool = True,
 		create_build: bool = True,
+		ignore_permissions_check: bool = False,
 	) -> str:
 		"""Creates and returns candidate name or build name depending on the point of invocation."""
 		rg: ReleaseGroup = frappe.get_doc("Release Group", self.group)
@@ -96,6 +97,7 @@ class BenchUpdate(Document):
 			apps_to_update=self.apps,
 			run_will_fail_check=run_will_fail_check,
 			validate_pre_candidate_checks=validate_pre_candidate_checks,
+			ignore_permissions_check=ignore_permissions_check,
 		)
 
 		self.candidate = candidate.name
@@ -110,7 +112,7 @@ class BenchUpdate(Document):
 			# In case we are not scheduling build from here (eg. new build flow) return candidate name here
 			return candidate.name
 
-		deploy = candidate.schedule_build_and_deploy()
+		deploy = candidate.schedule_build_and_deploy(ignore_permissions_check=ignore_permissions_check)
 
 		return deploy["name"]
 

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -242,6 +242,7 @@ class DeployCandidate(Document):
 		run_now: bool = True,
 		scheduled_time: datetime | None = None,
 		retry_count: int = 0,
+		ignore_permissions_check: bool = False,
 	):
 		if run_now and not is_suspended():
 			return {"error": False, "name": self.build_and_deploy()}
@@ -253,7 +254,7 @@ class DeployCandidate(Document):
 			scheduled_time=scheduled_time or now(),
 			retry_count=retry_count,
 		)
-		deploy_candidate_build.insert()
+		deploy_candidate_build.insert(ignore_permissions=ignore_permissions_check)
 		return {"error": False, "name": deploy_candidate_build.name}
 
 	def build_and_deploy(self, no_cache: bool = False) -> str:

--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -242,10 +242,13 @@ class DeployCandidate(Document):
 		run_now: bool = True,
 		scheduled_time: datetime | None = None,
 		retry_count: int = 0,
-		ignore_permissions_check: bool = False,
+		ignore_permissions: bool = False,
 	):
 		if run_now and not is_suspended():
-			return {"error": False, "name": self.build_and_deploy()}
+			return {
+				"error": False,
+				"name": self.build_and_deploy(ignore_permissions=ignore_permissions),
+			}
 
 		deploy_candidate_build = self.create_build(
 			no_cache=False,
@@ -254,12 +257,12 @@ class DeployCandidate(Document):
 			scheduled_time=scheduled_time or now(),
 			retry_count=retry_count,
 		)
-		deploy_candidate_build.insert(ignore_permissions=ignore_permissions_check)
+		deploy_candidate_build.insert(ignore_permissions=ignore_permissions)
 		return {"error": False, "name": deploy_candidate_build.name}
 
-	def build_and_deploy(self, no_cache: bool = False) -> str:
+	def build_and_deploy(self, no_cache: bool = False, ignore_permissions: bool = False) -> str:
 		deploy_candidate_build = self.create_build(no_cache=no_cache, deploy_after_build=True)
-		deploy_candidate_build.insert()
+		deploy_candidate_build.insert(ignore_permissions=ignore_permissions)
 		return deploy_candidate_build.name
 
 	def _set_app_cached_flags(self) -> None:

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -733,7 +733,11 @@ class ReleaseGroup(Document, TagHelpers):
 
 	@frappe.whitelist()
 	def create_deploy_candidate(
-		self, apps_to_update=None, run_will_fail_check=False, validate_pre_candidate_checks: bool = True
+		self,
+		apps_to_update=None,
+		run_will_fail_check=False,
+		validate_pre_candidate_checks: bool = True,
+		ignore_permissions_check: bool = False,
 	) -> "DeployCandidate | None":
 		if not self.enabled:
 			return None
@@ -782,7 +786,7 @@ class ReleaseGroup(Document, TagHelpers):
 
 			check_if_update_will_fail(self, new_dc)
 
-		new_dc.insert()
+		new_dc.insert(ignore_permissions=ignore_permissions_check)
 		return new_dc
 
 	def validate_dc_apps_against_rg(self, dc_apps) -> None:

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -737,7 +737,7 @@ class ReleaseGroup(Document, TagHelpers):
 		apps_to_update=None,
 		run_will_fail_check=False,
 		validate_pre_candidate_checks: bool = True,
-		ignore_permissions_check: bool = False,
+		ignore_permissions: bool = False,
 	) -> "DeployCandidate | None":
 		if not self.enabled:
 			return None
@@ -786,7 +786,7 @@ class ReleaseGroup(Document, TagHelpers):
 
 			check_if_update_will_fail(self, new_dc)
 
-		new_dc.insert(ignore_permissions=ignore_permissions_check)
+		new_dc.insert(ignore_permissions=ignore_permissions)
 		return new_dc
 
 	def validate_dc_apps_against_rg(self, dc_apps) -> None:

--- a/press/press/doctype/release_pipeline/release_pipeline.py
+++ b/press/press/doctype/release_pipeline/release_pipeline.py
@@ -182,7 +182,7 @@ class ReleasePipeline(WorkflowBuilder):
 		],
 	):
 		self.status = status
-		self.save()
+		self.save(ignore_permissions=True)
 
 		if self.status == "Failure":
 			self.send_failure_notification()
@@ -232,20 +232,22 @@ class ReleasePipeline(WorkflowBuilder):
 		"""Create a Deploy Candidate for the release group."""
 		assert isinstance(self.release_group, str)
 		bench_update: BenchUpdate = get_bench_update(
-			self.release_group, apps, sites, is_inplace_update=False, ignore_permissions_check=True
+			self.release_group, apps, sites, is_inplace_update=False, ignore_permissions=True
 		)
 		return bench_update.deploy(
 			run_will_fail_check=run_will_fail_check,
 			validate_pre_candidate_checks=False,
 			create_build=create_deploy,
-			ignore_permissions_check=True,
+			ignore_permissions=True,
 		)
 
 	@task(queue=_get_task_execution_queue())
 	def initiate_pre_build_validations(self, deploy_candidate: str) -> str:
 		"""Start the deploy candidate build process which will run the pre-build validations."""
 		candidate: DeployCandidate = frappe.get_doc("Deploy Candidate", deploy_candidate)
-		deploy_candidate_build = candidate.schedule_build_and_deploy()
+		deploy_candidate_build = candidate.schedule_build_and_deploy(
+			ignore_permissions=True,
+		)
 		return deploy_candidate_build["name"]
 
 	def _get_required_build_count(self, deploy_candidate: str) -> int:

--- a/press/press/doctype/release_pipeline/release_pipeline.py
+++ b/press/press/doctype/release_pipeline/release_pipeline.py
@@ -290,20 +290,17 @@ class ReleasePipeline(WorkflowBuilder):
 
 		deploy_candidate, platform = deploy_info
 
-		# Get the latest **retried** build
-		retried_build = frappe.db.get_value(
+		# Get the latest build
+		return frappe.db.get_value(
 			"Deploy Candidate Build",
 			{
 				"group": self.release_group,
 				"deploy_candidate": deploy_candidate,
-				"name": ("!=", deploy_candidate_build),
 				"platform": platform,
 			},
 			"name",
 			order_by="creation desc",
 		)
-
-		return retried_build or deploy_candidate_build
 
 	@task(queue=_get_task_execution_queue())
 	def monitor_pre_build_validation(self, deploy_candidate_build: str):
@@ -409,7 +406,6 @@ class ReleasePipeline(WorkflowBuilder):
 			return self.update_pipeline_status("Success")
 
 		if successful_deploys == 0:
-			self.update_pipeline_status("Failure")
 			raise ReleasePipelineFailure(f"All {expected_count} bench deploy(s) failed.")
 
 		# If some succeeded and others are permanently failed
@@ -604,8 +600,9 @@ class ReleasePipeline(WorkflowBuilder):
 		run_will_fail_check: bool = False,
 	):
 		"""Orchestrates the release process from validation to bench creation with recursive monitoring and retry handling"""
-		self.workflow = self.current_workflow
-		self.save()
+		if not self.workflow:
+			self.workflow = self.current_workflow
+			self.save()
 
 		try:
 			# 1. Validation Phase

--- a/press/press/doctype/release_pipeline/release_pipeline.py
+++ b/press/press/doctype/release_pipeline/release_pipeline.py
@@ -181,10 +181,11 @@ class ReleasePipeline(WorkflowBuilder):
 			"Retrying",
 		],
 	):
-		self.status = status
-		self.save(ignore_permissions=True)
+		# If the workflow doc touches this for any reason
+		# Document native methods would raise a `TimeStampMismatch` error
+		self.db_set("status", status)
 
-		if self.status == "Failure":
+		if status == "Failure":
 			self.send_failure_notification()
 
 	@cached_property

--- a/press/press/doctype/release_pipeline/release_pipeline.py
+++ b/press/press/doctype/release_pipeline/release_pipeline.py
@@ -238,6 +238,7 @@ class ReleasePipeline(WorkflowBuilder):
 			run_will_fail_check=run_will_fail_check,
 			validate_pre_candidate_checks=False,
 			create_build=create_deploy,
+			ignore_permissions_check=True,
 		)
 
 	@task(queue=_get_task_execution_queue())

--- a/press/press/doctype/release_pipeline/test_release_pipeline.py
+++ b/press/press/doctype/release_pipeline/test_release_pipeline.py
@@ -90,7 +90,7 @@ class TestReleasePipeline(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
-		server = create_test_server(use_for_build=True)
+		cls.server = create_test_server(use_for_build=True)
 		cls.test_frappe_app = create_test_app("frappe")
 		cls.test_erpnext_app = create_test_app("erpnext", "Erpnext App")
 		cls.test_frappe_release = create_test_app_release(
@@ -112,15 +112,15 @@ class TestReleasePipeline(FrappeTestCase):
 		cls.test_release_group = create_test_release_group(
 			apps=[cls.test_frappe_app, cls.test_erpnext_app],
 			frappe_version="Version 15",
-			servers=[server.name],
+			servers=[cls.server.name],
 		)
 		frappe.db.set_single_value("Press Settings", "build_directory", "/tmp/test-build-dir/")
 		frappe.db.set_single_value("Press Settings", "clone_directory", "/tmp/test-clone-dir/")
 		frappe.db.set_single_value("Press Settings", "use_new_deploy_flow", 1)
 
-	def create_deploy_and_update(self):
+	def create_deploy_and_update(self, release_group_name=None):
 		deploy_and_update(
-			self.test_release_group.name,
+			release_group_name or self.test_release_group.name,
 			apps=[
 				{
 					"app": "frappe",


### PR DESCRIPTION

- All records created via the pipeline (deploy candidate, deploy candidate build) must be without a permissions check.
- Updating pipeline status is causing timestamp errors correctly handle them
- Just get the latest build for the `Deploy Candidate`
  - Avoiding things like fetching a previously failed build instead of a current running retried build