### PR TITLE
fix(sidebar): @ getting clipped due to truncate class

### DIFF
--- a/dashboard/src/components/navigation/sidebar/Sidebar.vue
+++ b/dashboard/src/components/navigation/sidebar/Sidebar.vue
@@ -92,13 +92,13 @@ const helpDropdownOptions = [
             <FCLogo class="size-8 hidden md:flex shrink-0 rounded" />
             <LucideUser class='size-3.5 -mr-1.5 md:hidden' />
 
-            <div class="flex flex-col gap-1 ml-1 min-w-0 md:m-0">
-              <div class="text-base font-medium leading-none hidden md:flex text-ink-gray-9">
+            <div class="flex flex-col gap-0.5 ml-1 min-w-0 md:m-0">
+              <div class="text-base font-medium hidden md:flex text-ink-gray-9">
                 Frappe Cloud
               </div>
 
               <div
-                class="text-sm text-left leading-none text-ink-gray-7 truncate">
+                class="text-sm text-left text-ink-gray-7 truncate">
                 {{ $team?.get.loading ? 'Loading...' : $team?.doc?.user }}
               </div>
             </div>


### PR DESCRIPTION
### Before: 

<img width="550" height="178" alt="image" src="https://github.com/user-attachments/assets/24b4b2f7-44c8-4e3b-bb9c-f1ad1b38a518" />


### After: 

<img width="472" height="144" alt="image" src="https://github.com/user-attachments/assets/4764674e-29ae-4b0d-ba19-9ac0dcde8813" />

leading-none was causing it
