### PR TITLE
fix: add product trial agent job controller

### DIFF
--- a/press/saas/doctype/product_trial_request_agent_job/product_trial_request_agent_job.py
+++ b/press/saas/doctype/product_trial_request_agent_job/product_trial_request_agent_job.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class ProductTrialRequestAgentJob(Document):
+	pass


### PR DESCRIPTION
## Summary
- add the missing Python controller module for Product Trial Request Agent Job
- fixes migration failure when Frappe imports the new child DocType module

## Verification
- Python AST parse for the new controller
- git diff --check