### PR TITLE
fix(deploy-ui): fallback jobstep.duration with empty string

### DIFF
--- a/dashboard/src/components/benches/pipeline/Stages.vue
+++ b/dashboard/src/components/benches/pipeline/Stages.vue
@@ -139,7 +139,7 @@ const isStageDisabled = (x) => {
 							{{ jobstep.step_name }}
 
 							<span class="text-ink-gray-5 ml-auto pr-1">
-								{{ duration(jobstep.duration) }}
+								{{ jobstep.duration ? duration(jobstep.duration) : '' }}
 							</span>
 						</button>
 					</template>


### PR DESCRIPTION
Prevents Nan from being shown in Jobsteps duration