### PR TITLE
fix(support): Read web.error.log from bench, not site

### DIFF
--- a/press/incident_management/support_agent/collectors.py
+++ b/press/incident_management/support_agent/collectors.py
@@ -55,7 +55,7 @@ def collect_site_context(site_name: str) -> dict[str, Any]:
 		"bench_processes": get_bench_process_status(site.get("bench")),
 		"site_uptime": get_site_uptime(site_name),
 		"site_performance": get_site_performance_summary(site_name, site.get("bench")),
-		"web_error_log": get_web_error_log(site_name),
+		"web_error_log": get_web_error_log(site.get("bench")),
 	}
 
 
@@ -505,18 +505,19 @@ def _endpoint_module(path: str) -> str | None:
 	return rest.split(".")[0] or None
 
 
-def get_web_error_log(site_name: str) -> dict[str, Any]:
+def get_web_error_log(bench_name: str) -> dict[str, Any]:
 	"""
-	Recent ERROR/CRITICAL entries from web.error.log, redacted.
+	Recent ERROR/CRITICAL entries from the bench-level gunicorn web.error.log.
 
-	Only the exception message line (last line of the traceback) is included —
-	not full stack frames with local variables. All entries pass through redact()
-	before being stored.
+	Reads from the bench, not the site, because gunicorn's stderr is a bench-level
+	file shared across all sites on the bench. Only the exception message line (last
+	line of the traceback) is included. All entries pass through redact() before
+	being stored.
 	"""
 	from press.incident_management.support_agent.redaction import redact
 
 	try:
-		raw = frappe.get_doc("Site", site_name).get_server_log("web.error.log")
+		raw = frappe.get_doc("Bench", bench_name).get_server_log("web.error.log")
 	except Exception:
 		return {"available": False}
 

--- a/press/incident_management/support_agent/test_investigation.py
+++ b/press/incident_management/support_agent/test_investigation.py
@@ -112,15 +112,11 @@ class TestSupportAgentInvestigation(FrappeTestCase):
 	) -> dict:
 		bench_doc = MagicMock()
 		bench_doc.supervisorctl_status.return_value = processes if processes is not None else []
-
-		site_doc = MagicMock()
-		site_doc.get_server_log.return_value = {"web.error.log": web_log}
+		bench_doc.get_server_log.return_value = {"web.error.log": web_log}
 
 		def _mock_get_doc(doctype, name):
 			if doctype == "Bench":
 				return bench_doc
-			if doctype == "Site":
-				return site_doc
 			return MagicMock()
 
 		def _gsv(doctype, fieldname, *args, **kwargs):


### PR DESCRIPTION
## Summary

- `get_web_error_log` was calling `Site.get_server_log("web.error.log")`, which hits the agent at `benches/{bench}/sites/{site}/logs/web.error.log` — a per-site path that is empty or does not exist
- Gunicorn's stderr is a bench-level file at `benches/{bench}/logs/web.error.log`, accessible via `Bench.get_server_log`
- Switched the collector to read from the bench; updated the test mock accordingly

## Why it matters

Startup failures — syntax errors in `app.py`, import errors that crash gunicorn workers — are logged only to the gunicorn error log. The old code was silently returning `error_count: 0` even when the site was down because of such a crash (verified on staging: probe reported HTTP 500, but `web_error_log` showed no errors).

## Test plan

- [ ] Existing `TestSupportAgentInvestigation` tests pass (mock now attached to `bench_doc.get_server_log`)
- [ ] On staging: run an investigation against a site with a known gunicorn error; confirm `web_error_log.error_count > 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)