### PR TITLE
fix(marketplace): Add label for no public releases

### DIFF
--- a/dashboard/src/components/group/AddAppDialog.vue
+++ b/dashboard/src/components/group/AddAppDialog.vue
@@ -263,7 +263,13 @@ export default {
 					type: 'Component',
 					width: '8rem',
 					component: (row) => {
-						if (row.compatible)
+						if (row.no_public_releases)
+							return h(Badge, {
+								class: 'ml-auto',
+								label: 'No Public Releases',
+								theme: 'red',
+							});
+						else if (row.compatible)
 							return h(Button, {
 								label: 'Add',
 								iconLeft: this.addedApps.includes(row) ? 'check' : 'plus',

--- a/press/api/bench.py
+++ b/press/api/bench.py
@@ -483,7 +483,7 @@ def installable_apps(name):
 
 @frappe.whitelist()
 @protected("Release Group")
-def all_apps(name):
+def all_apps(name: str):
 	"""Return all apps in the marketplace that are not installed in the release group for adding new apps"""
 
 	release_group = frappe.get_doc("Release Group", name)
@@ -521,13 +521,22 @@ def all_apps(name):
 	total_installs_by_app = get_total_installs_by_app()
 
 	for app in marketplace_apps:
-		app["sources"] = find_all(
-			list(filter(lambda x: x.version == release_group.version, marketplace_app_sources)),
-			lambda x: x.app == app.app,
-		)
+		public_app_sources = list(filter(lambda source: source.app == app.app, marketplace_app_sources))
+
+		if not public_app_sources:
+			app["no_public_releases"] = True
+
+		app["sources"] = list(
+			filter(lambda source: source.version == release_group.version, public_app_sources)
+		)  # will be empty if there are no public releases
+
 		# for fetching repo details for incompatible apps
-		app_source = find(marketplace_app_sources, lambda x: x.app == app.app)
-		app["repo"] = f"{app_source.repository_owner}/{app_source.repository}" if app_source else None
+		app["repo"] = (
+			f"{public_app_sources[0].repository_owner}/{public_app_sources[0].repository}"
+			if app["sources"]
+			else None
+		)
+
 		app["total_installs"] = total_installs_by_app.get(app["name"], 0)
 
 	return marketplace_apps


### PR DESCRIPTION
Previously when there were no public releases for published marketplace apps, apps used to have "Not compatible" badge which was misleading (ref: https://support.frappe.io/helpdesk/tickets/63966). This commit adds an explicit badge "No Public Releases" when that happens.

Either never allow published marketplace apps with zero public releases, or merge this PR and fix the presentation.

### Before:
<img width="1440" height="398" alt="Screenshot 2026-04-26 at 12 27 34 PM" src="https://github.com/user-attachments/assets/cdf8bf6f-9dd7-4ccc-bd16-9701cdef6eda" />


### After:

<img width="1440" height="816" alt="Screenshot 2026-04-26 at 12 29 03 PM" src="https://github.com/user-attachments/assets/ef26d2c1-47a3-437b-aa4d-aa6fb20a818a" />

