### PR TITLE
fix(site): Skip file-tree walk when refreshing only database usage

### DIFF
--- a/press/agent.py
+++ b/press/agent.py
@@ -1198,8 +1198,11 @@ Response: {reason or getattr(result, "text", "Unknown")}
 			result = self.get(f"benches/{site.bench}/sites/{site.name}/sid")
 		return result and result.get("sid")
 
-	def get_site_info(self, site):
-		result = self.get(f"benches/{site.bench}/sites/{site.name}/info")
+	def get_site_info(self, site, database_only=False):
+		path = f"benches/{site.bench}/sites/{site.name}/info"
+		if database_only:
+			path += "?database_only=1"
+		result = self.get(path)
 		if result:
 			return result["data"]
 		return None

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -2062,9 +2062,9 @@ class Site(Document, TagHelpers):
 			frappe.throw(f"Could not login as {user}", frappe.ValidationError)  # nosemgrep
 		return sid
 
-	def fetch_info(self):
+	def fetch_info(self, database_only=False):
 		agent = Agent(self.server)
-		return agent.get_site_info(self)
+		return agent.get_site_info(self, database_only=database_only)
 
 	def fetch_analytics(self):
 		agent = Agent(self.server)
@@ -2103,6 +2103,24 @@ class Site(Document, TagHelpers):
 			self._update_configuration(new_config, save=False)
 			return True
 		return False
+
+	def _sync_database_usage(self, fetched_usage: dict):
+		"""Record a Site Usage row, refreshing only the database size.
+
+		Carries the last-known file sizes forward so a database-usage refresh
+		doesn't trigger the expensive file-tree walk in the agent's get_usage.
+		"""
+		last = self.get_disk_usages()
+		self._insert_site_usage(
+			{
+				"database": fetched_usage["database"],
+				"database_free": fetched_usage.get("database_free", 0),
+				"database_free_tables": fetched_usage.get("database_free_tables", []),
+				"public": last["public"] or 0,
+				"private": last["private"] or 0,
+				"backups": last["backups"] or 0,
+			}
+		)
 
 	def _sync_usage_info(self, fetched_usage: dict):
 		"""Generate a Site Usage doc for the site using the fetched_usage data.
@@ -2181,12 +2199,16 @@ class Site(Document, TagHelpers):
 		return False
 
 	@frappe.whitelist()
-	def sync_info(self, data=None):
+	def sync_info(self, data=None, database_only=False):
 		"""Updates Site Usage, site.config and timezone details for site."""
 		if not data:
-			data = self.fetch_info()
+			data = self.fetch_info(database_only=database_only)
 
 		if not data:
+			return
+
+		if database_only:
+			self._sync_database_usage(data["usage"])
 			return
 
 		fetched_usage = data["usage"]
@@ -3939,7 +3961,7 @@ class Site(Document, TagHelpers):
 	def refresh_database_usage(self):
 		# Check if schema parser enabled on db server
 		if not frappe.db.get_value("Database Server", self.database_server_name, "enable_schema_size_parser"):
-			self.sync_info()
+			self.sync_info(database_only=True)
 			return {
 				"synced": True,
 			}
@@ -5495,7 +5517,7 @@ def process_refresh_database_usage_job_update(job: AgentJob):
 	site: Site = frappe.get_doc("Site", job.site)
 	with suppress(Exception):
 		# Don't throw error on failure of syncing also
-		site.sync_info()
+		site.sync_info(database_only=True)
 
 
 def on_doctype_update():

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -2199,7 +2199,7 @@ class Site(Document, TagHelpers):
 		return False
 
 	@frappe.whitelist()
-	def sync_info(self, data=None, database_only=False):
+	def sync_info(self, data=None, database_only: bool = False):
 		"""Updates Site Usage, site.config and timezone details for site."""
 		if not data:
 			data = self.fetch_info(database_only=database_only)

--- a/press/press/doctype/site/test_site.py
+++ b/press/press/doctype/site/test_site.py
@@ -580,6 +580,31 @@ class TestSite(FrappeTestCase):
 		self.assertIsNotNone(site.site_usage_exceeded_on)
 		self.assertEqual(site.status, "Active")
 
+	def test_sync_info_database_only_refreshes_db_size_and_carries_files_forward(self):
+		site = create_test_site()
+		frappe.get_doc(
+			{
+				"doctype": "Site Usage",
+				"site": site.name,
+				"database": 100,
+				"public": 200,
+				"private": 300,
+				"backups": 400,
+			}
+		).insert()
+
+		# In database_only mode the agent returns only the database size; the
+		# file totals must be carried forward, not recomputed (no file walk).
+		with patch.object(Site, "fetch_info", return_value={"usage": {"database": 150}}) as fetch_info:
+			site.sync_info(database_only=True)
+
+		fetch_info.assert_called_once_with(database_only=True)
+		latest = frappe.get_last_doc("Site Usage", {"site": site.name})
+		self.assertEqual(latest.database, 150)
+		self.assertEqual(latest.public, 200)
+		self.assertEqual(latest.private, 300)
+		self.assertEqual(latest.backups, 400)
+
 	def test_free_sites_ignore_usage_exceed_tracking(self):
 		team = create_test_team(free_account=False)
 		plan_10 = create_test_plan("Site", price_usd=10.0, price_inr=750.0, plan_name="USD 10")


### PR DESCRIPTION
## Problem

`refresh_database_usage` (polled by the dashboard's Site Overview / Database Analyzer pages every few seconds) goes through the generic `sync_info`, which calls the agent's `get_usage`. That recursively walks the site's **entire file tree** (public, private, backups) just to sum file sizes — even though the caller only wants the database size.

On sites with large file trees the walk exceeds the gunicorn timeout and kills agent web workers (`WORKER TIMEOUT`). Because the dashboard re-polls every ~3s, a single bloated site keeps the walk running back-to-back.

## Fix

Thread a `database_only` flag through `get_site_info` → `fetch_info` → `sync_info`:

- In that mode the agent is asked (via `?database_only=1`) for just the cheap database size.
- `_sync_database_usage` records a `Site Usage` row that **carries the last-known file totals forward** instead of recomputing them, so disk-usage reporting is unaffected.
- Both DB-refresh callers (the `refresh_database_usage` parser-off branch and the `process_refresh_database_usage_job_update` callback) pass `database_only=True`.

## Deploy note

**Paired PR:** frappe/agent#548

Requires the matching agent change to honour `?database_only` (**frappe/agent#548**). Without it the agent ignores the param and falls back to the full walk (current behaviour), so the two can be deployed in either order safely.

## Test

Added `test_sync_info_database_only_refreshes_db_size_and_carries_files_forward` — asserts a database-only sync refreshes the DB size while carrying `public/private/backups` forward, and that `fetch_info` is called with `database_only=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
