### PR TITLE
fix(deploy-ui): Reload doc resource as fallback after an interval 

### DIFF
--- a/dashboard/src/components/benches/pipeline/Details.vue
+++ b/dashboard/src/components/benches/pipeline/Details.vue
@@ -94,7 +94,21 @@ const pipeline = props.deployview
 				const wiredId = 'release-pipeline' + props.id
 
 				const statuses = data?.steps?.stages?.map((x) => x.status)
-				if (statuses?.includes('Failure')) fetchSetErrs()
+
+				// sometimes when build status fails and socket doesnt emit properly
+				// fallback to reloading pipeline after some interval
+				if (statuses?.includes('Failure')) {
+					fetchSetErrs()
+
+					if (
+						!wired.has('bugged-pipeline') &&
+						pipeline?.doc?.status != 'Failure'
+					) {
+						wired.add('bugged-pipeline')
+
+						setTimeout(() => pipeline.reload(), 1.5 * 60 * 1000)
+					}
+				}
 
 				if (
 					['Pending', 'Running'].includes(data.status) &&
@@ -239,13 +253,6 @@ watch(
 	{ immediate: true },
 )
 
-watch(
-	() => pipeline?.doc?.status,
-	(x) => {
-		if (x == 'Failure') fetchSetErrs()
-	},
-)
-
 const handleAgentJobUpdate = (data) => {
 	const job = agentJobs?.value?.[data.id]
 	if (job?.doc) job.doc = { ...job.doc, ...data }
@@ -267,7 +274,11 @@ watch(
 				})
 			}
 
-			if (socket && !wired.has(`job:${id}`) && pipeline?.doc?.status === 'Running' ) {
+			if (
+				socket &&
+				!wired.has(`job:${id}`) &&
+				pipeline?.doc?.status === 'Running'
+			) {
 				socket.emit('doc_subscribe', 'Agent Job', id)
 				wired.add(`job:${id}`)
 			}

--- a/dashboard/src/components/benches/pipeline/Stages.vue
+++ b/dashboard/src/components/benches/pipeline/Stages.vue
@@ -94,7 +94,7 @@ const isStageDisabled = (x) => {
 					:disabled="build_step.status =='Pending'"
 				>
 					<StatusIcon :status="build_step.status" />
-					<span class="mr-3">
+					<span class="mr-3 truncate">
 						{{ build_step.stage }}
 						- {{ build_step.step }}
 					</span>


### PR DESCRIPTION
- Pipeline status isnt updated if one of the build steps fails, i have to reload the page to see the failiure status. So for now reload the resource after 1 minute after actual failure detcted