### PR TITLE
chore(build): Aggressive docker system prunes

### DIFF
--- a/press/playbooks/roles/docker_system_prune/tasks/main.yml
+++ b/press/playbooks/roles/docker_system_prune/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Prune docker system for last 20h hours
-  command: 'docker system prune -af --filter "until=20h"'
+- name: Prune docker system for last 10h hours
+  command: 'docker system prune -af --filter "until=10h"'
   async: 7200
   poll: 30

--- a/press/playbooks/roles/docker_system_prune/tasks/main.yml
+++ b/press/playbooks/roles/docker_system_prune/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Prune docker system for last 10h hours
+- name: Prune docker system older than 10h
   command: 'docker system prune -af --filter "until=10h"'
   async: 7200
   poll: 30


### PR DESCRIPTION
`20h` filter is not enough with the increasing number of builds