### PR TITLE
fix(dashboard): Team resources dialog trigger width

### DIFF
--- a/dashboard/src/components/settings/TeamResourcesDialog.vue
+++ b/dashboard/src/components/settings/TeamResourcesDialog.vue
@@ -171,24 +171,25 @@ watch(
 <template>
 	<!-- Trigger row: shows icons for implicit access + explicit resource count -->
 	<div
-		class="cursor-pointer flex items-center gap-3"
+		class="cursor-pointer flex items-center gap-1 max-w-[160px] min-w-0 overflow-hidden whitespace-nowrap"
+		:title="`${allServers ? 'All Servers, ' : ''}${allReleaseGroups ? 'All Release Groups, ' : ''}${allSites ? 'All Sites, ' : ''}${resourceCount} explicit resource${resourceCount !== 1 ? 's' : ''}`"
 		@click="isDialogOpen = true"
 	>
 		<Tooltip v-if="allServers" text="This user can access all servers">
-			<ServerIcon class="h-4 w-4" />
+			<ServerIcon class="h-4 w-4 shrink-0" />
 		</Tooltip>
 		<Tooltip
 			v-if="allReleaseGroups"
 			text="This user can access all release groups"
 		>
-			<ReleaseGroupIcon class="h-4 w-4" />
+			<ReleaseGroupIcon class="h-4 w-4 shrink-0" />
 		</Tooltip>
 		<Tooltip v-if="allSites" text="This user can access all sites">
-			<SiteIcon class="h-4 w-4" />
+			<SiteIcon class="h-4 w-4 shrink-0" />
 		</Tooltip>
-		<p>&mdash;</p>
+		<span class="shrink-0">&mdash;</span>
 		<Tooltip text="This user has access to these many resources explicitly">
-			<p>{{ resourceCount }}</p>
+			<span class="truncate min-w-[2ch]">{{ resourceCount }}</span>
 		</Tooltip>
 	</div>
 
@@ -234,9 +235,9 @@ watch(
 						<div class="col-span-1 py-2 px-3 font-medium flex items-center">
 							{{ resource.document_type }}
 						</div>
-						<div class="col-span-2 py-1 px-3">
-							<div class="flex items-center justify-between">
-								<div>{{ resource.document_name }}</div>
+						<div class="col-span-2 py-1 px-3 min-w-0">
+							<div class="flex items-center justify-between overflow-hidden">
+								<div class="truncate">{{ resource.document_name }}</div>
 								<Dropdown
 									:options="[
 										{
@@ -271,12 +272,14 @@ watch(
 
 				<!-- Add resources -->
 				<div class="flex items-center gap-2">
-					<MultiSelect
-						v-model="selectedResourcesToAdd"
-						:options="availableResourceOptions"
-						class="grow"
-						placeholder="Search resources..."
-					/>
+					<div class="min-w-0 overflow-hidden flex-1">
+						<MultiSelect
+							v-model="selectedResourcesToAdd"
+							:options="availableResourceOptions"
+							class="w-full"
+							placeholder="Search resources..."
+						/>
+					</div>
 					<Button
 						icon-left="plus"
 						:disabled="!selectedResourcesToAdd.length"


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR constrains the width of the `TeamResourcesDialog` trigger row and fixes overflow behaviour inside the resource list and `MultiSelect` wrapper to prevent layout blowout in the team-members table.

- The trigger row is capped at `max-w-[160px]` with `overflow-hidden` and `whitespace-nowrap`; icons gain `shrink-0`, the em-dash and count are changed from `<p>` to `<span>`, and a native `title` tooltip is added as an accessibility fallback.
- Long document names in the resource list now truncate with an ellipsis via `truncate`; `min-w-0` is added to the containing cells to enable proper flex truncation.
- The `MultiSelect` is wrapped in a `min-w-0 overflow-hidden flex-1` container so it respects its allocated flex space.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge with one layout concern worth addressing first — the Dropdown's remove menu may be clipped in the resource list rows.

The change is a focused UI-only fix with no backend, auth, or data-layer impact. The one real concern is that `overflow-hidden` was placed on the flex container that also wraps the `Dropdown` component; if frappe-ui's Dropdown floats its panel with `position: absolute` rather than `position: fixed`/teleport, the Remove menu will be clipped and invisible when opened.

dashboard/src/components/settings/TeamResourcesDialog.vue — specifically the `overflow-hidden` on the flex row wrapping the resource-name and Dropdown (lines 239–259).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| dashboard/src/components/settings/TeamResourcesDialog.vue | UI-only layout fixes to constrain the trigger row width and truncate long document names; introduces `overflow-hidden` on the flex container wrapping the Dropdown, which may clip the dropdown menu if frappe-ui uses absolute positioning. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Trigger row max-w-160px] --> B{allServers / allReleaseGroups / allSites}
    B -- true --> C[Icon + shrink-0]
    B -- false --> D[Hidden]
    A --> E[em-dash span shrink-0]
    A --> F[resourceCount span truncate]
    A --> G[native title tooltip]
    A -->|click| H[isDialogOpen = true]
    H --> I[Dialog opens]
    I --> J[Fetch resources]
    J --> K[Resource list rows]
    K --> L[document_type col]
    K --> M[document_name col truncate]
    M --> N[Dropdown Remove ⚠️ may be clipped]
    I --> O[MultiSelect wrapper min-w-0 flex-1]
    O --> P[MultiSelect w-full]
    P --> Q[Add button]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;develop&#39; into fix/dashboar..."](https://github.com/frappe/press/commit/72c638a8e57e670351df857f317736ddb92c4d63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34134995)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->