### PR TITLE
fix(github): Refresh access token after app (re)installation

### DIFF
--- a/press/api/github.py
+++ b/press/api/github.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 
 
 DEFAULT_GITHUB_REDIRECT_PATH = "/dashboard"
+GITHUB_OAUTH_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
 GITHUB_OAUTH_STATE_MAX_AGE = timedelta(minutes=10)
 
 
@@ -212,12 +213,26 @@ def get_safe_github_redirect_url(redirect_url: str | None = None) -> str:
 	return redirect_path
 
 
+def get_github_authorize_url(state: str) -> str:
+	"""User-authorization URL used to obtain a fresh OAuth code (and token).
+
+	GitHub redirects back to the app's registered callback (/github/authorize),
+	so we don't pass a redirect_uri and avoid a callback URL mismatch.
+	"""
+	client_id = frappe.db.get_single_value("Press Settings", "github_app_client_id")
+	return f"{GITHUB_OAUTH_AUTHORIZE_URL}?{urlencode({'client_id': client_id, 'state': state})}"
+
+
 def get_github_callback_login_redirect(code: str | None, state: str | None) -> str:
 	login_url = "/dashboard/login"
-	if not (code and state):
+	if not state:
 		return frappe.utils.get_url(login_url)
 
-	callback_url = f"/github/authorize?{urlencode({'code': code, 'state': state})}"
+	params = {}
+	if code:
+		params["code"] = code
+	params["state"] = state
+	callback_url = f"/github/authorize?{urlencode(params)}"
 	return frappe.utils.get_url(f"{login_url}?{urlencode({'redirect': callback_url})}")
 
 

--- a/press/api/tests/test_github.py
+++ b/press/api/tests/test_github.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import json
 from base64 import urlsafe_b64decode, urlsafe_b64encode
+from datetime import datetime
 from unittest.mock import Mock, patch
-from urllib.parse import urlencode
+from urllib.parse import parse_qs, urlencode, urlparse
 
 import frappe
 from frappe.tests.ui_test_helpers import create_test_user
@@ -123,8 +124,32 @@ class TestGitHubAuthorization(FrappeTestCase):
 
 		obtain_access_token.assert_not_called()
 		self.assertTrue(frappe.flags.redirect_location.startswith(GITHUB_OAUTH_AUTHORIZE_URL))
-		self.assertIn(f"state={state}", frappe.flags.redirect_location)
 		self.assertIn("client_id=client-id", frappe.flags.redirect_location)
+		reissued_state = parse_qs(urlparse(frappe.flags.redirect_location).query)["state"][0]
+		self.assertEqual(self._decode_state_payload(reissued_state)["team"], self.team.name)
+
+	def test_get_context_reissues_state_so_oauth_leg_gets_fresh_expiry_window(self):
+		from press.api.github import GITHUB_OAUTH_AUTHORIZE_URL
+
+		# Mint a state that is still valid but already nine minutes into its
+		# ten-minute window, simulating a slow install wizard.
+		aged_state, aged_payload = self._make_aged_state(self.team.name, "/dashboard/sites", age_seconds=540)
+		self._set_form_dict(state=aged_state, installation_id="123", setup_action="install")
+
+		with (
+			self.assertRaises(frappe.Redirect),
+			patch("press.api.github.frappe.db.get_single_value", return_value="client-id"),
+		):
+			self._get_context()(None)
+
+		self.assertTrue(frappe.flags.redirect_location.startswith(GITHUB_OAUTH_AUTHORIZE_URL))
+		reissued_state = parse_qs(urlparse(frappe.flags.redirect_location).query)["state"][0]
+		self.assertNotEqual(reissued_state, aged_state)
+
+		reissued_payload = self._decode_state_payload(reissued_state)
+		self.assertEqual(reissued_payload["team"], self.team.name)
+		self.assertEqual(reissued_payload["redirect_url"], "/dashboard/sites")
+		self.assertGreater(reissued_payload["issued_at"], aged_payload["issued_at"])
 
 	def test_get_context_does_not_start_authorization_when_user_denied_install(self):
 		state = self._encode_github_oauth_state(self.team.name, "/dashboard/sites")
@@ -179,6 +204,22 @@ class TestGitHubAuthorization(FrappeTestCase):
 				"token_type": "bearer",
 			},
 		)
+
+	def _make_aged_state(self, team: str, redirect_url: str, age_seconds: int) -> tuple[str, dict]:
+		from press.api.github import (
+			_encode_github_state_payload,
+			_sign_github_oauth_state,
+			get_safe_github_redirect_url,
+		)
+
+		payload = {
+			"issued_at": int(datetime.now().timestamp()) - age_seconds,
+			"redirect_url": get_safe_github_redirect_url(redirect_url),
+			"team": team,
+			"user": frappe.session.user,
+		}
+		encoded_payload = _encode_github_state_payload(payload)
+		return f"{encoded_payload}.{_sign_github_oauth_state(encoded_payload)}", payload
 
 	def _decode_state_payload(self, state: str) -> dict[str, str]:
 		encoded_payload = state.rsplit(".", 1)[0]

--- a/press/api/tests/test_github.py
+++ b/press/api/tests/test_github.py
@@ -105,6 +105,45 @@ class TestGitHubAuthorization(FrappeTestCase):
 		self.assertNotIn("code", log_error.call_args.kwargs)
 		self.assertEqual(frappe.flags.redirect_location, frappe.utils.get_url("/dashboard"))
 
+	def test_get_context_starts_user_authorization_when_install_callback_has_no_code(self):
+		from press.api.github import GITHUB_OAUTH_AUTHORIZE_URL
+
+		state = self._encode_github_oauth_state(self.team.name, "/dashboard/sites")
+		self._set_form_dict(state=state, installation_id="123", setup_action="install")
+
+		with (
+			self.assertRaises(frappe.Redirect),
+			patch(
+				"press.api.github.frappe.db.get_single_value",
+				return_value="client-id",
+			),
+			patch("press.www.github.authorize.obtain_access_token") as obtain_access_token,
+		):
+			self._get_context()(None)
+
+		obtain_access_token.assert_not_called()
+		self.assertTrue(frappe.flags.redirect_location.startswith(GITHUB_OAUTH_AUTHORIZE_URL))
+		self.assertIn(f"state={state}", frappe.flags.redirect_location)
+		self.assertIn("client_id=client-id", frappe.flags.redirect_location)
+
+	def test_get_context_does_not_start_authorization_when_user_denied_install(self):
+		state = self._encode_github_oauth_state(self.team.name, "/dashboard/sites")
+		self._set_form_dict(state=state, error="access_denied")
+
+		with self.assertRaises(frappe.Redirect):
+			self._get_context()(None)
+
+		self.assertEqual(frappe.flags.redirect_location, frappe.utils.get_url("/dashboard"))
+
+	def test_get_github_callback_login_redirect_preserves_state_without_code(self):
+		from press.api.github import get_github_callback_login_redirect
+
+		state = self._encode_github_oauth_state(self.team.name, "/dashboard/sites")
+		callback_url = f"/github/authorize?{urlencode({'state': state})}"
+		expected = frappe.utils.get_url(f"/dashboard/login?{urlencode({'redirect': callback_url})}")
+
+		self.assertEqual(get_github_callback_login_redirect(None, state), expected)
+
 	def test_obtain_access_token_redacts_oauth_code_and_token_from_logs(self):
 		response = {
 			"access_token": "secret-token",

--- a/press/www/github/authorize.py
+++ b/press/www/github/authorize.py
@@ -8,6 +8,7 @@ import requests
 from press.api.github import (
 	InvalidGitHubOAuthState,
 	decode_github_oauth_state,
+	encode_github_oauth_state,
 	get_github_authorize_url,
 	get_github_callback_login_redirect,
 )
@@ -49,12 +50,17 @@ def get_context(context):
 
 def start_user_authorization(state):
 	try:
-		decode_github_oauth_state(state)
+		decoded_state = decode_github_oauth_state(state)
 	except InvalidGitHubOAuthState:
 		log_error("GitHub OAuth Authorization Error")
 		return
 
-	frappe.flags.redirect_location = get_github_authorize_url(state)
+	# Re-issue the state so the authorization leg gets a fresh validity window.
+	# The original was minted before the install wizard, which may already have
+	# eaten most of GITHUB_OAUTH_STATE_MAX_AGE; reusing it risks the final
+	# code-bearing callback failing decode and silently skipping the refresh.
+	fresh_state = encode_github_oauth_state(decoded_state["team"], decoded_state["redirect_url"])
+	frappe.flags.redirect_location = get_github_authorize_url(fresh_state)
 	raise frappe.Redirect
 
 

--- a/press/www/github/authorize.py
+++ b/press/www/github/authorize.py
@@ -5,7 +5,12 @@
 import frappe
 import requests
 
-from press.api.github import decode_github_oauth_state, get_github_callback_login_redirect
+from press.api.github import (
+	InvalidGitHubOAuthState,
+	decode_github_oauth_state,
+	get_github_authorize_url,
+	get_github_callback_login_redirect,
+)
 from press.utils import get_valid_teams_for_user, log_error
 
 
@@ -17,6 +22,12 @@ def get_context(context):
 	if frappe.session.user == "Guest":
 		frappe.flags.redirect_location = get_github_callback_login_redirect(code, state)
 		raise frappe.Redirect
+
+	if state and not code and not frappe.form_dict.error:
+		# GitHub redirected back from a (re)installation without an OAuth code.
+		# The token stored on the team may now be stale, so start user
+		# authorization to exchange a fresh code for a new access token.
+		start_user_authorization(state)
 
 	if code and state:
 		try:
@@ -33,6 +44,17 @@ def get_context(context):
 			log_error("GitHub OAuth Authorization Error")
 
 	frappe.flags.redirect_location = redirect_url
+	raise frappe.Redirect
+
+
+def start_user_authorization(state):
+	try:
+		decode_github_oauth_state(state)
+	except InvalidGitHubOAuthState:
+		log_error("GitHub OAuth Authorization Error")
+		return
+
+	frappe.flags.redirect_location = get_github_authorize_url(state)
 	raise frappe.Redirect
 
 


### PR DESCRIPTION
Token refresh in the GitHub callback was gated entirely on an OAuth `code` being present:

    if code and state:
        obtain_access_token(code, team)

When a user (re)installs the Frappe Cloud GitHub App, GitHub redirects back to /github/authorize with installation_id + setup_action + the echoed state but no `code` (a code only appears when user-authorization runs). So the branch was skipped, the stale token survived in the Team doc, and the next "Add from GitHub" used a dead token.

Now when the callback arrives with a valid state but no code (and no error), start GitHub user-authorization so the user bounces back with a code that refreshes the token. If the app is already authorized this is a silent round-trip; a denied authorization falls through to a plain dashboard redirect, so there is no loop. Code-bearing callbacks are unchanged.

The guest-login redirect now preserves state without a code too, so a guest landing on the install callback completes the same refresh after logging in.