### PR TITLE
fix(nat): enable dhcp and ignore its routes in nat config

### DIFF
--- a/press/playbooks/roles/nat_iptables/tasks/main.yml
+++ b/press/playbooks/roles/nat_iptables/tasks/main.yml
@@ -15,8 +15,12 @@
     dest: /etc/netplan/99-custom-gateway.yaml
     content: |
       network:
+        version: 2
         ethernets:
           {{ ansible_default_ipv4.interface }}:
+            dhcp4: true
+            dhcp4-overrides:
+              use-routes: false
             routes:
               - to: default
                 via: {{ nat_gateway_ip }}


### PR DESCRIPTION
for trying in frankfurt cluster

according to gemini:

In AWS, if two instances are in the same subnet, they receive the same default gateway (the AWS .1 address) via DHCP

`use-routes: false`: By explicitly defining this, you instruct systemd-networkd (or NetworkManager) to bind the private IP allocated by AWS DHCP but drop the standard AWS .1 gateway route before it hit the kernel's routing table