### PR TITLE
feat(sidebar): Attention widget for major release/breaking change blog posts

### DIFF
--- a/dashboard/src/components/navigation/sidebar/AttentionWidget.vue
+++ b/dashboard/src/components/navigation/sidebar/AttentionWidget.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { Button } from 'frappe-ui'
+
+const latestPathName = ref<string | null>(null)
+const show = ref(false)
+
+const getLatestMajorBlogPath = async () => {
+	const url = '/releases'
+	const res = await fetch(url)
+	const html = await res.text()
+
+	const tagMatch = html.match(/<a[^>]*data-major="true"[^>]*/)
+	const href = tagMatch ? tagMatch[0].match(/href="([^"]+)"/)?.[1] : null
+
+	if (localStorage?.latestReleasePath !== href) {
+		latestPathName.value = href
+		show.value = true
+	}
+}
+
+const setLastBlogPathname = () => {
+	localStorage.latestReleasePath = latestPathName.value
+	show.value = false
+}
+
+onMounted(() => {
+	getLatestMajorBlogPath()
+})
+
+const openUrl = (latestPathName: string | null) => {
+  if (!latestPathName) return
+  window.open(`https://cloud.frappe.io${latestPathName}`)
+}
+</script>
+
+<template>
+	<div class="mt-auto" />
+	<div
+		class="hidden md:flex flex-col gap-2 p-3 border border-outline-gray-2 dark:border-outline-gray-1 rounded text-sm bg-surface-white dark:bg-surface-cards hadow mt-auto mb-1"
+		v-if="show"
+	>
+		<div class="flex gap-2">
+			<LucidePackageOpen class="size-4 shrink-0" />
+
+			<div class="leading-relaxed -mt-1 mb-2">
+				<span class="text-ink-gray-9 font-medium">What's new</span>
+				<p class="text-ink-gray-6">Explore our latest updates built for you</p>
+			</div>
+
+			<Button variant="ghost" class="-m-2" @click="setLastBlogPathname">
+				<LucideX class="size-3.5 shrink-0" />
+			</Button>
+		</div>
+
+    <Button @click="openUrl">
+			New Releases
+			<template #suffix>
+				<LucideArrowRight class="size-4" />
+			</template>
+		</Button>
+	</div>
+</template>

--- a/dashboard/src/components/navigation/sidebar/AttentionWidget.vue
+++ b/dashboard/src/components/navigation/sidebar/AttentionWidget.vue
@@ -28,9 +28,9 @@ onMounted(() => {
 	getLatestMajorBlogPath()
 })
 
-const openUrl = (latestPathName: string | null) => {
-  if (!latestPathName) return
-  window.open(`https://cloud.frappe.io${latestPathName}`)
+const openUrl = () => {
+  window.open(`https://cloud.frappe.io${latestPathName.value}`)
+  setLastBlogPathname()
 }
 </script>
 

--- a/dashboard/src/components/navigation/sidebar/Sidebar.vue
+++ b/dashboard/src/components/navigation/sidebar/Sidebar.vue
@@ -15,6 +15,7 @@ import LucideMoon from "~icons/lucide/moon";
 import LucideAlert from "~icons/lucide/notebook-text";
 import DarkModeLabel from "./DarkModeLabel.vue";
 import NavList from "./NavList.vue";
+import AttentionWidget from "./AttentionWidget.vue";
 
 import Item from "./Item.vue";
 import ItemGroup from "./ItemGroup.vue";
@@ -147,7 +148,9 @@ const helpDropdownOptions = [
         </template>
       </NavList>
 
-      <div :class='collapsed ? "flex-col" : "flex-row"' class='flex gap-1 justify-between items-center  mt-auto'>
+      <AttentionWidget />
+
+      <div :class='collapsed ? "flex-col" : "flex-row"' class='flex gap-1 justify-between items-center'>
         <Dropdown :options="helpDropdownOptions">
           <Button variant="ghost">
             <template #prefix v-if="!collapsed">


### PR DESCRIPTION
## Screenshot 


<img width="200"  alt="image" src="https://github.com/user-attachments/assets/a6acf74a-f70b-4218-8f83-543bfca56dbd" />


## Description 

- Blog posts regarding major releases and breaking changes will be written on https://cloud.frappe.io/releases 
- Show lil widget in the sidebar  getting the user's attention if the last visited url isnt same as major blog post url
- Closing the widget or going in its link will save users last visited release page url somewhere 



But! Not every blog post on https://cloud.frappe.io/releases will have major changes or is worthy of user's attention. So how do we determine the `latest major blog`? 


- fetch the first link from the releases page which has attribute of `data-major="true"`


<img width="1532" height="968" alt="image" src="https://github.com/user-attachments/assets/f34ff1c5-3fbf-4eeb-b746-e2c5939c9b7c" />


<br/> <br/>
And how will the link get `data-major` attribute? from the metadata of the page itself !!


<img width="2116" height="508" alt="image" src="https://github.com/user-attachments/assets/891ac234-7094-4a39-949a-ba609163acb6" />



<hr/>
The static site is written in Astro! https://github.com/frappe/press/tree/master/changelog

<hr/>
 

Note: right now the user's last visited releasepage* url is stored in localstorage and the widget is hidden on mobiles, I can add a custom field in User doctype but not sure if it'll get messy!


