### PR TITLE
fix(site): Ignore bahrain backups on archival

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 @AGENTS.md
 @taste.md
 
+## Commit messages
+
+@commit-guidelines.md
+
 ## Linting and Formatting
 
 Python (via ruff — runs on pre-commit):

--- a/commit-guidelines.md
+++ b/commit-guidelines.md
@@ -1,0 +1,53 @@
+# Commit guidelines
+
+Guidelines for writing good commit messages in this project.
+
+## Use one convention
+
+Use [Conventional Commits](https://www.conventionalcommits.org/).
+
+- Use sentence case for the title and the body. The first letter of the
+  description (the word right after the scope's `:`) is capital.
+- Always add scopes.
+- Use lowercase for the type and scope. Not title or capital. Not camel case.
+- Hyphenate. Don't use snake case.
+
+Example: `fix(site): Mark bahrain backups unavailable before offsite delete`
+
+## Write descriptive messages
+
+Messages must give sufficient information about the change and the context
+of the change. Changes like these don't add anything:
+
+```
+fix: added required doctypes
+fix: updated cluster.py
+```
+
+If the title isn't enough, write a body.
+
+## Write bodies
+
+A body is always better.
+
+Most changes aren't trivial. Try to explain why you're making the change.
+
+## Explain choices
+
+You are making choices all the time. Explain why that choice. Why not an
+alternative?
+
+## Link references
+
+Some references might be lost over time. We'll take what we can get. Link
+what's relevant:
+
+- Sentry issues / events
+- Error logs
+- Reports (error log analysis, stuck scheduled jobs, etc.)
+- Insights charts / dashboards
+- Code (commits, lines, PRs)
+- External (docs, blogs, StackOverflow)
+
+Some of this can go in the PR comments. But keep some information in the
+commit messages as well.

--- a/press/press/doctype/remote_file/test_remote_file.py
+++ b/press/press/doctype/remote_file/test_remote_file.py
@@ -17,6 +17,7 @@ def create_test_remote_file(
 	creation: datetime | None = None,
 	file_path: str | None = None,
 	file_size: int = 1024,
+	bucket: str | None = None,
 ):
 	"""Create test remote file doc for required timestamp."""
 	creation = creation or frappe.utils.now_datetime()
@@ -27,6 +28,7 @@ def create_test_remote_file(
 			"site": site,
 			"file_path": file_path,
 			"file_size": file_size,
+			"bucket": bucket,
 		}
 	).insert(ignore_if_duplicate=True)
 	remote_file.db_set("creation", creation)

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1796,12 +1796,41 @@ class Site(Document, TagHelpers):
 			# the background sync job might cause timestamp mismatch error or version error
 			frappe.get_doc("Virtual Disk Snapshot", snapshot, for_update=True).delete_snapshot()
 
+	def unavail_bahrain_backups(self):
+		"""
+		Mark the files_availability of bahrain backups as Unavailable as they are facing issue with s3 and we don't want to delete the backups until the issue is resolved to proceed with archival"""
+
+		remote_files = frappe.get_all(
+			"Remote File",
+			{"status": "Available", "bucket": "bahrain.backups.frappe.cloud", "site": self.name},
+			pluck="name",
+			distinct=True,  # to skip order_by; large table
+		)
+		if not remote_files:
+			return
+
+		fields = (
+			"remote_database_file",
+			"remote_public_file",
+			"remote_private_file",
+			"remote_config_file",
+		)
+
+		for field in fields:
+			frappe.db.set_value(
+				"Site Backup",
+				{field: ("in", remote_files)},
+				"files_availability",
+				"Unavailable",
+			)
+
 	def delete_offsite_backups(self, keep_latest: bool = True):
 		from press.press.doctype.remote_file.remote_file import (
 			delete_remote_backup_objects,
 		)
 
 		log_site_activity(self.name, "Drop Offsite Backups")
+		self.unavail_bahrain_backups()  # TODO remove this after bahrain issue is resolved at aws
 
 		sites_remote_files = []
 		all_backups = frappe.get_all(

--- a/press/press/doctype/site/test_site.py
+++ b/press/press/doctype/site/test_site.py
@@ -697,3 +697,78 @@ class TestSite(FrappeTestCase):
 		suspend_sites_exceeding_disk_usage_for_last_14_days()
 		site.reload()
 		self.assertEqual(site.status, "Suspended")
+
+	def test_unavail_bahrain_backups_marks_only_bahrain_backups_unavailable(self):
+		from press.press.doctype.site_backup.test_site_backup import create_test_site_backup
+
+		site = create_test_site("bahrainsite")
+		bahrain_backup = create_test_site_backup(site=site.name, bucket="bahrain.backups.frappe.cloud")
+		other_backup = create_test_site_backup(site=site.name, bucket="mumbai.backups.frappe.cloud")
+
+		site.unavail_bahrain_backups()
+
+		self.assertEqual(
+			frappe.db.get_value("Site Backup", bahrain_backup.name, "files_availability"),
+			"Unavailable",
+		)
+		self.assertEqual(
+			frappe.db.get_value("Site Backup", other_backup.name, "files_availability"),
+			"Available",
+		)
+
+	def test_unavail_bahrain_backups_does_not_touch_status_field(self):
+		"""files_availability is flipped, but the backup's status stays a valid option."""
+		from press.press.doctype.site_backup.test_site_backup import create_test_site_backup
+
+		site = create_test_site("bahrainsite")
+		bahrain_backup = create_test_site_backup(
+			site=site.name, bucket="bahrain.backups.frappe.cloud", status="Success"
+		)
+
+		site.unavail_bahrain_backups()
+
+		self.assertEqual(frappe.db.get_value("Site Backup", bahrain_backup.name, "status"), "Success")
+
+	def test_unavail_bahrain_backups_only_affects_the_given_site(self):
+		from press.press.doctype.site_backup.test_site_backup import create_test_site_backup
+
+		this_site = create_test_site("bahrainsite")
+		other_site = create_test_site("otherbahrainsite")
+		this_backup = create_test_site_backup(site=this_site.name, bucket="bahrain.backups.frappe.cloud")
+		other_backup = create_test_site_backup(site=other_site.name, bucket="bahrain.backups.frappe.cloud")
+
+		this_site.unavail_bahrain_backups()
+
+		self.assertEqual(
+			frappe.db.get_value("Site Backup", this_backup.name, "files_availability"),
+			"Unavailable",
+		)
+		self.assertEqual(
+			frappe.db.get_value("Site Backup", other_backup.name, "files_availability"),
+			"Available",
+		)
+
+	@patch("press.press.doctype.remote_file.remote_file.delete_remote_backup_objects")
+	def test_delete_offsite_backups_skips_bahrain_backups(self, mock_delete):
+		"""Bahrain backups must not be sent to S3 deletion while the bucket is unhealthy."""
+		from press.press.doctype.site_backup.test_site_backup import create_test_site_backup
+
+		site = create_test_site("bahrainsite")
+		bahrain_backup = create_test_site_backup(site=site.name, bucket="bahrain.backups.frappe.cloud")
+		other_backup = create_test_site_backup(site=site.name, bucket="mumbai.backups.frappe.cloud")
+
+		site.delete_offsite_backups(keep_latest=False)
+
+		deleted_files = mock_delete.call_args.args[0]
+		bahrain_files = {
+			bahrain_backup.remote_database_file,
+			bahrain_backup.remote_public_file,
+			bahrain_backup.remote_private_file,
+		}
+		other_files = {
+			other_backup.remote_database_file,
+			other_backup.remote_public_file,
+			other_backup.remote_private_file,
+		}
+		self.assertTrue(bahrain_files.isdisjoint(deleted_files))
+		self.assertTrue(other_files.issubset(set(deleted_files)))

--- a/press/press/doctype/site_backup/test_site_backup.py
+++ b/press/press/doctype/site_backup/test_site_backup.py
@@ -25,6 +25,7 @@ def create_test_site_backup(
 	files_availability: str = "Available",
 	offsite: bool = True,
 	status: str = "Success",
+	bucket: str | None = None,
 ):
 	"""
 	Create test site backup doc for required timestamp.
@@ -41,9 +42,9 @@ def create_test_site_backup(
 		"with_files": offsite,
 	}
 	if offsite:
-		params_dict["remote_public_file"] = create_test_remote_file(site, creation).name
-		params_dict["remote_private_file"] = create_test_remote_file(site, creation).name
-		params_dict["remote_database_file"] = create_test_remote_file(site, creation).name
+		params_dict["remote_public_file"] = create_test_remote_file(site, creation, bucket=bucket).name
+		params_dict["remote_private_file"] = create_test_remote_file(site, creation, bucket=bucket).name
+		params_dict["remote_database_file"] = create_test_remote_file(site, creation, bucket=bucket).name
 	site_backup = frappe.get_doc(params_dict).insert(ignore_if_duplicate=True)
 
 	site_backup.db_set("creation", creation)


### PR DESCRIPTION

- **docs(commit-guidelines): Add commit message conventions**
  Record the team's commit standards so they are applied consistently and
  survive across contributors and tooling, rather than living only in chat.
  
  The conventions: Conventional Commits with a required scope, sentence case
  for title and body (description after the scope's ':' starts capital),
  lowercase hyphenated type/scope, a body whenever the title alone isn't
  self-explanatory, an explanation of why a choice was made over alternatives,
  and links to references (Sentry, error logs, reports, Insights, PRs,
  external docs) that would otherwise be lost over time.
  
  Referenced from CLAUDE.md so it is picked up automatically.
  

- **feat(site): Skip deletion of bahrain backups during archival**
  The bahrain S3 bucket is currently facing issues, so we don't want to
  delete its backups while archiving sites until the issue is resolved at
  AWS. Add unavail_bahrain_backups, called from delete_offsite_backups, to
  mark the site's bahrain remote-file backups as files_availability
  Unavailable before the offsite deletion runs.
  
  delete_offsite_backups only selects backups whose files_availability is
  Available, so flipping them to Unavailable removes them from the deletion
  set and leaves the objects untouched in S3. Early-return when the site
  has no available bahrain remote files.
  

- **test(site): Cover skipping bahrain backups during archival**
  Add tests for unavail_bahrain_backups and its use in delete_offsite_backups:
  
  - Only bahrain-bucket backups for the site are flipped to
    files_availability Unavailable; other buckets stay Available.
  - The backup's status field is left untouched (regression guard against
    the earlier version that wrote "Unavailable" into status).
  - The flip is scoped to the given site and doesn't affect other sites.
  - delete_offsite_backups never sends bahrain remote files to S3 deletion,
    while non-bahrain files are still deleted.
  
  Thread an optional bucket through create_test_remote_file and
  create_test_site_backup so a backup can be placed in a specific bucket.
  create_test_site_backup is imported inside the test methods to avoid a
  circular import with test_site_backup, which imports create_test_site.
  