### PR TITLE
fix(ui): analytic cards action btn alignments in site analytics

### DIFF
--- a/dashboard/src/components/site/AnalyticsCard.vue
+++ b/dashboard/src/components/site/AnalyticsCard.vue
@@ -7,11 +7,11 @@
 			shouldHighlight && 'ring-1',
 		]"
 	>
-		<div class="flex items-center border-b p-3 gap-3">
+		<div class="flex items-center border-b p-3 gap-2">
 			<h3 class="text-base font-medium text-gray-900">{{ title }}</h3>
 			<slot name="action"></slot>
 
-			<button @click="shareCard" class="flex items-center gap-1.5 ml-auto">
+			<button @click="shareCard" class="flex items-center gap-1.5 ml-auto" aria-label="Copy">
 				<LucideLink
 					class="size-3 outline-none duration-200 hover:text-current cursor-pointer"
 				/>

--- a/dashboard/src/components/site/SiteAnalytics.vue
+++ b/dashboard/src/components/site/SiteAnalytics.vue
@@ -418,7 +418,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
-				class="sm:col-span-2"
+				class='sm:col-span-2 [&_[aria-label="Copy"]]:m-0'
 				title="Frequent Slow Queries"
 				@share-card="shareDashboard"
 			>
@@ -449,7 +449,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
-				class="sm:col-span-2"
+				class='sm:col-span-2 [&_[aria-label="Copy"]]:m-0'
 				title="Top Slow Queries"
 				@share-card="shareDashboard"
 			>


### PR DESCRIPTION
### Before:

<img width="2146" height="660" alt="image" src="https://github.com/user-attachments/assets/fecbeccc-4591-455a-8125-b3106670e6b5" />


### After: 

<img width="2134" height="682" alt="image" src="https://github.com/user-attachments/assets/1cc22f37-c0e7-4e08-840d-96f51a7dc8a5" />
