### PR TITLE
fix: Skip stale Press Role resources during sync

### DIFF
--- a/press/press/doctype/team_member_resource/team_member_resource.py
+++ b/press/press/doctype/team_member_resource/team_member_resource.py
@@ -131,6 +131,11 @@ def sync_press_role(doc, method=None):
 		# Loop through the resources and create `team-member-resource` entries if
 		# they don't exist.
 		for resource in resources:
+			# Skip stale resources whose document has been transferred or archived.
+			document_team = frappe.db.get_value(resource.document_type, resource.document_name, "team")
+			if document_team != team:
+				continue
+
 			# Check if a `team-member-resource` entry already exists for the team,
 			# user, document type, and document.
 			document = {


### PR DESCRIPTION
### Problem

The decouple_press_role_resources patch fails with a ValidationError when a Press Role Resource references a document that is no longer owned by the team. This happens when:

A site, bench, or server has been archived (renamed to {name}.archived)
A document has been transferred to another team (team switch)
A document has been deleted entirely
In all these cases, validate_document_name throws because the current document owner doesn't match the team on the resource being created.

```
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 248, in run
    self.run_schema_updates()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 53, in wrapper
    raise e
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 45, in wrapper
    ret = method(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 125, in run_schema_updates
    frappe.modules.patch_handler.run_all(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 76, in run_all
    run_patch(patch)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 62, in run_patch
    if not run_single(patchmodule=patch):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 152, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 188, in execute_patch
    _patch()
  File "/home/frappe/frappe-bench/apps/press/press/patches/v0_8_0/decouple_press_role_resources.py", line 12, in execute
    sync_press_role(press_role_doc)
  File "/home/frappe/frappe-bench/apps/press/press/press/doctype/team_member_resource/team_member_resource.py", line 145, in sync_press_role
    frappe.get_doc(document).insert(ignore_permissions=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 123, in wrapper
    return func(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 412, in insert
    self.run_before_save_methods()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1280, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1128, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1516, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1494, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1125, in fn
    return method_object(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/press/press/press/doctype/team_member_resource/team_member_resource.py", line 54, in validate
    self.validate_document_name()
  File "/home/frappe/frappe-bench/apps/press/press/press/doctype/team_member_resource/team_member_resource.py", line 77, in validate_document_name
    frappe.throw(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/messages.py", line 145, in throw
    msgprint(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/messages.py", line 106, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/messages.py", line 57, in _raise_exception
    raise exc
frappe.exceptions.ValidationError: Document ****.frappe.cloud.archived is not associated with team ******@*****.com
```

### Fix

In sync_press_role, check the document's current team before attempting to insert a Team Member Resource entry. If the document no longer belongs to the team (or doesn't exist), skip it silently.

This check is type-agnostic and covers all three permitted document types: Site, Release Group, and Server.