### PR TITLE
fix(backend): Do not sync firewall on server doc insert

### DIFF
--- a/press/press/doctype/server_firewall/server_firewall.py
+++ b/press/press/doctype/server_firewall/server_firewall.py
@@ -80,6 +80,8 @@ class ServerFirewall(Document):
 			self.validate_port(rule.port)
 
 	def on_update(self):
+		if self.is_new():
+			return
 		self.sync()
 
 	@frappe.whitelist()


### PR DESCRIPTION
Sync job should happen only after firewall rules are updated. Hence, the first sync job is useless and often confusing. This commit removes this unwanted job, which will fail 100% of the time.