### PR TITLE
fix(cluster): Write VPC flow logs to a per-cluster S3 key prefix

### DIFF
--- a/press/press/doctype/cluster/cluster.py
+++ b/press/press/doctype/cluster/cluster.py
@@ -15,6 +15,7 @@ import boto3
 import frappe
 import oci
 import pydo
+from frappe.desk.utils import slug
 from frappe.model.document import Document
 from frappe.query_builder import Criterion
 from frappe.query_builder.functions import Count, Sum
@@ -1298,7 +1299,7 @@ class Cluster(Document):
 			ResourceIds=[self.vpc_id],
 			TrafficType="ALL",
 			LogDestinationType="s3",
-			LogDestination=f"arn:aws:s3:::{self.vpc_flow_logs_s3_bucket}",
+			LogDestination=f"arn:aws:s3:::{self.vpc_flow_logs_s3_bucket}/flow-logs/{slug(self.name)}/",
 			TagSpecifications=[
 				{
 					"ResourceType": "vpc-flow-log",


### PR DESCRIPTION
### Problem

`TestClusterVPCFlowLogs.test_setup_vpc_flow_logs_creates_flow_log_and_enables_flag` is **failing on develop** (and therefore on every branch cut from it):

```
AssertionError: 'arn:aws:s3:::flow-logs-bucket' != 'arn:aws:s3:::flow-logs-bucket/flow-logs/mumbai/'
```

`setup_vpc_flow_logs` sets `LogDestination` to the bare bucket ARN, but the test (shipped in the same commit, `feat(cluster): VPC flow logs setup`) expects logs delivered under a per-cluster key prefix `…/flow-logs/<cluster-slug>/`. The code and test were inconsistent from the start.

### Fix

Append `flow-logs/<slug(cluster name)>/` to the `LogDestination` so each cluster's flow logs land under their own prefix (and the test passes):

```python
LogDestination=f"arn:aws:s3:::{self.vpc_flow_logs_s3_bucket}/flow-logs/{slug(self.name)}/"
```

This also avoids different clusters' flow logs colliding at the bucket root.

### Testing

`bench --site <site> run-tests --app press --module press.press.doctype.cluster.test_cluster` — all 14 tests pass (was 1 failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)