### PR TITLE
fix(deploy-candidate): Show app name in fetch error notification

### DIFF
--- a/press/press/doctype/deploy_candidate/deploy_notifications.py
+++ b/press/press/doctype/deploy_candidate/deploy_notifications.py
@@ -730,8 +730,10 @@ def update_with_app_not_fetchable(
 		in <i>Help</i>.</p>
 		"""
 	else:
-		message = """
-		<p>App could not be fetched from GitHub.</p>
+		app_name = exc.args[1] if len(exc.args) >= 2 else ""
+		app_str = f"<b>{app_name}</b> " if app_name else "App "
+		message = f"""
+		<p>{app_str}could not be fetched from GitHub.</p>
 
 		<p>This may have been due to an invalid installation id or due
 		to an invalid repository URL.</p>


### PR DESCRIPTION
When the fetch error fires from send_build_instructions_and_add_build_steps (outside the "apps" stage), the else branch showed a generic message with no app name. The GithubFetchError already carries the app name in args[1], so extract it and include it in the notification message.