### PR TITLE
feat(server): Warn users before downgrading server plan

### DIFF
--- a/dashboard/src/components/server/ServerPlansDialog.vue
+++ b/dashboard/src/components/server/ServerPlansDialog.vue
@@ -243,8 +243,12 @@ export default {
 					message: `
 						Are you sure you want to downgrade this server's plan from
 						<b>${fromPlan}</b> to <b>${toPlan}</b>?<br><br>
-						The new plan has fewer resources than the current one. Sites and
+						The new plan has fewer resources than the current one, so sites and
 						background jobs on this server may run slower or fail under load.
+						If you're not sure the smaller plan can handle this server's
+						workload, reach out at
+						<a href="https://support.frappe.io" target="_blank" class="underline">support.frappe.io</a>
+						before downgrading.
 					`,
 					primaryAction: {
 						label: 'Downgrade Plan',

--- a/dashboard/src/components/server/ServerPlansDialog.vue
+++ b/dashboard/src/components/server/ServerPlansDialog.vue
@@ -236,10 +236,8 @@ export default {
 					title: 'Downgrade Server Plan',
 					message: `
 						Are you sure you want to downgrade this server's plan?<br><br>
-						<div class="text-bg-base bg-surface-gray-2 p-2 rounded-md">
 						The new plan has fewer resources than the current one. Sites and
 						background jobs on this server may run slower or fail under load.
-						</div>
 					`,
 					primaryAction: {
 						label: 'Downgrade Plan',

--- a/dashboard/src/components/server/ServerPlansDialog.vue
+++ b/dashboard/src/components/server/ServerPlansDialog.vue
@@ -167,6 +167,7 @@
 </template>
 <script>
 import { Checkbox, getCachedDocumentResource, Spinner } from 'frappe-ui'
+import { confirmDialog } from '../../utils/components'
 import ServerPlansCards from './ServerPlansCards.vue'
 
 export default {
@@ -230,6 +231,28 @@ export default {
 		changePlan() {
 			// TODO: Add confirmation dialog for hetzner plan upgrade
 
+			if (this.isDowngrade) {
+				return confirmDialog({
+					title: 'Downgrade Server Plan',
+					message: `
+						Are you sure you want to downgrade this server's plan?<br><br>
+						<div class="text-bg-base bg-surface-gray-2 p-2 rounded-md">
+						The new plan has fewer resources than the current one. Sites and
+						background jobs on this server may run slower or fail under load.
+						</div>
+					`,
+					primaryAction: {
+						label: 'Downgrade Plan',
+						variant: 'solid',
+						theme: 'red',
+						onClick: ({ hide }) => this.submitPlanChange().then(hide),
+					},
+				})
+			}
+
+			return this.submitPlanChange()
+		},
+		submitPlanChange() {
 			return this.$server.changePlan.submit(
 				{
 					plan: this.plan.name,
@@ -282,6 +305,16 @@ export default {
 				plans = this.serverPlans.filter((p) => p.premium === 0)
 			}
 			return plans.filter((plan) => plan.plan_type === this.serverPlanType)
+		},
+		isDowngrade() {
+			const currentPlan = this.$server?.doc?.current_plan
+			if (!this.plan || !currentPlan) return false
+			// A plan with fewer resources than the current one is a downgrade.
+			return (
+				this.plan.vcpu < currentPlan.vcpu ||
+				this.plan.memory < currentPlan.memory ||
+				this.plan.disk < currentPlan.disk
+			)
 		},
 	},
 }

--- a/dashboard/src/components/server/ServerPlansDialog.vue
+++ b/dashboard/src/components/server/ServerPlansDialog.vue
@@ -232,10 +232,15 @@ export default {
 			// TODO: Add confirmation dialog for hetzner plan upgrade
 
 			if (this.isDowngrade) {
+				const fromPlan = this.$format.planTitle(this.$server.doc.current_plan)
+				const toPlan = this.$format.planTitle(this.plan)
+				// Hide the Change Plan dialog so the confirmation isn't stacked on top of it.
+				this.show = false
 				return confirmDialog({
 					title: 'Downgrade Server Plan',
 					message: `
-						Are you sure you want to downgrade this server's plan?<br><br>
+						Are you sure you want to downgrade this server's plan from
+						<b>${fromPlan}/mo</b> to <b>${toPlan}/mo</b>?<br><br>
 						The new plan has fewer resources than the current one. Sites and
 						background jobs on this server may run slower or fail under load.
 					`,

--- a/dashboard/src/components/server/ServerPlansDialog.vue
+++ b/dashboard/src/components/server/ServerPlansDialog.vue
@@ -232,15 +232,17 @@ export default {
 			// TODO: Add confirmation dialog for hetzner plan upgrade
 
 			if (this.isDowngrade) {
-				const fromPlan = this.$format.planTitle(this.$server.doc.current_plan)
-				const toPlan = this.$format.planTitle(this.plan)
+				const planLabel = (plan) =>
+					`${this.$format.planTitle(plan)}/mo (${plan.vcpu} vCPU / ${this.$format.bytes(plan.memory, 0, 2)} RAM)`
+				const fromPlan = planLabel(this.$server.doc.current_plan)
+				const toPlan = planLabel(this.plan)
 				// Hide the Change Plan dialog so the confirmation isn't stacked on top of it.
 				this.show = false
 				return confirmDialog({
 					title: 'Downgrade Server Plan',
 					message: `
 						Are you sure you want to downgrade this server's plan from
-						<b>${fromPlan}/mo</b> to <b>${toPlan}/mo</b>?<br><br>
+						<b>${fromPlan}</b> to <b>${toPlan}</b>?<br><br>
 						The new plan has fewer resources than the current one. Sites and
 						background jobs on this server may run slower or fail under load.
 					`,


### PR DESCRIPTION
### Problem

Closes #6118

Users can downgrade a server's plan with a single click. Moving to a plan with fewer resources (vCPU, memory, or disk) can cause sites and background jobs on that server to run slower or fail under load, but there is currently no warning before the change is applied.

### Solution

In the server **Change Plan** dialog (`ServerPlansDialog.vue`), detect when the selected plan has fewer resources than the current plan and show a confirmation dialog before submitting:

- Added an `isDowngrade` computed that compares the selected plan's `vcpu` / `memory` / `disk` against the server's `current_plan`.
- `changePlan()` now routes downgrades through a red-themed `confirmDialog` warning; the plan change is only submitted after explicit confirmation.
- Upgrades and same-tier changes are unaffected — they submit directly with no extra prompt.

Reuses the existing `confirmDialog` helper and styling for consistency with other destructive confirmations (e.g. site deactivation).

### How to test

1. Open a server's **Change Plan** dialog.
2. Select a plan smaller than the current one → the "Downgrade Server Plan" warning appears and only proceeds on confirmation.
3. Select a larger plan → submits with no warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)