### PR TITLE
fix(deploy-candidate): Fix Schedule Build and Deploy popup crash

### DIFF
--- a/press/press/doctype/deploy_candidate/deploy_candidate.js
+++ b/press/press/doctype/deploy_candidate/deploy_candidate.js
@@ -7,62 +7,62 @@ frappe.ui.form.on('Deploy Candidate', {
 			return {
 				query: 'press.press.doctype.deploy_candidate.deploy_candidate.desk_app',
 				filters: { release_group: doc.group },
-			};
-		};
+			}
+		}
 		set_handler(
 			frm,
 			'Complete',
 			'build',
 			{ no_push: false, no_build: false, no_cache: false },
 			'Build',
-		);
+		)
 		set_handler(
 			frm,
 			'Generate Context',
 			'build',
 			{ no_push: true, no_build: true, no_cache: false },
 			'Build',
-		);
+		)
 		set_handler(
 			frm,
 			'Without Cache',
 			'build',
 			{ no_push: false, no_build: false, no_cache: true },
 			'Build',
-		);
+		)
 		set_handler(
 			frm,
 			'Without Push',
 			'build',
 			{ no_push: true, no_build: false, no_cache: false },
 			'Build',
-		);
+		)
 		set_handler(
 			frm,
 			'Schedule Build and Deploy',
 			'schedule_build_and_deploy',
 			{ run_now: false },
 			'Deploy',
-		);
+		)
 	},
-});
+})
 
 function set_handler(frm, label, method, args, group) {
-	const handler = get_handler(frm, method, args);
-	frm.add_custom_button(label, handler, group);
+	const handler = get_handler(frm, method, args)
+	frm.add_custom_button(label, handler, group)
 }
 
 function get_handler(frm, method, args) {
 	return async function handler() {
-		const { message: data } = await frm.call({ method, args, doc: frm.doc });
+		const { message: data } = await frm.call({ method, args, doc: frm.doc })
 
 		if (data?.error) {
 			frappe.msgprint({
 				title: 'Action Failed',
 				indicator: 'yellow',
 				message: data.message,
-			});
-			return;
+			})
+			return
 		}
 
 		if (method.endsWith('redeploy') && data?.message) {
@@ -72,7 +72,7 @@ function get_handler(frm, method, args) {
 				message: __(`Duplicate {0} created and redeploy triggered.`, [
 					`<a href="/app/deploy-candidate/${data?.message}">Deploy Candidate</a>`,
 				]),
-			});
+			})
 		}
 
 		if (
@@ -83,9 +83,9 @@ function get_handler(frm, method, args) {
 				title: 'Deploy Candidate Build Created',
 				indicator: 'green',
 				message: __(`New {0} has been created`, [
-					`<a href="/app/deploy-candidate-build/${data.message.message}">Deploy Candidate Build</a>`,
+					`<a href="/app/deploy-candidate-build/${data.message ?? data.name}">Deploy Candidate Build</a>`,
 				]),
-			});
+			})
 		}
 
 		if (method === 'deploy' && data) {
@@ -96,11 +96,11 @@ function get_handler(frm, method, args) {
 					`{0} been created (or found) from current Deploy Candidate`,
 					[`<a href="/app/deploy/${data}">Deploy</a>`],
 				),
-			});
+			})
 		} else if (method === 'deploy' && !data) {
-			frappe.msgprint({ title: 'Deploy could not be created' });
+			frappe.msgprint({ title: 'Deploy could not be created' })
 		}
 
-		frm.refresh();
-	};
+		frm.refresh()
+	}
 }


### PR DESCRIPTION
The shared desk button handler builds a link with `data.message.message`, but the two methods it serves return different shapes:

- `build` returns `{error, message: <build_name>}`
- `schedule_build_and_deploy` returns `{error, name: <build_name>}`

So for Schedule Build and Deploy, `data.message` is undefined and `data.message.message` throws `TypeError: Cannot read properties of undefined (reading 'message')`. The exception aborts the handler before the success msgprint and `frm.refresh()`, so the button appears to do nothing (the Scheduled build is actually created server-side and runs via run_scheduled_builds). For `build` the same access silently produced a `/app/deploy-candidate-build/undefined` link.

Read `data.message ?? data.name` so the build name resolves for both methods. The Python return contract is left unchanged on purpose: release_pipeline.py, api/bench.py and release_group.py read the `name` key off schedule_build_and_deploy's result.

Regression introduced in 373f237d0 (data.message -> data.message.message).

The rest of the diff is biome stripping semicolons: the file predates the
repo's `semicolons: asNeeded` rule and pre-commit reformats it on touch.