### PR TITLE
fix(dashboard): Replace Select with Combobox for inline role editing

### DIFF
--- a/dashboard/src/components/settings/Team.vue
+++ b/dashboard/src/components/settings/Team.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { Badge, createResource, Select } from 'frappe-ui'
-import { h, ref } from 'vue'
+import { Badge, Combobox, createResource } from 'frappe-ui'
+import { computed, h, ref } from 'vue'
 import { toast } from 'vue-sonner'
 import session from '@/data/session'
 import { useUserStore } from '@/stores/user'
@@ -50,6 +50,11 @@ const roles = createResource({
 		dn: team.doc.name,
 	},
 	transform: (d) => d.message,
+})
+
+const roleOptions = computed(() => {
+	if (!roles.data) return []
+	return roles.data.map((r) => ({ label: r.label, value: r.value }))
 })
 
 const sendInvitation = createResource({
@@ -112,6 +117,118 @@ const updateRole = (member: string, role: string) => {
 	})
 }
 
+const columns = computed(() => [
+	{
+		label: 'User',
+		type: 'Component',
+		component: ({ row }) => {
+			return h(UserWithAvatarCell, {
+				avatarImage: row.user_image,
+				fullName: row.full_name || row.email,
+				isCurrentUser: row.email === user.email,
+			})
+		},
+	},
+	{
+		label: 'Email',
+		fieldname: 'email',
+	},
+	{
+		label: 'Status',
+		fieldname: 'status',
+		type: 'Component',
+		component: ({ row }) => {
+			return h(
+				Badge,
+				{
+					label: row.status,
+					theme: row.status === 'Active' ? 'green' : 'gray',
+					variant: 'subtle',
+				},
+				row.status,
+			)
+		},
+	},
+	{
+		label: 'Resources',
+		type: 'Component',
+		component: ({ row }) => {
+			return h(TeamResourcesDialog, {
+				team: team.doc.name,
+				userId: row.email,
+				userName: row.full_name || row.email,
+				resourceCount: row.resource_count,
+				allServers: row.all_servers,
+				allReleaseGroups: row.all_release_groups,
+				allSites: row.all_sites,
+				onUpdate: (key: string, value: boolean) => {
+					updateTeam.submit({
+						fieldname: 'team_members',
+						value: team.doc.team_members.map((m) => {
+							if (m.name === row.name) {
+								m[key] = value
+							}
+							return m
+						}),
+					})
+				},
+			})
+		},
+	},
+	{
+		label: 'Role',
+		fieldname: 'role',
+		type: 'Component',
+		component: ({ row }) => {
+			const memberRole = getMemberRole(row)
+			if (!session.isTeamAdmin) {
+				return h(
+					Badge,
+					{
+						label: memberRole,
+						theme: 'blue',
+						variant: 'subtle',
+					},
+					memberRole,
+				)
+			}
+			if (!roleOptions.value.length) {
+				return h(
+					Badge,
+					{
+						label: memberRole,
+						theme: 'blue',
+						variant: 'subtle',
+					},
+					memberRole,
+				)
+			}
+			if (row.status === 'Pending') {
+				return h(Combobox, {
+					class: 'w-min',
+					modelValue: memberRole,
+					options: roleOptions.value,
+					openOnFocus: true,
+					openOnClick: true,
+					'onUpdate:modelValue': (value) =>
+						updateInvitationRole.submit({
+							account_request: row.name,
+							role: value,
+						}),
+				})
+			}
+			return h(Combobox, {
+				class: 'w-min',
+				modelValue: memberRole,
+				options: roleOptions.value,
+				openOnFocus: true,
+				openOnClick: true,
+				'onUpdate:modelValue': (value) => updateRole(row.name, value),
+			})
+		},
+	},
+])
+
 const progress = (promise, msgLoading, msgSuccess) => {
 	toast.promise(promise, {
 		loading: msgLoading,
@@ -143,112 +260,7 @@ const progress = (promise, msgLoading, msgSuccess) => {
 			:options="{
 				rowHeight: 50,
 				list: members,
-				columns: [
-					{
-						label: 'User',
-						type: 'Component',
-						component: ({ row }) => {
-							return h(UserWithAvatarCell, {
-								avatarImage: row.user_image,
-								fullName: row.full_name || row.email,
-								isCurrentUser: row.email === user.email,
-							});
-						},
-					},
-					{
-						label: 'Email',
-						fieldname: 'email',
-					},
-					{
-						label: 'Status',
-						fieldname: 'status',
-						type: 'Component',
-						component: ({ row }) => {
-							return h(
-								Badge,
-								{
-									label: row.status,
-									theme: row.status === 'Active' ? 'green' : 'gray',
-									variant: 'subtle',
-								},
-								row.status,
-							);
-						},
-					},
-					{
-						label: 'Resources',
-						type: 'Component',
-						component: ({ row }) => {
-							return h(TeamResourcesDialog, {
-								team: team.doc.name,
-								userId: row.email,
-								userName: row.full_name || row.email,
-								resourceCount: row.resource_count,
-								allServers: row.all_servers,
-								allReleaseGroups: row.all_release_groups,
-								allSites: row.all_sites,
-								onUpdate: (key: string, value: boolean) => {
-									updateTeam.submit({
-										fieldname: 'team_members',
-										value: team.doc.team_members.map((m) => {
-											if (m.name === row.name) {
-												m[key] = value;
-											}
-											return m;
-										}),
-									})
-								},
-							});
-						}
-					},
-					{
-						label: 'Role',
-						fieldname: 'role',
-						type: 'Component',
-						component: ({ row }) => {
-							const memberRole = getMemberRole(row);
-							if (!session.isTeamAdmin) {
-								return h(
-									Badge,
-									{
-										label: memberRole,
-										theme: 'blue',
-										variant: 'subtle',
-									},
-									memberRole,
-								);
-							}
-							if (row.status === 'Pending') {
-								return h(
-									Select,
-									{
-										class: 'w-min relative -left-2',
-										variant: 'ghost',
-										modelValue: memberRole,
-										options: roles.data,
-										'onUpdate:modelValue': (value) =>
-											updateInvitationRole.submit({
-												account_request: row.name,
-												role: value,
-											}),
-									},
-									memberRole,
-								);
-							}
-							return h(
-								Select,
-								{
-									class: 'w-min relative -left-2',
-									variant: 'ghost',
-									modelValue: memberRole,
-									options: roles.data,
-									'onUpdate:modelValue': (value) => updateRole(row.name, value),
-								},
-								memberRole,
-							);
-						},
-					},
-				],
+				columns,
 				rowActions: ({ row }) => {
 					if (!session.isTeamAdmin) return [];
 					if (row.email === user.email) return [];

--- a/dashboard/src/components/settings/TeamInviteDialog.vue
+++ b/dashboard/src/components/settings/TeamInviteDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { createResource } from 'frappe-ui'
+import { Combobox, createResource } from 'frappe-ui'
 import { computed, ref } from 'vue'
 import { getTeam } from '../../data/team'
 
@@ -65,12 +65,12 @@ const close = () => {
 					label="Email addresses"
 					placeholder="name@example.com, name2@example.com"
 				/>
-				<FormControl
+				<Combobox
 					v-if="roleOptions.length > 0"
 					v-model="selectedRole"
-					type="select"
-					label="Role"
 					:options="roleOptions"
+					label="Role"
+					open-on-focus
 				/>
 			</div>
 		</template>

--- a/dashboard/src/components/settings/TeamInviteDialog.vue
+++ b/dashboard/src/components/settings/TeamInviteDialog.vue
@@ -65,13 +65,16 @@ const close = () => {
 					label="Email addresses"
 					placeholder="name@example.com, name2@example.com"
 				/>
-				<Combobox
-					v-if="roleOptions.length > 0"
-					v-model="selectedRole"
-					:options="roleOptions"
-					label="Role"
-					open-on-focus
-				/>
+				<div v-if="roleOptions.length > 0">
+					<label class="block text-xs leading-4 text-ink-gray-5 mb-1">
+						Role
+					</label>
+					<Combobox
+						v-model="selectedRole"
+						:options="roleOptions"
+						open-on-focus
+					/>
+				</div>
 			</div>
 		</template>
 	</Dialog>

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -1148,14 +1148,17 @@ class Team(Document):
 	@feature_preview.beta_testing()
 	@team_guard.only_admin()
 	def update_invitation_role(self, account_request: str, role: str):
-		self._validate_role(role)
+		from press.press.doctype.team.team_members import get_roles
+
+		all_roles = get_roles(str(self.name))
+		self._validate_role(role, all_roles)
 		d: AccountRequest = frappe.get_doc("Account Request", account_request, check_permission=True)
 		if d.team != self.name:
 			frappe.throw(
 				_("Account Request does not belong to this team."),
 				frappe.PermissionError,
 			)
-		self._set_invitation_role(d, role)
+		self._set_invitation_role(d, role, all_roles)
 		d.flags.ignore_links = True
 		d.save()
 		return self.get_members()

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -1067,10 +1067,10 @@ class Team(Document):
 	def get_members(self):
 		return get_invitations(str(self.name)) + get_members(str(self.name))
 
-	def _validate_role(self, role: str):
+	def _validate_role(self, role: str, all_roles=None):
 		from press.press.doctype.team.team_members import get_roles
 
-		all_roles = get_roles(str(self.name))
+		all_roles = all_roles or get_roles(str(self.name))
 		if not any(r["value"] == role for r in all_roles):
 			frappe.throw(
 				_('Invalid role "{0}". Must be one of: {1}').format(
@@ -1089,12 +1089,20 @@ class Team(Document):
 		handled inside team doctype itself. Account request should focus on
 		handling user management, unrelated to team.
 		"""
-		self._validate_role(role)
+		from press.press.doctype.team.team_members import get_roles
+
+		all_roles = get_roles(str(self.name))
+		self._validate_role(role, all_roles)
 		for n in names.split(","):
 			n = n.strip()
 			if frappe.db.exists("Account Request", n):
 				d: AccountRequest = frappe.get_doc("Account Request", n, check_permission=True)
-				self._set_invitation_role(d, role)
+				if d.team != self.name:
+					frappe.throw(
+						_("Account Request does not belong to this team."),
+						frappe.PermissionError,
+					)
+				self._set_invitation_role(d, role, all_roles)
 				d.flags.ignore_links = True
 				d.save()
 				d.send_verification_email()
@@ -1109,7 +1117,7 @@ class Team(Document):
 				},
 			):
 				dd: AccountRequest = frappe.get_doc("Account Request", account_request, check_permission=True)
-				self._set_invitation_role(dd, role)
+				self._set_invitation_role(dd, role, all_roles)
 				dd.flags.ignore_links = True
 				dd.save()
 				dd.send_verification_email()
@@ -1118,26 +1126,22 @@ class Team(Document):
 			ar: AccountRequest = frappe.new_doc("Account Request")
 			ar.team = self.name
 			ar.email = n
-			self._set_invitation_role(ar, role)
+			self._set_invitation_role(ar, role, all_roles)
 			ar.invited_by = frappe.session.user
 			ar.send_email = True
 			ar.flags.ignore_links = True
 			ar.save()
 		return self.get_members()
 
-	def _set_invitation_role(self, account_request: AccountRequest, role: str):
-		"""Set the role on an Account Request, storing in press_role when possible."""
-		from press.press.doctype.team.team_members import get_roles
+	def _set_invitation_role(self, account_request: AccountRequest, role: str, all_roles=None):
+		if all_roles is None:
+			from press.press.doctype.team.team_members import get_roles
 
-		all_roles = get_roles(str(self.name))
+			all_roles = get_roles(str(self.name))
 		matched = [r for r in all_roles if r["value"] == role]
 		if matched and matched[0].get("name"):
-			# Custom Press Role — store the doc name in the press_role Link field
 			account_request.press_role = matched[0]["name"]
 		else:
-			# Predefined role (Admin, Developer, Member, Viewer) or unknown —
-			# store the label in press_role (bypass Link validation since
-			# there's no Press Role document for it)
 			account_request.press_role = role
 
 	@dashboard_whitelist()


### PR DESCRIPTION
## Problem

The Role column in the team member list used the legacy `Select` component for inline role editing, while the invite dialog already used the newer `Combobox`. Additionally, when the `get_roles` API loaded asynchronously, the list cells never re-rendered because Vue couldn't track dependencies referenced inside closures (the column component functions).

## Changes

**dashboard: TeamInviteDialog** — Replaced `FormControl[type="select"]` with `<Combobox>` with `open-on-focus`.

**dashboard: Team.vue** — Key changes:
- Replaced `Select` with `Combobox` for role editing in both member and invitation rows
- Moved column definitions to a `computed()` to fix a reactivity hole: when `roles.data` loaded asynchronously, the cell component functions were never re-invoked, so the guard always showed a Badge. Now `columns` is reactive — when `roleOptions` changes, the parent re-renders, giving cells fresh component functions with actual role data.
- Added `roleOptions` computed to normalize API data to `{label, value}` format (matching the dialog)
- Two-stage guard: non-admins see a Badge (no edit), loading state shows a Badge until roles arrive, then auto-transitions to Combobox
- Added `openOnFocus` and `openOnClick` to match read-only select behavior

## Testing

Reload the Team settings page. While roles are loading, the Role column shows blue Badges. Once loaded, they should transition to Comboboxes. Non-admins see only Badges.