### PR TITLE
fix(billing): Avoid double OTP during add card via stripe

### DIFF
--- a/dashboard/src/components/billing/CardForm.vue
+++ b/dashboard/src/components/billing/CardForm.vue
@@ -227,18 +227,52 @@ const setupIntentSuccess = createResource({
 	},
 });
 
+const paymentIntentSuccess = createResource({
+	url: 'press.api.billing.payment_intent_success',
+	makeParams: ({ paymentIntent, address }) => ({
+		payment_intent: paymentIntent,
+		address,
+	}),
+	onSuccess: () => {
+		addingCard.value = false;
+		toast.success('Card added successfully');
+		emit('success');
+	},
+	onError: (error) => {
+		console.error(error);
+		addingCard.value = false;
+		errorMessage.value = error.messages.join('\n');
+		toast.error(errorMessage.value);
+	},
+});
+
 const verifyCardWithMicroCharge = createResource({
 	url: 'press.api.billing.create_payment_intent_for_micro_debit',
 	onSuccess: async (paymentIntent) => {
 		let { client_secret } = paymentIntent;
 
 		let payload = await stripe.value.confirmCardPayment(client_secret, {
-			payment_method: { card: card.value },
+			payment_method: {
+				card: card.value,
+				billing_details: {
+					name: billingInformation.cardHolderName,
+					address: {
+						line1: billingInformation.address,
+						city: billingInformation.city,
+						state: billingInformation.state,
+						postal_code: billingInformation.postal_code,
+						country: getCountryCode(team.doc?.country),
+					},
+				},
+			},
 		});
 
 		if (payload.paymentIntent?.status === 'succeeded') {
 			microChargeCompleted.value = true;
-			submit();
+			paymentIntentSuccess.submit({
+				paymentIntent: { id: payload.paymentIntent.id },
+				address: billingInformation,
+			});
 		} else {
 			tryingMicroCharge.value = false;
 			errorMessage.value = payload.error?.message;
@@ -261,17 +295,6 @@ async function setupStripeIntent() {
 const addressFormRef = ref(null);
 
 async function submit() {
-	addingCard.value = true;
-	let message = await addressFormRef.value.validate();
-
-	if (message) {
-		errorMessage.value = message;
-		addingCard.value = false;
-		return;
-	} else {
-		errorMessage.value = null;
-	}
-
 	const { setupIntent, error } = await stripe.value.confirmCardSetup(
 		_setupIntent.value.client_secret,
 		{
@@ -313,22 +336,28 @@ async function submit() {
 }
 
 async function verifyWithMicroChargeIfApplicable() {
+	addingCard.value = true;
+	let message = await addressFormRef.value.validate();
+	if (message) {
+		errorMessage.value = message;
+		addingCard.value = false;
+		return;
+	}
+	errorMessage.value = null;
+
 	const teamCurrency = team.doc?.currency;
 	const verifyCardsWithMicroCharge = window.verify_cards_with_micro_charge;
 	const isMicroChargeApplicable =
 		verifyCardsWithMicroCharge === 'Both INR and USD' ||
 		(verifyCardsWithMicroCharge == 'Only INR' && teamCurrency === 'INR') ||
 		(verifyCardsWithMicroCharge === 'Only USD' && teamCurrency === 'USD');
-	if (isMicroChargeApplicable) {
-		await _verifyWithMicroCharge();
-	} else {
-		submit();
-	}
-}
 
-async function _verifyWithMicroCharge() {
-	tryingMicroCharge.value = true;
-	return verifyCardWithMicroCharge.submit();
+	if (isMicroChargeApplicable) {
+		tryingMicroCharge.value = true;
+		verifyCardWithMicroCharge.submit();
+	} else {
+		await submit();
+	}
 }
 
 function getCountryCode(country) {

--- a/press/api/billing.py
+++ b/press/api/billing.py
@@ -271,6 +271,7 @@ def create_payment_intent_for_micro_debit():
 		metadata={
 			"payment_for": "micro_debit_test_charge",
 		},
+		setup_future_usage="off_session",
 		payment_method_options={
 			"card": {
 				"request_three_d_secure": "any" if team.is_trusted_team else "automatic",
@@ -578,6 +579,36 @@ def setup_intent_success(setup_intent, address=None):
 		setup_intent.payment_method,
 		setup_intent.id,
 		setup_intent.mandate,
+		mandate_reference,
+		set_default=True,
+		verified_with_micro_charge=True,
+	)
+	if address:
+		address = frappe._dict(address)
+		team.update_billing_details(address)
+
+	return {"payment_method_name": payment_method.name}
+
+
+@frappe.whitelist()
+@role_guard.api("billing")
+def payment_intent_success(payment_intent, address=None):
+	payment_intent = frappe._dict(payment_intent)
+
+	# Re-fetch from Stripe to get authoritative payment_method and mandate details
+	stripe = get_stripe()
+	payment_intent = stripe.PaymentIntent.retrieve(payment_intent.id)
+
+	team = get_current_team(True)
+	clear_setup_intent()
+	mandate_options = (
+		(payment_intent.get("payment_method_options") or {}).get("card", {}).get("mandate_options")
+	)
+	mandate_reference = mandate_options.get("reference") if mandate_options else None
+	payment_method = team.create_payment_method(
+		payment_intent.payment_method,
+		payment_intent.id,
+		payment_intent.get("mandate"),
 		mandate_reference,
 		set_default=True,
 		verified_with_micro_charge=True,

--- a/press/api/billing.py
+++ b/press/api/billing.py
@@ -255,6 +255,8 @@ def fetch_invoice_items(invoice):
 @frappe.whitelist()
 @role_guard.api("billing")
 def create_payment_intent_for_micro_debit():
+	from frappe.utils import random_string
+
 	team = get_current_team(True)
 	stripe = get_stripe()
 
@@ -262,7 +264,7 @@ def create_payment_intent_for_micro_debit():
 		"micro_debit_charge_usd" if team.currency == "USD" else "micro_debit_charge_inr"
 	)
 	amount = frappe.db.get_single_value("Press Settings", micro_debit_charge_field)
-
+	hash = random_string(10)
 	intent = stripe.PaymentIntent.create(
 		amount=int(amount * 100),
 		currency=team.currency.lower(),
@@ -272,9 +274,18 @@ def create_payment_intent_for_micro_debit():
 			"payment_for": "micro_debit_test_charge",
 		},
 		setup_future_usage="off_session",
+		payment_method_types=["card"],
 		payment_method_options={
 			"card": {
 				"request_three_d_secure": "any" if team.is_trusted_team else "automatic",
+				"mandate_options": {
+					"reference": f"Mandate-team:{team}-{hash}",
+					"amount_type": "maximum",
+					"amount": 1500000,
+					"start_date": int(frappe.utils.get_timestamp()),
+					"interval": "sporadic",
+					"supported_types": ["india"],
+				},
 			}
 		},
 	)
@@ -605,10 +616,24 @@ def payment_intent_success(payment_intent, address=None):
 		(payment_intent.get("payment_method_options") or {}).get("card", {}).get("mandate_options")
 	)
 	mandate_reference = mandate_options.get("reference") if mandate_options else None
+
+	# After confirmCardPayment with mandate_options, Stripe attaches the created mandate
+	# to the charge, not to the PaymentIntent top-level. Try in order:
+	#   1. payment_intent.mandate (set when an existing mandate is reused)
+	#   2. payment_intent.setup_intent -> SetupIntent.mandate (internal SI from setup_future_usage)
+	#   3. payment_intent.latest_charge -> Charge.mandate (where mandate ID lands after creation)
+	mandate_id = payment_intent.get("mandate")
+	if not mandate_id and payment_intent.get("setup_intent"):
+		setup_intent = stripe.SetupIntent.retrieve(payment_intent["setup_intent"])
+		mandate_id = setup_intent.get("mandate")
+	if not mandate_id and payment_intent.get("latest_charge"):
+		charge = stripe.Charge.retrieve(payment_intent["latest_charge"])
+		mandate_id = charge.get("mandate")
+
 	payment_method = team.create_payment_method(
 		payment_intent.payment_method,
 		payment_intent.id,
-		payment_intent.get("mandate"),
+		mandate_id,
 		mandate_reference,
 		set_default=True,
 		verified_with_micro_charge=True,


### PR DESCRIPTION
Removed setup intent and going only with payment intent and storing the card information as part of it. Verfied in local and this persists the card info for future usage