### PR TITLE
fix(site): Disable subscription when site creation fails

### DIFF
--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -4502,6 +4502,11 @@ def process_new_site_job_update(job):  # noqa: C901
 
 		site.sync_apps()  # Sync apps for this site as well to reflect dependant apps
 		marketplace_app_hook(site=site, op="install")
+		# Status is set via db.set_value below, bypassing on_update ->
+		# update_subscription. Re-enable the subscription explicitly so a site
+		# that recovers from a failed creation (retry / restore) starts billing
+		# again — the counterpart to disabling it on failure (#6110).
+		site.enable_subscription()
 	elif "Failure" in (first, second) or "Delivery Failure" in (first, second):
 		updated_status = "Broken"
 		frappe.db.set_value("Site", job.site, "creation_failed", frappe.utils.now())

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -4505,6 +4505,10 @@ def process_new_site_job_update(job):  # noqa: C901
 	elif "Failure" in (first, second) or "Delivery Failure" in (first, second):
 		updated_status = "Broken"
 		frappe.db.set_value("Site", job.site, "creation_failed", frappe.utils.now())
+		# Status is set via db.set_value below, which bypasses on_update ->
+		# update_subscription. Disable the subscription explicitly so the user
+		# isn't billed for a site that never came up (#6110).
+		Site("Site", job.site).disable_subscription()
 	elif "Running" in (first, second):
 		updated_status = "Installing"
 	else:

--- a/press/press/doctype/site/test_site.py
+++ b/press/press/doctype/site/test_site.py
@@ -647,6 +647,36 @@ class TestSite(FrappeTestCase):
 		self.assertEqual(frappe.db.get_value("Site", site.name, "status"), "Broken")
 		self.assertFalse(frappe.db.get_value("Subscription", subscription.name, "enabled"))
 
+	def test_subscription_is_reenabled_when_site_recovers_to_active(self):
+		"""A site recovering from a failed creation (retry/restore success) must re-enable the subscription (#6110)."""
+		from press.press.doctype.agent_job.test_agent_job import create_test_agent_job
+
+		plan = create_test_plan("Site", plan_name="USD 10")
+		site: Site = create_test_site(plan=plan.name)
+		site.create_subscription(plan=plan.name)
+		subscription = frappe.get_doc("Subscription", {"document_type": "Site", "document_name": site.name})
+
+		# Reproduce the disabled + Broken state left behind by a failed creation.
+		site.disable_subscription()
+		frappe.db.set_value("Site", site.name, "status", "Broken")
+		self.assertFalse(frappe.db.get_value("Subscription", subscription.name, "enabled"))
+
+		# Both creation jobs now succeed (retry / restore).
+		create_test_agent_job("Add Site to Upstream", server=site.server, status="Success").db_set(
+			"site", site.name
+		)
+		success_job = create_test_agent_job("New Site", server=site.server, status="Success")
+		success_job.db_set("site", site.name)
+
+		with (
+			patch.object(Site, "sync_apps", new=Mock()),
+			patch("press.press.doctype.site.site.marketplace_app_hook", new=Mock()),
+		):
+			process_new_site_job_update(success_job)
+
+		self.assertEqual(frappe.db.get_value("Site", site.name, "status"), "Active")
+		self.assertTrue(frappe.db.get_value("Subscription", subscription.name, "enabled"))
+
 	def test_reset_disk_usage_exceed_alert_on_changing_plan(self):
 		team = create_test_team()
 		plan_10 = create_test_plan("Site", price_usd=10.0, price_inr=750.0, plan_name="USD 10")

--- a/press/press/doctype/site/test_site.py
+++ b/press/press/doctype/site/test_site.py
@@ -35,6 +35,7 @@ from press.press.doctype.site.site import (
 	Site,
 	archive_suspended_sites,
 	notify_sites_before_archival,
+	process_new_site_job_update,
 	process_rename_site_job_update,
 	suspend_sites_exceeding_disk_usage_for_last_14_days,
 )
@@ -626,6 +627,25 @@ class TestSite(FrappeTestCase):
 		self.assertFalse(site.site_usage_exceeded)
 		self.assertIsNone(site.site_usage_exceeded_on)
 		self.assertEqual(site.status, "Active")
+
+	def test_subscription_is_disabled_when_site_creation_fails(self):
+		"""A failed site creation must disable the subscription so the user isn't billed (#6110)."""
+		from press.press.doctype.agent_job.test_agent_job import create_test_agent_job
+
+		plan = create_test_plan("Site", plan_name="USD 10")
+		site: Site = create_test_site(plan=plan.name)
+		site.create_subscription(plan=plan.name)
+
+		subscription = frappe.get_doc("Subscription", {"document_type": "Site", "document_name": site.name})
+		self.assertTrue(subscription.enabled)
+
+		job = create_test_agent_job("New Site", server=site.server, status="Failure")
+		job.db_set("site", site.name)
+
+		process_new_site_job_update(job)
+
+		self.assertEqual(frappe.db.get_value("Site", site.name, "status"), "Broken")
+		self.assertFalse(frappe.db.get_value("Subscription", subscription.name, "enabled"))
 
 	def test_reset_disk_usage_exceed_alert_on_changing_plan(self):
 		team = create_test_team()


### PR DESCRIPTION
### Problem

Closes #6110

When site creation fails, the site is marked **Broken** but the **Subscription** created during `Site.after_insert` stays enabled — so the user keeps getting billed for a site that never came up.

### Root cause

`process_new_site_job_update` sets the site status with `frappe.db.set_value(...)`, which bypasses the document's `on_update` hook. That hook (`update_subscription`) is what normally disables the subscription for `Broken`/`Archived`/`Suspended` sites and re-enables it for `Active` ones. Because it never runs in this path, the subscription state is never updated on create/fail/recover.

### Fix

In `process_new_site_job_update`, manage the subscription explicitly (reusing the existing `Site` methods), mirroring what `on_update` would have done:

- **Failure branch** → `disable_subscription()` so the user isn't billed for a broken site.
- **Success branch** → `enable_subscription()` so a site that **recovers** from a failed creation (a `New Site` retry or a restore — the only forward paths, since `check_allowed_actions` blocks `activate` on a creation-failed site) starts billing again. Idempotent for sites whose subscription was never disabled.

Other flows (manual activate/suspend, etc.) already go through `on_update` and are unaffected.

### Tests

- `test_subscription_is_disabled_when_site_creation_fails` — failed `New Site` job → site `Broken` **and** subscription disabled.
- `test_subscription_is_reenabled_when_site_recovers_to_active` — a disabled/Broken site whose creation jobs then succeed → site `Active` **and** subscription re-enabled.

Full `test_site` module passes (36 tests); `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)