### PR TITLE
feat(bench): Trigger install of SSH command guard on benches

### DIFF
--- a/press/agent.py
+++ b/press/agent.py
@@ -125,6 +125,16 @@ class Agent:
 			"Update Bench Configuration", f"benches/{bench.name}/config", data, bench=bench.name
 		)
 
+	def setup_bench_command_guard(self, bench: str):
+		from press.press.doctype.bench.bench import BLOCKED_BENCH_COMMANDS
+
+		return self.create_agent_job(
+			"Setup Bench Command Guard",
+			f"benches/{bench}/command-guard",
+			data={"blocked_commands": BLOCKED_BENCH_COMMANDS},
+			bench=bench,
+		)
+
 	def _get_managed_db_config(self, site):
 		managed_database_service = frappe.get_cached_value("Bench", site.bench, "managed_database_service")
 

--- a/press/fixtures/agent_job_type.json
+++ b/press/fixtures/agent_job_type.json
@@ -1,5 +1,23 @@
 [
 	{
+		"disabled_auto_retry": 0,
+		"docstatus": 0,
+		"doctype": "Agent Job Type",
+		"max_retry_count": 6,
+		"modified": "2026-06-15 00:00:00.000000",
+		"name": "Setup Bench Command Guard",
+		"request_method": "POST",
+		"request_path": "/benches/{bench}/command-guard",
+		"steps": [
+			{
+				"parent": "Setup Bench Command Guard",
+				"parentfield": "steps",
+				"parenttype": "Agent Job Type",
+				"step_name": "Setup Bench Command Guard"
+			}
+		]
+	},
+	{
 		"disabled_auto_retry": 1,
 		"docstatus": 0,
 		"doctype": "Agent Job Type",

--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -54,6 +54,20 @@ BENCH_QUEUE_EXECUTION_LOCK_KEY = "process_bench_queue_lock"
 
 EMPTY_BENCH_COURTESY_DAYS = 3
 
+# Bench (frappe) subcommands that mutate state Press manages and would put
+# Press's view of a site out of sync if run directly over SSH on a production bench. The
+# guard wrapper installed on the bench refuses these; the list is sent to the
+# agent so it can be updated from Press without rebuilding the image.
+BLOCKED_BENCH_COMMANDS = [
+	"drop-site",
+	"migrate",
+	"restore",
+	"reinstall",
+	"remove-app",
+	"uninstall-app",
+	"set-config",
+]
+
 MAX_GUNICORN_WORKERS = 36
 MIN_GUNICORN_WORKERS = 2
 MAX_BACKGROUND_WORKERS = 8
@@ -486,6 +500,15 @@ class Bench(Document):
 	def create_agent_request(self):
 		agent = Agent(self.server)
 		agent.new_bench(self)
+
+	def setup_command_guard(self):
+		"""Install the wrapper that blocks destructive bench commands run over SSH.
+
+		The wrapper lives on the container filesystem (not the image), so it is
+		(re)installed every time a bench becomes Active — including freshly built
+		containers from a redeploy.
+		"""
+		Agent(self.server).setup_bench_command_guard(self.name)
 
 	def _mark_applied_patch_as_archived(self):
 		frappe.db.set_value(
@@ -1343,6 +1366,23 @@ def cancel_and_retry_bench_job_if_required(job: AgentJob) -> bool:
 	return True
 
 
+def backfill_command_guard_on_active_benches():
+	"""Install the bench command guard on every running bench.
+
+	New benches get the guard automatically when they turn Active (see
+	process_new_bench_job_update); this covers benches that were already running
+	before the feature shipped. Run once after the agent endpoint is deployed:
+	`bench execute press.press.doctype.bench.bench.backfill_command_guard_on_active_benches`
+	"""
+	for name in frappe.get_all("Bench", {"status": "Active"}, pluck="name"):
+		try:
+			Bench("Bench", name).setup_command_guard()
+			frappe.db.commit()
+		except Exception:
+			frappe.db.rollback()
+			log_error("Failed to install bench command guard", bench=name)
+
+
 def process_new_bench_job_update(job: AgentJob):  # noqa: C901
 	bench = Bench("Bench", job.bench)
 
@@ -1363,6 +1403,9 @@ def process_new_bench_job_update(job: AgentJob):  # noqa: C901
 	if bench.team != "Administrator":
 		bench.status = updated_status  # just to ensure the status got changed in webhook payload, reload_doc is costly here
 		create_webhook_event("Bench Status Update", bench, bench.team)
+
+	if updated_status == "Active":
+		bench.setup_command_guard()
 
 	# check if new bench related to a site group deploy
 	site_group_deploy = frappe.db.get_value(


### PR DESCRIPTION
Pairs with the [agent-side bench wrapper](https://github.com/frappe/agent/pull/543) that blocks destructive commands (drop-site, migrate, restore, etc.) run directly over SSH on production benches, which would put a site's state out of sync with Frappe Cloud.

Press owns the blocklist (BLOCKED_BENCH_COMMANDS) and sends it to the agent, so it can change without rebuilding the bench image. The guard lives on the container filesystem rather than the image, so it is (re)installed every time a bench turns Active - covering both new benches and fresh containers from a redeploy. backfill_command_guard_on_active_benches covers benches already running; it is left out of patches.txt so it does not fire jobs before the agent endpoint is deployed.

The enforcement can't live in the bench CLI (pinned/immutable in prod), hence routing it through press > agent.