### PR TITLE
fix(deploy): Treat lockfile changes as build-requiring

### DIFF
--- a/press/press/doctype/deploy_candidate/deploy_candidate.py
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.py
@@ -642,6 +642,9 @@ def pull_update_file_filter(file_path: str) -> bool:
 		"setup.py",
 		# Requires yarn install, build
 		"package.json",
+		"yarn.lock",
+		"package-lock.json",
+		"pnpm-lock.yaml",
 		".vue",
 		".ts",
 		".jsx",


### PR DESCRIPTION
`pull_update_file_filter` blacklists `package.json` so a deploy with only a `package.json` change forces a full image rebuild. It did not blacklist `yarn.lock` / `package-lock.json` / `pnpm-lock.yaml`, so a commit that only bumps a transitive git dependency (e.g. `yarn add frappe/frappe-ui#main`, which moves the resolved commit in yarn.lock without touching package.json) was considered safe for the pull-update fast path. The bench would just `git pull` the app and keep the previously-baked `node_modules`, so the new dependency was never fetched or built.

Add the common JS lockfiles to the blacklist so a lockfile change triggers a real rebuild.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a gap in the pull-update fast-path filter where lockfile-only commits (e.g. `yarn add frappe/frappe-ui#main` moving only `yarn.lock`) bypassed the full rebuild and left stale `node_modules` in place. It adds `yarn.lock`, `package-lock.json`, and `pnpm-lock.yaml` to the existing `pull_update_file_filter` blacklist.

- `yarn.lock`, `package-lock.json`, and `pnpm-lock.yaml` are added alongside the already-blacklisted `package.json`, ensuring any JS dependency resolution change triggers a real image rebuild.
- The `bun.lockb` / `bun.lock` files (Bun's lockfile format) are not yet covered and would still take the fast path if Bun is used.
</details>

<h3>Confidence Score: 4/5</h3>

The change is safe to merge — it is a targeted addition to an existing filter list that makes the fast-path opt-out more conservative, with no risk of data loss or security regression.

The fix is minimal and correct: three lockfile names are appended to a well-understood blacklist. The only gap is Bun's lockfile format, which would still bypass the filter, but that is an incremental miss rather than a regression introduced by this PR.

deploy_candidate.py — specifically the pull_update_file_filter blacklist, to consider whether Bun's lockfile should also be covered.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| press/press/doctype/deploy_candidate/deploy_candidate.py | Adds yarn.lock, package-lock.json, and pnpm-lock.yaml to the pull-update blacklist so lockfile-only changes force a full image rebuild instead of a bare git-pull fast path. Logic is correct; bun.lockb (Bun's binary lockfile) is not covered. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Commit pushed] --> B{can_pull_update?}
    B --> C[For each changed file_path]
    C --> D{pull_update_file_filter}
    D --> E{endswith blacklisted entry?}
    E -- "requirements.txt / pyproject.toml / setup.py\npackage.json\nyarn.lock / package-lock.json / pnpm-lock.yaml\n.vue / .ts / .jsx / .tsx / .scss" --> F[return False → full rebuild]
    E -- No --> G{.html / .js / .css in /www/?}
    G -- Yes --> H[return True → pull update OK]
    G -- No --> I[return False → full rebuild]
    E -- "all files True" --> J[Pull Update fast path]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(deploy): Treat lockfile changes as b..."](https://github.com/frappe/press/commit/a74102dc64f6fc4df93e1a90ede3413e9ddadaee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34134957)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->