### PR TITLE
feat(server): Add skip-standby-site-creation flag

### DIFF
--- a/press/press/doctype/server/server.json
+++ b/press/press/doctype/server/server.json
@@ -251,6 +251,12 @@
 			"label": "Use For New Sites"
 		},
 		{
+			"default": "0",
+			"fieldname": "skip_standby_site_creation",
+			"fieldtype": "Check",
+			"label": "Skip Standby Site Creation"
+		},
+		{
 			"fieldname": "cluster",
 			"fieldtype": "Link",
 			"in_list_view": 1,

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -2890,6 +2890,7 @@ class Server(BaseServer):
 		use_for_build: DF.Check
 		use_for_new_benches: DF.Check
 		use_for_new_sites: DF.Check
+		skip_standby_site_creation: DF.Check
 		virtual_machine: DF.Link | None
 	# end: auto-generated types
 

--- a/press/press/doctype/site/erpnext_site.py
+++ b/press/press/doctype/site/erpnext_site.py
@@ -72,6 +72,7 @@ def get_erpnext_bench():
 			bench.server = server.name
 		WHERE
 			server.proxy_server in %s AND bench.status = "Active" AND bench.group = %s
+			AND server.skip_standby_site_creation = 0
 		ORDER BY
 			server.use_for_new_sites DESC, bench.creation DESC
 		LIMIT 1

--- a/press/press/doctype/site/saas_site.py
+++ b/press/press/doctype/site/saas_site.py
@@ -105,6 +105,7 @@ def get_saas_bench(app):
 			bench.server = server.name
 		WHERE
 			server.proxy_server in %s AND server.cluster = %s AND bench.status = "Active" AND bench.group = %s
+			AND server.skip_standby_site_creation = 0
 		ORDER BY
 			server.use_for_new_sites DESC, bench.creation DESC
 	""",

--- a/press/saas/doctype/product_trial/product_trial.py
+++ b/press/saas/doctype/product_trial/product_trial.py
@@ -357,7 +357,9 @@ class ProductTrial(Document):
 
 		server = self.get_server_from_cluster(cluster)
 		cluster_domains = frappe.db.get_all(
-			"Root Domain", {"name": ("like", f"%.{self.domain}"), "enabled": 1}, ["name", "default_cluster as cluster"]
+			"Root Domain",
+			{"name": ("like", f"%.{self.domain}"), "enabled": 1},
+			["name", "default_cluster as cluster"],
 		)
 		cluster_domain = find(
 			cluster_domains,
@@ -478,6 +480,7 @@ class ProductTrial(Document):
 			.join(Server)
 			.on(Server.name == ReleaseGroupServer.server)
 			.where(Server.cluster == cluster)
+			.where(Server.skip_standby_site_creation == 0)
 			.join(Bench)
 			.on(Bench.server == ReleaseGroupServer.server)
 			.run(pluck="server")


### PR DESCRIPTION
Adds a `Skip Standby Site Creation` Check field to the Server doctype. When enabled, the scheduler will not pick that server when replenishing standby site pools.

The flag is respected in all three pool systems:
- `product_trial.get_server_from_cluster` (product trial pools)
- `saas_site.get_saas_bench` (legacy SaaS app pools)
- `erpnext_site.get_erpnext_bench` (ERPNext site pool)