### PR TITLE
feat(site): Add migration shortcuts to the Actions tab

### DIFF
--- a/dashboard/src/components/SiteActions.vue
+++ b/dashboard/src/components/SiteActions.vue
@@ -22,12 +22,10 @@
 			</AlertBanner>
 			<!-- Migration shortcuts: deep-link to the Migrations tab with the dialog
 			     opened and the right migration type preselected. -->
-			<template
-				v-if="group.group == 'General Actions' && $site?.doc?.status !== 'Archived'"
-			>
+			<template v-if="$site?.doc?.status !== 'Archived'">
 				<div
 					class="py-3 first:pt-0 last:pb-0"
-					v-for="shortcut in migrationShortcuts"
+					v-for="shortcut in migrationShortcutsFor(group.group)"
 					:key="shortcut.action"
 				>
 					<div class="flex items-center justify-between gap-1">
@@ -41,7 +39,15 @@
 							class="whitespace-nowrap"
 							@click="openMigration(shortcut.action)"
 						>
-							{{ shortcut.buttonLabel }}
+							<p
+								:class="
+									group.group === 'Dangerous Actions'
+										? 'text-red-600'
+										: 'text-ink-gray-8'
+								"
+							>
+								{{ shortcut.buttonLabel }}
+							</p>
 						</Button>
 					</div>
 				</div>
@@ -77,7 +83,8 @@ export default {
 	data() {
 		return {
 			// `action` matches the keys returned by Site.get_migration_options, which
-			// the migration dialog uses to preselect the migration type.
+			// the migration dialog uses to preselect the migration type. `group`
+			// places the shortcut under the matching site action section.
 			migrationShortcuts: [
 				{
 					label: 'In-Place Migrate Site',
@@ -85,18 +92,21 @@ export default {
 					description:
 						'Run bench migrate on the current bench to apply pending patches and schema changes.',
 					buttonLabel: 'Migrate Site',
+					group: 'Dangerous Actions',
 				},
 				{
 					label: 'Move to a Different Server / Bench',
 					action: 'Move Site To Different Server / Bench',
 					description: 'Move this site to another private bench or server.',
 					buttonLabel: 'Move Site',
+					group: 'General Actions',
 				},
 				{
 					label: 'Move to a Different Region',
 					action: 'Move Site To Different Region',
 					description: 'Move this site to a bench in another region.',
 					buttonLabel: 'Move Site',
+					group: 'General Actions',
 				},
 			],
 		}
@@ -122,6 +132,11 @@ export default {
 		},
 	},
 	methods: {
+		migrationShortcutsFor(group) {
+			return this.migrationShortcuts.filter(
+				(shortcut) => shortcut.group === group,
+			)
+		},
 		openSiteMigrationsDoc() {
 			window.open(
 				'https://docs.frappe.io/cloud/site/site-migrations/introduction-to-site-migration',

--- a/dashboard/src/components/SiteActions.vue
+++ b/dashboard/src/components/SiteActions.vue
@@ -1,34 +1,5 @@
 <template>
 	<div class="mx-auto max-w-3xl space-y-4" v-if="$site?.doc?.actions">
-		<!-- Migration shortcuts: deep-link to the Migrations tab with the modal
-		     opened and the right migration type preselected. -->
-		<div
-			v-if="$site?.doc?.status !== 'Archived'"
-			class="divide-y rounded border border-outline-gray-1 p-5"
-		>
-			<div class="pb-3 text-lg font-semibold">Migrations</div>
-			<div
-				class="py-3 first:pt-0 last:pb-0"
-				v-for="shortcut in migrationShortcuts"
-				:key="shortcut.action"
-			>
-				<div class="flex items-center justify-between gap-1">
-					<div>
-						<h3 class="text-base font-medium">{{ shortcut.label }}</h3>
-						<p class="mt-1 text-p-base text-ink-gray-6">
-							{{ shortcut.description }}
-						</p>
-					</div>
-					<Button
-						class="whitespace-nowrap"
-						@click="openMigration(shortcut.action)"
-					>
-						{{ shortcut.buttonLabel }}
-					</Button>
-				</div>
-			</div>
-		</div>
-
 		<div
 			v-for="group in actions"
 			:key="group.group"
@@ -49,6 +20,32 @@
 					View Documentation
 				</Button>
 			</AlertBanner>
+			<!-- Migration shortcuts: deep-link to the Migrations tab with the dialog
+			     opened and the right migration type preselected. -->
+			<template
+				v-if="group.group == 'General Actions' && $site?.doc?.status !== 'Archived'"
+			>
+				<div
+					class="py-3 first:pt-0 last:pb-0"
+					v-for="shortcut in migrationShortcuts"
+					:key="shortcut.action"
+				>
+					<div class="flex items-center justify-between gap-1">
+						<div>
+							<h3 class="text-base font-medium">{{ shortcut.label }}</h3>
+							<p class="mt-1 text-p-base text-ink-gray-6">
+								{{ shortcut.description }}
+							</p>
+						</div>
+						<Button
+							class="whitespace-nowrap"
+							@click="openMigration(shortcut.action)"
+						>
+							{{ shortcut.buttonLabel }}
+						</Button>
+					</div>
+				</div>
+			</template>
 			<div
 				class="py-3 first:pt-0 last:pb-0"
 				v-for="row in group.actions"

--- a/dashboard/src/components/SiteActions.vue
+++ b/dashboard/src/components/SiteActions.vue
@@ -1,5 +1,34 @@
 <template>
 	<div class="mx-auto max-w-3xl space-y-4" v-if="$site?.doc?.actions">
+		<!-- Migration shortcuts: deep-link to the Migrations tab with the modal
+		     opened and the right migration type preselected. -->
+		<div
+			v-if="$site?.doc?.status !== 'Archived'"
+			class="divide-y rounded border border-outline-gray-1 p-5"
+		>
+			<div class="pb-3 text-lg font-semibold">Migrations</div>
+			<div
+				class="py-3 first:pt-0 last:pb-0"
+				v-for="shortcut in migrationShortcuts"
+				:key="shortcut.action"
+			>
+				<div class="flex items-center justify-between gap-1">
+					<div>
+						<h3 class="text-base font-medium">{{ shortcut.label }}</h3>
+						<p class="mt-1 text-p-base text-ink-gray-6">
+							{{ shortcut.description }}
+						</p>
+					</div>
+					<Button
+						class="whitespace-nowrap"
+						@click="openMigration(shortcut.action)"
+					>
+						{{ shortcut.buttonLabel }}
+					</Button>
+				</div>
+			</div>
+		</div>
+
 		<div
 			v-for="group in actions"
 			:key="group.group"
@@ -38,32 +67,61 @@
 	</div>
 </template>
 <script>
-import { getCachedDocumentResource } from 'frappe-ui';
-import SiteActionCell from './SiteActionCell.vue';
-import AlertBanner from './AlertBanner.vue';
+import { getCachedDocumentResource } from 'frappe-ui'
+import { defineAsyncComponent, h } from 'vue'
+import { renderDialog } from '../utils/components'
+import AlertBanner from './AlertBanner.vue'
+import SiteActionCell from './SiteActionCell.vue'
 
 export default {
 	name: 'SiteActions',
 	props: ['site'],
 	components: { SiteActionCell, AlertBanner },
+	data() {
+		return {
+			// `action` matches the keys returned by Site.get_migration_options, which
+			// the migration dialog uses to preselect the migration type.
+			migrationShortcuts: [
+				{
+					label: 'In-Place Migrate Site',
+					action: 'In-Place Migrate Site',
+					description:
+						'Run bench migrate on the current bench to apply pending patches and schema changes.',
+					buttonLabel: 'Migrate Site',
+				},
+				{
+					label: 'Move to a Different Server / Bench',
+					action: 'Move Site To Different Server / Bench',
+					description: 'Move this site to another private bench or server.',
+					buttonLabel: 'Move Site',
+				},
+				{
+					label: 'Move to a Different Region',
+					action: 'Move Site To Different Region',
+					description: 'Move this site to a bench in another region.',
+					buttonLabel: 'Move Site',
+				},
+			],
+		}
+	},
 	computed: {
 		$site() {
-			return getCachedDocumentResource('Site', this.site);
+			return getCachedDocumentResource('Site', this.site)
 		},
 		actions() {
 			const groupedActions = this.$site.doc.actions.reduce((acc, action) => {
-				const group = action.group || 'General Actions';
+				const group = action.group || 'General Actions'
 				if (!acc[group]) {
-					acc[group] = [];
+					acc[group] = []
 				}
-				acc[group].push(action);
-				return acc;
-			}, {});
+				acc[group].push(action)
+				return acc
+			}, {})
 
 			return Object.keys(groupedActions).map((group) => ({
 				group,
 				actions: groupedActions[group],
-			}));
+			}))
 		},
 	},
 	methods: {
@@ -71,8 +129,25 @@ export default {
 			window.open(
 				'https://docs.frappe.io/cloud/site/site-migrations/introduction-to-site-migration',
 				'_blank',
-			);
+			)
+		},
+		openMigration(action) {
+			// Land the user on the Migrations tab, then open the migration dialog
+			// with the chosen migration type preselected.
+			this.$router
+				.push({
+					name: 'Site Detail Migrations',
+					params: { name: this.site },
+				})
+				.then(() => {
+					renderDialog(
+						h(
+							defineAsyncComponent(() => import('./site/SiteMigration.vue')),
+							{ site: this.site, defaultAction: action },
+						),
+					)
+				})
 		},
 	},
-};
+}
 </script>


### PR DESCRIPTION
### What

Adds a **Migrations** card at the top of a site's **Actions** tab with a shortcut for each migration type:

- **In-Place Migrate Site** → *Migrate Site*
- **Move to a Different Server / Bench** → *Move Site*
- **Move to a Different Region** → *Move Site*

Clicking a shortcut routes the user to the **Migrations** tab and opens the migration dialog with the matching migration type **preselected** in the "Select Migration Type" dropdown.

### Why

The bench/server/region migration options were moved to the Migrations tab and are easy to miss from Actions (the Actions tab only shows a "moved to Migrations Tab" banner). These shortcuts make the common migrations discoverable and one click away, landing the user directly on the right choice.

### How

- New `migrationShortcuts` list in `SiteActions.vue`; each entry's `action` matches a key returned by `Site.get_migration_options`.
- `openMigration(action)` pushes to `Site Detail Migrations` and renders the existing `SiteMigration.vue` dialog with `defaultAction`.
- No backend change — reuses the dialog's existing `autoSelectMigrationOption()`, which already preselects from `defaultAction` / `?action=`.
- The card is hidden for `Archived` sites (matching the Migrations tab's own condition).

### Testing

Verified locally: the card renders in the Actions tab, and clicking a shortcut navigates to the Migrations tab and opens the dialog with the correct type preselected (e.g. "In-Place Migrate Site").

🤖 Generated with [Claude Code](https://claude.com/claude-code)