### PR TITLE
fix(build): Correct container mounts

### DIFF
--- a/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
+++ b/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
@@ -797,6 +797,8 @@ class DeployCandidateBuild(Document):
 			)
 
 		self.candidate._set_additional_packages()
+		self.candidate._set_container_mounts()
+
 		dockerfile = self._generate_dockerfile()
 		# Add build steps based on dockerfile checkpoints before starting the build
 		self.add_build_steps(dockerfile)


### PR DESCRIPTION
Purely for self hosted deployments correctly add container mounts in the `Dockerfile`