### PR TITLE
feat(billing): Add a Subscriptions tab to view the team's subscriptions

### DIFF
--- a/dashboard/src/pages/Billing.vue
+++ b/dashboard/src/pages/Billing.vue
@@ -40,6 +40,7 @@ export default {
 		tabs() {
 			const baseTabs = [
 				{ label: 'Overview', route: { name: 'BillingOverview' } },
+				{ label: 'Subscriptions', route: { name: 'BillingSubscriptions' } },
 				{ label: 'Forecast', route: { name: 'BillingForecast' } },
 				{ label: 'Invoices', route: { name: 'BillingInvoices' } },
 				{ label: 'Balances', route: { name: 'BillingBalances' } },
@@ -48,16 +49,15 @@ export default {
 					label: 'Marketplace Payouts',
 					route: { name: 'BillingMarketplacePayouts' },
 				},
-				{ label: 'Subscriptions', route: { name: 'BillingSubscriptions' } },
 			]
 
 			if (this.$team?.doc?.apply_limits && this.$team?.doc?.tier) {
 				baseTabs.push({ label: 'Limits', route: { name: 'BillingTiers' } })
 			}
 
-			// Add UPI Autopay tab for INR teams
+			// Add UPI Autopay tab for INR teams (before Marketplace Payouts)
 			if (this.$team?.doc?.currency === 'INR') {
-				baseTabs.splice(5, 0, {
+				baseTabs.splice(6, 0, {
 					label: 'UPI Autopay',
 					route: { name: 'BillingUPIAutopay' },
 				})

--- a/dashboard/src/pages/Billing.vue
+++ b/dashboard/src/pages/Billing.vue
@@ -48,6 +48,7 @@ export default {
 					label: 'Marketplace Payouts',
 					route: { name: 'BillingMarketplacePayouts' },
 				},
+				{ label: 'Subscriptions', route: { name: 'BillingSubscriptions' } },
 			]
 
 			if (this.$team?.doc?.apply_limits && this.$team?.doc?.tier) {

--- a/dashboard/src/pages/BillingSubscriptions.vue
+++ b/dashboard/src/pages/BillingSubscriptions.vue
@@ -1,0 +1,100 @@
+<template>
+	<div class="p-5">
+		<div
+			v-if="$resources.subscriptions.loading"
+			class="flex items-center justify-center py-20"
+		>
+			<Spinner class="h-4 w-4 text-ink-gray-6" />
+		</div>
+		<div v-else class="mx-auto max-w-3xl space-y-4">
+			<!-- Sites -->
+			<div class="divide-y rounded border border-outline-gray-1 p-5">
+				<div class="pb-3 text-lg font-semibold">Sites</div>
+				<p v-if="!data.sites.length" class="py-3 text-p-base text-ink-gray-5">
+					No active site subscriptions.
+				</p>
+				<div
+					v-for="site in data.sites"
+					:key="site.name"
+					class="flex items-center justify-between gap-2 py-3 first:pt-0 last:pb-0"
+				>
+					<span class="text-base text-ink-gray-9">{{ site.name }}</span>
+					<Badge v-if="site.plan" theme="gray" :label="site.plan" />
+				</div>
+			</div>
+
+			<!-- Servers -->
+			<div class="divide-y rounded border border-outline-gray-1 p-5">
+				<div class="pb-3 text-lg font-semibold">Servers</div>
+				<p v-if="!data.servers.length" class="py-3 text-p-base text-ink-gray-5">
+					No active server subscriptions.
+				</p>
+				<div
+					v-for="server in data.servers"
+					:key="server.name"
+					class="flex items-center justify-between gap-2 py-3 first:pt-0 last:pb-0"
+				>
+					<span class="text-base text-ink-gray-9">{{ server.name }}</span>
+					<Badge v-if="server.plan" theme="gray" :label="server.plan" />
+				</div>
+			</div>
+
+			<!-- Marketplace Apps -->
+			<div class="divide-y rounded border border-outline-gray-1 p-5">
+				<div class="pb-3 text-lg font-semibold">Marketplace Apps</div>
+				<p
+					v-if="!data.marketplace_apps.length"
+					class="py-3 text-p-base text-ink-gray-5"
+				>
+					No active marketplace app subscriptions.
+				</p>
+				<div
+					v-for="app in data.marketplace_apps"
+					:key="app.name"
+					class="py-3 first:pt-0 last:pb-0"
+				>
+					<div class="flex items-center justify-between gap-2">
+						<span class="text-base font-medium text-ink-gray-9">
+							{{ app.title }}
+						</span>
+						<Badge v-if="app.plan" theme="gray" :label="app.plan" />
+					</div>
+					<div class="mt-1 text-p-base text-ink-gray-6">
+						<span v-if="app.sites.length">
+							Installed on: {{ app.sites.join(', ') }}
+						</span>
+						<span v-else>Not installed on any site.</span>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+<script>
+import { Badge, Spinner } from 'frappe-ui'
+
+export default {
+	name: 'BillingSubscriptions',
+	components: { Badge, Spinner },
+	resources: {
+		subscriptions() {
+			return {
+				url: 'press.api.billing.subscriptions',
+				auto: true,
+				initialData: { sites: [], servers: [], marketplace_apps: [] },
+			}
+		},
+	},
+	computed: {
+		data() {
+			return (
+				this.$resources.subscriptions.data || {
+					sites: [],
+					servers: [],
+					marketplace_apps: [],
+				}
+			)
+		},
+	},
+}
+</script>

--- a/dashboard/src/pages/BillingSubscriptions.vue
+++ b/dashboard/src/pages/BillingSubscriptions.vue
@@ -6,64 +6,119 @@
 		>
 			<Spinner class="h-4 w-4 text-ink-gray-6" />
 		</div>
-		<div v-else class="mx-auto max-w-3xl space-y-4">
+		<div v-else class="mx-auto max-w-3xl space-y-5">
 			<!-- Sites -->
-			<div class="divide-y rounded border border-outline-gray-1 p-5">
-				<div class="pb-3 text-lg font-semibold">Sites</div>
-				<p v-if="!data.sites.length" class="py-3 text-p-base text-ink-gray-5">
-					No active site subscriptions.
-				</p>
+			<div class="overflow-hidden rounded-lg border border-outline-gray-2">
 				<div
-					v-for="site in data.sites"
-					:key="site.name"
-					class="flex items-center justify-between gap-2 py-3 first:pt-0 last:pb-0"
+					class="flex items-center gap-2 border-b border-outline-gray-2 bg-surface-gray-1 px-4 py-3"
 				>
-					<span class="text-base text-ink-gray-9">{{ site.name }}</span>
-					<Badge v-if="site.plan" theme="gray" :label="site.plan" />
+					<lucide-panel-top class="h-4 w-4 text-ink-gray-6" />
+					<h3 class="text-base font-medium text-ink-gray-9">Sites</h3>
+					<span class="text-p-sm text-ink-gray-5">{{ data.sites.length }}</span>
+				</div>
+				<div class="divide-y divide-outline-gray-1">
+					<p
+						v-if="!data.sites.length"
+						class="px-4 py-6 text-center text-p-base text-ink-gray-5"
+					>
+						No active site subscriptions.
+					</p>
+					<div
+						v-for="site in data.sites"
+						:key="site.name"
+						class="flex items-center justify-between gap-2 px-4 py-3 transition-colors hover:bg-surface-gray-1"
+					>
+						<div class="flex items-center gap-2.5 truncate">
+							<lucide-globe class="h-4 w-4 shrink-0 text-ink-gray-5" />
+							<span class="truncate text-base text-ink-gray-8"
+								>{{ site.name }}</span
+							>
+						</div>
+						<Badge v-if="site.plan" theme="gray" :label="site.plan" />
+					</div>
 				</div>
 			</div>
 
 			<!-- Servers -->
-			<div class="divide-y rounded border border-outline-gray-1 p-5">
-				<div class="pb-3 text-lg font-semibold">Servers</div>
-				<p v-if="!data.servers.length" class="py-3 text-p-base text-ink-gray-5">
-					No active server subscriptions.
-				</p>
+			<div class="overflow-hidden rounded-lg border border-outline-gray-2">
 				<div
-					v-for="server in data.servers"
-					:key="server.name"
-					class="flex items-center justify-between gap-2 py-3 first:pt-0 last:pb-0"
+					class="flex items-center gap-2 border-b border-outline-gray-2 bg-surface-gray-1 px-4 py-3"
 				>
-					<span class="text-base text-ink-gray-9">{{ server.name }}</span>
-					<Badge v-if="server.plan" theme="gray" :label="server.plan" />
+					<lucide-server class="h-4 w-4 text-ink-gray-6" />
+					<h3 class="text-base font-medium text-ink-gray-9">Servers</h3>
+					<span class="text-p-sm text-ink-gray-5"
+						>{{ data.servers.length }}</span
+					>
+				</div>
+				<div class="divide-y divide-outline-gray-1">
+					<p
+						v-if="!data.servers.length"
+						class="px-4 py-6 text-center text-p-base text-ink-gray-5"
+					>
+						No active server subscriptions.
+					</p>
+					<div
+						v-for="server in data.servers"
+						:key="server.name"
+						class="flex items-center justify-between gap-2 px-4 py-3 transition-colors hover:bg-surface-gray-1"
+					>
+						<div class="flex items-center gap-2.5 truncate">
+							<lucide-server class="h-4 w-4 shrink-0 text-ink-gray-5" />
+							<span class="truncate text-base text-ink-gray-8"
+								>{{ server.name }}</span
+							>
+						</div>
+						<Badge v-if="server.plan" theme="gray" :label="server.plan" />
+					</div>
 				</div>
 			</div>
 
 			<!-- Marketplace Apps -->
-			<div class="divide-y rounded border border-outline-gray-1 p-5">
-				<div class="pb-3 text-lg font-semibold">Marketplace Apps</div>
-				<p
-					v-if="!data.marketplace_apps.length"
-					class="py-3 text-p-base text-ink-gray-5"
-				>
-					No active marketplace app subscriptions.
-				</p>
+			<div class="overflow-hidden rounded-lg border border-outline-gray-2">
 				<div
-					v-for="app in data.marketplace_apps"
-					:key="app.name"
-					class="py-3 first:pt-0 last:pb-0"
+					class="flex items-center gap-2 border-b border-outline-gray-2 bg-surface-gray-1 px-4 py-3"
 				>
-					<div class="flex items-center justify-between gap-2">
-						<span class="text-base font-medium text-ink-gray-9">
-							{{ app.title }}
-						</span>
-						<Badge v-if="app.plan" theme="gray" :label="app.plan" />
-					</div>
-					<div class="mt-1 text-p-base text-ink-gray-6">
-						<span v-if="app.sites.length">
-							Installed on: {{ app.sites.join(', ') }}
-						</span>
-						<span v-else>Not installed on any site.</span>
+					<lucide-blocks class="h-4 w-4 text-ink-gray-6" />
+					<h3 class="text-base font-medium text-ink-gray-9">
+						Marketplace Apps
+					</h3>
+					<span class="text-p-sm text-ink-gray-5"
+						>{{ data.marketplace_apps.length }}</span
+					>
+				</div>
+				<div class="divide-y divide-outline-gray-1">
+					<p
+						v-if="!data.marketplace_apps.length"
+						class="px-4 py-6 text-center text-p-base text-ink-gray-5"
+					>
+						No active marketplace app subscriptions.
+					</p>
+					<div
+						v-for="app in data.marketplace_apps"
+						:key="app.name"
+						class="px-4 py-3 transition-colors hover:bg-surface-gray-1"
+					>
+						<div class="flex items-center justify-between gap-2">
+							<div class="flex items-center gap-2.5 truncate">
+								<lucide-blocks class="h-4 w-4 shrink-0 text-ink-gray-5" />
+								<span class="truncate text-base text-ink-gray-8"
+									>{{ app.title }}</span
+								>
+							</div>
+							<Badge v-if="app.plan" theme="gray" :label="app.plan" />
+						</div>
+						<div
+							v-if="app.sites.length"
+							class="mt-2 flex flex-wrap items-center gap-1.5 pl-[26px]"
+						>
+							<span class="text-p-sm text-ink-gray-5">Installed on</span>
+							<Badge
+								v-for="site in app.sites"
+								:key="site"
+								theme="gray"
+								:label="site"
+							/>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -192,6 +192,11 @@ let router = createRouter({
 					component: () => import('./pages/BillingMarketplacePayouts.vue'),
 				},
 				{
+					name: 'BillingSubscriptions',
+					path: 'subscriptions',
+					component: () => import('./pages/BillingSubscriptions.vue'),
+				},
+				{
 					name: 'BillingTiers',
 					path: 'tiers',
 					component: () => import('./pages/BillingTiers.vue'),

--- a/press/api/billing.py
+++ b/press/api/billing.py
@@ -112,8 +112,16 @@ def subscriptions():
 		if row.site:
 			app["sites"].append(row.site)
 
+	titles = dict(
+		frappe.get_all(
+			"Marketplace App",
+			filters={"name": ("in", list(apps_by_name))},
+			fields=["name", "title"],
+			as_list=True,
+		)
+	)
 	for name, app in apps_by_name.items():
-		app["title"] = frappe.db.get_value("Marketplace App", name, "title") or name
+		app["title"] = titles.get(name) or name
 
 	return {
 		"sites": sites,

--- a/press/api/billing.py
+++ b/press/api/billing.py
@@ -78,6 +78,52 @@ def get_balance_credit():
 
 @frappe.whitelist()
 @role_guard.api("billing")
+def subscriptions():
+	"""Active subscriptions owned by the current team, grouped by type, for the
+	billing Subscriptions tab: sites, servers, and marketplace apps (with the
+	sites each app is installed on)."""
+	team = get_current_team()
+
+	rows = frappe.get_all(
+		"Subscription",
+		filters={
+			"team": team,
+			"enabled": 1,
+			"document_type": ("in", ["Site", "Server"]),
+		},
+		fields=["document_type", "document_name", "plan"],
+		order_by="document_name asc",
+	)
+	sites = [{"name": r.document_name, "plan": r.plan} for r in rows if r.document_type == "Site"]
+	servers = [{"name": r.document_name, "plan": r.plan} for r in rows if r.document_type == "Server"]
+
+	app_rows = frappe.get_all(
+		"Marketplace App Subscription",
+		filters={"team": team, "status": "Active"},
+		fields=["app", "plan", "site"],
+		order_by="app asc",
+	)
+	apps_by_name: dict[str, dict] = {}
+	for row in app_rows:
+		app = apps_by_name.setdefault(
+			row.app,
+			{"name": row.app, "title": None, "plan": row.plan, "sites": []},
+		)
+		if row.site:
+			app["sites"].append(row.site)
+
+	for name, app in apps_by_name.items():
+		app["title"] = frappe.db.get_value("Marketplace App", name, "title") or name
+
+	return {
+		"sites": sites,
+		"servers": servers,
+		"marketplace_apps": list(apps_by_name.values()),
+	}
+
+
+@frappe.whitelist()
+@role_guard.api("billing")
 def past_invoices():
 	return get_current_team(True).get_past_invoices()
 

--- a/press/marketplace/doctype/marketplace_app_subscription/marketplace_app_subscription.json
+++ b/press/marketplace/doctype/marketplace_app_subscription/marketplace_app_subscription.json
@@ -92,7 +92,8 @@
 			"fieldname": "team",
 			"fieldtype": "Link",
 			"label": "Team",
-			"options": "Team"
+			"options": "Team",
+			"search_index": 1
 		},
 		{
 			"fieldname": "subscription",


### PR DESCRIPTION
### What

Closes #6835

Adds a **Subscriptions** tab under **Billing** that gives a team a single, consolidated view of everything they're subscribed to, grouped by type:

- **Sites** — each subscribed site and its plan
- **Servers** — each subscribed server and its plan
- **Marketplace Apps** — each subscribed app, its plan, and the **sites it's installed on** for the team

### Why

There was no direct, user-facing way for a team to see all the subscriptions they own — the info was only reachable via summary of the invoice.

### How

- **Backend** — `press.api.billing.subscriptions()` (`@role_guard.api("billing")`): returns active `Subscription` rows of type Site/Server for the current team, plus `Marketplace App Subscription`s grouped by app (with their installed sites).
- **Frontend** — new `BillingSubscriptions.vue` page + route, added as a tab in `Billing.vue`. Renders the three grouped sections with plan badges.

<img width="1440" height="803" alt="image" src="https://github.com/user-attachments/assets/63357f56-ea63-4c5f-9cb6-7768b1f9c395" />


### Testing

Verified locally — the tab renders the three sections populated with the team's site/server/marketplace-app subscriptions (screenshot below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)