### PR TITLE
fix(onboarding): Update certificate link request handling

### DIFF
--- a/press/api/partner.py
+++ b/press/api/partner.py
@@ -124,18 +124,6 @@ def send_link_certificate_request(user_email: str, certificate_type: str) -> Non
 
 
 @frappe.whitelist()
-def approve_certificate_link_request(key: str) -> None:
-	from press.partner.doctype.certificate_link_request.certificate_link_request import (
-		CertificateLinkRequest,
-	)
-
-	CertificateLinkRequest.approve_from_key(key)
-
-	frappe.response.type = "redirect"
-	frappe.response.location = "/dashboard/partner-onboarding"
-
-
-@frappe.whitelist()
 @role_guard.api("partner")
 def get_resource_url() -> str | None:
 	return frappe.db.get_value("Press Settings", "Press Settings", "drive_resource_link")

--- a/press/partner/doctype/certificate_link_request/certificate_link_request.json
+++ b/press/partner/doctype/certificate_link_request/certificate_link_request.json
@@ -31,9 +31,9 @@
 		{ "fieldname": "column_break_wpyz", "fieldtype": "Column Break" },
 		{
 			"fieldname": "user_email",
-			"fieldtype": "Link",
+			"fieldtype": "Data",
 			"label": "User Email",
-			"options": "User"
+			"options": "Email"
 		},
 		{ "fieldname": "key", "fieldtype": "Data", "label": "Key", "read_only": 1 },
 		{

--- a/press/partner/doctype/certificate_link_request/certificate_link_request.py
+++ b/press/partner/doctype/certificate_link_request/certificate_link_request.py
@@ -6,6 +6,33 @@ from frappe.model.document import Document
 from frappe.utils import get_url
 
 
+def _resolve_partner_name(team: str) -> str | None:
+	"""Display name of the requesting team, shown to the certificate holder.
+
+	company_name is the team's identity, persisted on the Team during partner
+	registration. billing_name is a defensive fallback that is always present
+	from account creation.
+	"""
+	values = frappe.db.get_value("Team", team, ["company_name", "billing_name"], as_dict=True)
+	if not values:
+		return None
+	return values.company_name or values.billing_name
+
+
+def notify_partner_team(team: str, event: str) -> None:
+	"""Push a realtime onboarding event to every member of the partner team.
+
+	The change can originate outside the team's own session — a Partner Manager
+	approving in Desk, or a certificate holder approving on the guest www page
+	(certificate holders are often not Frappe Cloud users). So we cannot rely on
+	frappe.session.user. Broadcasting to the site room ("all") would only reach
+	Desk users, but partners use the dashboard as Website users, so we must emit
+	to each member's user room explicitly for them to receive the update.
+	"""
+	for user in frappe.get_all("Team Member", filters={"parent": team}, pluck="user"):
+		frappe.publish_realtime(event, message={"team": team}, user=user, after_commit=True)
+
+
 class CertificateLinkRequest(Document):
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
@@ -20,12 +47,12 @@ class CertificateLinkRequest(Document):
 		partner: DF.Data | None
 		partner_team: DF.Link | None
 		status: DF.Literal["Approved", "Cancelled", "Pending"]
-		user_email: DF.Link | None
+		user_email: DF.Data | None
 	# end: auto-generated types
 
 	def before_insert(self):
 		self.status = "Pending"
-		self.partner = frappe.db.get_value("Team", self.partner_team, "company_name")
+		self.partner = _resolve_partner_name(self.partner_team)
 		self.key = frappe.generate_hash(15)
 
 	def on_update(self):
@@ -39,7 +66,7 @@ class CertificateLinkRequest(Document):
 		self.publish_status_update()
 
 	def send_validation_email(self):
-		link = get_url(f"/api/method/press.api.partner.approve_certificate_link_request?key={self.key}")
+		link = get_url(f"/certificate-approval?key={self.key}")
 
 		frappe.sendmail(
 			recipients=[self.user_email],
@@ -75,12 +102,7 @@ class CertificateLinkRequest(Document):
 		)
 
 	def publish_status_update(self):
-		frappe.publish_realtime(
-			"partner_onboarding_certificates_updated",
-			message={"team": self.partner_team},
-			doctype="Team",
-			after_commit=True,
-		)
+		notify_partner_team(self.partner_team, "partner_onboarding_certificates_updated")
 
 	@staticmethod
 	def get_certificate(user_email: str, course: str):
@@ -163,12 +185,10 @@ class CertificateLinkRequest(Document):
 				"Certificate link request has already been approved. Refresh the page to see the latest status."
 			)
 
-		if doc.user_email != frappe.session.user:
-			frappe.throw(
-				"Log in with the email address attached to this certificate. Then open the link again."
-			)
-
+		# The secret key is emailed only to the certificate holder and is
+		# consumed on first use, so possession of a valid key authorizes the
+		# approval. The holder need not be a Frappe Cloud user, so we must not
+		# require a matching logged-in session here.
 		doc.status = "Approved"
-		# key + user email is sufficient to approve the request
 		doc.save(ignore_permissions=True)
 		return doc

--- a/press/partner/doctype/partner_onboarding/partner_onboarding.py
+++ b/press/partner/doctype/partner_onboarding/partner_onboarding.py
@@ -6,11 +6,14 @@ from typing import Any
 
 import frappe
 from frappe.model.document import Document
-from frappe.utils import flt, get_last_day, now_datetime, today
+from frappe.utils import add_months, flt, get_last_day, getdate, now_datetime, today
 from pypika.enums import Order
 
 from press.guards import role_guard
-from press.partner.doctype.certificate_link_request.certificate_link_request import CertificateLinkRequest
+from press.partner.doctype.certificate_link_request.certificate_link_request import (
+	CertificateLinkRequest,
+	notify_partner_team,
+)
 from press.utils import get_current_team
 
 
@@ -111,13 +114,7 @@ class PartnerOnboarding(Document):
 		self.reviewed_on = now_datetime()
 		self.reviewer_comments = None
 		self.save()
-		# publish a realtime event to update the partner onboarding status
-		frappe.publish_realtime(
-			"partner_onboarding_status_updated",
-			message={"team": self.team},
-			doctype="Team",
-			after_commit=True,
-		)
+		notify_partner_team(self.team, "partner_onboarding_status_updated")
 
 	@frappe.whitelist()
 	def reject(self, reason: str | None = None):
@@ -137,13 +134,7 @@ class PartnerOnboarding(Document):
 		self.reviewed_on = now_datetime()
 		self.reviewer_comments = reason
 		self.save()
-		# publish a realtime event to update the partner onboarding status
-		frappe.publish_realtime(
-			"partner_onboarding_status_updated",
-			message={"team": self.team},
-			doctype="Team",
-			after_commit=True,
-		)
+		notify_partner_team(self.team, "partner_onboarding_status_updated")
 
 
 def _active_onboarding_filters(team: str) -> dict:
@@ -187,12 +178,7 @@ def _clear_certificate_links(team: str) -> None:
 			{"status": "Cancelled", "key": None},
 		)
 
-	frappe.publish_realtime(
-		"partner_onboarding_certificates_updated",
-		message={"team": team},
-		user=frappe.session.user,
-		after_commit=True,
-	)
+	notify_partner_team(team, "partner_onboarding_certificates_updated")
 
 
 def _get_certificate_link_status(team: str) -> dict:
@@ -248,22 +234,43 @@ def _get_mrr_currency(team) -> str:
 	return "USD"
 
 
+def _get_mrr_subscription_invoices(team_name: str) -> list:
+	"""Pick the invoice cycle that best represents the team's MRR.
+
+	Past the 15th the current month's billing cycle has accrued enough usage
+	to be representative, so we count it even when still Unpaid — the partner
+	is assumed to settle the invoice due at month end. Earlier in the month
+	that cycle is too young, so we fall back to last month's settled (Paid)
+	invoice instead.
+	"""
+	invoice = frappe.qb.DocType("Invoice")
+	query = (
+		frappe.qb.from_(invoice)
+		.select(invoice.currency, invoice.total_before_discount)
+		.where((invoice.team == team_name) & (invoice.type == "Subscription"))
+	)
+
+	if getdate(today()).day > 15:
+		# Current cycle is representative. Count it even when still a draft,
+		# Unpaid invoice (Unpaid invoices are not submitted, so docstatus is 0)
+		# — the partner is assumed to settle the invoice due at month end.
+		query = query.where((invoice.due_date == get_last_day(today())) & (invoice.docstatus < 2))
+	else:
+		# Too early in the cycle to trust it, so require last month's settled
+		# (Paid, hence submitted) invoice instead.
+		last_month_due_date = get_last_day(add_months(today(), -1))
+		query = query.where(
+			(invoice.due_date == last_month_due_date) & (invoice.status == "Paid") & (invoice.docstatus == 1)
+		)
+
+	return query.run(as_dict=True)
+
+
 def _get_mrr_status(team) -> dict:
 	team_currency = _get_mrr_currency(team)
 	target_amount = 10000 if team_currency == "INR" else 100
 
-	invoice = frappe.qb.DocType("Invoice")
-	invoices = (
-		frappe.qb.from_(invoice)
-		.select(invoice.currency, invoice.total_before_discount)
-		.where(
-			(invoice.partner_email == team.partner_email)
-			& (invoice.due_date == get_last_day(today()))
-			& (invoice.type == "Subscription")
-			& (invoice.docstatus == 1)
-		)
-		.run(as_dict=True)
-	)
+	invoices = _get_mrr_subscription_invoices(team.name)
 
 	current_amount = 0
 	for row in invoices:
@@ -309,6 +316,13 @@ def get_partner_onboarding() -> dict | None:
 	return doc.as_dict()
 
 
+def _sync_company_name_to_team(team, company_name: str | None) -> None:
+	"""The company name is the team's identity (shown to certificate holders,
+	in partner listings, etc.), so keep it on the Team as the source of truth."""
+	if company_name and company_name != team.company_name:
+		frappe.db.set_value("Team", team.name, "company_name", company_name)
+
+
 @frappe.whitelist(methods=["POST"])
 @role_guard.api("partner")
 def save_partner_onboarding(details: dict[str, Any]) -> dict:
@@ -342,6 +356,8 @@ def save_partner_onboarding(details: dict[str, Any]) -> dict:
 		doc.insert()
 	else:
 		doc.save()
+
+	_sync_company_name_to_team(team, doc.company_name)
 
 	return doc.as_dict()
 

--- a/press/partner/doctype/partner_onboarding/test_partner_onboarding.py
+++ b/press/partner/doctype/partner_onboarding/test_partner_onboarding.py
@@ -1,11 +1,19 @@
 # Copyright (c) 2026, Frappe and Contributors
 # See license.txt
 
+from unittest.mock import Mock, patch
+
 import frappe
 from frappe.tests import IntegrationTestCase
+from frappe.utils import add_months, get_last_day, today
 
-from press.partner.doctype.partner_onboarding.partner_onboarding import has_partner_onboarding
+from press.partner.doctype.partner_onboarding.partner_onboarding import (
+	_get_mrr_status,
+	has_partner_onboarding,
+)
+from press.press.doctype.invoice.invoice import Invoice
 from press.press.doctype.team.test_team import create_test_team
+from press.tests.before_test import freeze_time
 
 # On IntegrationTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
@@ -13,7 +21,13 @@ from press.press.doctype.team.test_team import create_test_team
 EXTRA_TEST_RECORD_DEPENDENCIES: list[str] = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES: list[str] = []  # eg. ["User"]
 
+# A day past the 15th and a day on/before the 15th, used to drive the
+# month-position branching in _get_mrr_status deterministically.
+AFTER_MID_MONTH = "2026-01-20"
+BEFORE_MID_MONTH = "2026-01-10"
 
+
+@patch.object(Invoice, "create_invoice_on_frappeio", new=Mock())
 class IntegrationTestPartnerOnboarding(IntegrationTestCase):
 	"""
 	Integration tests for PartnerOnboarding.
@@ -24,13 +38,45 @@ class IntegrationTestPartnerOnboarding(IntegrationTestCase):
 		frappe.db.rollback()
 
 	def _create_onboarding(self, team: str, status: str = "Draft"):
+		# The Register Company modal collects these four fields on first
+		# registration, so they are mandatory at creation. Supply them here
+		# to mirror a real draft record.
 		return frappe.get_doc(
 			{
 				"doctype": "Partner Onboarding",
 				"team": team,
 				"status": status,
+				"company_name": "Test Partner Company",
+				"registered_country": "India",
+				"company_email": "partner@example.com",
+				"contact": "+919876543210",
 			}
 		).insert(ignore_permissions=True)
+
+	def _create_subscription_invoice(
+		self,
+		team: str,
+		due_date: str,
+		amount: float,
+		status: str = "Unpaid",
+		submitted: bool = False,
+	):
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=team,
+			type="Subscription",
+			due_date=due_date,
+			status=status,
+			items=[{"quantity": 1, "rate": amount}],
+		).insert()
+		if submitted:
+			# Paid Subscription invoices are submitted in production, but the
+			# "Invoice must be Paid to be submitted" guard makes a normal submit
+			# awkward in tests — force the persisted state the query reads.
+			frappe.db.set_value(
+				"Invoice", invoice.name, {"status": status, "docstatus": 1}, update_modified=False
+			)
+		return invoice
 
 	def test_has_partner_onboarding_is_false_without_a_record(self):
 		team = create_test_team()
@@ -46,3 +92,69 @@ class IntegrationTestPartnerOnboarding(IntegrationTestCase):
 		onboarding = self._create_onboarding(team.name)
 		onboarding.db_set("status", "Cancelled")
 		self.assertFalse(has_partner_onboarding(team.name))
+
+	def test_mrr_after_mid_month_counts_unpaid_current_invoice(self):
+		"""Past the 15th, an Unpaid current-month invoice over the threshold
+		is enough — we assume the partner will pay."""
+		team = create_test_team()
+		with freeze_time(AFTER_MID_MONTH):
+			self._create_subscription_invoice(team.name, get_last_day(today()), 12000, status="Unpaid")
+			status = _get_mrr_status(team)
+
+		self.assertEqual(status["currency"], "INR")
+		self.assertEqual(status["target_amount"], 10000)
+		self.assertEqual(status["current_amount"], 12000)
+		self.assertTrue(status["requirement_complete"])
+
+	def test_mrr_after_mid_month_below_threshold_is_incomplete(self):
+		team = create_test_team()
+		with freeze_time(AFTER_MID_MONTH):
+			self._create_subscription_invoice(team.name, get_last_day(today()), 5000, status="Unpaid")
+			status = _get_mrr_status(team)
+
+		self.assertEqual(status["current_amount"], 5000)
+		self.assertFalse(status["requirement_complete"])
+
+	def test_mrr_after_mid_month_ignores_other_months(self):
+		"""Only the current cycle counts after the 15th."""
+		team = create_test_team()
+		with freeze_time(AFTER_MID_MONTH):
+			last_month_due = get_last_day(add_months(today(), -1))
+			self._create_subscription_invoice(team.name, last_month_due, 12000, status="Paid", submitted=True)
+			status = _get_mrr_status(team)
+
+		self.assertEqual(status["current_amount"], 0)
+		self.assertFalse(status["requirement_complete"])
+
+	def test_mrr_before_mid_month_uses_last_month_paid_invoice(self):
+		"""On/before the 15th, last month's settled invoice is used."""
+		team = create_test_team()
+		with freeze_time(BEFORE_MID_MONTH):
+			last_month_due = get_last_day(add_months(today(), -1))
+			self._create_subscription_invoice(team.name, last_month_due, 12000, status="Paid", submitted=True)
+			status = _get_mrr_status(team)
+
+		self.assertEqual(status["current_amount"], 12000)
+		self.assertTrue(status["requirement_complete"])
+
+	def test_mrr_before_mid_month_ignores_unpaid_last_month_invoice(self):
+		"""An unpaid (unsubmitted) last-month invoice does not count early in
+		the cycle."""
+		team = create_test_team()
+		with freeze_time(BEFORE_MID_MONTH):
+			last_month_due = get_last_day(add_months(today(), -1))
+			self._create_subscription_invoice(team.name, last_month_due, 12000, status="Unpaid")
+			status = _get_mrr_status(team)
+
+		self.assertEqual(status["current_amount"], 0)
+		self.assertFalse(status["requirement_complete"])
+
+	def test_mrr_before_mid_month_ignores_current_month_invoice(self):
+		"""The young current-month invoice is not used before the 15th."""
+		team = create_test_team()
+		with freeze_time(BEFORE_MID_MONTH):
+			self._create_subscription_invoice(team.name, get_last_day(today()), 12000, status="Unpaid")
+			status = _get_mrr_status(team)
+
+		self.assertEqual(status["current_amount"], 0)
+		self.assertFalse(status["requirement_complete"])

--- a/press/templates/emails/partner_link_certificate.html
+++ b/press/templates/emails/partner_link_certificate.html
@@ -8,9 +8,9 @@
         <p>Hello,</p>
         <p>Partner {{ partner }} has raised a request to link your certificate with their Frappe Cloud team account.</p>
         <p>
-           Confirm your consent by clicking on the following button.
+           Review the request and confirm your consent by clicking on the following button.
         </p>
-        {{ utils.button('Approve', link, true) }}
+        {{ utils.button('Review request', link, true) }}
         {{ utils.separator() }}
         {{ utils.signature() }}
     </div>

--- a/press/www/certificate-approval.html
+++ b/press/www/certificate-approval.html
@@ -1,0 +1,103 @@
+{% extends "templates/web.html" %}
+
+{% block title %}Certificate Link Request{% endblock %}
+
+{% block page_content %}
+<div class="cert-approval">
+	<div class="cert-card">
+		{% if state == "pending" %}
+		<h1 class="cert-title">Approve certificate link</h1>
+		<p class="cert-text">
+			<strong>{{ partner }}</strong> has requested to link your
+			{% if course %}<strong>{{ course }}</strong> {% endif %}certificate to their
+			Frappe Cloud partner account.
+		</p>
+		<p class="cert-text">Approve only if you recognise this partner.</p>
+		<form method="POST" class="cert-form">
+			<input type="hidden" name="key" value="{{ frappe.form_dict.key or '' }}">
+			<input type="hidden" name="csrf_token" value="{{ frappe.session.csrf_token }}">
+			<button type="submit" class="cert-button">Approve link request</button>
+		</form>
+
+		{% elif state == "approved" %}
+		<h1 class="cert-title">Certificate linked</h1>
+		<p class="cert-text">
+			Your certificate has been linked to <strong>{{ partner }}</strong>.
+			You can close this tab.
+		</p>
+
+		{% elif state == "already_approved" %}
+		<h1 class="cert-title">Already linked</h1>
+		<p class="cert-text">
+			This request has already been approved. No further action is needed —
+			you can close this tab.
+		</p>
+
+		{% elif state == "error" %}
+		<h1 class="cert-title">Couldn't link certificate</h1>
+		<p class="cert-text">{{ error_message }}</p>
+
+		{% else %}
+		<h1 class="cert-title">Link not valid</h1>
+		<p class="cert-text">
+			This certificate link request is invalid or has expired. Please ask the
+			partner to send a new request.
+		</p>
+		{% endif %}
+	</div>
+</div>
+
+<style>
+	.cert-approval {
+		display: flex;
+		justify-content: center;
+		padding: 64px 16px;
+	}
+
+	.cert-card {
+		width: 100%;
+		max-width: 480px;
+		padding: 32px;
+		border: 1px solid #e2e2e2;
+		border-radius: 12px;
+		background: #fff;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+		text-align: center;
+	}
+
+	.cert-title {
+		font-size: 20px;
+		font-weight: 600;
+		color: #171717;
+		margin-bottom: 12px;
+	}
+
+	.cert-text {
+		font-size: 14px;
+		line-height: 1.6;
+		color: #525252;
+		margin-bottom: 12px;
+	}
+
+	.cert-form {
+		margin-top: 24px;
+	}
+
+	.cert-button {
+		display: inline-block;
+		width: 100%;
+		padding: 10px 16px;
+		font-size: 14px;
+		font-weight: 500;
+		color: #fff;
+		background: #171717;
+		border: none;
+		border-radius: 8px;
+		cursor: pointer;
+	}
+
+	.cert-button:hover {
+		background: #000;
+	}
+</style>
+{% endblock %}

--- a/press/www/certificate_approval.py
+++ b/press/www/certificate_approval.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+import frappe
+
+from press.partner.doctype.certificate_link_request.certificate_link_request import (
+	CertificateLinkRequest,
+)
+
+no_cache = 1
+
+
+def get_context(context):
+	"""Public consent page for a certificate holder to approve a partner's
+	link request.
+
+	The page is intentionally guest-accessible: the holder need not be a Frappe
+	Cloud user. The GET renders the request for review (read-only); the POST,
+	triggered by the holder clicking Approve, performs the approval. Keeping the
+	mutation behind a POST prevents email scanners and link prefetchers (which
+	issue GET requests) from approving on the holder's behalf.
+	"""
+	context.no_cache = 1
+
+	key = frappe.form_dict.get("key")
+	request = _get_request(key)
+
+	if not request:
+		context.state = "invalid"
+		return context
+
+	context.partner = request.partner or "A Frappe Cloud partner"
+	context.course = _humanize_course(request.course)
+
+	if frappe.request.method == "POST":
+		if request.status != "Pending":
+			context.state = "already_approved" if request.status == "Approved" else "invalid"
+			return context
+		try:
+			CertificateLinkRequest.approve_from_key(key)
+			frappe.db.commit()
+			context.state = "approved"
+		except frappe.ValidationError as e:
+			frappe.db.rollback()
+			context.state = "error"
+			context.error_message = str(e)
+		return context
+
+	if request.status == "Pending":
+		context.state = "pending"
+	elif request.status == "Approved":
+		context.state = "already_approved"
+	else:
+		context.state = "invalid"
+
+	return context
+
+
+def _get_request(key: str | None):
+	if not key:
+		return None
+	name = frappe.db.get_value("Certificate Link Request", {"key": key}, "name")
+	if not name:
+		return None
+	return frappe.db.get_value(
+		"Certificate Link Request",
+		name,
+		["status", "partner", "course"],
+		as_dict=True,
+	)
+
+
+def _humanize_course(course: str | None) -> str:
+	if not course:
+		return ""
+	return course.replace("-", " ").title()


### PR DESCRIPTION

- Removed the `approve_certificate_link_request` function from the API, transitioning to a new certificate approval flow via a dedicated public page.
- Changed the `user_email` field type from Link to Data in the certificate link request JSON schema for better clarity.
- Introduced `_resolve_partner_name` and `notify_partner_team` functions to enhance partner name resolution and real-time notifications for onboarding events.
- Updated email templates to clarify the action required from users.
- Added a new public endpoint for certificate approval, ensuring security by using POST requests for state changes.
- Enhanced the onboarding process with improved MRR status calculations and invoice handling logic.