### PR TITLE
fix(site): In app plan selector dialog, use deafult pricing format

### DIFF
--- a/dashboard/src/components/site/SiteAppPlanSelectorDialog.vue
+++ b/dashboard/src/components/site/SiteAppPlanSelectorDialog.vue
@@ -50,15 +50,6 @@ export default {
 		plans() {
 			return this.app.plans.map((plan) => {
 				return {
-					label:
-						plan.price_inr === 0 || plan.price_usd === 0
-							? 'Free'
-							: `${this.$format.userCurrency(
-									this.$team.doc.currency === 'INR'
-										? plan.price_inr
-										: plan.price_usd,
-								)}/mo`,
-					sublabel: ' ',
 					...plan,
 					features: plan.features.map((f) => ({
 						value: f,


### PR DESCRIPTION
(cherry picked from commit 16d1b6c)

<img width="896" height="480" alt="image" src="https://github.com/user-attachments/assets/f917f112-f1cc-4711-9876-139b76aa44a4" />

<img width="913" height="482" alt="image" src="https://github.com/user-attachments/assets/6af99a48-4790-4447-aae2-2b3f23f7db3e" />

