### PR TITLE
fix(deploy-ui): Show team instead of owner in deploys list

### DIFF
--- a/dashboard/src/pages/benches/Deploys.vue
+++ b/dashboard/src/pages/benches/Deploys.vue
@@ -39,7 +39,7 @@ const deployBuilds = createListResource({
 
 const pipelines = createListResource({
 	doctype: 'Release Pipeline',
-	fields: ['name', 'status', 'creation', 'team'],
+	fields: ['name', 'status', 'creation', 'team.user as team'],
 	filters: {
 		release_group: props.name,
 	},

--- a/press/press/doctype/release_pipeline/release_pipeline.py
+++ b/press/press/doctype/release_pipeline/release_pipeline.py
@@ -144,6 +144,7 @@ class ReleasePipeline(WorkflowBuilder):
 		"release_group",
 		"status",
 		"creation",
+		"team",
 	)
 
 	def send_failure_notification(self):


### PR DESCRIPTION
The deploys list was displaying the document owner instead of the team that initiated the deploy. 

Joined team.user to get the team's user email and exposed the team field via the whitelist in release_pipeline.py.

### Before 
<img width="2426" height="952" alt="image" src="https://github.com/user-attachments/assets/06372a79-c777-45d6-b6ba-6b03d055c54b" />
