### PR TITLE
fix(limits): Rename tiers to limits in dashboard

### DIFF
--- a/dashboard/src/pages/Billing.vue
+++ b/dashboard/src/pages/Billing.vue
@@ -51,7 +51,7 @@ export default {
 			]
 
 			if (this.$team?.doc?.apply_limits && this.$team?.doc?.tier) {
-				baseTabs.push({ label: 'Tiers', route: { name: 'BillingTiers' } })
+				baseTabs.push({ label: 'Limits', route: { name: 'BillingTiers' } })
 			}
 
 			// Add UPI Autopay tab for INR teams

--- a/dashboard/src/pages/BillingTiers.vue
+++ b/dashboard/src/pages/BillingTiers.vue
@@ -5,7 +5,7 @@
 		<div class="flex flex-col gap-1">
 			<h2 class="text-xl font-semibold text-ink-gray-9">Spending Limits</h2>
 			<p class="text-p-base text-ink-gray-5">
-				This determine your monthly spending limit on Frappe Cloud. You are
+				These determine your monthly spending limit on Frappe Cloud. You are
 				automatically moved to a higher tier once your usage and payment history
 				meet the qualifying conditions.
 			</p>

--- a/dashboard/src/pages/BillingTiers.vue
+++ b/dashboard/src/pages/BillingTiers.vue
@@ -1,11 +1,13 @@
 <template>
-	<div class="flex flex-1 flex-col gap-6 overflow-y-auto px-20 pb-12 pt-6">
+	<div
+		class="flex flex-1 flex-col gap-6 overflow-y-auto px-20 pb-12 pt-6 lg:px-60 xl:px-96"
+	>
 		<div class="flex flex-col gap-1">
-			<h2 class="text-xl font-semibold text-ink-gray-9">Team Tiers</h2>
-			<p class="max-w-3xl text-p-base text-ink-gray-6">
-				Team tiers determine your monthly spending limit on Frappe Cloud. You
-				are automatically moved to a higher tier once your usage and payment
-				history meet the qualifying conditions below.
+			<h2 class="text-xl font-semibold text-ink-gray-9">Spending Limits</h2>
+			<p class="text-p-base text-ink-gray-5">
+				This determine your monthly spending limit on Frappe Cloud. You are
+				automatically moved to a higher tier once your usage and payment history
+				meet the qualifying conditions.
 			</p>
 		</div>
 
@@ -21,135 +23,154 @@
 		<ErrorMessage v-else-if="teamTiers.error" :message="teamTiers.error" />
 
 		<template v-else-if="teamTiers.data">
-			<!-- Your current standing -->
+			<!-- Current standing -->
 			<div
 				class="rounded-lg border border-outline-gray-2 bg-surface-gray-1 p-4"
 			>
 				<div class="flex flex-wrap items-center justify-between gap-3">
 					<div class="flex flex-col gap-1">
-						<div class="text-sm font-normal text-ink-gray-6">
-							Your current subscribed amount
-						</div>
+						<div class="text-sm text-ink-gray-6">Current subscribed amount</div>
 						<div class="flex items-center gap-2">
 							<span class="text-xl font-semibold text-ink-gray-9">
 								{{ formatAmount($team.doc.total_subscribed_amount) }}
 							</span>
-							<Badge
-								v-if="teamTiers.data.current_tier"
-								theme="blue"
-								:label="`${currentTierLabel}`"
-							/>
 						</div>
 					</div>
 					<div class="flex flex-col gap-1 text-right">
 						<div class="text-sm text-ink-gray-6">
 							Paying since
-							<span class="font-medium text-ink-gray-9">
-								{{ payingSinceLabel }}
-							</span>
+							<span class="font-medium text-ink-gray-9"
+								>{{ payingSinceLabel }}</span
+							>
 						</div>
 						<div class="text-sm text-ink-gray-6">
 							Last paid invoice
 							<span class="font-medium text-ink-gray-9">
-								{{ formatAmount(metrics.last_invoice_amount, skip_format=1) }}
+								{{ formatAmount(metrics.last_invoice_amount, 1) }}
 							</span>
 						</div>
 					</div>
 				</div>
 			</div>
 
-			<!-- Tier cards -->
-			<div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-				<div
-					v-for="(tier, idx) in teamTiers.data.tiers"
-					:key="tier.name"
-					class="flex flex-col gap-4 rounded-lg border bg-surface-white p-5 shadow-sm transition-all"
-					:class="
-						isCurrentTier(tier)
-							? 'border-outline-blue-2 ring-1 ring-outline-blue-2'
-							: 'border-outline-gray-2'
-					"
-				>
-					<div class="flex items-start justify-between">
-						<div class="flex flex-col gap-1">
-							<div class="text-lg font-semibold text-ink-gray-9">
-								{{ tier.tier }}
-							</div>
-						</div>
-						<Badge v-if="isCurrentTier(tier)" theme="blue" label="Current" />
-						<Badge
-							v-else-if="qualifiesForTier(tier)"
-							theme="green"
-							label="Qualifies"
-						/>
-					</div>
-
-					<div class="flex items-baseline gap-1">
-						<span class="text-3xl font-semibold text-ink-gray-9">
-							{{ formatAmount(tier.amount) }}
-						</span>
-						<span class="text-sm text-ink-gray-6">spending limit</span>
-					</div>
-
-					<div class="border-t border-outline-gray-1" />
-
-					<div class="flex flex-col gap-2">
-						<div
-							class="text-xs font-medium uppercase tracking-wide text-ink-gray-5"
+			<!-- Tiers table -->
+			<div
+				class="overflow-hidden rounded-lg border border-outline-gray-2 bg-surface-white"
+			>
+				<table class="w-full text-left">
+					<thead>
+						<tr class="border-b border-outline-gray-2 bg-surface-gray-1">
+							<th
+								class="px-4 py-3 text-normal font-medium tracking-wide text-ink-gray-5"
+							>
+								Tier
+							</th>
+							<th
+								class="px-4 py-3 text-normal font-medium tracking-wide text-ink-gray-5"
+							>
+								Requirements
+							</th>
+							<th
+								class="px-4 py-3 text-right text-normal font-medium tracking-wide text-ink-gray-5"
+							>
+								Spending Limit
+							</th>
+						</tr>
+					</thead>
+					<tbody class="divide-y divide-outline-gray-2">
+						<tr
+							v-for="(tier, idx) in teamTiers.data.tiers"
+							:key="tier.name"
+							class="transition-colors hover:bg-surface-gray-1"
 						>
-							How to qualify
-						</div>
-						<ul class="flex flex-col gap-2 text-sm text-ink-gray-7">
-							<li v-for="(req, i) in requirementsFor(tier, idx)" :key="i">
-								<div class="flex items-center gap-2">
-									<lucide-check-circle-2
-										v-if="req.met"
-										class="h-4 w-4 shrink-0 text-ink-green-3"
-									/>
-									<lucide-circle
-										v-else
-										class="h-4 w-4 shrink-0 text-ink-gray-4"
-									/>
-									<span :class="req.met ? 'text-ink-gray-9' : ''">
-										{{ req.text }}
+							<td class="px-4 py-4 align-middle">
+								<div class="flex flex-wrap items-center gap-2">
+									<span class="text-sm font-semibold text-ink-gray-9">
+										{{ tier.tier }}
 									</span>
+									<Badge
+										v-if="isCurrentTier(tier)"
+										theme="blue"
+										label="Current"
+									/>
 								</div>
-							</li>
-						</ul>
-					</div>
-				</div>
+							</td>
+							<td class="px-4 py-4 align-top">
+								<ul class="flex flex-col gap-1.5">
+									<li
+										v-for="(req, i) in requirementsFor(tier, idx)"
+										:key="i"
+										class="flex items-center gap-2"
+									>
+										<lucide-check-circle-2
+											v-if="req.met"
+											class="h-3.5 w-3.5 shrink-0 text-ink-green-3"
+										/>
+										<lucide-circle
+											v-else
+											class="h-3.5 w-3.5 shrink-0 text-ink-gray-4"
+										/>
+										<span
+											class="text-sm"
+											:class="req.met ? 'text-ink-gray-9' : 'text-ink-gray-6'"
+										>
+											{{ req.text }}
+										</span>
+									</li>
+								</ul>
+							</td>
+							<td class="px-4 py-4 text-right align-middle">
+								<span class="text-sm font-semibold text-ink-gray-9">
+									{{ formatAmount(tier.amount) }}
+								</span>
+							</td>
+						</tr>
+					</tbody>
+				</table>
 			</div>
 
 			<!-- How tiers work -->
 			<div class="rounded-lg border border-outline-gray-2 bg-surface-white p-5">
-				<div class="flex items-start gap-3">
-					<lucide-info class="mt-0.5 h-5 w-5 shrink-0 text-ink-gray-5" />
+				<div class="flex items-start">
 					<div class="flex flex-col gap-2">
-						<div class="text-base font-medium text-ink-gray-9">
-							How tier upgrades work
+						<div class="flex items-center gap-2">
+							<lucide-info class="h-5 w-5 shrink-0 text-ink-gray-5" />
+							<div class="text-base font-medium text-ink-gray-9">
+								How tier upgrades work
+							</div>
 						</div>
-						<ul
-							class="flex list-disc flex-col gap-1.5 pl-5 text-sm text-ink-gray-7"
-						>
-							<li>
-								Tiers control the maximum amount your team can spend in a
-								billing cycle.
-							</li>
-							<li>
-								You are automatically upgraded to a higher tier when your last
-								paid subscription invoice meets that tier's threshold and you
-								have at least three consecutive paid invoices.
-							</li>
-							<li>
-								New teams start at the base tier with a default spending limit.
-								Adding a payment method or buying prepaid credits is required to
-								remain at or above the base tier.
-							</li>
-							<li>
-								Need a higher limit immediately? Reach out to support and we
-								will review your account.
-							</li>
-						</ul>
+						<div class="flex flex-col gap-2">
+							<ul
+								class="flex list-disc flex-col gap-1.5 pl-5 text-sm text-ink-gray-7"
+							>
+								<li>
+									Tiers control the maximum amount your team can spend in a
+									billing cycle.
+								</li>
+								<li>
+									You are automatically upgraded to a higher tier when your last
+									paid subscription invoice meets that tier's threshold and you
+									have at least three consecutive paid invoices.
+								</li>
+								<li>
+									New teams start at the base tier with a default spending
+									limit. Adding a payment method or buying prepaid credits is
+									required to remain at or above the base tier.
+								</li>
+								<li>
+									Need a higher limit immediately? Reach out to
+									<a
+										href="https://support.frappe.io"
+										target="_blank"
+										rel="noopener noreferrer"
+										class="text-ink-blue-3 underline underline-offset-2 hover:text-ink-blue-4"
+									>
+										support
+									</a>
+									and we will review your account.
+								</li>
+							</ul>
+						</div>
 					</div>
 				</div>
 			</div>
@@ -179,7 +200,8 @@ function formatAmount(value, skip_format = false) {
 	if (skip_format) {
 		amount = Number(value)
 	}
-	return `${symbol}${amount.toLocaleString('en-US', {
+	const value_format = isINR ? 'en-IN' : 'en-US'
+	return `${symbol}${amount.toLocaleString(value_format, {
 		maximumFractionDigits: 2,
 	})}`
 }
@@ -202,29 +224,14 @@ function isCurrentTier(tier) {
 }
 
 function tierInvoiceThresholdInTeamCurrency(tier) {
-	// tier.last_invoice_amount is stored in USD; metrics.last_invoice_amount is in team currency.
-	// Convert the tier threshold to the team's currency before comparing.
 	const isINR = team.doc.currency === 'INR'
 	return isINR
 		? Number(tier.last_invoice_amount ?? 0) * 82
 		: Number(tier.last_invoice_amount ?? 0)
 }
 
-function qualifiesForTier(tier) {
-	const m = metrics.value
-	// Base tier: needs a payment method or prepaid credits
-	if (!tier.paying_user_since && !tier.last_invoice_amount) {
-		return !!m.has_payment_method
-	}
-	const monthsOk = (m.paying_since_months ?? 0) >= (tier.paying_user_since ?? 0)
-	const invoiceOk =
-		(m.last_invoice_amount ?? 0) >= tierInvoiceThresholdInTeamCurrency(tier)
-	return monthsOk && invoiceOk
-}
-
 function requirementsFor(tier, idx) {
 	const m = metrics.value
-	// Base tier (no historical conditions): payment method / prepaid credits
 	if (!tier.paying_user_since && !tier.last_invoice_amount) {
 		return [
 			{

--- a/dashboard/src/pages/BillingTiers.vue
+++ b/dashboard/src/pages/BillingTiers.vue
@@ -206,12 +206,6 @@ function formatAmount(value, skip_format = false) {
 	})}`
 }
 
-const currentTierLabel = computed(() => {
-	const current = teamTiers.data?.current_tier
-	if (!current) return 'Not set'
-	return current
-})
-
 const payingSinceLabel = computed(() => {
 	const months = metrics.value.paying_since_months ?? 0
 	if (!months) return '—'


### PR DESCRIPTION
- Show the tiers in tabular format

<img width="2863" height="1393" alt="Screenshot from 2026-05-27 16-35-51" src="https://github.com/user-attachments/assets/58082b64-c3e8-4e43-b1fc-b426e9bda991" />

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR renames the \"Tiers\" billing tab to \"Limits\" and replaces the tier card grid with a compact table layout, also adding proper INR locale formatting in `toLocaleString` and a clickable support link.

- `Billing.vue`: tab label changed from \"Tiers\" to \"Limits\" — one-line cosmetic fix.
- `BillingTiers.vue`: heading renamed to \"Spending Limits\", card grid replaced by a table, `qualifiesForTier` helper removed (its logic lives only in `requirementsFor` now), and `formatAmount` gains `value_format` for correct INR number grouping. The `currentTierLabel` computed property is left behind as dead code after its badge was removed.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a frontend UI refactor with no backend changes or logic regressions.

All changes are confined to Vue template markup and cosmetic script adjustments. The only dead code left behind (currentTierLabel) does not affect runtime behaviour. The INR locale fix and support link are straightforward and correct.

No files require special attention beyond the unused currentTierLabel in BillingTiers.vue.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| dashboard/src/pages/Billing.vue | Single-line label rename from "Tiers" to "Limits" for the billing tab — trivially correct, no logic changed. |
| dashboard/src/pages/BillingTiers.vue | Refactors the tiers UI from a card grid to a table layout, renames heading to "Spending Limits", adds an INR-aware locale to toLocaleString, removes the qualifiesForTier helper, and adds a clickable support link. The currentTierLabel computed property is now dead code after its referencing badge was removed. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BillingTiers page loads] --> B[teamTiers API call]
    B --> C{Response}
    C -->|loading| D[Spinner]
    C -->|error| E[ErrorMessage]
    C -->|data| F[Current Standing Card]
    F --> G[Tiers Table]
    G --> H{For each tier}
    H --> I[Tier name + Current badge if isCurrentTier]
    H --> J[requirementsFor - check met/unmet with icons]
    H --> K[formatAmount - spending limit]
    G --> L[How tier upgrades work info box]
    L --> M[Support link → support.frappe.io]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(limits): Grammar"](https://github.com/frappe/press/commit/644fa40e9325ca0e58d83490e1114342bbcd7374) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34140856)</sub>

<!-- /greptile_comment -->