### PR TITLE
refactor(serverOverview): Use computed property for servers()

### DIFF
--- a/dashboard/src/components/server/ServerOverview.vue
+++ b/dashboard/src/components/server/ServerOverview.vue
@@ -6,26 +6,10 @@
 		/>
 		<div class="grid grid-cols-1 items-start gap-5 sm:grid-cols-2">
 			<div
-				v-for="server in $appServer?.doc?.secondary_server
-					? $dbReplicaServer?.doc
-						? [
-								'Server',
-								'App Secondary Server',
-								'Database Server',
-								'Replication Server',
-							]
-						: ['Server', 'App Secondary Server', 'Database Server']
-					: $dbReplicaServer?.doc
-						? ['Server', 'Database Server', 'Replication Server']
-						: ['Server', 'Database Server']"
+				v-for="server in servers" 
 				class="col-span-1 rounded-md border lg:col-span-2"
 			>
 				<div
-					v-if="
-						!(
-							server === 'Database Server' && $appServer?.doc?.is_unified_server
-						)
-					"
 					class="grid grid-cols-2 lg:grid-cols-4"
 					:class="{
 						'opacity-70 pointer-events-none':
@@ -716,6 +700,21 @@ export default {
 		},
 	},
 	computed: {
+    servers() {
+      const list = ["Server"];
+
+      if (this.$appServer?.doc?.secondary_server) 
+        list.push("App Secondary Server");
+
+      if (!this.$appServer?.doc?.is_unified_server) 
+        list.push("Database Server");
+
+      if (this.$dbReplicaServer?.doc) 
+        list.push("Replication Server");
+
+      return list;
+    },
+
 		serverInformation() {
 			return [
 				{


### PR DESCRIPTION
## Description
- removes ugly logic in the markup
- Previous logic was creating a divider like ui cuz 
  example : [ "server", "database server" ]
  
  now we loop over and render 2 cards as per the array 
  
  but if we have unified server then we were not rendering the database server* item. But the outer wrapper had border on it. hence causing divider. 🫠 
  
 ### Before: 

<img width="1537" height="784" alt="image" src="https://github.com/user-attachments/assets/e59721ac-8a0e-4c08-a65b-ef0bdd11765b" />

<img width="1232" height="250" alt="image" src="https://github.com/user-attachments/assets/782fe533-df3f-4268-b22a-b570b94b45e1" />


### After:  

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/c089100c-0109-4895-af46-7c4438ba9d4f" />
