### PR TITLE
fix(site): Allow enabling product warranty irrespective of cooldown

### DIFF
--- a/dashboard/src/components/ManageProductWarrantyDialog.vue
+++ b/dashboard/src/components/ManageProductWarrantyDialog.vue
@@ -66,10 +66,23 @@ const nextChangeAvailableOn = computed(() => {
 	}
 })
 
+const hasWarrantyQuota = computed(
+	() => site.doc?.dedicated_server_warranty_limit?.available > 0,
+)
+
+const cooldownPassed = computed(
+	() => nextChangeAvailableOn.value === 'Available Now',
+)
+
+// Enabling warranty is gated only by available quota (the cooldown does not
+// apply, so a site can reclaim a free slot any time); disabling is gated by the
+// cooldown.
+const isToggleDisabled = computed(() =>
+	isSupportEnabled.value ? !cooldownPassed.value : !hasWarrantyQuota.value,
+)
+
 const disablePrimaryAction = computed(
-	() =>
-		switchValue.value === isSupportEnabled.value ||
-		nextChangeAvailableOn.value !== 'Available Now',
+	() => switchValue.value === isSupportEnabled.value || isToggleDisabled.value,
 )
 
 function onClickSave() {
@@ -102,7 +115,7 @@ function onClickSave() {
 						v-model="switchValue"
 						size="md"
 						class="px-4"
-						:disabled="nextChangeAvailableOn !== 'Available Now' || (site.doc?.dedicated_server_warranty_limit?.available <= 0 && !isSupportEnabled)"
+						:disabled="isToggleDisabled"
 					/>
 				</div>
 

--- a/dashboard/src/components/ManageProductWarrantyDialog.vue
+++ b/dashboard/src/components/ManageProductWarrantyDialog.vue
@@ -85,6 +85,13 @@ const disablePrimaryAction = computed(
 	() => switchValue.value === isSupportEnabled.value || isToggleDisabled.value,
 )
 
+// The cooldown only blocks disabling, so this date is relevant only while
+// warranty is on and the cooldown has not yet elapsed. Hide it otherwise — when
+// the change is possible there is nothing to wait for.
+const showNextChangeAvailableOn = computed(
+	() => isSupportEnabled.value && !cooldownPassed.value,
+)
+
 function onClickSave() {
 	$toast.promise(site.setPlan.submit({ plan: nextSitePlanName.value }), {
 		loading: 'Changing product warranty...',
@@ -149,17 +156,9 @@ function onClickSave() {
 							sites
 						</p>
 					</div>
-					<div class="flex">
+					<div v-if="showNextChangeAvailableOn" class="flex">
 						<p class="flex-grow text-ink-gray-6">Next change available after</p>
-						<p
-							:class="
-								nextChangeAvailableOn === 'Available Now'
-									? 'text-ink-green-3 font-medium'
-									: ''
-							"
-						>
-							{{ nextChangeAvailableOn }}
-						</p>
+						<p>{{ nextChangeAvailableOn }}</p>
 					</div>
 				</div>
 

--- a/press/api/site.py
+++ b/press/api/site.py
@@ -301,19 +301,24 @@ def _check_warranty_restrictions(
 	is_new_plan_supported = is_product_warranty_enabled_for_plan_(new_plan)
 	if is_current_plan_supported == is_new_plan_supported:
 		return
+	if is_new_plan_supported:
+		# Enabling warranty is gated only by the server quota (it consumes a slot).
+		# The cooldown deliberately does not apply: the only enable the cooldown
+		# would block is a site reclaiming the slot it itself just gave up, which
+		# is legitimate as long as a slot is free. Rotating support to a *different*
+		# site is already prevented by the quota plus the cooldown on disabling.
+		quota = get_available_warranty_quota_for_server(server)
+		if quota.get("available") <= 0:
+			frappe.throw(
+				"You have exhausted the site warranty quota for this server. To increase limit, please contact support."
+			)
+		return
+	# Disabling warranty is gated by the cooldown to deter freeing a slot only to
+	# rotate it onto another site.
 	next_warranty_change = get_next_allowed_dedicated_product_warranty_change_date(site)
 	if get_datetime() < next_warranty_change:
 		pretty_date = format_datetime(next_warranty_change, "MMM d, YYYY hh:mm a")
 		frappe.throw(f"Cannot change product warranty for this site before {pretty_date}")  # nosemgrep
-	# The quota check only gates enabling warranty (which consumes a slot);
-	# disabling is always allowed once the cooldown above has passed.
-	if not is_new_plan_supported:
-		return
-	quota = get_available_warranty_quota_for_server(server)
-	if quota.get("available") <= 0:
-		frappe.throw(
-			"You have exhausted the site warranty quota for this server. To increase limit, please contact support."
-		)
 
 
 def _is_plan_allowed_on_server(server: str, new_site_plan: dict) -> bool:

--- a/press/api/tests/test_site.py
+++ b/press/api/tests/test_site.py
@@ -1114,9 +1114,10 @@ class TestAPISiteDomain(FrappeTestCase):
 class TestCheckWarrantyRestrictions(FrappeTestCase):
 	"""Tests for _check_warranty_restrictions.
 
-	The cooldown applies to both enabling and disabling. The server quota,
-	however, only gates enabling (which consumes a slot) — disabling is
-	always allowed once the cooldown has passed.
+	Enabling support is gated only by the server quota (it consumes a slot) and is
+	allowed irrespective of the cooldown, so a site can reclaim a free slot any
+	time. Disabling support is gated only by the cooldown, which deters freeing a
+	slot only to rotate it onto another site.
 	"""
 
 	def _check(self, *, current_supported, new_supported, quota_available=0, cooldown_active=False):
@@ -1166,6 +1167,27 @@ class TestCheckWarrantyRestrictions(FrappeTestCase):
 	def test_enabling_warranty_allowed_when_quota_available(self):
 		"""Enabling support with quota left must not throw."""
 		self._check(current_supported=False, new_supported=True, quota_available=1)
+
+	def test_enabling_warranty_allowed_during_cooldown_when_quota_available(self):
+		"""Reclaiming a free slot is allowed even while the cooldown is active."""
+		self._check(
+			current_supported=False,
+			new_supported=True,
+			quota_available=1,
+			cooldown_active=True,
+		)
+
+	def test_enabling_warranty_blocked_when_quota_exhausted_during_cooldown(self):
+		"""Enabling with no free slot must throw on quota, not silently pass."""
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"exhausted the site warranty quota",
+			self._check,
+			current_supported=False,
+			new_supported=True,
+			quota_available=0,
+			cooldown_active=True,
+		)
 
 	def test_disabling_warranty_blocked_during_cooldown(self):
 		"""Disabling support is still subject to the cooldown window."""


### PR DESCRIPTION
## Allow enabling product warranty irrespective of cooldown

### Problem

Enabling product warranty for a dedicated-server site was gated by **both**
the server quota and the per-site change cooldown.

The cooldown exists to deter partners from rotating a limited number of
support slots across many sites — disable a slotted site, enable an
unslotted one — and so getting support for more sites than they pay for.

But it also blocked a legitimate case:

> A customer has 5 supported sites (quota: 5). They disable support for one
> of them. Later they realise they still need it and try to re-enable — but
> the cooldown blocks them, even though re-enabling does **not** exceed quota.

They aren't misusing the quota, so they should be allowed.

### Insight

The cooldown is enforced **per-site**. The only enable the cooldown ever
blocked is a site **reclaiming the slot it itself just gave up** — exactly
the legitimate case above. Enabling a *different* site was never blocked by
the cooldown; it's gated by **quota** (a slot must be freed first).

What actually deters rotation is the cooldown on **disabling**: once a
partner frees a slot, that site is locked, so they can't rapidly
free-and-reassign support across many sites.

### Change

Split the two gates by direction:

- **Enabling** → gated by **quota only**. A site can reclaim a free slot at
  any time, irrespective of cooldown.
- **Disabling** → gated by the **cooldown only** (freeing a slot never needs
  quota).

Re-enabling only succeeds when a slot is genuinely free — if the freed slot
was already taken by another site, quota is full and the reclaim is correctly
rejected. So the quota ceiling and the anti-rotation deterrent are both
preserved.

### Backend — `press/api/site.py`

`_check_warranty_restrictions` now branches on direction: enabling checks
quota and returns; disabling checks the cooldown.

### Frontend — `dashboard/src/components/ManageProductWarrantyDialog.vue`

The toggle and Save button mirror the backend (quota gates enabling, cooldown
gates disabling). The "Next change available after" row now appears only while
warranty is **on** and the cooldown is still active — the single state where
the cooldown blocks the action. It's hidden when warranty is off, since
enabling ignores the cooldown there.

### Tests — `press/api/tests/test_site.py`

`TestCheckWarrantyRestrictions` updated to the new policy, adding:
- enabling is allowed during cooldown when a slot is free (the fix)
- enabling is still blocked when quota is exhausted, even during cooldown

### Note

The disable cooldown is now the **sole** deterrent against slot rotation, so
the `site_warranty_change_cooldown` value on Server matters more than before.
