### PR TITLE
fix(release-group): Disabled benches should not be able to update 

### DIFF
--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -912,6 +912,7 @@ class ReleaseGroup(Document, TagHelpers):
 			or self.dependency_update_pending
 		)
 		out.update_available = False if out.has_running_release_pipeline else out.update_available
+		out.update_available = out.update_available if self.enabled else False
 		out.number_of_apps = len(self.apps)
 
 		out.sites = [

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -1165,6 +1165,9 @@ class ReleaseGroup(Document, TagHelpers):
 
 	@property
 	def status(self):
+		if not self.enabled:
+			return "Disabled"
+
 		active_benches = frappe.db.get_all(
 			"Bench", {"group": self.name, "status": "Active"}, limit=1, order_by="creation desc"
 		)

--- a/press/press/doctype/release_pipeline/release_pipeline.py
+++ b/press/press/doctype/release_pipeline/release_pipeline.py
@@ -519,9 +519,7 @@ class ReleasePipeline(WorkflowBuilder):
 		if not is_enabled:
 			self.is_user_addressable_failure = True
 			self.save()
-			raise ReleasePipelineFailure(
-				"Release Group is disabled. Please enable to proceed with the release."
-			)
+			raise ReleasePipelineFailure("Release Group is disabled. Updates can not be initiated.")
 
 		try:
 			self.validate_app_hashes(apps)  # This sets status to "Running"

--- a/press/press/doctype/release_pipeline/release_pipeline.py
+++ b/press/press/doctype/release_pipeline/release_pipeline.py
@@ -515,6 +515,14 @@ class ReleasePipeline(WorkflowBuilder):
 	@task(queue=_get_task_execution_queue())
 	def run_pre_release_checks(self, apps: list[dict[str, str]]):
 		"""Groups all early-exit validation logic."""
+		is_enabled = frappe.db.get_value("Release Group", self.release_group, "enabled")
+		if not is_enabled:
+			self.is_user_addressable_failure = True
+			self.save()
+			raise ReleasePipelineFailure(
+				"Release Group is disabled. Please enable to proceed with the release."
+			)
+
 		try:
 			self.validate_app_hashes(apps)  # This sets status to "Running"
 			self.validate_server_storages()


### PR DESCRIPTION
If the bench group is not cleanup by the scheduled job, users can still try and trigger deploys.