### PR TITLE
feat(team-settings): Make role names clickable to navigate to role page

### DIFF
--- a/dashboard/src/components/settings/TeamSettings.vue
+++ b/dashboard/src/components/settings/TeamSettings.vue
@@ -9,6 +9,7 @@ import { createResource } from 'frappe-ui'
 import { defineAsyncComponent, h, ref } from 'vue'
 import { toast } from 'vue-sonner'
 import { getTeam } from '../../data/team'
+import router from '../../router'
 import { confirmDialog, renderDialog } from '../../utils/components'
 import { getToastErrorMessage } from '../../utils/toast'
 import ObjectList from '../ObjectList.vue'
@@ -49,9 +50,37 @@ const teamMembersListOptions = ref({
 		},
 		{
 			label: 'Role',
-			fieldname: 'roles',
+			type: 'Component',
 			width: '500px',
-			format: (v) => v.join(', '),
+			component: ({ row }) => {
+				let roles = row.roles || []
+				return h(
+					'div',
+					{ class: 'flex flex-wrap gap-1.5' },
+					roles.map((role) =>
+						h(
+							'a',
+							{
+								href: router.resolve({
+									name: 'SettingsPermissionRolePermissions',
+									params: { id: role.name },
+								}).href,
+								onClick: (e) => {
+									e.preventDefault()
+									e.stopPropagation()
+									router.push({
+										name: 'SettingsPermissionRolePermissions',
+										params: { id: role.name },
+									})
+								},
+								class:
+									'font-medium no-underline border-b border-[var(--ink-gray-3)] transition-colors duration-[80ms] cursor-pointer text-ink-gray-9 hover:text-ink-gray-7',
+							},
+							role.title,
+						),
+					),
+				)
+			},
 		},
 	],
 	rowActions({ row }) {

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -1082,12 +1082,17 @@ class Team(Document):
 			.join(PressRole)
 			.on(PressRoleUser.parent == PressRole.name)
 			.where(PressRole.team == self.name)
-			.select(PressRoleUser.user, PressRole.title)
+			.select(PressRoleUser.user, PressRole.title, PressRole.name)
 			.run(as_dict=True)
 		)
 		user_roles = {}
 		for row in role_rows:
-			user_roles.setdefault(row.user, []).append(row.title)
+			user_roles.setdefault(row.user, []).append(
+				{
+					"name": row.name,
+					"title": row.title,
+				}
+			)
 
 		r = []
 		for member in self.team_members:


### PR DESCRIPTION
- Return role name and title from members() method
- Render roles as clickable <a> tags with persistent border-bottom
- Navigate to SettingsPermissionRolePermissions route on click