### PR TITLE
fix(billing): Show in banner about card payment failure

### DIFF
--- a/dashboard/src/components/AlertCardExpired.vue
+++ b/dashboard/src/components/AlertCardExpired.vue
@@ -1,6 +1,6 @@
 <template>
 	<AlertBanner
-		title="Your card has expired. Please update your payment details."
+		title="Your card has expired. Please update your payment details to avoid site suspension."
 		type="warning"
 	>
 		<Button class="ml-auto" route="/billing" variant="outline">
@@ -9,10 +9,10 @@
 	</AlertBanner>
 </template>
 <script>
-import AlertBanner from './AlertBanner.vue';
+import AlertBanner from './AlertBanner.vue'
 
 export default {
 	name: 'AlertCardExpired',
 	components: { AlertBanner },
-};
+}
 </script>

--- a/dashboard/src/components/AlertCardPaymentFailed.vue
+++ b/dashboard/src/components/AlertCardPaymentFailed.vue
@@ -1,0 +1,30 @@
+<template>
+	<AlertBanner :title="bannerMessage" type="warning">
+		<a class="ml-auto" :href="stripeUrl" target="_blank">
+			<Button variant="outline">Pay Now</Button>
+		</a>
+	</AlertBanner>
+</template>
+<script>
+import AlertBanner from './AlertBanner.vue'
+
+export default {
+	name: 'AlertCardPaymentFailed',
+	components: { AlertBanner },
+	props: {
+		errorMessage: {
+			type: String,
+			required: true,
+		},
+		stripeUrl: {
+			type: String,
+			required: true,
+		},
+	},
+	computed: {
+		bannerMessage() {
+			return `Payment failed: ${this.errorMessage} Please settle the payment to avoid site suspension.`
+		},
+	},
+}
+</script>

--- a/dashboard/src/components/AlertMandateInfo.vue
+++ b/dashboard/src/components/AlertMandateInfo.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
 		<AlertBanner
-			title="Due to RBI regulations, we need to generate a mandate to process payments from your card."
+			title="Due to RBI regulations, we need to generate a mandate to process payments from your card. Please update your card to avoid site suspension."
 			type="warning"
 		>
 			<Button
@@ -19,8 +19,8 @@
 	</div>
 </template>
 <script>
-import AlertBanner from './AlertBanner.vue';
-import StripeCardDialog from './StripeCardDialog.vue';
+import AlertBanner from './AlertBanner.vue'
+import StripeCardDialog from './StripeCardDialog.vue'
 
 export default {
 	name: 'AlertMandateInfo',
@@ -28,7 +28,7 @@ export default {
 	data() {
 		return {
 			showAddCardDialog: false,
-		};
+		}
 	},
-};
+}
 </script>

--- a/dashboard/src/pages/ListPage.vue
+++ b/dashboard/src/pages/ListPage.vue
@@ -39,6 +39,18 @@
 				"
 				:amount="hasUnpaidInvoices"
 			/>
+			<AlertCardPaymentFailed
+				class="mb-5"
+				v-if="
+					cardPaymentFailure &&
+					$team.doc.payment_mode == 'Card' &&
+					isAfterFirstWeek &&
+					!isCardExpired &&
+					!isMandateNotSet
+				"
+				:errorMessage="cardPaymentFailure.stripe_payment_error"
+				:stripeUrl="cardPaymentFailure.stripe_invoice_url"
+			/>
 			<AlertBudgetThreshold
 				class="mb-5"
 				v-if="displayBudgetAlert > 0"
@@ -51,12 +63,12 @@
 </template>
 
 <script>
-import Header from '../components/Header.vue';
-import ObjectList from '../components/ObjectList.vue';
-import { Breadcrumbs, Button, Dropdown, TextInput } from 'frappe-ui';
-import { getObject } from '../objects';
-import { defineAsyncComponent } from 'vue';
-import dayjs from '../utils/dayjs';
+import { Breadcrumbs, Button, Dropdown, TextInput } from 'frappe-ui'
+import { defineAsyncComponent } from 'vue'
+import Header from '../components/Header.vue'
+import ObjectList from '../components/ObjectList.vue'
+import { getObject } from '../objects'
+import dayjs from '../utils/dayjs'
 
 export default {
 	components: {
@@ -81,6 +93,9 @@ export default {
 		AlertUnpaidInvoices: defineAsyncComponent(
 			() => import('../components/AlertUnpaidInvoices.vue'),
 		),
+		AlertCardPaymentFailed: defineAsyncComponent(
+			() => import('../components/AlertCardPaymentFailed.vue'),
+		),
 		AlertBudgetThreshold: defineAsyncComponent(
 			() => import('../components/AlertBudgetThreshold.vue'),
 		),
@@ -101,37 +116,55 @@ export default {
 				params: {
 					name: row.name,
 				},
-			};
+			}
 		},
 	},
 	computed: {
 		object() {
-			return getObject(this.objectType);
+			return getObject(this.objectType)
 		},
 		listOptions() {
 			return {
 				...this.object.list,
 				doctype: this.object.doctype,
 				route: this.object.detail ? this.getRoute : null,
-			};
+			}
 		},
 		isCardExpired() {
 			if (this.$team.doc.payment_method?.expiry_year < dayjs().year()) {
-				return true;
+				return true
 			} else if (
 				this.$team.doc.payment_method?.expiry_year == dayjs().year() &&
 				this.$team.doc.payment_method?.expiry_month < dayjs().month() + 1
 			) {
-				return true;
+				return true
 			} else {
-				return false;
+				return false
 			}
 		},
 		isMandateNotSet() {
-			return !this.$team.doc?.payment_method?.stripe_mandate_id;
+			return !this.$team.doc?.payment_method?.stripe_mandate_id
 		},
 		hasUnpaidInvoices() {
-			return this.$resources.getAmountDue.data;
+			return this.$resources.getAmountDue.data
+		},
+		isAfterFirstWeek() {
+			return dayjs().date() > 6
+		},
+		cardPaymentFailure() {
+			const invoices = this.$resources.getUnpaidInvoices.data
+			if (!invoices) return null
+			return (
+				invoices.find((inv) => {
+					if (!inv.stripe_payment_failed || !inv.stripe_invoice_url)
+						return false
+					const error = (inv.stripe_payment_error || '').toLowerCase()
+					return (
+						error.includes('insufficient fund') ||
+						error.includes('mandate amount')
+					)
+				}) || null
+			)
 		},
 		displayBudgetAlert() {
 			if (
@@ -139,14 +172,14 @@ export default {
 				!this.$team.doc.monthly_alert_threshold ||
 				this.$team.doc.monthly_alert_threshold <= 0
 			) {
-				return 0;
+				return 0
 			}
 
 			let difference =
 				this.$resources.getCurrentBillingAmount.data -
-				this.$team.doc.monthly_alert_threshold;
+				this.$team.doc.monthly_alert_threshold
 
-			return difference > 0 ? difference.toFixed(2) : 0;
+			return difference > 0 ? difference.toFixed(2) : 0
 		},
 	},
 	resources: {
@@ -154,15 +187,28 @@ export default {
 			return {
 				url: 'press.api.billing.total_unpaid_amount',
 				auto: true,
-			};
+			}
+		},
+		getUnpaidInvoices() {
+			return {
+				url: 'press.api.client.get_list',
+				params: {
+					doctype: 'Invoice',
+					fields: ['name', 'stripe_invoice_url'],
+					filters: { status: 'Unpaid', type: 'Subscription' },
+					order_by: 'creation desc',
+					limit: 1,
+				},
+				auto: this.$team?.doc?.payment_mode === 'Card' && this.isAfterFirstWeek,
+			}
 		},
 		getCurrentBillingAmount() {
 			return {
 				url: 'press.api.billing.get_current_billing_amount',
 				auto: true,
 				cache: 'Current Billing Amount',
-			};
+			}
 		},
 	},
-};
+}
 </script>

--- a/dashboard/src/pages/ListPage.vue
+++ b/dashboard/src/pages/ListPage.vue
@@ -42,6 +42,7 @@
 			<AlertCardPaymentFailed
 				class="mb-5"
 				v-if="
+					$team?.doc &&
 					cardPaymentFailure &&
 					$team.doc.payment_mode == 'Card' &&
 					isAfterFirstWeek &&
@@ -194,7 +195,12 @@ export default {
 				url: 'press.api.client.get_list',
 				params: {
 					doctype: 'Invoice',
-					fields: ['name', 'stripe_invoice_url'],
+					fields: [
+						'name',
+						'stripe_invoice_url',
+						'stripe_payment_failed',
+						'stripe_payment_error',
+					],
 					filters: { status: 'Unpaid', type: 'Subscription' },
 					order_by: 'creation desc',
 					limit: 1,


### PR DESCRIPTION
This banner currently shows up only for insufficient fund and mandate amount approval for card related payment. For card declined, do not honour code by bank error it wont show up in banner as I am not sure what user action would be relevant in that case; Change/update card, make current payment etc. So showing up this banner only for valid case where showing pay now CTA makes sense. Also it will show this banner after 1st week of month so that we give enough time for Stripe to make retry.