### PR TITLE
fix: Guard add_resource and sync against cross-team docs

### DIFF
--- a/press/press/doctype/press_role/press_role.py
+++ b/press/press/doctype/press_role/press_role.py
@@ -119,6 +119,11 @@ class PressRole(Document):
 				frappe.throw(message, frappe.ValidationError)
 
 			document_team = frappe.db.get_value(document_type, document_name, "team")
+			if document_team is None:
+				frappe.throw(
+					_("Document {0} does not exist").format(document_name),
+					frappe.DoesNotExistError,
+				)
 			if document_team != self.team:
 				frappe.throw(
 					_("Document {0} is not associated with this team").format(document_name),

--- a/press/press/doctype/press_role/press_role.py
+++ b/press/press/doctype/press_role/press_role.py
@@ -117,6 +117,13 @@ class PressRole(Document):
 			if self.get("resources", resource_dict):
 				message = _("{0} already belongs to {1}").format(document_name, self.title)
 				frappe.throw(message, frappe.ValidationError)
+
+			document_team = frappe.db.get_value(document_type, document_name, "team")
+			if document_team != self.team:
+				frappe.throw(
+					_("Document {0} is not associated with this team").format(document_name),
+					frappe.ValidationError,
+				)
 			self.append("resources", resource_dict)
 		self.save()
 

--- a/press/press/doctype/press_role/test_press_role.py
+++ b/press/press/doctype/press_role/test_press_role.py
@@ -55,6 +55,20 @@ class TestPressRole(FrappeTestCase):
 		self.assertFalse(perm_role_user_exists)
 		self.assertRaises(frappe.ValidationError, self.perm_role.remove_user, self.team_member.name)
 
+	def test_add_resource_rejects_cross_team_document(self):
+		other_team = create_test_team()
+		self.addCleanup(frappe.delete_doc, "Team", other_team.name, force=True)
+		subdomain = frappe.generate_hash(length=8)
+		site_name = f"{subdomain}.frappe.cloud"
+		create_test_site_record(site_name, subdomain, other_team.name)
+		self.addCleanup(lambda: frappe.db.sql("DELETE FROM `tabSite` WHERE name = %s", (site_name,)))
+
+		with self.assertRaises(frappe.ValidationError):
+			self.perm_role.add_resource([{"document_type": "Site", "document_name": site_name}])
+
+		self.perm_role.reload()
+		self.assertFalse(any(r.document_name == site_name for r in self.perm_role.resources))
+
 
 # utils
 def create_permission_role(team, allow_site_creation=0):
@@ -79,3 +93,13 @@ def create_user(email):
 
 def get_users(role):
 	return role.users
+
+
+def create_test_site_record(name, subdomain, team_name):
+	"""Insert a bare Site row without running any hooks. For use in tests only."""
+	frappe.db.sql(
+		"INSERT INTO `tabSite`"
+		" (name, team, subdomain, status, server, bench, cluster, `group`)"
+		" VALUES (%s, %s, %s, 'Active', 'test-server', 'test-bench', 'Default', 'test-group')",
+		(name, team_name, subdomain),
+	)

--- a/press/press/doctype/team_member_resource/team_member_resource.py
+++ b/press/press/doctype/team_member_resource/team_member_resource.py
@@ -131,6 +131,11 @@ def sync_press_role(doc, method=None):
 		# Loop through the resources and create `team-member-resource` entries if
 		# they don't exist.
 		for resource in resources:
+			# Skip resources whose document no longer belongs to this team (stale data).
+			document_team = frappe.db.get_value(resource.document_type, resource.document_name, "team")
+			if document_team != team:
+				continue
+
 			# Check if a `team-member-resource` entry already exists for the team,
 			# user, document type, and document.
 			document = {

--- a/press/press/doctype/team_member_resource/team_member_resource.py
+++ b/press/press/doctype/team_member_resource/team_member_resource.py
@@ -128,12 +128,25 @@ def sync_press_role(doc, method=None):
 			.run(as_dict=True)
 		)
 
+		# Batch-resolve which resources still belong to this team (one query per doctype).
+		by_doctype: dict[str, list[str]] = {}
+		for resource in resources:
+			by_doctype.setdefault(resource.document_type, []).append(resource.document_name)
+
+		team_owned: set[tuple[str, str]] = set()
+		for document_type, names in by_doctype.items():
+			owned = frappe.get_all(
+				document_type,
+				filters={"name": ("in", names), "team": team},
+				pluck="name",
+			)
+			for name in owned:
+				team_owned.add((document_type, name))
+
 		# Loop through the resources and create `team-member-resource` entries if
 		# they don't exist.
 		for resource in resources:
-			# Skip resources whose document no longer belongs to this team (stale data).
-			document_team = frappe.db.get_value(resource.document_type, resource.document_name, "team")
-			if document_team != team:
+			if (resource.document_type, resource.document_name) not in team_owned:
 				continue
 
 			# Check if a `team-member-resource` entry already exists for the team,

--- a/press/press/doctype/team_member_resource/test_team_member_resource.py
+++ b/press/press/doctype/team_member_resource/test_team_member_resource.py
@@ -1,20 +1,87 @@
 # Copyright (c) 2026, Frappe and Contributors
 # See license.txt
 
-# import frappe
-from frappe.tests import IntegrationTestCase
+import frappe
+from frappe.tests.utils import FrappeTestCase
 
-# On IntegrationTestCase, the doctype test records and all
-# link-field test record dependencies are recursively loaded
-# Use these module variables to add/remove to/from that list
-EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
-IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+from press.press.doctype.press_role.test_press_role import (
+	create_permission_role,
+	create_test_site_record,
+	create_user,
+)
+from press.press.doctype.team.test_team import create_test_team
+from press.press.doctype.team_member_resource.team_member_resource import sync_press_role
 
 
-class IntegrationTestTeamMemberResource(IntegrationTestCase):
-	"""
-	Integration tests for TeamMemberResource.
-	Use this class for testing interactions between multiple components.
-	"""
+class TestSyncPressRole(FrappeTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+		frappe.db.delete("Press Role")
+		self.team = create_test_team()
+		self.member = create_user(frappe.mock("email"))
+		self.team.append("team_members", {"user": self.member.name})
+		self.team.save()
+		self.role = create_permission_role(self.team.name)
+		self.role.append("users", {"user": self.member.name})
+		self.role.save()
+		self.test_sites = []
 
-	pass
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for site_name in self.test_sites:
+			frappe.db.sql("DELETE FROM `tabSite` WHERE name = %s", (site_name,))
+		frappe.db.delete("Team Member Resource", {"team": self.team.name})
+		frappe.delete_doc("Press Role", self.role.name, force=True)
+		frappe.delete_doc("Team", self.team.name, force=True)
+		frappe.delete_doc("User", self.member.name, force=True)
+		frappe.local._current_team = None
+
+	def create_site(self, team_name):
+		subdomain = frappe.generate_hash(length=8)
+		name = f"{subdomain}.frappe.cloud"
+		create_test_site_record(name, subdomain, team_name)
+		self.test_sites.append(name)
+		return name
+
+	def add_role_resource(self, document_type, document_name):
+		resource = self.role.append(
+			"resources",
+			{
+				"document_type": document_type,
+				"document_name": document_name,
+			},
+		)
+		resource.db_insert()
+		self.role.reload()
+
+	def test_sync_skips_stale_resource(self):
+		other_team = create_test_team()
+		self.addCleanup(frappe.delete_doc, "Team", other_team.name, force=True)
+		stale_site = self.create_site(other_team.name)
+		self.add_role_resource("Site", stale_site)
+
+		sync_press_role(self.role)
+
+		self.assertFalse(
+			frappe.db.exists(
+				{"doctype": "Team Member Resource", "team": self.team.name, "document_name": stale_site}
+			)
+		)
+
+	def test_sync_creates_team_member_resource(self):
+		valid_site = self.create_site(self.team.name)
+		self.add_role_resource("Site", valid_site)
+
+		sync_press_role(self.role)
+
+		self.assertTrue(
+			frappe.db.exists(
+				{
+					"doctype": "Team Member Resource",
+					"team": self.team.name,
+					"user": self.member.name,
+					"document_type": "Site",
+					"document_name": valid_site,
+				}
+			)
+		)


### PR DESCRIPTION
### Error 
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 116, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 51, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 84, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1512, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
  File "apps/press/press/api/client.py", line 378, in run_doc_method
    _run_doc_method(
  File "apps/frappe/frappe/handler.py", line 297, in run_doc_method
    response = doc.run_method(method, args)
  File "apps/frappe/frappe/model/document.py", line 1128, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1516, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1494, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 1125, in fn
    return method_object(*args, **kwargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
  File "apps/press/press/guards/team_guard.py", line 54, in inner
    return fn(self, *args, **kwargs)
  File "apps/press/press/press/doctype/press_role/press_role.py", line 121, in add_resource
    self.save()
  File "apps/frappe/frappe/model/document.py", line 123, in wrapper
    return func(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 483, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 123, in wrapper
    return func(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 537, in _save
    self.run_post_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1317, in run_post_save_methods
    self.run_method("on_update")
  File "apps/frappe/frappe/model/document.py", line 1128, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1516, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1498, in runner
    add_to_return_value(self, f(self, method, *args, **kwargs))
  File "apps/press/press/press/doctype/team_member_resource/team_member_resource.py", line 145, in sync_press_role
    frappe.get_doc(document).insert(ignore_permissions=True)
  File "apps/frappe/frappe/model/document.py", line 123, in wrapper
    return func(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 412, in insert
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1280, in run_before_save_methods
    self.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 1128, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1516, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1494, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 1125, in fn
    return method_object(*args, **kwargs)
  File "apps/press/press/press/doctype/team_member_resource/team_member_resource.py", line 54, in validate
    self.validate_document_name()
  File "apps/press/press/press/doctype/team_member_resource/team_member_resource.py", line 77, in validate_document_name
    frappe.throw(
  File "apps/frappe/frappe/utils/messages.py", line 145, in throw
    msgprint(
  File "apps/frappe/frappe/utils/messages.py", line 106, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/utils/messages.py", line 57, in _raise_exception
    raise exc
frappe.exceptions.ValidationError: Document ****.frappe.cloud is not associated with team *****@*****.com
```

### Problem
Two related gaps in Press Role resource management:

add_resource had no check that the document being added belongs to the role's team. A site transferred to another team (or added by mistake) could be stored as a Press Role resource.

sync_press_role hard-failed on any resource whose document no longer belongs to the team, aborting the entire sync and blocking all valid resources from being created. The fix skips stale resources silently instead.


### Fix
- press/press/doctype/press_role/press_role.py — add_resource now validates document team ownership before appending
- press/press/doctype/team_member_resource/team_member_resource.py — sync_press_role skips resources whose document belongs to a different team
- press/press/doctype/press_role/test_press_role.py — test for cross-team rejection + create_test_site_record helper
- press/press/doctype/team_member_resource/test_team_member_resource.py — TestSyncPressRole with tests for stale skip and valid TMR creation
