### PR TITLE
fix(restore): carry over site config in restore_site_from_files

### DIFF
--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1234,7 +1234,7 @@ class Site(Document, TagHelpers):
 	@dashboard_whitelist()
 	@site_action(["Active", "Broken"])
 	def restore_site_from_files(self, files, skip_failing_patches=False):
-		for key in ("database", "public", "private"):
+		for key in ("database", "public", "private", "config"):
 			rf_name = files.get(key)
 			if rf_name:
 				rf_team = frappe.db.get_value("Remote File", rf_name, "team")
@@ -1246,6 +1246,7 @@ class Site(Document, TagHelpers):
 		self.remote_database_file = files["database"]
 		self.remote_public_file = files["public"]
 		self.remote_private_file = files["private"]
+		self.remote_config_file = files.get("config", "")
 		self.save()
 		self.reload()
 		return self.restore_site(skip_failing_patches=skip_failing_patches)


### PR DESCRIPTION
## Problem

The offsite-backup **Restore** action in the dashboard sends the backup's `remote_config_file` in its `files` payload:

https://github.com/frappe/press/blob/develop/dashboard/src/objects/site.js#L920-L926

```js
site.restoreSiteFromFiles.submit({
  files: {
    database: row.remote_database_file,
    public: row.remote_public_file,
    private: row.remote_private_file,
    config: row.remote_config_file,
  },
})
```

But `Site.restore_site_from_files` only persisted `database`/`public`/`private` and silently dropped `config`. As a result the site's `remote_config_file` was never updated for this path, so the agent received no `sanitized_config_content`. For **encrypted** backups this means `bench restore` had no `backup_encryption_key` to decrypt with.

## Fix

Persist `remote_config_file` from the payload and include it in the per-file team-ownership check, mirroring the REST `press.api.site.restore` route which already handled config (`files.get("config", "")`).

```python
for key in ("database", "public", "private", "config"):
    ...
self.remote_config_file = files.get("config", "")
```

Using `.get("config", "")` keeps other/internal callers unaffected and clears any stale value so the restore reflects exactly the files chosen.

## Scope / verification

- Only the **offsite-backup restore** button (`site.js:920`) calls `restore_site_from_files` — that's the affected path.
- The two action dialogs ("Restore with files" → `SiteDatabaseRestoreDialog.vue`, "Restore from an existing site" → `SiteDatabaseRestoreFromURLDialog.vue`) submit to `press.api.site.restore`, which already persisted config — they were not affected and need no change.
- Downstream unchanged: `restore_site` validates the config file exists on S3, and `Agent.restore_site` sanitizes it + forces `maintenance_mode: 0` before sending `sanitized_config_content` to the agent.

No tests run as part of this change.