### PR TITLE
fix(product-trial): update provisioning progress UI

### DIFF
--- a/dashboard/src/pages/LoginSignup.vue
+++ b/dashboard/src/pages/LoginSignup.vue
@@ -295,19 +295,19 @@
 							class="mt-4 flex flex-col"
 							v-if="!hasForgotPassword && !isOauthLogin && !is2FA"
 						>
-							<div v-if="$route.name === 'Signup'">
-								<span class="text-base font-normal text-ink-gray-6">
+							<div class="text-p-base" v-if="$route.name === 'Signup'">
+								<span class="text-ink-gray-6">
 									{{ 'By signing up, you agree to our ' }}
 								</span>
 								<a
-									class="text-base font-normal text-ink-gray-9 underline hover:text-ink-gray-7"
+									class="text-ink-gray-9 underline hover:text-ink-gray-7"
 									href="https://frappecloud.com/policies"
 								>
 									Terms & Policies
 								</a>
 							</div>
-							<div v-if="!(otpRequested || resetPasswordEmailSent)">
-								<span class="text-base font-normal text-ink-gray-6">
+							<div class="mt-2" v-if="!(otpRequested || resetPasswordEmailSent)">
+								<span class="text-p-base text-ink-gray-6">
 									{{
 										$route.name == 'Login'
 											? 'New member? '
@@ -315,7 +315,7 @@
 									}}
 								</span>
 								<router-link
-									class="text-base font-normal text-ink-gray-9 underline hover:text-ink-gray-7"
+									class="text-p-base text-ink-gray-9 underline hover:text-ink-gray-7"
 									:to="{
 										name: $route.name == 'Login' ? 'Signup' : 'Login',
 										query: { ...$route.query, forgot: undefined },
@@ -492,7 +492,7 @@ export default {
 							html: `
 							You are not part of an active team<br/>
 							<span class="text-sm text-ink-gray-8">
-								If the issue persists, please contact 
+								If the issue persists, please contact
 								<a href="https://support.frappe.io" class="font-medium underline" target="_blank" rel="noopener noreferrer">
 									support.
 								</a>
@@ -910,7 +910,7 @@ export default {
 				return 'Log in to your account';
 			} else {
 				if (this.saasProduct) {
-					return `Sign up to create your ${this.saasProduct.title} site`;
+					return `Sign up for ${this.saasProduct.title}`;
 				}
 
 				return 'Create your Frappe Cloud account';

--- a/dashboard/src/pages/signup/LoginToSite.vue
+++ b/dashboard/src/pages/signup/LoginToSite.vue
@@ -77,14 +77,7 @@ export default {
 			product_trial_request: this.$route.query.product_trial_request,
 			progressCount: 0,
 			currentBuildStep: 'Configuring your setup',
-			mockProgressTimer: null,
 		};
-	},
-	mounted() {
-		if (this.isMockMode) this.startMockProgress();
-	},
-	beforeUnmount() {
-		clearInterval(this.mockProgressTimer);
 	},
 	resources: {
 		saasProduct() {
@@ -92,7 +85,7 @@ export default {
 				type: 'document',
 				doctype: 'Product Trial',
 				name: this.productId,
-				auto: !this.isMockMode,
+				auto: true,
 			};
 		},
 		siteRequest() {
@@ -101,7 +94,7 @@ export default {
 				doctype: 'Product Trial Request',
 				name: this.product_trial_request,
 				realtime: true,
-				auto: !this.isMockMode,
+				auto: true,
 				onSuccess(doc) {
 					if (doc.status === 'Site Created') {
 						this.showCompleteProgress();
@@ -178,33 +171,10 @@ export default {
 		},
 	},
 	computed: {
-		isMockMode() {
-			return (
-				this.$route.name === 'ProductTrialProgressMock' ||
-				this.$route.query.mock === '1'
-			);
-		},
 		saasProduct() {
-			if (this.isMockMode) {
-				return {
-					logo: '/assets/press/images/frappe-cloud-logo.png',
-					help_texts: [
-						{ help_text: 'We are preparing your trial workspace.' },
-						{ help_text: 'This preview is using local mock data.' },
-						{ help_text: 'The real page updates from Agent Job progress.' },
-					],
-				};
-			}
 			return this.$resources.saasProduct.doc;
 		},
 		siteRequestDoc() {
-			if (this.isMockMode) {
-				return {
-					status: 'Adding Domain',
-					domain: 'acme.frappe.cloud',
-					site: 'acme.frappe.cloud',
-				};
-			}
 			return this.$resources?.siteRequest?.doc;
 		},
 		currentHelpText() {
@@ -226,24 +196,6 @@ export default {
 		},
 	},
 	methods: {
-		startMockProgress() {
-			let tick = 0;
-			const mockSteps = [
-				'Configuring your site',
-				'Configuring your domain',
-				'Finalizing your setup',
-				'Almost there',
-			];
-
-			this.progressCount = 18;
-			this.currentBuildStep = mockSteps[0];
-			this.mockProgressTimer = setInterval(() => {
-				const activeStep = Math.min(Math.floor(tick / 4), mockSteps.length - 1);
-				this.currentBuildStep = mockSteps[activeStep];
-				this.progressCount = Math.min(95, this.progressCount + 2.4);
-				tick += 1;
-			}, 1000);
-		},
 		showCompleteProgress() {
 			this.progressCount = 100;
 			this.currentBuildStep = 'Almost there';

--- a/dashboard/src/pages/signup/LoginToSite.vue
+++ b/dashboard/src/pages/signup/LoginToSite.vue
@@ -2,12 +2,9 @@
 	<div class="flex h-screen overflow-hidden">
 		<div class="w-full overflow-auto">
 			<LoginBox
-				v-if="$resources?.siteRequest?.doc?.status === 'Error'"
+				v-if="siteRequestDoc?.status === 'Error'"
 				title="Site creation failed"
-				:subtitle="
-					$resources?.siteRequest?.doc?.domain ||
-					$resources?.siteRequest?.doc?.site
-				"
+				:subtitle="siteRequestDoc?.domain || siteRequestDoc?.site"
 			>
 				<template v-slot:logo v-if="saasProduct">
 					<div class="flex space-x-2">
@@ -35,10 +32,7 @@
 			<LoginBox
 				v-else
 				title="Let's set up your site"
-				:subtitle="
-					this.$resources?.siteRequest?.doc?.domain ||
-					this.$resources?.siteRequest?.doc?.site
-				"
+				:subtitle="siteRequestDoc?.domain || siteRequestDoc?.site"
 			>
 				<template v-slot:logo v-if="saasProduct">
 					<div class="flex space-x-2">
@@ -49,7 +43,7 @@
 					</div>
 				</template>
 				<template v-slot:default>
-					<div class="flex mt-12 flex-col items-center justify-center">
+					<div class="mt-12 flex flex-col items-center justify-center">
 						<Progress
 							size="lg"
 							:value="progressCount"
@@ -83,7 +77,14 @@ export default {
 			product_trial_request: this.$route.query.product_trial_request,
 			progressCount: 0,
 			currentBuildStep: 'Configuring your setup',
+			mockProgressTimer: null,
 		};
+	},
+	mounted() {
+		if (this.isMockMode) this.startMockProgress();
+	},
+	beforeUnmount() {
+		clearInterval(this.mockProgressTimer);
 	},
 	resources: {
 		saasProduct() {
@@ -91,7 +92,7 @@ export default {
 				type: 'document',
 				doctype: 'Product Trial',
 				name: this.productId,
-				auto: true,
+				auto: !this.isMockMode,
 			};
 		},
 		siteRequest() {
@@ -100,16 +101,14 @@ export default {
 				doctype: 'Product Trial Request',
 				name: this.product_trial_request,
 				realtime: true,
-				auto: true,
+				auto: !this.isMockMode,
 				onSuccess(doc) {
 					if (doc.status === 'Site Created') {
+						this.showCompleteProgress();
 						setTimeout(() => {
 							this.loginToSite();
-						}, 2000);
-					} else if (
-						doc.status === 'Wait for Site' ||
-						doc.status === 'Prefilling Setup Wizard'
-					) {
+						}, 500);
+					} else if (this.isSiteProvisioning(doc.status)) {
 						this.$resources.siteRequest.getProgress.reload();
 					}
 				},
@@ -118,15 +117,15 @@ export default {
 						method: 'get_progress',
 						makeParams() {
 							return {
-								current_progress:
-									this.$resources.siteRequest.getProgress.data?.progress || 0,
+								current_progress: this.progressCount,
 							};
 						},
 						onSuccess: (data) => {
 							if (data.current_step === 'Site Created') {
+								this.showCompleteProgress();
 								setTimeout(() => {
 									this.loginToSite();
-								}, 2000);
+								}, 500);
 								return;
 							}
 
@@ -142,7 +141,7 @@ export default {
 								currentStepMap[data.current_step] ||
 								data.current_step ||
 								this.currentBuildStep;
-							this.progressCount += 1;
+							const nextProgress = Number(data.progress || 0);
 
 							if (
 								!(
@@ -150,7 +149,11 @@ export default {
 									this.progressCount <= 10
 								)
 							) {
-								this.progressCount = Math.round(data.progress * 10) / 10;
+								const visibleProgress = Math.min(
+									Math.max(nextProgress, this.progressCount + 0.2),
+									95,
+								);
+								this.progressCount = Math.round(visibleProgress * 10) / 10;
 								setTimeout(() => {
 									if (
 										['Site Created', 'Error'].includes(
@@ -175,8 +178,34 @@ export default {
 		},
 	},
 	computed: {
+		isMockMode() {
+			return (
+				this.$route.name === 'ProductTrialProgressMock' ||
+				this.$route.query.mock === '1'
+			);
+		},
 		saasProduct() {
+			if (this.isMockMode) {
+				return {
+					logo: '/assets/press/images/frappe-cloud-logo.png',
+					help_texts: [
+						{ help_text: 'We are preparing your trial workspace.' },
+						{ help_text: 'This preview is using local mock data.' },
+						{ help_text: 'The real page updates from Agent Job progress.' },
+					],
+				};
+			}
 			return this.$resources.saasProduct.doc;
+		},
+		siteRequestDoc() {
+			if (this.isMockMode) {
+				return {
+					status: 'Adding Domain',
+					domain: 'acme.frappe.cloud',
+					site: 'acme.frappe.cloud',
+				};
+			}
+			return this.$resources?.siteRequest?.doc;
 		},
 		currentHelpText() {
 			const defaultHelpTexts = [
@@ -197,6 +226,33 @@ export default {
 		},
 	},
 	methods: {
+		startMockProgress() {
+			let tick = 0;
+			const mockSteps = [
+				'Configuring your site',
+				'Configuring your domain',
+				'Finalizing your setup',
+				'Almost there',
+			];
+
+			this.progressCount = 18;
+			this.currentBuildStep = mockSteps[0];
+			this.mockProgressTimer = setInterval(() => {
+				const activeStep = Math.min(Math.floor(tick / 4), mockSteps.length - 1);
+				this.currentBuildStep = mockSteps[activeStep];
+				this.progressCount = Math.min(95, this.progressCount + 2.4);
+				tick += 1;
+			}, 1000);
+		},
+		showCompleteProgress() {
+			this.progressCount = 100;
+			this.currentBuildStep = 'Almost there';
+		},
+		isSiteProvisioning(status) {
+			return ['Wait for Site', 'Prefilling Setup Wizard', 'Adding Domain'].includes(
+				status,
+			);
+		},
 		loginToSite() {
 			this.$resources.siteRequest.getLoginSid.submit();
 		},

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -478,6 +478,17 @@ let router = createRouter({
 			name: 'Enable Servers',
 			component: () => import('./pages/EnableServers.vue'),
 		},
+		...(import.meta.env.DEV
+			? [
+					{
+						name: 'ProductTrialProgressMock',
+						path: '/dev/product-trial-progress',
+						component: () => import('./pages/signup/LoginToSite.vue'),
+						props: { productId: 'hrms' },
+						meta: { allowGuest: true, hideSidebar: true },
+					},
+				]
+			: []),
 		{
 			path: '/database-analyzer',
 			name: 'DB Analyzer',
@@ -658,7 +669,7 @@ router.beforeEach(async (to, from, next) => {
 			next()
 		}
 	} else {
-		if (goingToLoginPage) {
+		if (goingToLoginPage || to.meta.allowGuest) {
 			next()
 		} else {
 			if (to.name == 'Site Login') {

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -478,17 +478,6 @@ let router = createRouter({
 			name: 'Enable Servers',
 			component: () => import('./pages/EnableServers.vue'),
 		},
-		...(import.meta.env.DEV
-			? [
-					{
-						name: 'ProductTrialProgressMock',
-						path: '/dev/product-trial-progress',
-						component: () => import('./pages/signup/LoginToSite.vue'),
-						props: { productId: 'hrms' },
-						meta: { allowGuest: true, hideSidebar: true },
-					},
-				]
-			: []),
 		{
 			path: '/database-analyzer',
 			name: 'DB Analyzer',
@@ -669,7 +658,7 @@ router.beforeEach(async (to, from, next) => {
 			next()
 		}
 	} else {
-		if (goingToLoginPage || to.meta.allowGuest) {
+		if (goingToLoginPage) {
 			next()
 		} else {
 			if (to.name == 'Site Login') {

--- a/press/saas/doctype/product_trial_request/product_trial_request.py
+++ b/press/saas/doctype/product_trial_request/product_trial_request.py
@@ -432,7 +432,10 @@ class ProductTrialRequest(Document):
 
 	@dashboard_whitelist()
 	def get_progress(self, current_progress=None):  # noqa: C901
-		current_progress = float(current_progress or 10)
+		try:
+			current_progress = float(current_progress or 10)
+		except (TypeError, ValueError):
+			current_progress = 10.0
 		if agent_job := self.get_current_agent_job():
 			agent_job_data = frappe.db.get_value(
 				"Agent Job",

--- a/press/saas/doctype/product_trial_request/product_trial_request.py
+++ b/press/saas/doctype/product_trial_request/product_trial_request.py
@@ -432,19 +432,25 @@ class ProductTrialRequest(Document):
 
 	@dashboard_whitelist()
 	def get_progress(self, current_progress=None):  # noqa: C901
-		current_progress = current_progress or 10
+		current_progress = float(current_progress or 10)
 		if agent_job := self.get_current_agent_job():
-			job_name, status, job_type = frappe.db.get_value(
+			agent_job_data = frappe.db.get_value(
 				"Agent Job",
 				{"name": agent_job, "site": self.site},
 				["name", "status", "job_type"],
+				as_dict=True,
 			)
 		else:
-			job_name, status, job_type = frappe.db.get_value(
+			agent_job_data = frappe.db.get_value(
 				"Agent Job",
 				{"site": self.site, "job_type": ["in", ["New Site", "Rename Site"]]},
 				["name", "status", "job_type"],
+				as_dict=True,
 			)
+
+		job_name = agent_job_data.name if agent_job_data else None
+		status = agent_job_data.status if agent_job_data else None
+		job_type = agent_job_data.job_type if agent_job_data else None
 
 		if status in ("Failure", "Delivery Failure"):
 			return {"progress": current_progress, "current_step": self.status, "error": True}
@@ -477,13 +483,13 @@ class ProductTrialRequest(Document):
 						step.step_name, step.step_name
 					)
 					break
-			return {"progress": progress + 0.1, "current_step": current_running_step}
+			return {"progress": progress + 0.1, "current_step": current_running_step or self.status}
 
 		if self.status == "Error":
-			return {"progress": current_progress, "error": True}
+			return {"progress": current_progress, "current_step": self.status, "error": True}
 
 		# If agent job is undelivered, pending
-		return {"progress": current_progress + 0.1}
+		return {"progress": current_progress + 0.1, "current_step": self.status}
 
 	def prefill_setup_wizard_data(self):
 		if self.status == "Prefilling Setup Wizard":


### PR DESCRIPTION
## Summary
- keep signup provisioning polling active through Adding Domain
- update progress from the local visible value so it keeps moving between backend updates
- remove step-row UI and keep only the Progress label
- briefly show 100% / Almost there before redirecting to the created site
- add a dev-only mock route for local preview at /dashboard/dev/product-trial-progress

## Verification
- python AST parse for product_trial_request.py
- node --check dashboard/src/router.js
- git diff --check
- yarn build from dashboard/

Frappe tests not run; site name required.