### PR TITLE
fix(site): Skip host_name update when site domain is not yet active

### DIFF
--- a/press/press/doctype/agent_job/agent_job.py
+++ b/press/press/doctype/agent_job/agent_job.py
@@ -37,6 +37,7 @@ from press.utils import log_error, timer
 
 AGENT_LOG_KEY = "agent-jobs"
 AGENT_JOB_TIMEOUT_HOURS = 4
+CALLBACK_FAILURE_LIMIT = 5000
 
 BYPASS_AGENT_JOB_HALT = ["Change Bench Directory", "Remove Redis Localhost Bind"]
 
@@ -1174,6 +1175,15 @@ def process_job_updates(job_name: str, response_data: dict | None = None):  # no
 				reference_doctype="Agent Job",
 				reference_name=job_name,
 			)
+
+		if failure_count >= CALLBACK_FAILURE_LIMIT:
+			frappe.db.rollback()
+			frappe.db.set_value("Agent Job", job_name, "status", "Failure")
+			job.add_comment(
+				text=f"Callback processing stopped after {failure_count} failures.\n\n{traceback.format_exc()}"
+			)
+			return
+
 		log_update(job, start, e)
 		raise AgentCallbackException from e
 

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -4565,6 +4565,10 @@ def process_add_domain_job_update(job):
 		product_trial_request.update_status_from_agent_jobs()
 
 		site_domain = json.loads(job.request_data).get("domain")
+		site_domain_status = frappe.db.get_value("Site Domain", site_domain, "status")
+		if site_domain_status != "Active":
+			return
+
 		site = Site("Site", job.site)
 		auto_generated_domain = site.host_name
 		site.host_name = site_domain

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -4570,6 +4570,9 @@ def process_add_domain_job_update(job):
 			return
 
 		site = Site("Site", job.site)
+		if site.host_name == site_domain:
+			return  # already set by process_add_domain_to_upstream_job_update
+
 		auto_generated_domain = site.host_name
 		site.host_name = site_domain
 		site.save()

--- a/press/press/doctype/site_domain/site_domain.py
+++ b/press/press/doctype/site_domain/site_domain.py
@@ -247,10 +247,27 @@ def process_add_domain_to_upstream_job_update(job):
 	if updated_status != domain_status:
 		frappe.db.set_value("Site Domain", domain, "status", updated_status)
 
+	if updated_status == "Active" and job.site:
+		_set_product_trial_site_host_name(job.site, domain)
+
 	if job.status in ["Failure", "Delivery Failure"] and (
 		request := frappe.db.get_value("Product Trial Request", {"domain": domain})
 	):
 		frappe.get_doc("Product Trial Request", request).update_status_from_agent_jobs(job.data)
+
+
+def _set_product_trial_site_host_name(site_name: str, domain: str):
+	if not frappe.db.exists("Product Trial Request", {"site": site_name}):
+		return
+	from press.press.doctype.site.site import Site
+
+	site = Site("Site", site_name)
+	if site.host_name == domain:
+		return  # already set by process_add_domain_job_update
+	auto_generated_domain = site.host_name
+	site.host_name = domain
+	site.save()
+	site.set_redirect(auto_generated_domain)
 
 
 def update_dns_type():


### PR DESCRIPTION
- Agent jobs with persistent callback failures (≥ 5000) are now marked as Failure and a comment with the full exception traceback is added to the job, preventing endless retry loops
- Skip setting host_name in process_add_domain_job_update when the site domain is not yet Active, avoiding a race condition where the "Add Domain" job completes before "Add Domain to Upstream" sets the domain active
- https://github.com/frappe/press/pull/6794