### PR TITLE
fix: Skip legacy subscriptions with null plan or plan_type

### DIFF
--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -657,6 +657,8 @@ class Team(Document):
 		)
 		total = 0
 		for sub in subscriptions:
+			if not sub.plan_type or not sub.plan:
+				continue
 			if sub.plan_type == "Server Storage Plan":
 				total += (frappe.db.get_value(sub.plan_type, sub.plan, "price_usd") or 0) * flt(
 					sub.additional_storage

--- a/press/press/doctype/team/test_team.py
+++ b/press/press/doctype/team/test_team.py
@@ -95,3 +95,41 @@ class TestTeam(FrappeTestCase):
 				account_request2, "John", "Meyer", "jonmeyer@gmail.com", country="Pakistan"
 			)
 		self.assertEqual(team2.currency, "USD")
+
+	def test_total_subscribed_amount_skips_legacy_subscriptions_with_null_plan_fields(self):
+		team = create_test_team()
+		plan = frappe.get_doc(
+			{
+				"doctype": "Site Plan",
+				"name": "Test-Plan-USD-50",
+				"document_type": "Site",
+				"interval": "Daily",
+				"price_usd": 50,
+				"price_inr": 3000,
+			}
+		).insert()
+
+		def make_sub(todo_desc):
+			todo = frappe.get_doc(doctype="ToDo", description=todo_desc).insert()
+			return frappe.get_doc(
+				{
+					"doctype": "Subscription",
+					"document_type": "ToDo",
+					"document_name": todo.name,
+					"team": team.name,
+					"plan_type": "Site Plan",
+					"plan": plan.name,
+					"enabled": 1,
+				}
+			).insert()
+
+		make_sub("valid")
+
+		null_plan_type_sub = make_sub("null plan_type")
+		frappe.db.set_value("Subscription", null_plan_type_sub.name, "plan_type", None)
+
+		null_plan_sub = make_sub("null plan")
+		frappe.db.set_value("Subscription", null_plan_sub.name, "plan", None)
+
+		total = team.total_subscribed_amount()
+		self.assertEqual(total, 50)


### PR DESCRIPTION
### Problem
Team.total_subscribed_amount() was crashing for teams that have legacy Subscription records (mostly old Self Hosted Server subscriptions from 2023) where plan_type is NULL in the database. The method passed None directly to frappe.db.get_value(None, plan, "price_usd"), which errors out.

Affected records included subscriptions like SUB-2023-95823, SUB-2023-90013, SUB-2023-58834 with document_type = "Self Hosted Server" and plan_type = None.

### Fix
In [team.py:659-667], skip any subscription where plan_type or plan is falsy before attempting the DB lookup:


if not sub.plan_type or not sub. plan:
    continue
Both fields must be present to construct a valid frappe.db.get_value(doctype, name, field) call. (additional_storage was already safe — flt(None) returns 0.0.)

### Test
Added test_total_subscribed_amount_skips_legacy_subscriptions_with_null_plan_fields in [test_team.py](vscode-webview://13thmpsr5lavv28gsm9h6o9hk9ikopp4kpj2q6srmpb11dv2nm6u/apps/press/press/press/doctype/team/test_team.py) which:

Creates one valid subscription (price_usd = $50)
Creates a second with plan_type nulled out via frappe.db.set_value (simulating legacy data)
Creates a third with plan nulled out
Asserts the total is exactly $50 — confirming the broken records are skipped without raising