### PR TITLE
fix(db-server): Database replica provisioning from a server snapshot

### DIFF
--- a/press/playbooks/roles/mariadb_add_skip_slave_start/tasks/main.yml
+++ b/press/playbooks/roles/mariadb_add_skip_slave_start/tasks/main.yml
@@ -9,6 +9,10 @@
   systemd:
     daemon_reload: true
     name: mariadb
+    # Servers provisioned from an already-current data disk snapshot skip the
+    # MariaDB upgrade role (which would otherwise unmask the unit via apt), so
+    # mariadb.service can still be masked here. Unmask before the first start.
+    masked: false
     state: restarted
     enabled: yes
   when: restart_mariadb | default(true) | bool

--- a/press/playbooks/roles/mariadb_prepare_replica/tasks/main.yml
+++ b/press/playbooks/roles/mariadb_prepare_replica/tasks/main.yml
@@ -55,6 +55,9 @@
   ansible.builtin.systemd:
     daemon_reload: true
     name: mariadb
+    # Unmask defensively in case this role runs before the unit is unmasked
+    # (e.g. on a server provisioned from an already-current data disk snapshot).
+    masked: false
     state: restarted
     enabled: yes
 

--- a/press/playbooks/roles/mariadb_remove_skip_slave_start/tasks/main.yml
+++ b/press/playbooks/roles/mariadb_remove_skip_slave_start/tasks/main.yml
@@ -8,6 +8,9 @@
   ansible.builtin.systemd:
     daemon_reload: true
     name: mariadb
+    # Unmask defensively so this restart is self-sufficient regardless of role
+    # order (mariadb.service may still be masked on snapshot-provisioned servers).
+    masked: false
     state: restarted
     enabled: yes
   when: restart_mariadb | default(true) | bool

--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -1037,6 +1037,9 @@ class DatabaseServer(BaseServer):
 			if play.status == "Success":
 				self.status = "Active"
 				self.is_replication_setup = True
+				# A replication-configured server must not auto purge binlogs by size
+				# (enforced in on_update). New DB servers default it on, so disable it.
+				self.auto_purge_binlog_based_on_size = False
 				self.mariadb_root_password = mariadb_root_password
 			else:
 				self.status = "Broken"
@@ -1317,6 +1320,10 @@ class DatabaseServer(BaseServer):
 
 		if not self.is_replication_setup:
 			self.is_replication_setup = True
+			# New DB servers default binlog auto purge on, but a replication-configured
+			# server must not auto purge binlogs by size (enforced in on_update). Disable
+			# it as the server becomes a replica.
+			self.auto_purge_binlog_based_on_size = False
 			self.save()
 
 	def reset_replication(self):

--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -1307,6 +1307,13 @@ class DatabaseServer(BaseServer):
 		if self.is_primary:
 			return
 
+		# Provisioning steps run as separate jobs. The preceding Prepare step leaves
+		# MariaDB running, but a retry of Configure in isolation could hit a stopped
+		# server and fail with a connection-refused deep in the agent. Make sure it is
+		# up before issuing replication commands (restart_mysql.yml uses a Type=notify
+		# unit, so it returns only once MariaDB accepts connections).
+		self._restart_mariadb()
+
 		primary_db: "DatabaseServer" = frappe.get_doc("Database Server", self.primary)
 
 		agent = self.agent

--- a/press/press/doctype/database_server/test_database_server.py
+++ b/press/press/doctype/database_server/test_database_server.py
@@ -9,6 +9,7 @@ from frappe.core.utils import find
 from frappe.model.naming import make_autoname
 from frappe.tests.utils import FrappeTestCase
 
+from press.agent import Agent
 from press.press.doctype.database_server.database_server import DatabaseServer
 from press.press.doctype.server.server import BaseServer
 from press.press.doctype.virtual_machine.test_virtual_machine import create_test_virtual_machine
@@ -128,6 +129,25 @@ class TestDatabaseServer(FrappeTestCase):
 		Mock_Ansible.side_effect = Exception()
 		server = create_test_database_server()
 		self.assertRaises(Exception, server.reconfigure_mariadb_exporter)  # noqa
+
+	@patch.object(Agent, "configure_replication", return_value={"success": True})
+	def test_configure_replication_disables_binlog_auto_purge_on_replica(self, _):
+		"""New DB servers default binlog auto purge on, but on_update forbids it for
+		replication-configured servers. configure_replication must clear the flag as the
+		server becomes a replica instead of tripping that guard and failing provisioning."""
+		primary = create_test_database_server()
+		replica = create_test_database_server()
+		replica.is_primary = False
+		replica.primary = primary.name
+		replica.auto_purge_binlog_based_on_size = True
+		replica.is_replication_setup = False
+		replica.save()
+
+		replica.configure_replication()
+		replica.reload()
+
+		self.assertTrue(replica.is_replication_setup)
+		self.assertFalse(replica.auto_purge_binlog_based_on_size)
 
 	@patch("press.press.doctype.database_server.database_server.Ansible", new=Mock())
 	@patch(

--- a/press/press/doctype/database_server/test_database_server.py
+++ b/press/press/doctype/database_server/test_database_server.py
@@ -149,6 +149,29 @@ class TestDatabaseServer(FrappeTestCase):
 		self.assertTrue(replica.is_replication_setup)
 		self.assertFalse(replica.auto_purge_binlog_based_on_size)
 
+	@patch.object(DatabaseServer, "_restart_mariadb")
+	@patch.object(Agent, "configure_replication", return_value={"success": True})
+	def test_configure_replication_starts_mariadb_before_contacting_agent(
+		self, mock_agent_configure, mock_restart
+	):
+		"""Configure runs as a separate job from Prepare; a stopped MariaDB would fail
+		with connection-refused in the agent. configure_replication must start MariaDB
+		before contacting the agent."""
+		call_order = []
+		mock_restart.side_effect = lambda *a, **k: call_order.append("restart")
+		mock_agent_configure.side_effect = lambda *a, **k: call_order.append("agent") or {"success": True}
+
+		primary = create_test_database_server()
+		replica = create_test_database_server()
+		replica.is_primary = False
+		replica.primary = primary.name
+		replica.save()
+
+		replica.configure_replication()
+
+		mock_restart.assert_called_once()
+		self.assertEqual(call_order, ["restart", "agent"])
+
 	@patch("press.press.doctype.database_server.database_server.Ansible", new=Mock())
 	@patch(
 		"press.press.doctype.database_server.database_server.frappe.enqueue_doc",

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1830,6 +1830,12 @@ class BaseServer(Document, TagHelpers):
 		if not self.virtual_machine:
 			return
 		machine = frappe.get_doc("Virtual Machine", self.virtual_machine)
+		if machine.data_disk_snapshot and not machine.data_disk_snapshot_attached:
+			# The VMI's default data volume is about to be deleted and replaced by the
+			# volume created from data_disk_snapshot. Don't seed mounts off the doomed
+			# volume — sync_attached_volumes seeds them after the snapshot volume is
+			# attached, once data_disk_snapshot_attached is set.
+			return
 		if machine.has_data_volume and len(machine.volumes) > 1 and not self.mounts:
 			self.fetch_volumes_from_virtual_machine()
 			self.set_default_mount_points()

--- a/press/press/doctype/server/test_server.py
+++ b/press/press/doctype/server/test_server.py
@@ -7,6 +7,7 @@ import typing
 from unittest.mock import Mock, patch
 
 import frappe
+from frappe.core.utils import find
 from frappe.model.naming import make_autoname
 from frappe.tests.utils import FrappeTestCase
 from moto import mock_aws
@@ -383,6 +384,77 @@ class TestServer(FrappeTestCase):
 		)
 		self.assertEqual(len(incidents), 1)
 		self.assertEqual(incidents[0].server, self.high_mem_server.name)
+
+	def test_validate_mounts_seeds_snapshot_volume_not_doomed_default_volume(self):
+		"""A server built from a data disk snapshot first boots with the VMI's default data
+		volume, which is then deleted and replaced by the volume created from the snapshot.
+		validate_mounts must not seed mounts off the doomed default volume — otherwise the
+		mount keeps a deleted volume id and its by-id device path, and the Mount Volumes
+		playbook fails. It should seed only after the snapshot volume is attached."""
+		database_server = create_test_database_server()
+		virtual_machine = database_server.virtual_machine
+		default_volume_id = f"vol-{frappe.generate_hash(11)}"
+		snapshot_volume_id = f"vol-{frappe.generate_hash(11)}"
+
+		# VM has booted with root + the VMI's default data volume, snapshot swap still pending
+		self._set_virtual_machine_volumes(
+			virtual_machine,
+			[
+				{"device": "/dev/sda1", "size": 8, "volume_id": f"vol-{frappe.generate_hash(11)}"},
+				{"device": "/dev/sdf", "size": 600, "volume_id": default_volume_id},
+			],
+		)
+		frappe.db.set_value(
+			"Virtual Machine",
+			virtual_machine,
+			{
+				"has_data_volume": True,
+				"data_disk_snapshot": "dummy-snapshot",
+				"data_disk_snapshot_attached": False,
+			},
+		)
+
+		database_server.validate_mounts()
+		self.assertEqual(
+			len(database_server.mounts),
+			0,
+			"Mounts must not be seeded off the default volume while the snapshot swap is pending",
+		)
+
+		# Default volume deleted, snapshot volume created and attached
+		self._set_virtual_machine_volumes(
+			virtual_machine,
+			[
+				{"device": "/dev/sda1", "size": 8, "volume_id": f"vol-{frappe.generate_hash(11)}"},
+				{"device": "/dev/sdf", "size": 600, "volume_id": snapshot_volume_id},
+			],
+		)
+		frappe.db.set_value("Virtual Machine", virtual_machine, "data_disk_snapshot_attached", True)
+
+		database_server.validate_mounts()
+
+		volume_mount = find(database_server.mounts, lambda m: m.mount_type == "Volume")
+		self.assertIsNotNone(volume_mount, "A volume mount should be seeded after the snapshot is attached")
+		self.assertEqual(volume_mount.volume_id, snapshot_volume_id)
+		self.assertNotEqual(volume_mount.volume_id, default_volume_id)
+		self.assertIn(snapshot_volume_id.replace("-", ""), volume_mount.source)
+
+	def _set_virtual_machine_volumes(self, virtual_machine: str, volumes: list[dict]):
+		frappe.db.delete("Virtual Machine Volume", {"parent": virtual_machine})
+		for volume in volumes:
+			frappe.get_doc(
+				{
+					"doctype": "Virtual Machine Volume",
+					"parenttype": "Virtual Machine",
+					"parent": virtual_machine,
+					"parentfield": "volumes",
+					"volume_type": "gp3",
+					"throughput": 125,
+					"device": volume["device"],
+					"size": volume["size"],
+					"volume_id": volume["volume_id"],
+				}
+			).insert()
 
 	def test_disable_auto_storage_on_database_server_clears_db_flag_not_app_flag(self):
 		database_server = create_test_database_server()


### PR DESCRIPTION
## Summary

Provisioning a database replica from a **Consistent** server snapshot
(`setup_db_replication`) failed at three successive steps of the `Create Server`
press job. Each failure shares one root theme: **the create-server flow assumes
the upgrade / mount / default-config steps did setup work that gets skipped — or
conflicts — when the snapshot is already at the current version.** Fixing each
unblocked the next, so all three are needed for the flow to complete.

| Step that failed | Cause | Fix |
|---|---|---|
| `Upgrade Mariadb` (mount failed) | Mount kept a deleted volume id | Refresh mount after snapshot swap |
| `Restart MariaDB … skip-slave-start` | `mariadb.service` masked | Unmask before restart |
| `Configure Mariadb Replica` | `auto_purge_binlog` on a replica | Clear flag when configuring replica |

## Fix 1 — Stale data-volume mount id (`Upgrade Mariadb`)

**Symptom:** the `Mount Volumes` playbook couldn't mount the data disk. The
Database Server's mount pointed at `vol-0843daa3133…`, but the VM only had
`vol-046afa9acba5e91aa` (data) + root.

**Cause:** a snapshot-based server first boots with the VMI's *default* data
volume. During early provisioning, `VirtualMachine.sync()` → `update_servers()`
→ `server.save()` → `validate()` → `validate_mounts()` seeds the mount off that
default volume and computes its AWS by-id source path. `create_volume_from_snapshot`
then deletes that volume and creates a fresh one from the snapshot. The later
`Sync Attached Volumes` step calls `validate_mounts` again to reseed, but its
`not self.mounts` guard makes it a no-op — so the mount keeps the deleted volume
id and its dead device path.

**Change:** in `validate_mounts`, skip seeding while a snapshot swap is pending
(`machine.data_disk_snapshot and not machine.data_disk_snapshot_attached`). The
default volume is about to be deleted; `Sync Attached Volumes` seeds correctly
once the snapshot volume is attached. Unit-tested.

## Fix 2 — Masked mariadb.service (`Restart MariaDB … skip-slave-start`)

**Symptom:** `Unit mariadb.service is masked.`

**Cause:** the replica's root volume comes from the standard database VMI, where
`mariadb.service` is masked. On a normal provision it's unmasked as a side effect
of `apt install mariadb-server` in the MariaDB upgrade role — but that whole role
is skipped when the snapshot is already at the target version (11.8). The data
volume was also mounted with `start_mariadb_after_mount=False` (the replica must
be prepared before starting), so the first task to touch the service is the
skip-slave-start restart, which uses `name: mariadb` and hits the masked unit.

**Change:** add `masked: false` to the three `name: mariadb` restart tasks in the
`mariadb_prepare_replica.yml` chain (`add_skip_slave_start`, `prepare_replica`,
`remove_skip_slave_start`). The systemd module unmasks before restarting, so each
task is self-sufficient regardless of role order or whether the upgrade role ran.

## Fix 3 — Binlog auto purge on a replica (`Configure Mariadb Replica`)

**Symptom:** `ValidationError: Cannot enable binlog auto purge for replication
configured servers`.

**Cause:** `on_update` forbids `auto_purge_binlog_based_on_size` on a replication
configured server, but every new Database Server defaults that flag on
(`before_insert` sets it in both branches, and `Cluster.create_server` too), and
nothing clears it when the server becomes a replica. When `configure_replication()`
flips `is_replication_setup` to True and saves, the guard rejects the save.

**Change:** clear `auto_purge_binlog_based_on_size` at the two points where a
server transitions to replication configured (`configure_replication` and
`_setup_secondary`), so the invariant holds before the save. The guard is left
intact — a user enabling auto purge on an existing replica is still rejected.
Unit-tested.

## Testing

- Fix 1: `test_validate_mounts_seeds_snapshot_volume_not_doomed_default_volume`
- Fix 3: `test_configure_replication_disables_binlog_auto_purge_on_replica`
- `server` and `database_server` test modules green.
- Fix 2 is an Ansible playbook change (no Python test layer); YAML validated, all
  three restart tasks resolve to `masked=False`. Verify end-to-end by provisioning
  a replica from an already-11.8 snapshot.