### PR TITLE
refactor(release-group): Fetch team from release group team

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -427,29 +427,6 @@
         "line_number": 46
       }
     ],
-    "press/press/doctype/deploy_candidate/test_deploy_candidate.py": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "press/press/doctype/deploy_candidate/test_deploy_candidate.py",
-        "hashed_secret": "970feb5e6f6a0122899d8fc7e10beb1aa6f6264d",
-        "is_verified": false,
-        "line_number": 409
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "press/press/doctype/deploy_candidate/test_deploy_candidate.py",
-        "hashed_secret": "2d42cd2d5a3616a3b8bd8f8c1b34b5f44965f75f",
-        "is_verified": false,
-        "line_number": 416
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "press/press/doctype/deploy_candidate/test_deploy_candidate.py",
-        "hashed_secret": "1bca6c0532a5bd34f039194102956286e4a0855a",
-        "is_verified": false,
-        "line_number": 423
-      }
-    ],
     "press/press/doctype/invoice/fixtures/stripe_payment_intent_succeeded_webhook.json": [
       {
         "type": "Base64 High Entropy String",
@@ -547,5 +524,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-15T16:58:31Z"
+  "generated_at": "2026-04-24T17:21:58Z"
 }

--- a/press/press/doctype/deploy_candidate/test_deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/test_deploy_candidate.py
@@ -105,26 +105,6 @@ class TestDeployCandidate(FrappeTestCase):
 			self.fail("PermissionError raised in pre_build")
 
 	@patch("press.press.doctype.deploy_candidate.deploy_candidate.frappe.enqueue_doc")
-	@patch.object(DeployCandidateBuild, "_build", new=Mock())
-	def test_old_style_press_admin_team_can_pre_build(self, mock_enqueue_doc, mock_commit):
-		"""
-		Test if old style press admin team can pre build
-
-		Checks permission. Make sure no PermissionError is raised
-		"""
-		app = create_test_app()
-		group = create_test_release_group([app], self.user)
-		group.db_set("team", self.team.name)
-		frappe.rename_doc("Team", self.team.name, self.user)
-		frappe.set_user(self.user)
-		deploy_candidate = create_test_deploy_candidate(group)
-		deploy_candidate_build = create_test_deploy_candidate_build(deploy_candidate, no_build=True)
-		try:
-			deploy_candidate_build.insert()
-		except frappe.PermissionError:
-			self.fail("PermissionError raised in pre_build")
-
-	@patch("press.press.doctype.deploy_candidate.deploy_candidate.frappe.enqueue_doc")
 	def test_deploy_with_empty_apps_creates_deploy_candidate_with_same_release(
 		self, mock_enqueue_doc, mock_commit
 	):
@@ -406,21 +386,21 @@ def create_cache_test_apps(team: "Team") -> dict[str, "AppInfo"]:
 			"Frappe Framework",
 			"Nightly",
 			"develop",
-			"d26c67df75a95ef43d329eadd48d7998ea656856",
+			"d26c67df75a95ef43d329eadd48d7998ea656856",  # pragma: allowlist secret
 		),
 		(
 			"https://github.com/frappe/wiki",
 			"Frappe Wiki",
 			"Nightly",
 			"master",
-			"8b369c63dd90b4f36195844d4a84e2aaa3b8f39a",
+			"8b369c63dd90b4f36195844d4a84e2aaa3b8f39a",  # pragma: allowlist secret
 		),
 		(
 			"https://github.com/The-Commit-Company/raven",
 			"Raven",
 			"Nightly",
 			"develop",
-			"317de412bc4b66c21052a929021c1013bbe31335",
+			"317de412bc4b66c21052a929021c1013bbe31335",  # pragma: allowlist secret
 		),
 	]
 

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -1294,7 +1294,7 @@ class ReleaseGroup(Document, TagHelpers):
 
 	def get_next_apps(self, current_apps) -> list[frappe._dict[str, str | datetime]]:  # noqa: C901
 		marketplace_app_sources = self.get_marketplace_app_sources()
-		# Only users with access to the team can reach this stage therefore we can trust `self.team``
+		# Only users with access to the team can reach this stage therefore we can trust `self.team`
 		current_team: Team = frappe.get_doc("Team", self.team)
 		app_publishers_team = [current_team.name]
 

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
 	from datetime import datetime
 	from typing import Any
 
+	from press.press.doctype.team.team import Team
 	from press.press.doctype.user_ssh_key.user_ssh_key import UserSSHKey
 
 DEFAULT_DEPENDENCIES = [
@@ -1293,7 +1294,7 @@ class ReleaseGroup(Document, TagHelpers):
 
 	def get_next_apps(self, current_apps) -> list[frappe._dict[str, str | datetime]]:  # noqa: C901
 		marketplace_app_sources = self.get_marketplace_app_sources()
-		current_team = get_current_team(True)
+		current_team: Team = frappe.get_doc("Team", self.team)
 		app_publishers_team = [current_team.name]
 
 		if current_team.parent_team:

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -1294,6 +1294,7 @@ class ReleaseGroup(Document, TagHelpers):
 
 	def get_next_apps(self, current_apps) -> list[frappe._dict[str, str | datetime]]:  # noqa: C901
 		marketplace_app_sources = self.get_marketplace_app_sources()
+		# Only users with access to the team can reach this stage therefore we can trust `self.team``
 		current_team: Team = frappe.get_doc("Team", self.team)
 		app_publishers_team = [current_team.name]
 


### PR DESCRIPTION
Removed a older test of team rename deploy ability;

Since post rename users won't be able to initiate deploy anyways since the deploy would not allow that?

https://github.com/frappe/press/blob/4062758cc375ec1214ebb4f6a48d34cc4831f3c0/press/api/bench.py#L815-L816