### PR TITLE
perf(agent): Polling job will be improved and will run frequently

### DIFF
--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -572,9 +572,8 @@ def populate_output_cache(polled_job, job):
 def filter_active_servers(servers):
 	# Prepare list of all_active_servers for each server_type
 	# Return servers that are in all_active_servers
-	server_types = [server.server_type for server in servers]
 	all_active_servers = {}
-	for server_type in server_types:
+	for server_type in {server.server_type for server in servers}:
 		all_active_servers[server_type] = set(frappe.get_all(server_type, {"status": "Active"}, pluck="name"))
 
 	active_servers = []


### PR DESCRIPTION
We are running poll_pending_jobs for every 5 seconds once, but as each call is taking longer than 30 seconds, the polling is not happening frequently. As we are running redundant loop in the process, the call is delayed. Fixed the root cause, and this can bring down the time taken for signup.