### PR TITLE
fix: Misc 2 (static ip billing)

### DIFF
--- a/press/press/doctype/static_ip_log/static_ip_log.py
+++ b/press/press/doctype/static_ip_log/static_ip_log.py
@@ -113,21 +113,17 @@ class StaticIPLog(Document):
 			)
 
 	def _disable_subscription(self):
-		if not (
-			sub := frappe.db.get_value(
-				"Subscription",
-				{
-					"enabled": 1,
-					"document_type": self.server_type,
-					"document_name": self.server,
-					"plan_type": "Static IP Plan",
-				},
-				"name",
-			)
-		):
-			frappe.throw(f"No active Static IP subscription found for {self.server_type} {self.server}.")
-
-		frappe.db.set_value("Subscription", sub, "enabled", 0)
+		frappe.db.set_value(
+			"Subscription",
+			{
+				"enabled": 1,
+				"document_type": self.server_type,
+				"document_name": self.server,
+				"plan_type": "Static IP Plan",
+			},
+			"enabled",
+			0,
+		)
 
 
 def create_static_ip_log(server: str, server_type: str, static_ip: str, status: str = "Attached"):

--- a/press/press/doctype/static_ip_plan/static_ip_plan.json
+++ b/press/press/doctype/static_ip_plan/static_ip_plan.json
@@ -57,7 +57,7 @@
 			"fieldtype": "Column Break"
 		},
 		{
-			"description": "Hourly Rate",
+			"description": "Daily Rate",
 			"fieldname": "price_usd",
 			"fieldtype": "Currency",
 			"in_list_view": 1,
@@ -68,7 +68,7 @@
 	"grid_page_length": 50,
 	"index_web_pages_for_search": 1,
 	"links": [],
-	"modified": "2026-05-18 11:54:13.354600",
+	"modified": "2026-05-19 11:54:13.354600",
 	"modified_by": "Administrator",
 	"module": "Press",
 	"name": "Static IP Plan",

--- a/press/press/doctype/static_ip_plan/static_ip_plan.py
+++ b/press/press/doctype/static_ip_plan/static_ip_plan.py
@@ -27,5 +27,5 @@ class StaticIPPlan(Document):
 		if interval == "Daily":
 			return frappe.utils.flt(price, 2)
 
-		frappe.throw("Invalid interval. Interval must be either 'Hourly' or 'Daily'.")
+		frappe.throw("Invalid interval. Interval must be 'Daily'.")
 		return 0.0

--- a/press/press/doctype/static_ip_plan/static_ip_plan.py
+++ b/press/press/doctype/static_ip_plan/static_ip_plan.py
@@ -24,10 +24,8 @@ class StaticIPPlan(Document):
 	def get_price_for_interval(self, interval, currency):
 		price = self.price_inr if currency == "INR" else self.price_usd
 
-		if interval == "Hourly":
-			return frappe.utils.flt(price, 2)
 		if interval == "Daily":
-			return frappe.utils.flt(price * 24, 2)
+			return frappe.utils.flt(price, 2)
 
 		frappe.throw("Invalid interval. Interval must be either 'Hourly' or 'Daily'.")
 		return 0.0

--- a/press/press/doctype/subscription/subscription.py
+++ b/press/press/doctype/subscription/subscription.py
@@ -266,6 +266,7 @@ class Subscription(Document):
 		if not self.is_new():
 			return
 		filters = {
+			"enabled": 1,
 			"team": self.team,
 			"document_type": self.document_type,
 			"document_name": self.document_name,


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two billing issues for the Static IP feature: it changes the pricing model so `price_usd`/`price_inr` is stored and charged as a **daily** rate (removing the old `× 24` hourly-to-daily conversion), and it allows re-subscription after a detach by scoping the duplicate-subscription guard to only active (`enabled = 1`) subscriptions.

- **`static_ip_plan.py`**: `get_price_for_interval` now returns `price` directly for the `Daily` interval instead of `price * 24`, and the old `Hourly` branch is removed. The JSON description field is updated to \"Daily Rate\" to match.
- **`subscription.py`**: `validate_duplicate` adds `\"enabled\": 1` to its filter so a previously disabled subscription no longer blocks creating a new one for the same document/plan combination.
- **`static_ip_log.py`**: `_disable_subscription` is simplified to call `frappe.db.set_value` with a dict filter directly, silently no-opping when no active subscription is found (confirmed intentional).
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge if no production Static IP Plan records exist; if any records were entered under the old hourly-rate schema they will silently generate daily charges at 1/24th the intended amount.

The pricing change in `static_ip_plan.py` redefines the stored value from an hourly rate to a daily rate without a data migration. Any existing plan records will immediately produce incorrect (too-low) daily billing amounts after the deploy. Everything else in the PR — the duplicate-subscription guard and the detach simplification — looks correct.

press/press/doctype/static_ip_plan/static_ip_plan.py — the daily-rate interpretation change needs verification that no existing plan records hold the old hourly-rate values.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| press/press/doctype/static_ip_log/static_ip_log.py | Simplified `_disable_subscription` to use dict-filter form of `frappe.db.set_value`; intentional silent no-op when no matching subscription exists (confirmed as intended in prior review thread). |
| press/press/doctype/static_ip_plan/static_ip_plan.json | Updated `price_usd` field description from "Hourly Rate" to "Daily Rate" to match the new pricing model; modified timestamp bumped. |
| press/press/doctype/static_ip_plan/static_ip_plan.py | Removed Hourly support and changed Daily price to use `price` directly instead of `price * 24`, making `price_usd`/`price_inr` store the daily rate. Any existing DB records with the old hourly-rate values will now be billed at 1/24th the previously intended daily amount. |
| press/press/doctype/subscription/subscription.py | Added `"enabled": 1` to `validate_duplicate` filter so that a disabled subscription no longer blocks re-subscription after a Static IP is detached then re-attached. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Caller
    participant SIL as StaticIPLog
    participant Sub as Subscription
    participant SIP as StaticIPPlan

    C->>SIL: create_static_ip_log(server, Attached)
    SIL->>SIL: before_insert → _check_if_can_enable_subscription
    SIL->>Sub: "get_value(enabled=1, plan_type=Static IP Plan)"
    SIL->>SIL: after_insert → _create_subscription
    SIL->>Sub: "insert(interval=Daily)"
    Note over Sub: validate_duplicate now filters enabled=1

    C->>SIL: create_static_ip_log(server, Detached)
    SIL->>SIL: after_insert → _disable_subscription
    SIL->>Sub: "set_value({enabled=1,...}, enabled=0)"

    Sub->>Sub: create_usage_record(Daily)
    Sub->>SIP: get_price_for_interval(Daily, currency)
    Note over SIP: price_usd = daily rate directly
    SIP-->>Sub: price
    Sub-->>C: Usage Record created
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;develop&#39; into static-ip-bi..."](https://github.com/frappe/press/commit/5066360b2191f5a1538434dd9360cade932dd949) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34129154)</sub>

<!-- /greptile_comment -->