### PR TITLE
fix(release-pipeline): Emit status update event only after commit

### DIFF
--- a/press/press/doctype/release_pipeline/release_pipeline.py
+++ b/press/press/doctype/release_pipeline/release_pipeline.py
@@ -192,6 +192,7 @@ class ReleasePipeline(WorkflowBuilder):
 			{"doctype": "Release Pipeline", "name": self.name},
 			doctype="Release Pipeline",
 			docname=self.name,
+			after_commit=True,
 		)
 
 		if status == "Failure":


### PR DESCRIPTION
### Description 

- Many times when a some step in build fails, we dont get the emitted event for release pipeline. As a result the status  badge just shows Running but after page reload it shows the correct one i.e `Failure`

- This PR fixes it

