### PR TITLE
fix(mariadb): Fallback to system allocator if MariaDB doesn't start

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -615,6 +615,7 @@
         "tanmoy",
         "tanmoysrt",
         "tanxxxxxxkar",
+        "tcmalloc",
         "Telangana",
         "termenv",
         "Thgcy",

--- a/press/playbooks/roles/mariadb_memory_allocator/tasks/main.yml
+++ b/press/playbooks/roles/mariadb_memory_allocator/tasks/main.yml
@@ -28,7 +28,7 @@
     dest: /etc/systemd/system/mariadb.service.d/allocator.conf
     owner: root
     group: root
-    mode: 0644
+    mode: 644
   when: allocator != "system"
 
 - name: Remove Memory Allocator
@@ -43,6 +43,22 @@
     name: mariadb
     enabled: yes
     state: restarted
+  ignore_errors: true # We need to recover from a failed restart if the allocator is not compatible
+  register: restart_result
+
+- name: Fallback to System Memory Allocator
+  file:
+    path: /etc/systemd/system/mariadb.service.d/allocator.conf
+    state: absent
+  when: restart_result is failed
+
+- name: Restart MariaDB after Fallback
+  systemd:
+    daemon_reload: true
+    name: mariadb
+    enabled: yes
+    state: restarted
+  when: restart_result is failed
 
 - name: Show Memory Allocator
   mysql_query:

--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -1787,9 +1787,16 @@ class DatabaseServer(BaseServer):
 			query_result = result.get("query_result")
 			if query_result:
 				self.reload()
-				self.memory_allocator = memory_allocator
+				self.memory_allocator = self._get_memory_allocator_display_name(query_result[0][0]["Value"])
 				self.memory_allocator_version = query_result[0][0]["Value"]
 				self.save()
+
+	def _get_memory_allocator_display_name(self, allocator_version):
+		if "jemalloc" in allocator_version.lower():
+			return "jemalloc"
+		if "tcmalloc" in allocator_version.lower():
+			return "TCMalloc"
+		return "System"
 
 	@dashboard_whitelist()
 	def get_mariadb_variables(self):


### PR DESCRIPTION
If MariaDB fails to restart after changing the allocator then fallback to the system allocator.

Assumes that system allocator will always work!!!

Reference: https://gameplan.frappe.cloud/g/space/166/discussion/5255/incident-30th-april-2026-m116-ksa