### PR TITLE
fix(server): Persist auto increase storage disable on DB servers

### DIFF
--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -367,7 +367,10 @@ class BaseServer(Document, TagHelpers):
 	def configure_auto_add_storage(self, server: str, enabled: bool, min: int = 0, max: int = 0) -> None:
 		# `self` is always the app server (the dashboard dispatches on $appServer);
 		# `server` identifies the actual target, which may be a Database Server.
+		# The dashboard API only team-checks `self`, and the disable path below writes via
+		# `set_value` (which skips permission hooks), so authorize the resolved target here.
 		server_doc = self if server == self.name else frappe.get_doc("Database Server", server)
+		server_doc.check_permission("write")
 
 		if not enabled:
 			frappe.db.set_value(server_doc.doctype, server_doc.name, "auto_increase_storage", False)

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -365,8 +365,12 @@ class BaseServer(Document, TagHelpers):
 
 	@dashboard_whitelist()
 	def configure_auto_add_storage(self, server: str, enabled: bool, min: int = 0, max: int = 0) -> None:
+		# `self` is always the app server (the dashboard dispatches on $appServer);
+		# `server` identifies the actual target, which may be a Database Server.
+		server_doc = self if server == self.name else frappe.get_doc("Database Server", server)
+
 		if not enabled:
-			frappe.db.set_value(self.doctype, self.name, "auto_increase_storage", False)
+			frappe.db.set_value(server_doc.doctype, server_doc.name, "auto_increase_storage", False)
 			return
 
 		if min < 0 or max < 0:
@@ -374,17 +378,10 @@ class BaseServer(Document, TagHelpers):
 		if min > max:
 			frappe.throw(_("Minimum storage size must be less than the maximum storage size"))
 
-		if server == self.name:
-			self.auto_increase_storage = True
-			self.auto_add_storage_min = min
-			self.auto_add_storage_max = max
-			self.save()
-		else:
-			server_doc = frappe.get_doc("Database Server", server)
-			server_doc.auto_increase_storage = True
-			server_doc.auto_add_storage_min = min
-			server_doc.auto_add_storage_max = max
-			server_doc.save()
+		server_doc.auto_increase_storage = True
+		server_doc.auto_add_storage_min = min
+		server_doc.auto_add_storage_max = max
+		server_doc.save()
 
 	@staticmethod
 	def on_not_found(name):

--- a/press/press/doctype/server/test_server.py
+++ b/press/press/doctype/server/test_server.py
@@ -403,3 +403,34 @@ class TestServer(FrappeTestCase):
 		server.configure_auto_add_storage(server=server.name, enabled=False)
 
 		self.assertFalse(frappe.db.get_value("Server", server.name, "auto_increase_storage"))
+
+	def test_configure_auto_storage_rejects_another_teams_database_server(self):
+		"""The dashboard API only team-checks the app server. A Press User must not be able to
+		flip auto_increase_storage on another team's Database Server by passing its name as the
+		`server` argument — the disable path writes via set_value, which skips permission hooks."""
+		from frappe.tests.ui_test_helpers import create_test_user
+
+		attacker_email = frappe.mock("email")
+		create_test_user(attacker_email)
+		attacker = frappe.get_doc("User", {"email": attacker_email})
+		attacker.remove_roles(*frappe.get_all("Role", pluck="name"))
+		attacker.add_roles("Press User")
+		attacker_team = create_test_team(attacker_email)
+
+		own_database_server = create_test_database_server()
+		frappe.db.set_value("Database Server", own_database_server.name, "team", attacker_team.name)
+		server = create_test_server(database_server=own_database_server.name, team=attacker_team.name)
+
+		victim_database_server = create_test_database_server()
+		frappe.db.set_value(
+			"Database Server",
+			victim_database_server.name,
+			{"team": create_test_team().name, "auto_increase_storage": True},
+		)
+
+		with self.set_user(attacker_team.user), self.assertRaises(frappe.PermissionError):
+			server.configure_auto_add_storage(server=victim_database_server.name, enabled=False)
+
+		self.assertTrue(
+			frappe.db.get_value("Database Server", victim_database_server.name, "auto_increase_storage")
+		)

--- a/press/press/doctype/server/test_server.py
+++ b/press/press/doctype/server/test_server.py
@@ -383,3 +383,23 @@ class TestServer(FrappeTestCase):
 		)
 		self.assertEqual(len(incidents), 1)
 		self.assertEqual(incidents[0].server, self.high_mem_server.name)
+
+	def test_disable_auto_storage_on_database_server_clears_db_flag_not_app_flag(self):
+		database_server = create_test_database_server()
+		frappe.db.set_value("Database Server", database_server.name, "auto_increase_storage", True)
+		server = create_test_server(database_server=database_server.name, auto_increase_storage=True)
+
+		# Dashboard always dispatches on the app server, passing the real target as `server`.
+		server.configure_auto_add_storage(server=database_server.name, enabled=False)
+
+		self.assertFalse(
+			frappe.db.get_value("Database Server", database_server.name, "auto_increase_storage")
+		)
+		self.assertTrue(frappe.db.get_value("Server", server.name, "auto_increase_storage"))
+
+	def test_disable_auto_storage_on_app_server_clears_app_flag(self):
+		server = create_test_server(auto_increase_storage=True)
+
+		server.configure_auto_add_storage(server=server.name, enabled=False)
+
+		self.assertFalse(frappe.db.get_value("Server", server.name, "auto_increase_storage"))


### PR DESCRIPTION
`configure_auto_add_storage` is always dispatched on the app server from the dashboard ($appServer), with the real target passed as the `server` argument. The enable branch routed to the right doc via `server`, but the disable branch hardcoded `self`, so disabling on a DB/replication server cleared the flag on the app server instead. The target server kept `auto_increase_storage = True` and the checkbox reverted on reload.

Resolve the target doc once and use it in both branches.