### PR TITLE
fix: Track product trial provisioning agent jobs

### DIFF
--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -717,23 +717,24 @@ class Site(Document, TagHelpers):
 
 	def generate_saas_communication_secret(self, create_agent_job=False, save=True):
 		if self.saas_communication_secret:
-			return
+			return None
 
 		# Ensure site isn't owned by Administrator
 		if not self.team:
-			return
+			return None
 
 		if frappe.get_value("Team", self.team, "user") == "Administrator":
-			return
+			return None
 
 		self.saas_communication_secret = frappe.generate_hash(length=32)
 		config = {
 			"fc_communication_secret": self.saas_communication_secret,
 		}
 		if create_agent_job:
-			self.update_site_config(config)
+			return self.update_site_config(config)
 		else:
 			self._update_configuration(config=config, save=save)
+		return None
 
 	def rename_upstream(self, new_name: str):
 		proxy_server = frappe.db.get_value("Server", self.server, "proxy_server")
@@ -1623,7 +1624,7 @@ class Site(Document, TagHelpers):
 		domain = domain.lower().strip(".")
 		log_site_activity(self.name, "Add Domain")
 		create_dns_record(doc=self, record_name=domain)
-		frappe.get_doc(
+		site_domain = frappe.get_doc(
 			{
 				"doctype": "Site Domain",
 				"status": "Pending",
@@ -1632,6 +1633,7 @@ class Site(Document, TagHelpers):
 				"dns_type": "CNAME",
 			}
 		).insert(ignore_if_duplicate=True)
+		return site_domain.flags.get("add_domain_to_upstream_job")
 
 	@frappe.whitelist()
 	def create_dns_record(self):
@@ -1665,7 +1667,7 @@ class Site(Document, TagHelpers):
 		domains.add(domain)
 		self._update_configuration({"domains": list(domains)})
 		agent = Agent(self.server)
-		agent.add_domain(self, domain)
+		return agent.add_domain(self, domain)
 
 	def remove_domain_from_config(self, domain):
 		domains = set(self.get_config_value_for_key("domains") or [])
@@ -4547,8 +4549,7 @@ def update_product_trial_request_status_based_on_site_status(site, is_site_activ
 	product_trial_request = frappe.get_doc("Product Trial Request", records[0].name, for_update=True)
 	if is_site_active:
 		product_trial_request.prefill_setup_wizard_data()
-		product_trial_request.status = "Site Created"
-		product_trial_request.save(ignore_permissions=True)
+		product_trial_request.update_status_from_agent_jobs()
 	else:
 		product_trial_request.status = "Error"
 		product_trial_request.error = error
@@ -4562,6 +4563,8 @@ def process_complete_setup_wizard_job_update(job):
 	product_trial_request = frappe.get_doc("Product Trial Request", records[0].name, for_update=True)
 	if job.status == "Success":
 		frappe.db.set_value("Site", job.site, "additional_system_user_created", True)
+		if product_trial_request.update_status_from_agent_jobs():
+			return
 		if frappe.get_all("Site Domain", filters={"site": job.site, "status": ["!=", "Active"]}):
 			product_trial_request.status = "Adding Domain"
 		else:
@@ -4583,10 +4586,7 @@ def process_add_domain_job_update(job):
 		if product_trial_request.status == "Site Created":
 			return
 
-		product_trial_request.status = "Site Created"
-		product_trial_request.site_creation_completed_on = now_datetime()
-
-		product_trial_request.save(ignore_permissions=True)
+		product_trial_request.update_status_from_agent_jobs()
 
 		site_domain = json.loads(job.request_data).get("domain")
 		site = Site("Site", job.site)
@@ -4601,8 +4601,7 @@ def process_add_domain_job_update(job):
 			job.db_set("retry_count", job.retry_count + 1)
 			job.retry_in_place()
 		else:
-			product_trial_request.status = "Error"
-			product_trial_request.save(ignore_permissions=True)
+			product_trial_request.update_status_from_agent_jobs(job.data)
 
 
 def get_remove_step_status(job):

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -732,8 +732,8 @@ class Site(Document, TagHelpers):
 		}
 		if create_agent_job:
 			return self.update_site_config(config)
-		else:
-			self._update_configuration(config=config, save=save)
+
+		self._update_configuration(config=config, save=save)
 		return None
 
 	def rename_upstream(self, new_name: str):
@@ -4563,14 +4563,11 @@ def process_complete_setup_wizard_job_update(job):
 	product_trial_request = frappe.get_doc("Product Trial Request", records[0].name, for_update=True)
 	if job.status == "Success":
 		frappe.db.set_value("Site", job.site, "additional_system_user_created", True)
-		if product_trial_request.update_status_from_agent_jobs():
-			return
 		if frappe.get_all("Site Domain", filters={"site": job.site, "status": ["!=", "Active"]}):
 			product_trial_request.status = "Adding Domain"
+			product_trial_request.save(ignore_permissions=True)
 		else:
-			product_trial_request.status = "Site Created"
-			product_trial_request.site_creation_completed_on = now_datetime()
-		product_trial_request.save(ignore_permissions=True)
+			product_trial_request.update_status_from_agent_jobs()
 	elif job.status in ("Failure", "Delivery Failure"):
 		product_trial_request.status = "Error"
 		product_trial_request.save(ignore_permissions=True)

--- a/press/press/doctype/site_domain/site_domain.py
+++ b/press/press/doctype/site_domain/site_domain.py
@@ -247,9 +247,10 @@ def process_add_domain_to_upstream_job_update(job):
 	if updated_status != domain_status:
 		frappe.db.set_value("Site Domain", domain, "status", updated_status)
 
-	if job.status in ["Failure", "Delivery Failure"]:
-		if request := frappe.db.get_value("Product Trial Request", {"domain": domain}):
-			frappe.get_doc("Product Trial Request", request).update_status_from_agent_jobs(job.data)
+	if job.status in ["Failure", "Delivery Failure"] and (
+		request := frappe.db.get_value("Product Trial Request", {"domain": domain})
+	):
+		frappe.get_doc("Product Trial Request", request).update_status_from_agent_jobs(job.data)
 
 
 def update_dns_type():

--- a/press/press/doctype/site_domain/site_domain.py
+++ b/press/press/doctype/site_domain/site_domain.py
@@ -87,7 +87,9 @@ class SiteDomain(Document):
 
 		if self.has_root_tls_certificate:
 			server = frappe.db.get_value("Site", self.site, "server")
-			self.agent.add_domain_to_upstream(server=server, site=self.site, domain=self.domain)
+			self.flags.add_domain_to_upstream_job = self.agent.add_domain_to_upstream(
+				server=server, site=self.site, domain=self.domain
+			)
 			return
 
 		self.create_tls_certificate()
@@ -246,9 +248,8 @@ def process_add_domain_to_upstream_job_update(job):
 		frappe.db.set_value("Site Domain", domain, "status", updated_status)
 
 	if job.status in ["Failure", "Delivery Failure"]:
-		frappe.db.set_value(
-			"Product Trial Request", {"domain": request_data.get("domain")}, "status", "Error"
-		)
+		if request := frappe.db.get_value("Product Trial Request", {"domain": domain}):
+			frappe.get_doc("Product Trial Request", request).update_status_from_agent_jobs(job.data)
 
 
 def update_dns_type():

--- a/press/saas/doctype/product_trial/product_trial.py
+++ b/press/saas/doctype/product_trial/product_trial.py
@@ -108,7 +108,7 @@ class ProductTrial(Document):
 		standby_site = self.get_standby_site(cluster, account_request)
 
 		trial_end_date = frappe.utils.add_days(None, self.trial_days or 14)
-		agent_job_name: str | None = None
+		agent_jobs = []
 		plan = self.trial_plan
 
 		if standby_site:
@@ -123,10 +123,20 @@ class ProductTrial(Document):
 				site._update_configuration(apps_site_config, save=False)
 				site._update_configuration(get_plan_config(plan), save=False)
 				site.signup_time = frappe.utils.now()
-				site.generate_saas_communication_secret(create_agent_job=True, save=False)
+				communication_secret_job = site.generate_saas_communication_secret(
+					create_agent_job=True, save=False
+				)
+				if communication_secret_job:
+					agent_jobs.append(
+						{
+							"agent_job": communication_secret_job,
+							"purpose": "Update Site Configuration",
+							"required_for_completion": False,
+						}
+					)
 				site.save()  # Save is needed for create_subscription to work TODO: remove this
 				site.reload()
-				self.set_site_domain(site, site_domain)
+				agent_jobs.extend(self.set_site_domain(site, site_domain))
 			except Exception:
 				frappe.db.rollback()
 				frappe.db.set_value("Site", standby_site, "is_standby", 1)
@@ -159,9 +169,10 @@ class ProductTrial(Document):
 			site._update_configuration(get_plan_config(plan), save=False)
 			site.generate_saas_communication_secret(create_agent_job=False, save=False)
 			site.insert()
-			agent_job_name = site.flags.get("new_site_agent_job_name", None)
+			if agent_job_name := site.flags.get("new_site_agent_job_name", None):
+				agent_jobs.append({"agent_job": agent_job_name, "purpose": "Create Site"})
 
-		return site, agent_job_name, bool(standby_site)
+		return site, agent_jobs, bool(standby_site)
 
 	def get_site_apps(self, account_request: str | None = None):
 		"""Get the list of site apps to include in the site creation
@@ -217,14 +228,24 @@ class ProductTrial(Document):
 		return proxy_servers_for_available_clusters
 
 	def set_site_domain(self, site: Site, site_domain: str):
+		agent_jobs = []
 		if not site_domain:
-			return
+			return agent_jobs
 
 		if site.name == site_domain or site.host_name == site_domain:
-			return
+			return agent_jobs
 
-		site.add_domain_for_product_site(site_domain)
-		site.add_domain_to_config(site_domain)
+		if add_domain_to_upstream_job := site.add_domain_for_product_site(site_domain):
+			agent_jobs.append(
+				{
+					"agent_job": add_domain_to_upstream_job,
+					"purpose": "Add Domain to Upstream",
+					"required_for_completion": False,
+				}
+			)
+		if add_domain_job := site.add_domain_to_config(site_domain):
+			agent_jobs.append({"agent_job": add_domain_job, "purpose": "Add Domain"})
+		return agent_jobs
 
 	def get_available_clusters(self):
 		release_group = frappe.get_doc("Release Group", self.release_group)

--- a/press/saas/doctype/product_trial_request/product_trial_request.json
+++ b/press/saas/doctype/product_trial_request/product_trial_request.json
@@ -16,6 +16,8 @@
 		"account_request",
 		"agent_job",
 		"cluster",
+		"agent_jobs_tab",
+		"agent_jobs",
 		"section_break_zlzx",
 		"site_creation_started_on",
 		"is_standby_site",
@@ -127,6 +129,17 @@
 			"fieldname": "is_subscription_created",
 			"fieldtype": "Check",
 			"label": "Is Subscription Created"
+		},
+		{
+			"fieldname": "agent_jobs_tab",
+			"fieldtype": "Tab Break",
+			"label": "Agent Jobs"
+		},
+		{
+			"fieldname": "agent_jobs",
+			"fieldtype": "Table",
+			"label": "Agent Jobs",
+			"options": "Product Trial Request Agent Job"
 		}
 	],
 	"grid_page_length": 50,

--- a/press/saas/doctype/product_trial_request/product_trial_request.py
+++ b/press/saas/doctype/product_trial_request/product_trial_request.py
@@ -234,8 +234,6 @@ class ProductTrialRequest(Document):
 
 		if self.has_failed_required_agent_job():
 			self.status = "Error"
-			if error:
-				self.error = error
 			self.save(ignore_permissions=True)
 			return False
 

--- a/press/saas/doctype/product_trial_request/product_trial_request.py
+++ b/press/saas/doctype/product_trial_request/product_trial_request.py
@@ -66,7 +66,24 @@ class ProductTrialRequest(Document):
 			"Update Site Configuration": "Configuring your site",
 			"Enable Scheduler": "Finalizing your setup",
 			"Bench Setup Nginx": "Finalizing your setup",
+			"Bench Setup NGINX": "Finalizing your setup",
 			"Reload Nginx": "Almost there",
+			"Reload NGINX": "Almost there",
+		},
+		"Update Site Configuration": {
+			"Update Site Configuration": "Configuring your site",
+		},
+		"Add Domain to Upstream": {
+			"Add Site File to Upstream Directory": "Configuring your domain",
+			"Reload Nginx": "Finalizing your setup",
+			"Reload NGINX": "Finalizing your setup",
+		},
+		"Add Domain": {
+			"Update Site Configuration": "Configuring your domain",
+			"Bench Setup Nginx": "Finalizing your setup",
+			"Bench Setup NGINX": "Finalizing your setup",
+			"Reload Nginx": "Almost there",
+			"Reload NGINX": "Almost there",
 		},
 	}
 
@@ -132,6 +149,104 @@ class ProductTrialRequest(Document):
 				self.db_set({"is_site_accessible": "No"})
 		except Exception as e:
 			self.db_set({"is_site_accessible": "No", "error": str(e)})
+
+	def add_agent_job(self, agent_job, purpose: str | None = None, required_for_completion: bool = True):
+		if not agent_job:
+			return
+
+		agent_job_name = getattr(agent_job, "name", agent_job)
+		if any(row.agent_job == agent_job_name for row in self.agent_jobs):
+			return
+
+		job_type = getattr(agent_job, "job_type", None) or frappe.db.get_value(
+			"Agent Job", agent_job_name, "job_type"
+		)
+		self.append(
+			"agent_jobs",
+			{
+				"agent_job": agent_job_name,
+				"job_type": job_type,
+				"purpose": purpose or job_type,
+				"required_for_completion": required_for_completion,
+				"sequence": len(self.agent_jobs) + 1,
+			},
+		)
+
+		if required_for_completion and not self.agent_job:
+			self.agent_job = agent_job_name
+
+	def add_agent_jobs(self, agent_jobs):
+		for agent_job in agent_jobs or []:
+			self.add_agent_job(**agent_job)
+
+	def get_required_agent_job_names(self) -> list[str]:
+		return [
+			row.agent_job
+			for row in sorted(self.agent_jobs, key=lambda row: row.sequence or 0)
+			if row.required_for_completion and row.agent_job
+		]
+
+	def get_current_agent_job(self) -> str | None:
+		agent_jobs = self.get_required_agent_job_names()
+		if not agent_jobs:
+			return self.agent_job
+
+		for agent_job in agent_jobs:
+			status = frappe.db.get_value("Agent Job", agent_job, "status")
+			if status != "Success":
+				return agent_job
+		return agent_jobs[-1]
+
+	def has_failed_required_agent_job(self) -> bool:
+		agent_jobs = self.get_required_agent_job_names()
+		if not agent_jobs:
+			return False
+		return bool(
+			frappe.db.exists(
+				"Agent Job",
+				{
+					"name": ("in", agent_jobs),
+					"status": ("in", ["Failure", "Delivery Failure"]),
+				},
+			)
+		)
+
+	def required_agent_jobs_complete(self) -> bool:
+		agent_jobs = self.get_required_agent_job_names()
+		if not agent_jobs:
+			return True
+
+		completed_jobs = frappe.db.count(
+			"Agent Job",
+			{
+				"name": ("in", agent_jobs),
+				"status": "Success",
+			},
+		)
+		return completed_jobs == len(agent_jobs)
+
+	def update_status_from_agent_jobs(self, error=None):
+		if error:
+			self.status = "Error"
+			self.error = error
+			self.save(ignore_permissions=True)
+			return False
+
+		if self.has_failed_required_agent_job():
+			self.status = "Error"
+			if error:
+				self.error = error
+			self.save(ignore_permissions=True)
+			return False
+
+		if not self.required_agent_jobs_complete():
+			return False
+
+		self.status = "Site Created"
+		if not self.site_creation_completed_on:
+			self.site_creation_completed_on = now_datetime()
+		self.save(ignore_permissions=True)
+		return True
 
 	def after_insert(self):
 		self.capture_posthog_event("product_trial_request_created")
@@ -237,7 +352,7 @@ class ProductTrialRequest(Document):
 			self.domain = f"{subdomain}.{domain}"
 			cluster = frappe.db.get_value("Root Domain", domain, "default_cluster")
 			self.cluster = cluster
-			site, agent_job_name, is_standby_site = product.setup_trial_site(
+			site, agent_jobs, is_standby_site = product.setup_trial_site(
 				subdomain=subdomain,
 				domain=domain,
 				team=self.team,
@@ -245,14 +360,19 @@ class ProductTrialRequest(Document):
 				account_request=self.account_request,
 			)
 			self.is_standby_site = is_standby_site
-			self.agent_job = agent_job_name
 			self.site = site.name
+			self.add_agent_jobs(agent_jobs)
 			if not is_standby_site:
 				self.is_subscription_created = 1
 			self.save()
 
 			if is_standby_site:
 				self.prefill_setup_wizard_data()
+				if self.required_agent_jobs_complete():
+					self.update_status_from_agent_jobs()
+				elif self.site != self.domain:
+					self.status = "Adding Domain"
+					self.save()
 
 			user_mail = frappe.db.get_value("Team", self.team, "user")
 			frappe.get_doc(
@@ -279,15 +399,22 @@ class ProductTrialRequest(Document):
 	@dashboard_whitelist()
 	def get_progress(self, current_progress=None):  # noqa: C901
 		current_progress = current_progress or 10
-		if self.agent_job:
-			filters = {"name": self.agent_job, "site": self.site}
+		if agent_job := self.get_current_agent_job():
+			job_name, status, job_type = frappe.db.get_value(
+				"Agent Job",
+				{"name": agent_job, "site": self.site},
+				["name", "status", "job_type"],
+			)
 		else:
-			filters = {"site": self.site, "job_type": ["in", ["New Site", "Rename Site"]]}
-		job_name, status, job_type = frappe.db.get_value(
-			"Agent Job",
-			filters,
-			["name", "status", "job_type"],
-		)
+			job_name, status, job_type = frappe.db.get_value(
+				"Agent Job",
+				{"site": self.site, "job_type": ["in", ["New Site", "Rename Site"]]},
+				["name", "status", "job_type"],
+			)
+
+		if status in ("Failure", "Delivery Failure"):
+			return {"progress": current_progress, "current_step": self.status, "error": True}
+
 		if status == "Success":
 			if self.status == "Site Created":
 				return {"progress": 100, "current_step": self.status}

--- a/press/saas/doctype/product_trial_request_agent_job/product_trial_request_agent_job.json
+++ b/press/saas/doctype/product_trial_request_agent_job/product_trial_request_agent_job.json
@@ -1,0 +1,61 @@
+{
+	"actions": [],
+	"creation": "2026-06-23 00:00:00.000000",
+	"doctype": "DocType",
+	"editable_grid": 1,
+	"engine": "InnoDB",
+	"field_order": ["agent_job", "job_type", "purpose", "required_for_completion", "sequence"],
+	"fields": [
+		{
+			"fieldname": "agent_job",
+			"fieldtype": "Link",
+			"in_list_view": 1,
+			"label": "Agent Job",
+			"options": "Agent Job",
+			"read_only": 1
+		},
+		{
+			"fieldname": "job_type",
+			"fieldtype": "Link",
+			"in_list_view": 1,
+			"label": "Job Type",
+			"options": "Agent Job Type",
+			"read_only": 1
+		},
+		{
+			"fieldname": "purpose",
+			"fieldtype": "Data",
+			"in_list_view": 1,
+			"label": "Purpose",
+			"read_only": 1
+		},
+		{
+			"default": "1",
+			"fieldname": "required_for_completion",
+			"fieldtype": "Check",
+			"in_list_view": 1,
+			"label": "Required for Completion",
+			"read_only": 1
+		},
+		{
+			"fieldname": "sequence",
+			"fieldtype": "Int",
+			"label": "Sequence",
+			"read_only": 1
+		}
+	],
+	"grid_page_length": 50,
+	"index_web_pages_for_search": 1,
+	"istable": 1,
+	"links": [],
+	"modified": "2026-06-23 00:00:00.000000",
+	"modified_by": "Administrator",
+	"module": "SaaS",
+	"name": "Product Trial Request Agent Job",
+	"owner": "Administrator",
+	"permissions": [],
+	"row_format": "Dynamic",
+	"sort_field": "modified",
+	"sort_order": "DESC",
+	"states": []
+}


### PR DESCRIPTION
## Summary
- add a child table to Product Trial Request for related Agent Jobs
- register product trial provisioning jobs during fresh-site and standby-site flows
- drive progress and completion from the tracked required jobs
- return created agent jobs from site/domain helpers so the trial flow can track them

