### PR TITLE
fix(site): Marketplace app site key handling for devs

### DIFF
--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -838,9 +838,21 @@ class Site(Document, TagHelpers):
 
 	def install_marketplace_conf(self, app: str, plan: str | None = None):
 		if plan:
-			MarketplaceAppPlan.create_marketplace_app_subscription(self.name, app, plan, self.team)
+			subscription = MarketplaceAppPlan.create_marketplace_app_subscription(
+				self.name, app, plan, self.team
+			)
 		else:
-			create_free_app_subscription(app, self.name)
+			subscription = create_free_app_subscription(app, self.name)
+
+		# Marketplace apps authenticate to the Marketplace Developer API with a per-site
+		# secret read from their own site_config as `sk_<app>`. The secret lives on the
+		# Subscription doc; push it to the running site so the key reaches the bench.
+		# `update_site_config` (not `_update_configuration`) is required because the site
+		# is already live and arbitrary config changes are not propagated on save.
+		# A free app without a free plan yields no subscription, so there's nothing to push.
+		if subscription:
+			self.update_site_config({f"sk_{subscription.document_name}": subscription.secret_key})
+
 		marketplace_app_hook(app=app, site=self, op="install")
 
 	def uninstall_marketplace_conf(self, app: str):


### PR DESCRIPTION
Fixed a bug reported on a support ticket.

Installing a marketplace app on a running site (install_app → install_marketplace_conf) created the Subscription (with a generated secret_key) but never wrote sk_<app> into the site's site_config.json. So the app couldn't authenticate to the Marketplace Developer API — every callback (subscription status, billing, plan change) would 401.

Solution
Capture the returned Subscription and push the key to the live site via update_site_config (which issues the agent job that updates site_config.json). Mirrors what the SaaS-trial flow already does, but at install-time. 