### PR TITLE
fix(monitor): Use correct credentials for prometheus rules API

### DIFF
--- a/press/playbooks/roles/grafana/tasks/main.yml
+++ b/press/playbooks/roles/grafana/tasks/main.yml
@@ -76,7 +76,7 @@
 - name: Setup Grafana Authentication
   become: yes
   become_user: frappe
-  command: "htpasswd -Bbc /home/frappe/agent/nginx/grafana.htpasswd frappe {{ grafana_password }}"
+  command: "htpasswd -Bbc /home/frappe/agent/nginx/grafana.htpasswd {{ prometheus_username }} {{ grafana_password }}"
 
 - name: Setup Grafana HTTP Authentication
   become: yes

--- a/press/press/doctype/monitor_server/monitor_server.json
+++ b/press/press/doctype/monitor_server/monitor_server.json
@@ -70,7 +70,10 @@
 			"read_only": 1,
 			"set_only_once": 1
 		},
-		{ "fieldname": "column_break_4", "fieldtype": "Column Break" },
+		{
+			"fieldname": "column_break_4",
+			"fieldtype": "Column Break"
+		},
 		{
 			"default": "Generic",
 			"fieldname": "provider",
@@ -99,7 +102,10 @@
 			"label": "IP",
 			"set_only_once": 1
 		},
-		{ "fieldname": "column_break_9", "fieldtype": "Column Break" },
+		{
+			"fieldname": "column_break_9",
+			"fieldtype": "Column Break"
+		},
 		{
 			"fetch_from": "virtual_machine.private_ip_address",
 			"fieldname": "private_ip",
@@ -162,7 +168,10 @@
 			"label": "Frappe Public Key",
 			"read_only": 1
 		},
-		{ "fieldname": "column_break_20", "fieldtype": "Column Break" },
+		{
+			"fieldname": "column_break_20",
+			"fieldtype": "Column Break"
+		},
 		{
 			"fieldname": "root_public_key",
 			"fieldtype": "Code",
@@ -195,7 +204,10 @@
 			"label": "Cluster",
 			"options": "Cluster"
 		},
-		{ "fieldname": "column_break_nzet", "fieldtype": "Column Break" },
+		{
+			"fieldname": "column_break_nzet",
+			"fieldtype": "Column Break"
+		},
 		{
 			"default": "/home/frappe/prometheus/data",
 			"fieldname": "prometheus_data_directory",
@@ -207,7 +219,10 @@
 			"fieldtype": "Data",
 			"label": "Grafana Username"
 		},
-		{ "fieldname": "column_break_ilpd", "fieldtype": "Column Break" },
+		{
+			"fieldname": "column_break_ilpd",
+			"fieldtype": "Column Break"
+		},
 		{
 			"description": "Begin with / but don't end with /",
 			"fieldname": "node_exporter_dashboard_path",
@@ -215,12 +230,17 @@
 			"label": "Node Exporter Dashboard Path"
 		},
 		{
+			"default": "frappe",
 			"description": "for /prometheus",
 			"fieldname": "prometheus_username",
 			"fieldtype": "Data",
 			"label": "Prometheus Username"
 		},
-		{ "fieldname": "ssh_user", "fieldtype": "Data", "label": "SSH User" },
+		{
+			"fieldname": "ssh_user",
+			"fieldtype": "Data",
+			"label": "SSH User"
+		},
 		{
 			"default": "22",
 			"fieldname": "ssh_port",
@@ -253,8 +273,13 @@
 		}
 	],
 	"grid_page_length": 50,
-	"links": [{ "link_doctype": "Ansible Play", "link_fieldname": "server" }],
-	"modified": "2026-02-16 11:36:45.578971",
+	"links": [
+		{
+			"link_doctype": "Ansible Play",
+			"link_fieldname": "server"
+		}
+	],
+	"modified": "2026-06-19 12:16:29.159355",
 	"modified_by": "Administrator",
 	"module": "Press",
 	"name": "Monitor Server",

--- a/press/press/doctype/monitor_server/monitor_server.py
+++ b/press/press/doctype/monitor_server/monitor_server.py
@@ -241,20 +241,28 @@ class MonitorServer(BaseServer):
 
 	@property
 	def alerts(self):
-		print(
-			f"https://{self.name}/prometheus/api/v1/rules",
-		)
 		ret = requests.get(
 			f"https://{self.name}/prometheus/api/v1/rules",
-			auth=HTTPBasicAuth(self.prometheus_username, self.get_password("grafana_password")),
+			auth=HTTPBasicAuth("frappe", self.get_password("grafana_password")),
 			params={"type": "alert"},
+			timeout=15,
 		)
 
 		ret.raise_for_status()
+
 		data = ret.json()
-		if data["status"] != "success":
-			frappe.throw("Error fetching sites down")
-		return data["data"]["groups"][0]["rules"]
+
+		if data.get("status") != "success":
+			frappe.throw("Error fetching alerts from Prometheus")
+
+		groups = data.get("data", {}).get("groups", [])
+
+		alerts = []
+
+		for group in groups:
+			alerts.extend(group.get("rules", []))
+
+		return alerts
 
 	@property
 	def sites_down_alerts(self) -> list[SitesDownAlert]:

--- a/press/press/doctype/monitor_server/monitor_server.py
+++ b/press/press/doctype/monitor_server/monitor_server.py
@@ -255,7 +255,13 @@ class MonitorServer(BaseServer):
 		data = ret.json()
 
 		if data.get("status") != "success":
-			frappe.throw("Error fetching alerts from Prometheus")
+			frappe.throw(
+				"""
+			Failed to fetch alerts from Prometheus.
+
+			Please verify that Prometheus is running and reachable.
+			"""
+			)
 
 		groups = data.get("data", {}).get("groups", [])
 

--- a/press/press/doctype/monitor_server/monitor_server.py
+++ b/press/press/doctype/monitor_server/monitor_server.py
@@ -156,6 +156,7 @@ class MonitorServer(BaseServer):
 					"clusters_json": json.dumps(clusters),
 					"private_ip": self.private_ip,
 					"grafana_password": self.get_password("grafana_password"),
+					"prometheus_username": self.prometheus_username,
 					"certificate_private_key": certificate.private_key,
 					"certificate_full_chain": certificate.full_chain,
 					"certificate_intermediate_chain": certificate.intermediate_chain,
@@ -229,6 +230,7 @@ class MonitorServer(BaseServer):
 					"log_servers_json": json.dumps(log_servers),
 					"clusters_json": json.dumps(clusters),
 					"grafana_password": self.get_password("grafana_password"),
+					"prometheus_username": self.prometheus_username,
 				},
 			)
 			ansible.run()
@@ -243,7 +245,7 @@ class MonitorServer(BaseServer):
 	def alerts(self):
 		ret = requests.get(
 			f"https://{self.name}/prometheus/api/v1/rules",
-			auth=HTTPBasicAuth("frappe", self.get_password("grafana_password")),
+			auth=HTTPBasicAuth(self.prometheus_username, self.get_password("grafana_password")),
 			params={"type": "alert"},
 			timeout=15,
 		)


### PR DESCRIPTION
* Pass `prometheus_username` during monitor server provisioning and use it when creating `grafana.htpasswd`.

* Previously, monitor server provisioning hardcoded the username as:
  `htpasswd -Bbc /home/frappe/agent/nginx/grafana.htpasswd frappe {{ grafana_password }}`

* Keep `frappe` as the default value for `prometheus_username`.

* Handle empty rule groups gracefully instead of assuming `groups[0]` exists.