### PR TITLE
fix(site-migration): Only remove site from source proxy if the proxy servers are different during server migration

### DIFF
--- a/press/press/doctype/site_migration/site_migration.py
+++ b/press/press/doctype/site_migration/site_migration.py
@@ -620,6 +620,13 @@ class SiteMigration(Document):
 				"status": "Pending",
 			},
 			{
+				"step_title": self.remove_site_from_source_proxy.__doc__,
+				"method_name": self.remove_site_from_source_proxy.__name__,
+				"status": "Pending",
+				"condition": frappe.db.get_value("Server", self.source_server, "proxy_server")
+				!= frappe.db.get_value("Server", self.destination_server, "proxy_server"),
+			},
+			{
 				"step_title": self.restore_site_on_destination_proxy.__doc__,
 				"method_name": self.restore_site_on_destination_proxy.__name__,
 				"status": "Pending",
@@ -641,7 +648,9 @@ class SiteMigration(Document):
 			},
 		]
 		for step in steps:
-			self.append("steps", step)
+			if step.get("condition", None) is None or step["condition"]:
+				step.pop("condition", None)
+				self.append("steps", step)
 
 	def deactivate_site_on_source_server(self):
 		"""Deactivate site on source"""


### PR DESCRIPTION
reverts https://github.com/frappe/press/pull/6497 for the case when we *might* have multiple proxies per cluster and adds it conditionally