### PR TITLE
fix(onboarding): page crash due to accessing null field in trialSite

### DIFF
--- a/dashboard/src/App.vue
+++ b/dashboard/src/App.vue
@@ -108,7 +108,7 @@ provide('team', team);
 provide('session', session);
 
 watch(
-  () => team.doc?.onboarding?.complete,
+  () => team?.doc?.onboarding?.complete,
   (x) => {
     if(x) useSearch();
   },

--- a/dashboard/src/components/Onboarding.vue
+++ b/dashboard/src/components/Onboarding.vue
@@ -126,7 +126,7 @@
 						<TextInsideCircle>3</TextInsideCircle>
 						<span class="text-base font-medium"> Complete billing setup </span>
 					</div>
-					<div class="pl-7 mt-2" v-if="$team.doc.onboarding.site_created">
+					<div class="pl-7 mt-2" v-if="$team.doc.onboarding.site_created && trialSite">
 						<p class="text-p-base text-gray-800">
 							Add your billing details and payment method to activate your
 							subscription.You won't be charged until your trial ends on


### PR DESCRIPTION

<img width="1936" height="740" alt="image" src="https://github.com/user-attachments/assets/bd592430-b30b-4990-8667-cb6761b5dad0" />


### Reason

- user has 0 trialSites as per api response
-  but the site_created field is true
- Because the user created site year ago but it got archived
- so the trialSite value here is always undefined and we are trying to access its value because site_created is true? its true because the user created site year ago!

This is a rare edgecase

Maybe the backend api must return archived sites in trial sites. For now ive added my check on the frontend which fixes the issue