### PR TITLE
fix(domain): Don't allow user to add domain with parent domain

### DIFF
--- a/press/api/site.py
+++ b/press/api/site.py
@@ -30,6 +30,7 @@ from press.press.doctype.marketplace_app.marketplace_app import (
 	get_total_installs_by_app,
 )
 from press.press.doctype.remote_file.remote_file import get_remote_key
+from press.press.doctype.root_domain.root_domain import get_matching_domain
 from press.press.doctype.server.server import is_dedicated_server
 from press.press.doctype.site.site import (
 	Site,
@@ -2231,6 +2232,11 @@ def setup_wizard_complete(name):
 @frappe.whitelist()
 @protected("Site")
 def check_dns(name, domain):
+	domain = domain.lower().strip(".")
+	if d := get_matching_domain(domain):
+		frappe.throw(
+			f"Cannot add {d} domain as it is a system reserved domain. Please use a different domain for your site."
+		)
 	return check_dns_cname_a(name, domain)
 
 

--- a/press/api/tests/test_site.py
+++ b/press/api/tests/test_site.py
@@ -1062,3 +1062,76 @@ class TestAPISiteList(FrappeTestCase):
 
 	def test_list_tagged_sites(self):
 		self.assertEqual(all(site_filter={"status": "", "tag": "test_tag"}), [self.tagged_site_dict])
+
+
+class TestAPISiteDomain(FrappeTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+		frappe.set_user("Administrator")
+
+	def test_check_dns_blocks_system_domain(self):
+		"""check_dns should throw for system reserved domains without making a DNS query."""
+		from press.api.site import check_dns
+
+		site = create_test_site()
+		with (
+			patch("press.api.site.get_matching_domain", return_value="test-system.io"),
+			patch("press.api.site.check_dns_cname_a") as mock_dns,
+		):
+			self.assertRaisesRegex(
+				frappe.ValidationError,
+				"system reserved domain",
+				check_dns,
+				site.name,
+				"sub.test-system.io",
+			)
+			mock_dns.assert_not_called()
+
+	def test_check_dns_returns_dns_result_for_custom_domain(self):
+		"""check_dns should return DNS check result for non-system domains."""
+		from press.api.site import check_dns
+
+		site = create_test_site()
+		dns_result = {"matched": True, "valid": True, "type": "A", "CNAME": {}, "A": {}}
+		with (
+			patch("press.api.site.get_matching_domain", return_value=None),
+			patch("press.api.site.check_dns_cname_a", return_value=dns_result) as mock_dns,
+		):
+			result = check_dns(site.name, "example.com")
+			mock_dns.assert_called_once_with(site.name, "example.com")
+		self.assertEqual(result, dns_result)
+
+	def test_add_domain_blocks_system_domain(self):
+		"""add_domain should throw for system reserved domains without making a DNS query."""
+		from press.api.site import add_domain
+
+		site = create_test_site()
+		with (
+			patch("press.press.doctype.site.site.get_matching_domain", return_value="test-system.io"),
+			patch("press.press.doctype.site.site.check_dns_cname_a") as mock_dns,
+		):
+			self.assertRaisesRegex(
+				frappe.ValidationError,
+				"system reserved domain",
+				add_domain,
+				site.name,
+				"sub.test-system.io",
+			)
+			mock_dns.assert_not_called()
+
+	@patch.object(AgentJob, "enqueue_http_request", new=Mock())
+	@patch("press.press.doctype.site_domain.site_domain.SiteDomain.create_tls_certificate", new=Mock())
+	def test_add_domain_creates_site_domain_when_dns_matches(self):
+		"""add_domain should create a Site Domain record when DNS check passes."""
+		from press.api.site import add_domain
+
+		site = create_test_site()
+		with (
+			patch("press.press.doctype.site.site.get_matching_domain", return_value=None),
+			patch(
+				"press.press.doctype.site.site.check_dns_cname_a",
+				return_value={"matched": True, "type": "A"},
+			),
+		):
+			add_domain(site.name, "example.com")
+		self.assertTrue(frappe.db.exists("Site Domain", {"site": site.name, "domain": "example.com"}))

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -329,7 +329,6 @@ scheduler_events = {
 			"press.press.doctype.bench.bench.process_bench_queue",
 		],
 		"* * * * * 0/30": [
-			"press.press.doctype.account_request.account_request.expire_request_key",
 			"press.press.doctype.physical_backup_restoration.physical_backup_restoration.process_scheduled_restorations",
 			"press.press.doctype.site_action.site_action.process_site_actions",
 		],
@@ -384,6 +383,7 @@ scheduler_events = {
 			"press.press.doctype.server_plan.server_plan.sync_machine_availability_status_of_plans",
 		],
 		"*/30 * * * *": [
+			"press.press.doctype.account_request.account_request.expire_request_key",
 			"press.press.doctype.site_update.scheduled_auto_updates.trigger",
 			"press.press.doctype.team.suspend_sites.execute",
 			"press.press.doctype.site_backup.site_backup.delete_successful_unavailable_backups_for_archived_sites",

--- a/press/press/doctype/account_request/account_request.py
+++ b/press/press/doctype/account_request/account_request.py
@@ -349,7 +349,7 @@ class AccountRequest(Document):
 
 def expire_request_key():
 	"""
-	Expire the request key requested 10 minutes ago.
+	Expire account request keys that have passed their expiration time.
 	"""
 	frappe.db.set_value(
 		"Account Request",

--- a/press/press/doctype/account_request/account_request.py
+++ b/press/press/doctype/account_request/account_request.py
@@ -85,7 +85,7 @@ class AccountRequest(Document):
 
 		if not self.request_key:
 			self.request_key = random_string(32)
-			self.request_key_expiration_time = frappe.utils.add_to_date(minutes=10)
+			self.request_key_expiration_time = frappe.utils.add_to_date(hours=24)
 
 		if not self.otp:
 			self.otp = generate_otp()
@@ -181,7 +181,7 @@ class AccountRequest(Document):
 	def reset_otp(self):
 		if not self.request_key:
 			self.request_key = random_string(32)
-			self.request_key_expiration_time = frappe.utils.add_to_date(minutes=10)
+			self.request_key_expiration_time = frappe.utils.add_to_date(hours=24)
 		self.otp = generate_otp()
 		if frappe.conf.developer_mode and frappe.local.dev_server:
 			self.otp = 111111

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1562,11 +1562,11 @@ class Site(Document, TagHelpers):
 	@site_action(["Active"])
 	def add_domain(self, domain):
 		domain = domain.lower().strip(".")
-		response = check_dns_cname_a(self.name, domain)
 		if d := get_matching_domain(domain):
 			frappe.throw(
 				f"Cannot add {d} domain as it is a system reserved domain. Please use a different domain for your site."
 			)
+		response = check_dns_cname_a(self.name, domain)
 		if response["matched"]:
 			if frappe.db.exists("Site Domain", {"domain": domain}):
 				frappe.throw(


### PR DESCRIPTION
Verify if there is parent domain match in the domain name provided by the user. If it matches, then don't allow user to add that domain as its system reserved.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents users from adding system-reserved (root) domains to their sites by introducing a `get_matching_domain` guard that runs before any DNS query in both `check_dns` and `Site.add_domain`. It also bundles two unrelated fixes: extending the account-request key TTL from 10 minutes to 24 hours and moving the corresponding cleanup scheduler entry to match the new cadence.

- **Domain guard** (`press/api/site.py`, `press/press/doctype/site/site.py`): `get_matching_domain` is called early (fast-fail before the DNS round-trip) and throws if the supplied domain is equal to, or a subdomain of, any enabled Root Domain. Four new tests cover blocked and allowed paths for both endpoints.
- **Account request TTL** (`account_request.py`, `hooks.py`): `request_key_expiration_time` is extended to 24 hours in `before_insert` and `reset_otp`; the `expire_request_key` scheduler job is moved from the every-30-seconds bucket to every-30-minutes, which is consistent with the longer TTL.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the domain-guard logic is correct, tests cover the key paths, and the account-request TTL change is internally consistent.

The new guard correctly short-circuits before the DNS query and is tested end-to-end. The hooks.py rescheduling aligns with the extended key TTL. The only findings are missing _() translation wrappers on two new error messages, which do not affect runtime correctness.

No files require special attention beyond the two untranslated frappe.throw() strings in press/api/site.py and press/press/doctype/site/site.py.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| press/api/site.py | Adds system-domain guard to `check_dns` before the DNS query; normalizes the domain first. Error message lacks `_()` translation wrapper. |
| press/press/doctype/site/site.py | Reorders `add_domain` to check `get_matching_domain` before the DNS query (correct fast-fail). Error message also lacks `_()` translation wrapper. |
| press/api/tests/test_site.py | Adds four tests covering blocked system domains and valid custom-domain flows for both `check_dns` and `add_domain`; logic and assertions are correct. |
| press/hooks.py | Moves `expire_request_key` from every-30-seconds bucket to every-30-minutes schedule, consistent with the new 24-hour key TTL. |
| press/press/doctype/account_request/account_request.py | Extends `request_key` expiration from 10 minutes to 24 hours in `before_insert` and `reset_otp`; updates docstring accordingly. Semantically clean change. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([User submits domain]) --> B[check_dns / add_domain]
    B --> C[Normalize: lower + strip dots]
    C --> D{get_matching_domain}
    D -- match found --> E[frappe.throw — system reserved]
    D -- no match --> F[check_dns_cname_a]
    F --> G{DNS matched?}
    G -- No --> H[Return DNS result]
    G -- Yes --> I{Site Domain exists?}
    I -- Yes --> J[frappe.throw — domain unavailable]
    I -- No --> K[Insert Site Domain record]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(domain): Dont allow to add parent do..."](https://github.com/frappe/press/commit/56a1c46b8d217064165f04a1dd553ff8fccdfa86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33927781)</sub>

**Context used:**

- Context used - This is a Frappe Framework application (Python bac... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->