### PR TITLE
fix(cluster): Check SSH key content and not the name

### DIFF
--- a/press/press/doctype/cluster/cluster.py
+++ b/press/press/doctype/cluster/cluster.py
@@ -437,7 +437,7 @@ class Cluster(Document):
 		except APIException as e:
 			# If the SSH key already exists, retrieve it
 			if e.code != "uniqueness_error":
-				raise
+				frappe.throw(f"Failed to create SSH key on Hetzner: {e!s}")
 
 		try:
 			# Create Server Firewall

--- a/press/press/doctype/cluster/cluster.py
+++ b/press/press/doctype/cluster/cluster.py
@@ -434,11 +434,10 @@ class Cluster(Document):
 				name=self.ssh_key,
 				public_key=frappe.db.get_value("SSH Key", self.ssh_key, "public_key"),
 			)
-		except APIException:
+		except APIException as e:
 			# If the SSH key already exists, retrieve it
-			existing_keys = client.ssh_keys.get_all(name=self.ssh_key)
-			if len(existing_keys) == 0:
-				frappe.throw(f"SSH Key creation failed and '{self.ssh_key}' not found on Hetzner Cloud.")
+			if e.code != "uniqueness_error":
+				raise
 
 		try:
 			# Create Server Firewall


### PR DESCRIPTION
## Problem

While provisioning a Hetzner cluster, SSH key uniqueness was effectively validated using the key name rather than the actual public key content. As a result, if an identical SSH key already existed on Hetzner under a different name, cluster provisioning failed even though the key was already available for use.

## Error

```text
SSH key not unique (uniqueness_error)
```

This resulted in provisioning failing with:

```text
SSH Key creation failed and '<key-name>' not found on Hetzner Cloud.
```

## Solution

Handle Hetzner's `uniqueness_error` explicitly and continue provisioning, since the SSH key already exists and is available for use.