### PR TITLE
fix(site): Update schedule_updates_server method

### DIFF
--- a/press/press/doctype/site_update/site_update.py
+++ b/press/press/doctype/site_update/site_update.py
@@ -905,11 +905,8 @@ def schedule_updates_server(server):
 	# Shuffle sites list, to achieve this
 	random.shuffle(sites)
 
-	benches = {}
 	update_triggered_count = 0
 	for site in sites:
-		if site.bench in benches:
-			continue
 		if update_triggered_count > queue_size:
 			break
 		if not should_try_update(site) or frappe.db.exists(


### PR DESCRIPTION
 Update the schedule_updates_server method to remove one site per bench per run limit.

fix #6719 