### PR TITLE
refactor(marketplace): Remove redundant permission decorator

### DIFF
--- a/press/api/marketplace.py
+++ b/press/api/marketplace.py
@@ -1390,7 +1390,6 @@ def is_desk_user(user: str | None = None) -> bool:
 
 
 @frappe.whitelist(methods=["GET"])
-@protected(["Marketplace App", "Marketplace App Audit"])
 def get_app_audit(app: str):
 	"""
 	Fetches the latest audit report for the given marketplace app.


### PR DESCRIPTION
The decorator is certainly stupid as it tries to access hard coded params. Should have seen this before. We anyways have a perm check inside, so can be removed completely.