### PR TITLE
fix(site): Allow enabling product warranty irrespective of cooldown

### DIFF
--- a/dashboard/src/components/ManageProductWarrantyDialog.vue
+++ b/dashboard/src/components/ManageProductWarrantyDialog.vue
@@ -66,10 +66,23 @@ const nextChangeAvailableOn = computed(() => {
 	}
 })
 
+const hasWarrantyQuota = computed(
+	() => site.doc?.dedicated_server_warranty_limit?.available > 0,
+)
+
+const cooldownPassed = computed(
+	() => nextChangeAvailableOn.value === 'Available Now',
+)
+
+// Enabling warranty is gated only by available quota (the cooldown does not
+// apply, so a site can reclaim a free slot any time); disabling is gated by the
+// cooldown.
+const isToggleDisabled = computed(() =>
+	isSupportEnabled.value ? !cooldownPassed.value : !hasWarrantyQuota.value,
+)
+
 const disablePrimaryAction = computed(
-	() =>
-		switchValue.value === isSupportEnabled.value ||
-		nextChangeAvailableOn.value !== 'Available Now',
+	() => switchValue.value === isSupportEnabled.value || isToggleDisabled.value,
 )
 
 function onClickSave() {
@@ -102,7 +115,7 @@ function onClickSave() {
 						v-model="switchValue"
 						size="md"
 						class="px-4"
-						:disabled="nextChangeAvailableOn !== 'Available Now' || (site.doc?.dedicated_server_warranty_limit?.available <= 0 && !isSupportEnabled)"
+						:disabled="isToggleDisabled"
 					/>
 				</div>
 

--- a/dashboard/src/components/ManageProductWarrantyDialog.vue
+++ b/dashboard/src/components/ManageProductWarrantyDialog.vue
@@ -85,6 +85,13 @@ const disablePrimaryAction = computed(
 	() => switchValue.value === isSupportEnabled.value || isToggleDisabled.value,
 )
 
+// The cooldown only blocks disabling, so this date is relevant only while
+// warranty is on and the cooldown has not yet elapsed. Hide it otherwise — when
+// the change is possible there is nothing to wait for.
+const showNextChangeAvailableOn = computed(
+	() => isSupportEnabled.value && !cooldownPassed.value,
+)
+
 function onClickSave() {
 	$toast.promise(site.setPlan.submit({ plan: nextSitePlanName.value }), {
 		loading: 'Changing product warranty...',
@@ -149,17 +156,9 @@ function onClickSave() {
 							sites
 						</p>
 					</div>
-					<div class="flex">
+					<div v-if="showNextChangeAvailableOn" class="flex">
 						<p class="flex-grow text-ink-gray-6">Next change available after</p>
-						<p
-							:class="
-								nextChangeAvailableOn === 'Available Now'
-									? 'text-ink-green-3 font-medium'
-									: ''
-							"
-						>
-							{{ nextChangeAvailableOn }}
-						</p>
+						<p>{{ nextChangeAvailableOn }}</p>
 					</div>
 				</div>
 

--- a/press/api/site.py
+++ b/press/api/site.py
@@ -299,17 +299,24 @@ def _validate_warranty_change(
 		return
 	if is_current_plan_supported == is_product_warranty_enabled_for_plan_(new_plan):
 		return
-
+	if is_product_warranty_enabled_for_plan_(new_plan):
+		# Enabling warranty is gated only by the server quota (it consumes a slot).
+		# The cooldown deliberately does not apply: the only enable the cooldown
+		# would block is a site reclaiming the slot it itself just gave up, which
+		# is legitimate as long as a slot is free. Rotating support to a *different*
+		# site is already prevented by the quota plus the cooldown on disabling.
+		quota = get_available_warranty_quota_for_server(server)
+		if quota.get("available") <= 0:
+			frappe.throw(
+				"You have exhausted the site warranty quota for this server. To increase limit, please contact support."
+			)
+		return
+	# Disabling warranty is gated by the cooldown to deter freeing a slot only to
+	# rotate it onto another site.
 	next_warranty_change = get_next_allowed_dedicated_product_warranty_change_date(site)
 	if get_datetime() < next_warranty_change:
 		pretty_date = format_datetime(next_warranty_change, "MMM d, YYYY hh:mm a")
 		frappe.throw(f"Cannot change product warranty for this site before {pretty_date}")  # nosemgrep
-
-	quota = get_available_warranty_quota_for_server(server)
-	if quota.get("available") <= 0:
-		frappe.throw(
-			"You have exhausted the site warranty quota for this server. To increase limit, please contact support."
-		)
 
 
 def _is_free_dedicated_plan_allowed(server: str, new_site_plan: dict) -> bool:

--- a/press/api/tests/test_site.py
+++ b/press/api/tests/test_site.py
@@ -1102,3 +1102,93 @@ class TestAPISiteDomain(FrappeTestCase):
 		):
 			add_domain(site.name, "example.com")
 		self.assertTrue(frappe.db.exists("Site Domain", {"site": site.name, "domain": "example.com"}))
+
+
+class TestValidateWarrantyChange(FrappeTestCase):
+	"""Tests for _validate_warranty_change.
+
+	Enabling support is gated only by the server quota (it consumes a slot) and is
+	allowed irrespective of the cooldown, so a site can reclaim a free slot any
+	time. Disabling support is gated only by the cooldown, which deters freeing a
+	slot only to rotate it onto another site.
+	"""
+
+	def _check(self, *, current_supported, new_supported, quota_available=0, cooldown_active=False):
+		from press.api.site import _validate_warranty_change
+
+		now = datetime.datetime.now()
+		next_change = now + datetime.timedelta(days=1) if cooldown_active else now
+		with (
+			patch(
+				"press.api.site.is_product_warranty_enabled_for_plan_",
+				return_value=new_supported,
+			),
+			patch(
+				"press.api.site.get_next_allowed_dedicated_product_warranty_change_date",
+				return_value=next_change,
+			),
+			patch(
+				"press.api.site.get_available_warranty_quota_for_server",
+				return_value={"available": quota_available},
+			),
+		):
+			_validate_warranty_change(
+				site="test-site.frappe.cloud",
+				server="test-server",
+				new_plan="test-plan",
+				is_new=False,
+				is_system_user=False,
+				is_current_dedicated_server_plan=True,
+				is_current_plan_supported=current_supported,
+			)
+
+	def test_disabling_warranty_allowed_even_when_quota_exhausted(self):
+		"""Disabling support on a server with no quota left must not throw."""
+		self._check(current_supported=True, new_supported=False, quota_available=0)
+
+	def test_enabling_warranty_blocked_when_quota_exhausted(self):
+		"""Enabling support on a server with no quota left must throw."""
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"exhausted the site warranty quota",
+			self._check,
+			current_supported=False,
+			new_supported=True,
+			quota_available=0,
+		)
+
+	def test_enabling_warranty_allowed_when_quota_available(self):
+		"""Enabling support with quota left must not throw."""
+		self._check(current_supported=False, new_supported=True, quota_available=1)
+
+	def test_enabling_warranty_allowed_during_cooldown_when_quota_available(self):
+		"""Reclaiming a free slot is allowed even while the cooldown is active."""
+		self._check(
+			current_supported=False,
+			new_supported=True,
+			quota_available=1,
+			cooldown_active=True,
+		)
+
+	def test_enabling_warranty_blocked_when_quota_exhausted_during_cooldown(self):
+		"""Enabling with no free slot must throw on quota, not silently pass."""
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"exhausted the site warranty quota",
+			self._check,
+			current_supported=False,
+			new_supported=True,
+			quota_available=0,
+			cooldown_active=True,
+		)
+
+	def test_disabling_warranty_blocked_during_cooldown(self):
+		"""Disabling support is still subject to the cooldown window."""
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"Cannot change product warranty for this site before",
+			self._check,
+			current_supported=True,
+			new_supported=False,
+			cooldown_active=True,
+		)


### PR DESCRIPTION
Backport to `master` of the warranty-cooldown fix (already on `develop`).

## What

Enabling product warranty for a dedicated-server site was gated by **both** the
server quota and the per-site change cooldown. The cooldown exists to deter
partners from rotating a limited number of support slots across many sites
(disable a slotted site, enable an unslotted one), but it also blocked a
legitimate case: a customer who disables support for one of their supported
sites and then realises they still need it could not re-enable it until the
cooldown elapsed — even though re-enabling does not exceed quota.

The only enable the cooldown ever blocked is a site reclaiming the slot it
itself just gave up, which is legitimate as long as a slot is free. Rotating
support onto a *different* site is already gated by quota (a slot must be freed
first) plus the cooldown on disabling, which is what actually deters flapping.

So now:
- **Enabling** warranty is gated **only by quota**.
- **Disabling** warranty keeps the **cooldown**.

## Changes

- `press/api/site.py` — `_validate_warranty_change` splits enabling (quota only) from disabling (cooldown only).
- `dashboard/.../ManageProductWarrantyDialog.vue` — hides the "Next change available after" date unless warranty is on and the cooldown has not elapsed (the only state where it blocks the action).
- `press/api/tests/test_site.py` — adds `TestValidateWarrantyChange` covering the enable/disable × quota × cooldown matrix.

## Backport notes

Cherry-picked from develop commits `bbed08696` and `6fc8f08e6`. `site.py` and
`test_site.py` had conflicts because `master` carries a divergently-refactored
version of the function (`_validate_warranty_change`, vs develop's
`_check_warranty_restrictions`). Resolved by applying the commit's intent onto
master's function shape and renaming the test references accordingly.