### PR TITLE
fix(site-migration): Don't remove site entry from proxy if only doing server migration

### DIFF
--- a/press/press/doctype/site_migration/site_migration.py
+++ b/press/press/doctype/site_migration/site_migration.py
@@ -620,11 +620,6 @@ class SiteMigration(Document):
 				"status": "Pending",
 			},
 			{
-				"step_title": self.remove_site_from_source_proxy.__doc__,
-				"method_name": self.remove_site_from_source_proxy.__name__,
-				"status": "Pending",
-			},
-			{
 				"step_title": self.restore_site_on_destination_proxy.__doc__,
 				"method_name": self.restore_site_on_destination_proxy.__name__,
 				"status": "Pending",


### PR DESCRIPTION
this is handled on agent side to remove conflicting entry and only then add the new one

https://github.com/frappe/agent/blob/fc737ed8c2124fce6fd60d1bbee232b11e7b16d2/agent/proxy.py#L99-L100