### PR TITLE
fix(ip): IP allocation for bigger series

### DIFF
--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -802,7 +802,12 @@ class DatabaseServer(BaseServer):
 
 	def validate_server_id(self):
 		if self.is_new() and not self.server_id:
-			server_ids = frappe.get_all("Database Server", fields=["server_id"], pluck="server_id")
+			server_ids = frappe.get_all(
+				"Database Server",
+				filters={"is_unified_server": self.is_unified_server},
+				fields=["server_id"],
+				pluck="server_id",
+			)
 			if server_ids:
 				self.server_id = max(server_ids or []) + 1
 			else:

--- a/press/press/doctype/virtual_machine/test_virtual_machine.py
+++ b/press/press/doctype/virtual_machine/test_virtual_machine.py
@@ -100,3 +100,24 @@ class TestVirtualMachine(FrappeTestCase):
 			vm.create_database_server()
 		except Exception as e:
 			self.fail(e)
+
+	def test_no_private_ip_collision(self):
+		list_of_series = ["n", "f", "m", "c", "p", "e", "r", "u", "t", "nfs", "fs", "nat"]
+		list_of_big_series = ["f", "m", "u", "t"]
+		vm_doc: VirtualMachine = frappe.new_doc("Virtual Machine")
+		vm_doc.subnet_cidr_block = "10.29.0.0/16"
+
+		allocated_ips = set()  # to keep track of collisions
+		for series in list_of_series:
+			if series in ["c", "r"]:  # unused
+				continue
+			vm_doc.series = series
+			max_index = 256  # most series will never have these many instances
+			if series in list_of_big_series:
+				max_index = 8192  # f, m, u and t have a theoretical max of 8192
+
+			for idx in range(max_index):
+				vm_doc.index = idx + 1
+				ip = vm_doc.get_private_ip()
+				self.assertTrue(ip not in allocated_ips)
+				allocated_ips.add(ip)

--- a/press/press/doctype/virtual_machine/virtual_machine.py
+++ b/press/press/doctype/virtual_machine/virtual_machine.py
@@ -2084,7 +2084,7 @@ class VirtualMachine(Document):
 			"cluster": self.cluster,
 			"provider": self.cloud_provider,
 			"virtual_machine": self.name,
-			"server_id": self.index,
+			"server_id": self.index + 1000000,  # u servers shouldn't cause any issues with m servers
 			"is_primary": True,
 			"team": self.team,
 			"is_unified_server": True,

--- a/press/press/doctype/virtual_machine/virtual_machine.py
+++ b/press/press/doctype/virtual_machine/virtual_machine.py
@@ -87,6 +87,7 @@ HETZNER_ROOT_DISK_ID = "hetzner-root-disk"
 DIGITALOCEAN_ROOT_DISK_ID = "digital-ocean-root-disk"
 HETZNER_ACTION_RETRIES = 10  # retry count; try to keep it lower so that it doesn't surpass than default RQ job timeout of 300 seconds
 HETZNER_POLL_INTERVAL = 6  # increased from default of 1 so that we don't hit limit of 3600/hour
+BIG_SERIES = ["f", "m", "u", "t"]  # space for two more
 
 
 class VirtualMachine(Document):
@@ -189,6 +190,20 @@ class VirtualMachine(Document):
 		self.save()
 
 	def get_private_ip(self) -> str:
+		if self.index <= 256:
+			return self.get_private_ip_old_logic()
+		return self.get_private_ip_new_logic()
+
+	def get_private_ip_new_logic(self) -> str:
+		ip = ipaddress.IPv4Interface(self.subnet_cidr_block).ip
+		start = ip + 2**14
+		offset = BIG_SERIES.index(self.series) * 2**13
+		index = (
+			self.index - 257
+		)  # so a max of 8192 + 256 = 8448 ips for each big series. or could remove index for consistency
+		return str(start + offset + index)
+
+	def get_private_ip_old_logic(self) -> str:
 		ip = ipaddress.IPv4Interface(self.subnet_cidr_block).ip
 		index = self.index + 356
 


### PR DESCRIPTION
- Our VPC subnets are /16, (e.g., 10.29.0.0 -- 10.29.255.255), so we get 65536 ips in total

- u, f, t (ref, @tanmoysrt ) and m servers are the most used, so we need to give the highest allocation to all of them.

- Let's assume each of the clusters has 2**13 = 8192 (~2k shy of 10k, but I hope this suffices) of them each.

- "n": n servers start at 1.101. The first contention occurs with f at 513th n server. Congrats if you have 513 n servers in you cluster.

- "f": starts at 3.101 and contends for the first time with p (at its 1) at 513 (7.101). Minimum pivot point, 513. Only Mumbai has crossed that point, but it already has a fucked up series so ignoring. And new logic will take newer servers to safer subnets.
  Note: there's some changes in the logic in the past, so you get gems like this:
  ```python
  In [5]: x = frappe.get_doc("Virtual Machine", {"series": "f", "index": 156, "cluster": "Mumbai"})

  In [6]: x.private_ip_address
  Out[6]: '10.3.4.0'

  In [7]: x.get_private_ip()
  Out[7]: '10.3.5.0'

  In [8]: x.cluster
  Out[8]: 'Mumbai'
  ```
  ignoring those as those are problems of the past.

- "m": starts at 4.101 and contends for the first time with t (at its 1) at 769 (10.101). Minimum pivot point, 513.

- "u": starts at 9.101 and contends for the first time with nfs (at its 1) at 257 (11.101). @Aradhya-Tripathi's kids. Minimum pivot point, 257. Bad. But there are only two servers with that logic anyways: ['m256', 'f256'], in Mumbai. Let's ignore. They already don't follow the logic. The logic only starts matching at 653.

- "t": starts at 10.101 and contends for the first time with fs (at its 1) at 257 (12.101). Minimum pivot point, still 257.

- "n", "p", "e", "nfs", "fs" and "nat" can be ignored (reason similar to "n"). "c" and "r" don't have servers at all so idk what they are for.

- Question to @phot0n , why does nat start directly at 26.101?

- Strategy, pivot to a safer allocation algorithm at "f", "m", "u" and "t" at 257. Safe bet because only ever the Mumbai cluster has provisioning till here.

- Partitioning of the 2**16 subnet will be as follows:
  1. first quarter to support the current mess we have. (10.0.0.0 -- 10.0.63.255). 16384 ips in total. Doesn't matter as all the remaining series will be low volume.
  2. Remaining three quarters for the high volume ips. (10.0.64.0 -- 10.0.255.255). 49152 in total.

- If each series can have a theoretical max of 8192 servers (considering the number of sites doubling every year (conservative estimate), we will have 8kish by the end of 2028 (but would a subnet of /16 even be enough then?), the trend seems to have slowed down though: https://cloud.frappe.io/app/console-log/Log%20on%202026-05-15%2001%3A26%3A33.001166). So divide 3/4th by 8192. 49152/8192 = 6. We can have two more big volume serieses here. Nice!
- For code, see ip_allocation.py. It has a check for contention.

checking if it works (ip ranges has all the ips with the index part temporarily removed from the files):
```
ip_ranges ) ls
10_nfs_series  12_nat_series  2_f_series  5_p_series  8_u_series
11_fs_series   1_n_series     3_m_series  6_e_series  9_t_series
ip_ranges ) head 1_n_series 
10.50.1.101
10.50.1.102
10.50.1.103
10.50.1.104
10.50.1.105
10.50.1.106
10.50.1.107
10.50.1.108
10.50.1.109
10.50.1.110
ip_ranges ) cat ./* > all_of_them
ip_ranges ) wc all_of_them -l
35328 all_of_them
ip_ranges ) sort all_of_them | uniq | wc -l
35328
```

Conclusion: It works!
