### PR TITLE
fix: Align partner-onboarding MRR and warranty tests with merged code

### DIFF
--- a/press/api/tests/test_site.py
+++ b/press/api/tests/test_site.py
@@ -1105,7 +1105,7 @@ class TestAPISiteDomain(FrappeTestCase):
 
 
 class TestCheckWarrantyRestrictions(FrappeTestCase):
-	"""Tests for _check_warranty_restrictions.
+	"""Tests for _validate_warranty_change.
 
 	The cooldown applies to both enabling and disabling. The server quota,
 	however, only gates enabling (which consumes a slot) — disabling is
@@ -1113,7 +1113,7 @@ class TestCheckWarrantyRestrictions(FrappeTestCase):
 	"""
 
 	def _check(self, *, current_supported, new_supported, quota_available=0, cooldown_active=False):
-		from press.api.site import _check_warranty_restrictions
+		from press.api.site import _validate_warranty_change
 
 		now = datetime.datetime.now()
 		next_change = now + datetime.timedelta(days=1) if cooldown_active else now
@@ -1131,7 +1131,7 @@ class TestCheckWarrantyRestrictions(FrappeTestCase):
 				return_value={"available": quota_available},
 			),
 		):
-			_check_warranty_restrictions(
+			_validate_warranty_change(
 				site="test-site.frappe.cloud",
 				server="test-server",
 				new_plan="test-plan",

--- a/press/partner/doctype/partner_onboarding/test_partner_onboarding.py
+++ b/press/partner/doctype/partner_onboarding/test_partner_onboarding.py
@@ -93,11 +93,12 @@ class IntegrationTestPartnerOnboarding(IntegrationTestCase):
 		onboarding.db_set("status", "Cancelled")
 		self.assertFalse(has_partner_onboarding(team.name))
 
-	def test_mrr_after_mid_month_counts_unpaid_current_invoice(self):
-		"""Past the 15th, an Unpaid current-month invoice over the threshold
-		is enough — we assume the partner will pay."""
+	def test_mrr_new_team_counts_unpaid_current_month_invoice(self):
+		"""A team in its first billing month only has a Draft/Unpaid current
+		invoice, so it is counted regardless of the day of the month — the
+		partner should not be blocked by billing timing."""
 		team = create_test_team()
-		with freeze_time(AFTER_MID_MONTH):
+		with freeze_time(BEFORE_MID_MONTH):
 			self._create_subscription_invoice(team.name, get_last_day(today()), 12000, status="Unpaid")
 			status = _get_mrr_status(team)
 
@@ -106,7 +107,7 @@ class IntegrationTestPartnerOnboarding(IntegrationTestCase):
 		self.assertEqual(status["current_amount"], 12000)
 		self.assertTrue(status["requirement_complete"])
 
-	def test_mrr_after_mid_month_below_threshold_is_incomplete(self):
+	def test_mrr_new_team_below_threshold_is_incomplete(self):
 		team = create_test_team()
 		with freeze_time(AFTER_MID_MONTH):
 			self._create_subscription_invoice(team.name, get_last_day(today()), 5000, status="Unpaid")
@@ -115,45 +116,40 @@ class IntegrationTestPartnerOnboarding(IntegrationTestCase):
 		self.assertEqual(status["current_amount"], 5000)
 		self.assertFalse(status["requirement_complete"])
 
-	def test_mrr_after_mid_month_ignores_other_months(self):
-		"""Only the current cycle counts after the 15th."""
-		team = create_test_team()
-		with freeze_time(AFTER_MID_MONTH):
-			last_month_due = get_last_day(add_months(today(), -1))
-			self._create_subscription_invoice(team.name, last_month_due, 12000, status="Paid", submitted=True)
-			status = _get_mrr_status(team)
-
-		self.assertEqual(status["current_amount"], 0)
-		self.assertFalse(status["requirement_complete"])
-
-	def test_mrr_before_mid_month_uses_last_month_paid_invoice(self):
-		"""On/before the 15th, last month's settled invoice is used."""
+	def test_mrr_established_team_before_mid_month_counts_unpaid_last_month(self):
+		"""Once a previous cycle exists, on/before the 15th last month's invoice
+		is used even when still Unpaid — it is assumed to settle by month end.
+		The current-month invoice that makes the team established is ignored."""
 		team = create_test_team()
 		with freeze_time(BEFORE_MID_MONTH):
 			last_month_due = get_last_day(add_months(today(), -1))
-			self._create_subscription_invoice(team.name, last_month_due, 12000, status="Paid", submitted=True)
+			self._create_subscription_invoice(team.name, last_month_due, 12000, status="Unpaid")
+			self._create_subscription_invoice(team.name, get_last_day(today()), 5000, status="Unpaid")
 			status = _get_mrr_status(team)
 
 		self.assertEqual(status["current_amount"], 12000)
 		self.assertTrue(status["requirement_complete"])
 
-	def test_mrr_before_mid_month_ignores_unpaid_last_month_invoice(self):
-		"""An unpaid (unsubmitted) last-month invoice does not count early in
-		the cycle."""
+	def test_mrr_established_team_after_mid_month_requires_paid_last_month(self):
+		"""Past the 15th last month's cycle should be settled, so only a Paid
+		last-month invoice counts; the current-month invoice is ignored."""
 		team = create_test_team()
-		with freeze_time(BEFORE_MID_MONTH):
+		with freeze_time(AFTER_MID_MONTH):
 			last_month_due = get_last_day(add_months(today(), -1))
-			self._create_subscription_invoice(team.name, last_month_due, 12000, status="Unpaid")
+			self._create_subscription_invoice(team.name, last_month_due, 12000, status="Paid", submitted=True)
+			self._create_subscription_invoice(team.name, get_last_day(today()), 5000, status="Unpaid")
 			status = _get_mrr_status(team)
 
-		self.assertEqual(status["current_amount"], 0)
-		self.assertFalse(status["requirement_complete"])
+		self.assertEqual(status["current_amount"], 12000)
+		self.assertTrue(status["requirement_complete"])
 
-	def test_mrr_before_mid_month_ignores_current_month_invoice(self):
-		"""The young current-month invoice is not used before the 15th."""
+	def test_mrr_established_team_after_mid_month_ignores_unpaid_last_month(self):
+		"""Past the 15th an Unpaid last-month invoice is too unsettled to count."""
 		team = create_test_team()
-		with freeze_time(BEFORE_MID_MONTH):
-			self._create_subscription_invoice(team.name, get_last_day(today()), 12000, status="Unpaid")
+		with freeze_time(AFTER_MID_MONTH):
+			last_month_due = get_last_day(add_months(today(), -1))
+			self._create_subscription_invoice(team.name, last_month_due, 12000, status="Unpaid")
+			self._create_subscription_invoice(team.name, get_last_day(today()), 5000, status="Unpaid")
 			status = _get_mrr_status(team)
 
 		self.assertEqual(status["current_amount"], 0)


### PR DESCRIPTION
## Why

Merging `release/2026-W26` into master (#6762) surfaced 6 failing tests (4 errors + 2 failures). In both cases, the **tests were stale** 

## What

### 1. Warranty restriction tests — `ImportError` (4 tests)

The merge-conflict resolution in 68840b8 adopted master's function name
`_validate_warranty_change`, replacing the release branch's
`_check_warranty_restrictions`. The test in `press/api/tests/test_site.py`

still imported the old name, so all four `TestCheckWarrantyRestrictions` tests errored at import.

The signature and logic are identical and the test passes every argument by keyword, so the fix is a straight rename of the import and call.

### 2. Partner-onboarding MRR tests — 2 failures

Two commits on Jun 19 (27e7103, f313b13, "Consider current month only for new team") deliberately reworked `_get_mrr_subscription_invoices` to branch
on **invoice count** instead of day-of-month alone:

- **New team (≤ 1 subscription invoice):** count the current-month invoice
  regardless of the date.
- **Established team (≥ 2 invoices):** use last month's invoice — Paid-only
  after the 15th, Paid-or-Unpaid on/before.

The tests (last touched before those commits) still encoded the old day-of-month-only spec; two failed outright and several others passed only incidentally under misleading names. Replaced the MRR test block with five tests that exercise the new branching directly:

- `test_mrr_new_team_counts_unpaid_current_month_invoice`
- `test_mrr_new_team_below_threshold_is_incomplete`
- `test_mrr_established_team_before_mid_month_counts_unpaid_last_month`
- `test_mrr_established_team_after_mid_month_requires_paid_last_month`
- `test_mrr_established_team_after_mid_month_ignores_unpaid_last_month`

The established team tests add a second invoice for the current month with a different amount, so the assertions also confirm that the invoice is correctly ignored.