### PR TITLE
fix(virtual-machine): Give hetzner more default wait time for ssh

### DIFF
--- a/press/press/doctype/virtual_machine/virtual_machine.py
+++ b/press/press/doctype/virtual_machine/virtual_machine.py
@@ -1663,7 +1663,7 @@ class VirtualMachine(Document):
 		result = ping.run()
 		return result.status == "Success"
 
-	def wait_for_ssh(self, timeout=120, interval=2):
+	def wait_for_ssh(self, timeout=500, interval=2):
 		server_doc = frappe.db.get_value(
 			"Server",
 			{


### PR DESCRIPTION
- Sometimes on Hetzner VMs, `systemd-networkd-wait-online.service` waits for its full 2-minute timeout before the network becomes available, delaying SSH readiness.