### PR TITLE
feat(server): Add plan support filter in dedicated server sites tab

### DIFF
--- a/dashboard/src/objects/server.js
+++ b/dashboard/src/objects/server.js
@@ -322,6 +322,16 @@ export default {
 								options: ['', 'Active', 'Inactive', 'Suspended', 'Broken'],
 							},
 							{
+								type: 'select',
+								label: 'Plan',
+								fieldname: 'plan.support_included',
+								options: [
+									{ label: 'All', value: null },
+									{ label: 'Supported', value: '1' },
+									{ label: 'Not Supported', value: '0' },
+								],
+							},
+							{
 								type: 'link',
 								label: 'Version',
 								fieldname: 'group.version',


### PR DESCRIPTION
## Summary

- Adds a **Plan** filter to the Sites tab on the dedicated server page
- Filter options: **All**, **Supported**, **Not Supported** — backed by `plan.support_included`
- Allows operators to instantly identify which sites on a dedicated server have active product warranty / support coverage without scrolling through the full list

## Test plan

- [ ] Go to **Servers → \<dedicated server\> → Sites**
- [ ] Confirm the **Plan** filter appears next to Status
- [ ] Select **Supported** — only sites on plans with `support_included = 1` should appear
- [ ] Select **Not Supported** — only sites on plans with `support_included = 0` should appear
- [ ] Select **All** — all sites are shown (filter cleared)

Fixes #6647

🤖 Generated with [Claude Code](https://claude.com/claude-code)