### PR TITLE
fix(ui): Show bench state correctly after deploy

### DIFF
--- a/dashboard/src/components/global/Badge.vue
+++ b/dashboard/src/components/global/Badge.vue
@@ -39,6 +39,7 @@ export default {
 				'Update Available': 'blue',
 				Enabled: 'blue',
 				'Awaiting Approval': 'orange',
+				'Deploying': 'blue',
 				'Awaiting Deploy': 'orange',
 				Success: 'green',
 				Completed: 'green',

--- a/dashboard/src/objects/group.js
+++ b/dashboard/src/objects/group.js
@@ -746,10 +746,7 @@ export default {
 			let { documentResource: group } = context;
 			let team = getTeam();
 
-			if (
-				group.doc?.deploy_information?.has_running_release_pipeline &&
-				!group.doc?.deploy_information?.deploy_in_progress
-			) {
+			if (group.doc?.deploy_information?.has_running_release_pipeline) {
 				pollReleasePipelineValidationStatus(group);
 			}
 

--- a/dashboard/src/utils/pollReleasePipeline.ts
+++ b/dashboard/src/utils/pollReleasePipeline.ts
@@ -29,12 +29,22 @@ export function pollReleasePipelineValidationStatus(group) {
 					}
 				}
 
-				if (is_validating) {
-					setTimeout(poll, 2000) // still validating, keep polling
+				if (is_validating || is_deploy_in_progress) {
+					group.doc.status = 'Deploying'
+					setTimeout(poll, 2000) // still validating or building, keep polling
 				} else {
-					// Validation done
-					group.doc.deploy_information.has_running_release_pipeline = false
-					pollingGroups.delete(group.doc.name)
+					// Deploy finished (idle)
+					group
+						.reload()
+						.then(() => {
+							pollingGroups.delete(group.doc.name)
+							if (group.doc.deploy_information.has_running_release_pipeline) {
+								pollReleasePipelineValidationStatus(group)
+							}
+						})
+						.catch(() => {
+							pollingGroups.delete(group.doc.name)
+						})
 				}
 			})
 			.catch(() => {

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -1171,6 +1171,9 @@ class ReleaseGroup(Document, TagHelpers):
 		if not self.enabled:
 			return "Disabled"
 
+		if self.deploy_in_progress or self.has_running_release_pipeline:
+			return "Deploying"
+
 		active_benches = frappe.db.get_all(
 			"Bench", {"group": self.name, "status": "Active"}, limit=1, order_by="creation desc"
 		)


### PR DESCRIPTION
## Description 

- Bench status badge in header didnt had the Deploying status, so I added it
- Closes https://github.com/frappe/press/issues/6551 

### Before

- It either shows `Active` or `Awaiting Deploy` and user has to reload the page, the live updating of status is broken

https://github.com/user-attachments/assets/cdce3898-c1b3-40e4-9152-22c46a536c10

### After


https://github.com/user-attachments/assets/d35611da-6427-41eb-ae21-ed385f08b761



