### PR TITLE
fix(restore): carry over site config in restore_site_from_files

### DIFF
--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1222,9 +1222,19 @@ class Site(Document, TagHelpers):
 	@dashboard_whitelist()
 	@site_action(["Active", "Broken"])
 	def restore_site_from_files(self, files, skip_failing_patches=False):
+		for key in ("database", "public", "private", "config"):
+			rf_name = files.get(key)
+			if rf_name:
+				rf_team = frappe.db.get_value("Remote File", rf_name, "team")
+				if rf_team is not None and rf_team != self.team:
+					frappe.throw(
+						_("Remote File {0} does not belong to site's team").format(rf_name),
+						frappe.PermissionError,
+					)
 		self.remote_database_file = files["database"]
 		self.remote_public_file = files["public"]
 		self.remote_private_file = files["private"]
+		self.remote_config_file = files.get("config", "")
 		self.save()
 		self.reload()
 		return self.restore_site(skip_failing_patches=skip_failing_patches)


### PR DESCRIPTION
Backport of #6808 to `master`.

## Problem

The offsite-backup **Restore** action in the dashboard sends the backup's `remote_config_file` in its `files` payload (`dashboard/src/objects/site.js`):

```js
site.restoreSiteFromFiles.submit({
  files: {
    database: row.remote_database_file,
    public: row.remote_public_file,
    private: row.remote_private_file,
    config: row.remote_config_file,
  },
})
```

But `Site.restore_site_from_files` only persisted `database`/`public`/`private` and silently dropped `config`. As a result the site's `remote_config_file` was never updated for this path, so the agent received no `sanitized_config_content`. For **encrypted** backups this means `bench restore` had no `backup_encryption_key` to decrypt with.

The agent side is already equipped: `Agent.restore_site` sanitizes the config and `restore_job` applies it (`update_config`) before `bench restore`. The only missing link was Press persisting the config file on this path.

## Fix

Persist `remote_config_file` from the payload and include it in the per-file team-ownership check, mirroring the REST `press.api.site.restore` route which already handled config.

```python
for key in ("database", "public", "private", "config"):
    ...
self.remote_config_file = files.get("config", "")
```

Using `.get("config", "")` keeps other/internal callers unaffected and clears any stale value so the restore reflects exactly the files chosen.

> Note: `master` did not previously have the per-file team-ownership validation loop (it's present on `develop`). This backport brings the full loop — including the `config` key — so the function body converges to the same state on both branches and the config Remote File is validated for team ownership like the rest.

## Scope

- Only the **offsite-backup restore** button calls `restore_site_from_files` — that's the affected path.
- The two action dialogs ("Restore with files", "Restore from an existing site") submit to `press.api.site.restore`, which already persisted config — not affected.

No tests run as part of this change.