### PR TITLE
fix(billing): Edge cases in UPI autopay

### DIFF
--- a/dashboard/src/components/billing/PaymentDetails.vue
+++ b/dashboard/src/components/billing/PaymentDetails.vue
@@ -401,7 +401,11 @@ function updatePaymentMode(mode) {
 		return;
 	}
 	if (mode === 'UPI Autopay') {
-		router.push({ name: 'BillingUPIAutopay' });
+		if (team.doc.default_razorpay_mandate) {
+			if (!changePaymentMode.loading) changePaymentMode.submit({ mode });
+		} else {
+			router.push({ name: 'BillingUPIAutopay' });
+		}
 		return;
 	}
 	if (!changePaymentMode.loading) changePaymentMode.submit({ mode });

--- a/dashboard/src/pages/BillingUPIAutopay.vue
+++ b/dashboard/src/pages/BillingUPIAutopay.vue
@@ -106,7 +106,6 @@ export default {
 					'auth_type',
 					'max_amount',
 					'expires_on',
-					'is_default',
 					'upi_vpa',
 					'creation',
 				],
@@ -142,16 +141,6 @@ export default {
 					},
 					{
 						label: '',
-						fieldname: 'is_default',
-						type: 'Component',
-						component({ row }) {
-							if (row.is_default) {
-								return h(Badge, { theme: 'blue' }, () => 'Default');
-							}
-						},
-					},
-					{
-						label: '',
 						fieldname: 'creation',
 						type: 'Timestamp',
 						align: 'right',
@@ -159,26 +148,6 @@ export default {
 				],
 				rowActions: ({ listResource, row }) => {
 					return [
-						{
-							label: 'Set as default',
-							onClick: () => {
-								toast.promise(
-									listResource.runDocMethod.submit({
-										method: 'set_default',
-										name: row.name,
-									}),
-									{
-										loading: 'Setting as default...',
-										success: () => {
-											this.$team.reload();
-											return 'Default mandate set';
-										},
-										error: 'Could not set default mandate',
-									},
-								);
-							},
-							condition: () => !row.is_default && row.status === 'Active',
-						},
 						{
 							label: 'Cancel',
 							onClick: () => {

--- a/press/api/billing.py
+++ b/press/api/billing.py
@@ -742,18 +742,6 @@ def get_razorpay_mandates() -> list[dict]:
 
 @frappe.whitelist()
 @role_guard.api("billing")
-def set_razorpay_mandate_as_default(mandate_name: str):
-	"""Set a Razorpay mandate as the default for the team"""
-	team = get_current_team()
-
-	mandate = frappe.get_doc("Razorpay Mandate", {"name": mandate_name, "team": team})
-	mandate.set_default()
-
-	return {"success": True}
-
-
-@frappe.whitelist()
-@role_guard.api("billing")
 def cancel_razorpay_mandate(mandate_name: str):
 	"""Cancel a Razorpay mandate"""
 	team = get_current_team()

--- a/press/press/doctype/razorpay_mandate/razorpay_mandate.py
+++ b/press/press/doctype/razorpay_mandate/razorpay_mandate.py
@@ -159,6 +159,13 @@ class RazorpayMandate(Document):
 		if reason:
 			self.failure_reason = reason
 		self.save(ignore_permissions=True)
+		if self.is_default:
+			frappe.db.set_value("Team", self.team, "default_razorpay_mandate", None)
+			if frappe.db.get_value("Team", self.team, "payment_mode") == "UPI Autopay":
+				frappe.db.set_value("Team", self.team, "payment_mode", "")
+				frappe.get_doc("Team", self.team).send_email_for_failed_upi_payment(
+					error_reason="MANDATE_CANCELLED", upi_vpa=self.upi_vpa
+				)
 
 	def pause(self):
 		"""Pause the mandate"""

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -1345,7 +1345,7 @@ class Team(Document):
 		message = f"Failed Invoice Payment [{invoice}]({invoice_url}) of Partner: [{self.name}]({team_url})"
 		TelegramMessage.enqueue(message=message)
 
-	def send_email_for_failed_upi_payment(self, invoice, error_reason=None, upi_vpa=None):
+	def send_email_for_failed_upi_payment(self, invoice=None, error_reason=None, upi_vpa=None):
 		if isinstance(invoice, str):
 			invoice = frappe.get_doc("Invoice", invoice)
 
@@ -1358,7 +1358,7 @@ class Team(Document):
 			template="payment_failed_upi_autopay",
 			args={
 				"subject": subject,
-				"amount": invoice.get_formatted("amount_due_with_tax"),
+				"amount": invoice.get_formatted("amount_due_with_tax") if invoice else None,
 				"upi_vpa": upi_vpa,
 				"error_reason": error_reason,
 				"upi_autopay_link": frappe.utils.get_url("/dashboard/billing/upi-autopay"),

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -160,6 +160,7 @@ class Team(Document):
 		"hybrid_servers_enabled",
 		"relaxed_permissions",
 		"upi_autopay_enabled",
+		"default_razorpay_mandate",
 	)
 
 	def get_doc(self, doc):

--- a/press/templates/emails/payment_failed_upi_autopay.html
+++ b/press/templates/emails/payment_failed_upi_autopay.html
@@ -47,6 +47,12 @@
 			<p><a href="{{ upi_autopay_link }}">Manage UPI Autopay</a></p>
 			<p><a href="{{ billing_link }}">Pay Now</a></p>
 
+		{% elif error_reason == "MANDATE_CANCELLED" %}
+			<p>Your UPI Autopay mandate has been <strong>cancelled</strong>. Your account currently has no active payment method.</p>
+			<p>To ensure uninterrupted service and avoid site suspension, please set up a new UPI Autopay mandate or update your billing details with a valid payment method.</p>
+			<p><a href="{{ upi_autopay_link }}">Set Up UPI Autopay</a></p>
+			<p><a href="{{ billing_link }}">Update Billing Details</a></p>
+
 		{% else %}
 			<p>We attempted to auto-debit <strong>{{ amount }}</strong>{% if upi_vpa %} from your UPI account (<strong>{{ upi_vpa }}</strong>){% endif %} for your Frappe Cloud subscription, but the payment failed.</p>
 			<p>Please check your UPI Autopay mandate or pay this invoice now. Your sites may be suspended if the invoice remains unpaid. If you need help, <a href="https://frappecloud.com/support">contact support</a>.</p>


### PR DESCRIPTION
Removing dead/unreachable codeblock.  Adding edge case where mandate already exists and allowing user to change the mode of payment alone.