### PR TITLE
feat: Add check field on Server dt and send as stream arg on backup

### DIFF
--- a/press/agent.py
+++ b/press/agent.py
@@ -564,7 +564,6 @@ class Agent:
 		data = {
 			"with_files": site_backup.with_files,
 			"agent_job_timeout": site.backup_timeout,
-			"stream": bool(frappe.get_value("Server", site.server, "stream_backups")),
 		}
 		if site_backup.offsite:
 			backups_path = os.path.join(site.name, str(date.today()))
@@ -578,7 +577,10 @@ class Agent:
 				{
 					"keep_files_locally_after_offsite_backup": bool(
 						frappe.get_value("Server", site.server, "keep_files_on_server_in_offsite_backup")
-					)
+					),
+					# Streaming only applies to offsite backups (agent streams the
+					# artifacts straight to S3), so only send it for offsite jobs.
+					"stream": bool(frappe.get_value("Server", site.server, "stream_backups")),
 				}
 			)
 

--- a/press/agent.py
+++ b/press/agent.py
@@ -564,6 +564,7 @@ class Agent:
 		data = {
 			"with_files": site_backup.with_files,
 			"agent_job_timeout": site.backup_timeout,
+			"stream": bool(frappe.get_value("Server", site.server, "stream_backups")),
 		}
 		if site_backup.offsite:
 			backups_path = os.path.join(site.name, str(date.today()))

--- a/press/press/doctype/server/server.json
+++ b/press/press/doctype/server/server.json
@@ -103,6 +103,7 @@
 		"ram",
 		"backups_section",
 		"skip_scheduled_backups",
+		"stream_backups",
 		"standalone_section",
 		"is_standalone",
 		"column_break_edyf",
@@ -506,6 +507,13 @@
 			"label": "Skip Scheduled Backups"
 		},
 		{
+			"default": "0",
+			"description": "Stream backups directly to offsite storage instead of staging them on the server",
+			"fieldname": "stream_backups",
+			"fieldtype": "Check",
+			"label": "Stream Backups"
+		},
+		{
 			"fieldname": "column_break_pdbx",
 			"fieldtype": "Column Break"
 		},
@@ -813,7 +821,7 @@
 			"link_fieldname": "app_server"
 		}
 	],
-	"modified": "2026-06-09 14:44:11.417294",
+	"modified": "2026-06-18 10:49:09.702133",
 	"modified_by": "Administrator",
 	"module": "Press",
 	"name": "Server",

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -2884,6 +2884,7 @@ class Server(BaseServer):
 		status: DF.Literal["Pending", "Installing", "Active", "Broken", "Archived"]
 		stop_deployments: DF.Check
 		stop_incident_actions: DF.Check
+		stream_backups: DF.Check
 		supported_site_quota: DF.Int
 		tags: DF.Table[ResourceTag]
 		team: DF.Link | None


### PR DESCRIPTION
Add a checkbox in Backups section in Server doctype called 'stream_backups'. Does as expected for all future site backup attempts on that server.