### PR TITLE
Revert "fix: Enable check_dependent_apps for private bench release groups"

### DIFF
--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -1921,7 +1921,6 @@ def new_release_group(title, version, apps, team=None, cluster=None, saas_app=""
 			"servers": servers,
 			"team": team,
 			"saas_app": saas_app,
-			"check_dependent_apps": 1,
 		}
 	).insert()
 


### PR DESCRIPTION
Reverts frappe/press#6844