### PR TITLE
fix(deploy): In new flow use group team for build creation

### DIFF
--- a/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
+++ b/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
@@ -1131,6 +1131,13 @@ class DeployCandidateBuild(Document):
 		)
 		return False
 
+	def get_team_for_build(self):
+		"""Default to group team in case of new flow"""
+		new_flow = frappe.get_single_value("Press Settings", "use_new_deploy_flow")
+		return (
+			frappe.db.get_value("Release Group", self.group, "team") if new_flow else get_current_team(True)
+		)
+
 	def pre_build(self, **kwargs):
 		self.reset_build_state()
 		self.add_pre_build_steps()
@@ -1154,7 +1161,7 @@ class DeployCandidateBuild(Document):
 		) = (
 			frappe.session.user,
 			frappe.session.data,
-			get_current_team(True),
+			self.get_team_for_build(),
 		)
 
 		frappe.set_user(frappe.get_value("Team", team.name, "user"))

--- a/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
+++ b/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
@@ -1164,7 +1164,7 @@ class DeployCandidateBuild(Document):
 			self.get_team_for_build(),
 		)
 
-		frappe.set_user(frappe.get_value("Team", team.name, "user"))
+		frappe.set_user(frappe.get_value("Team", team if isinstance(team, str) else team.name, "user"))
 		queue = "default" if frappe.conf.developer_mode else "build"
 
 		frappe.enqueue_doc(


### PR DESCRIPTION
When in new deploy flow build is initiated by the group team, therefore default to it when creating the build instead of the on-the-fly team check