### PR TITLE
feat: log out of Frappe Cloud account from all active devices

### DIFF
--- a/dashboard/src/components/settings/profile/AccountProfile.vue
+++ b/dashboard/src/components/settings/profile/AccountProfile.vue
@@ -85,6 +85,17 @@
 			</ListItem>
 			<ListItem
 				class="border-t"
+				title="Log out of all active devices"
+				subtitle="Log out of Frappe Cloud on every device except this one"
+			>
+				<template #actions>
+					<Button @click="showLogoutAllDevicesDialog = true">
+						<span class="text-red-600">Log Out</span>
+					</Button>
+				</template>
+			</ListItem>
+			<ListItem
+				class="border-t"
 				:title="teamEnabled ? 'Disable Account' : 'Enable Account'"
 				:subtitle="
 					teamEnabled
@@ -199,6 +210,34 @@
 			</template>
 		</Dialog>
 
+		<Dialog
+			:options="{
+				title: 'Log out of all active devices',
+				actions: [
+					{
+						label: 'Log Out',
+						variant: 'solid',
+						theme: 'red',
+						loading: $resources.logoutAllDevices.loading,
+						onClick: () => $resources.logoutAllDevices.submit(),
+					},
+				],
+			}"
+			v-model="showLogoutAllDevicesDialog"
+		>
+			<template v-slot:body-content>
+				<div class="prose text-base">
+					By confirming this action:
+					<ul>
+						<li>You will stay signed in on this device</li>
+						<li>All other active Frappe Cloud sessions will be logged out</li>
+					</ul>
+					Do you want to continue?
+				</div>
+				<ErrorMessage class="mt-2" :message="$resources.logoutAllDevices.error" />
+			</template>
+		</Dialog>
+
 		<AddPrepaidCreditsDialog
 			:showMessage="showMessage"
 			v-if="showAddPrepaidCreditsDialog"
@@ -245,6 +284,7 @@ export default {
 			showProfileEditDialog: false,
 			showEnableAccountDialog: false,
 			showDisableAccountDialog: false,
+			showLogoutAllDevicesDialog: false,
 			showAddPrepaidCreditsDialog: false,
 			showCommunicationInfoDialog: false,
 			showActiveServersDialog: false,
@@ -304,6 +344,13 @@ export default {
 				toast.success('Your account was enabled successfully');
 				this.reloadAccount();
 				this.showEnableAccountDialog = false;
+			},
+		},
+		logoutAllDevices: {
+			url: 'press.api.account.logout_from_all_devices',
+			onSuccess() {
+				this.showLogoutAllDevicesDialog = false;
+				toast.success('You were logged out of all other devices');
 			},
 		},
 		upcomingInvoice: {

--- a/dashboard/src/components/settings/profile/AccountProfile.vue
+++ b/dashboard/src/components/settings/profile/AccountProfile.vue
@@ -94,6 +94,17 @@
 			</ListItem>
 			<ListItem
 				class="border-t"
+				title="Log out of all active devices"
+				subtitle="Log out of Frappe Cloud on every device except this one"
+			>
+				<template #actions>
+					<Button @click="showLogoutAllDevicesDialog = true">
+						<span class="text-red-600">Log Out</span>
+					</Button>
+				</template>
+			</ListItem>
+			<ListItem
+				class="border-t"
 				:title="teamEnabled ? 'Disable Account' : 'Enable Account'"
 				:subtitle="
 					teamEnabled
@@ -208,6 +219,34 @@
 			</template>
 		</Dialog>
 
+		<Dialog
+			:options="{
+				title: 'Log out of all active devices',
+				actions: [
+					{
+						label: 'Log Out',
+						variant: 'solid',
+						theme: 'red',
+						loading: $resources.logoutAllDevices.loading,
+						onClick: () => $resources.logoutAllDevices.submit(),
+					},
+				],
+			}"
+			v-model="showLogoutAllDevicesDialog"
+		>
+			<template v-slot:body-content>
+				<div class="prose text-base">
+					By confirming this action:
+					<ul>
+						<li>You will stay signed in on this device</li>
+						<li>All other active Frappe Cloud sessions will be logged out</li>
+					</ul>
+					Do you want to continue?
+				</div>
+				<ErrorMessage class="mt-2" :message="$resources.logoutAllDevices.error" />
+			</template>
+		</Dialog>
+
 		<AddPrepaidCreditsDialog
 			:showMessage="showMessage"
 			v-if="showAddPrepaidCreditsDialog"
@@ -256,6 +295,7 @@ export default {
 			showProfileEditDialog: false,
 			showEnableAccountDialog: false,
 			showDisableAccountDialog: false,
+			showLogoutAllDevicesDialog: false,
 			showAddPrepaidCreditsDialog: false,
 			showCommunicationInfoDialog: false,
 			showActiveServersDialog: false,
@@ -323,6 +363,13 @@ export default {
 				toast.success('Your account was enabled successfully')
 				this.reloadAccount()
 				this.showEnableAccountDialog = false
+			},
+		},
+		logoutAllDevices: {
+			url: 'press.api.account.logout_from_all_devices',
+			onSuccess() {
+				this.showLogoutAllDevicesDialog = false;
+				toast.success('You were logged out of all other devices');
 			},
 		},
 		upcomingInvoice: {

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -1276,9 +1276,10 @@ def enable_2fa(totp_code):
 def logout_from_all_devices():
 	"""Log out all other sessions for the current user."""
 
-	from frappe.sessions import clear_sessions
+	from frappe.sessions import clear_sessions, get_sessions_to_clear
 
-	clear_sessions(user=frappe.session.user, keep_current=True, force=True)
+	while get_sessions_to_clear(user=frappe.session.user, keep_current=True, force=True):
+		clear_sessions(user=frappe.session.user, keep_current=True, force=True)
 
 
 @frappe.whitelist()

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -1273,6 +1273,15 @@ def enable_2fa(totp_code):
 
 
 @frappe.whitelist()
+def logout_from_all_devices():
+	"""Log out all other sessions for the current user."""
+
+	from frappe.sessions import clear_sessions
+
+	clear_sessions(user=frappe.session.user, keep_current=True, force=True)
+
+
+@frappe.whitelist()
 def disable_2fa(totp_code):
 	"""Disable 2FA for the user after verifying the TOTP code"""
 

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -1272,7 +1272,7 @@ def enable_2fa(totp_code):
 	]
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def logout_from_all_devices():
 	"""Log out all other sessions for the current user."""
 

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -1339,6 +1339,15 @@ def enable_2fa(totp_code):
 
 
 @frappe.whitelist()
+def logout_from_all_devices():
+	"""Log out all other sessions for the current user."""
+
+	from frappe.sessions import clear_sessions
+
+	clear_sessions(user=frappe.session.user, keep_current=True, force=True)
+
+
+@frappe.whitelist()
 def disable_2fa(totp_code):
 	"""Disable 2FA for the user after verifying the TOTP code"""
 

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -1338,7 +1338,7 @@ def enable_2fa(totp_code):
 	]
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def logout_from_all_devices():
 	"""Log out all other sessions for the current user."""
 

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -1342,9 +1342,10 @@ def enable_2fa(totp_code):
 def logout_from_all_devices():
 	"""Log out all other sessions for the current user."""
 
-	from frappe.sessions import clear_sessions
+	from frappe.sessions import clear_sessions, get_sessions_to_clear
 
-	clear_sessions(user=frappe.session.user, keep_current=True, force=True)
+	while get_sessions_to_clear(user=frappe.session.user, keep_current=True, force=True):
+		clear_sessions(user=frappe.session.user, keep_current=True, force=True)
 
 
 @frappe.whitelist()

--- a/press/api/tests/test_account.py
+++ b/press/api/tests/test_account.py
@@ -82,8 +82,9 @@ class TestAccountApi(TestCase):
 		other_sid = self._create_session(user)
 		another_sid = self._create_session(user)
 
-		with user_context(user), patch(
-			"frappe.sessions.delete_session", side_effect=self._delete_session_without_commit
+		with (
+			user_context(user),
+			patch("frappe.sessions.delete_session", side_effect=self._delete_session_without_commit),
 		):
 			frappe.session.sid = current_sid
 
@@ -99,8 +100,9 @@ class TestAccountApi(TestCase):
 		create_test_user(user)
 		current_sid = self._create_session(user)
 
-		with user_context(user), patch(
-			"frappe.sessions.delete_session", side_effect=self._delete_session_without_commit
+		with (
+			user_context(user),
+			patch("frappe.sessions.delete_session", side_effect=self._delete_session_without_commit),
 		):
 			frappe.session.sid = current_sid
 

--- a/press/api/tests/test_account.py
+++ b/press/api/tests/test_account.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 import frappe
 from frappe.tests.ui_test_helpers import create_test_user
 
-from press.api.account import accept_team_invite, signup, validate_pincode
+from press.api.account import accept_team_invite, logout_from_all_devices, signup, validate_pincode
 from press.press.doctype.account_request.account_request import AccountRequest
 from press.press.doctype.team.test_team import create_test_team
 
@@ -14,12 +14,14 @@ from press.press.doctype.team.test_team import create_test_team
 def user_context(user: str):
 	"""Run the wrapped block as `user`, restoring the session afterwards."""
 	session_user = frappe.session.user
+	session_sid = frappe.session.sid
 	session_data = frappe.session.data.copy()
 	try:
 		frappe.set_user(user)
 		yield
 	finally:
 		frappe.set_user(session_user)
+		frappe.session.sid = session_sid
 		frappe.session.data = session_data
 
 
@@ -51,11 +53,78 @@ class TestAccountApi(TestCase):
 			signup(email)
 		return mock_send_email
 
+	def _create_session(self, user: str, sid: str | None = None) -> str:
+		sid = sid or frappe.generate_hash(length=32)
+		sessions = frappe.qb.DocType("Sessions")
+
+		(
+			frappe.qb.into(sessions)
+			.columns(sessions.sessiondata, sessions.user, sessions.lastupdate, sessions.sid, sessions.status)
+			.insert((frappe.as_json({"user": user}), user, frappe.utils.now(), sid, "Active"))
+		).run()
+
+		return sid
+
+	def _delete_session_without_commit(self, sid=None, **_kwargs):
+		frappe.db.delete("Sessions", {"sid": sid})
+
 	def test_account_request_is_created_from_signup(self):
 		acc_req_count_before = frappe.db.count("Account Request")
 		self._fake_signup()
 		acc_req_count_after = frappe.db.count("Account Request")
 		self.assertGreater(acc_req_count_after, acc_req_count_before)
+
+	def test_logout_from_all_devices_clears_other_sessions_and_keeps_current(self):
+		user = frappe.mock("email")
+		create_test_user(user)
+		frappe.db.set_value("User", user, "simultaneous_sessions", 3)
+		current_sid = self._create_session(user)
+		other_sid = self._create_session(user)
+		another_sid = self._create_session(user)
+
+		with user_context(user), patch(
+			"frappe.sessions.delete_session", side_effect=self._delete_session_without_commit
+		):
+			frappe.session.sid = current_sid
+
+			logout_from_all_devices()
+
+			self.assertTrue(frappe.db.exists("Sessions", {"sid": current_sid}))
+			self.assertFalse(frappe.db.exists("Sessions", {"sid": other_sid}))
+			self.assertFalse(frappe.db.exists("Sessions", {"sid": another_sid}))
+			self.assertEqual(frappe.session.user, user)
+
+	def test_logout_from_all_devices_with_only_current_session_does_not_error(self):
+		user = frappe.mock("email")
+		create_test_user(user)
+		current_sid = self._create_session(user)
+
+		with user_context(user), patch(
+			"frappe.sessions.delete_session", side_effect=self._delete_session_without_commit
+		):
+			frappe.session.sid = current_sid
+
+			logout_from_all_devices()
+
+			self.assertTrue(frappe.db.exists("Sessions", {"sid": current_sid}))
+			self.assertEqual(frappe.db.count("Sessions", {"user": user}), 1)
+
+	def test_logout_from_all_devices_rejects_guest_call(self):
+		from frappe.handler import execute_cmd
+
+		request = getattr(frappe.local, "request", None)
+		form_dict = frappe.local.form_dict
+
+		try:
+			with user_context("Guest"):
+				frappe.local.request = frappe._dict(method="POST")
+				frappe.local.form_dict = frappe._dict(cmd="press.api.account.logout_from_all_devices")
+
+				with self.assertRaises(frappe.PermissionError):
+					execute_cmd(frappe.local.form_dict.cmd)
+		finally:
+			frappe.local.request = request
+			frappe.local.form_dict = form_dict
 
 	def test_accept_team_invite_with_blank_existing_member_role(self):
 		team = create_test_team()

--- a/press/api/tests/test_account.py
+++ b/press/api/tests/test_account.py
@@ -8,6 +8,7 @@ from frappe.tests.ui_test_helpers import create_test_user
 from press.api.account import (
 	accept_team_invite,
 	leave_team,
+	logout_from_all_devices,
 	reactivate_account,
 	set_2fa_recovery_code_reminders,
 	signup,
@@ -29,12 +30,14 @@ from press.utils import get_disabled_team_of_user
 def user_context(user: str):
 	"""Run the wrapped block as `user`, restoring the session afterwards."""
 	session_user = frappe.session.user
+	session_sid = frappe.session.sid
 	session_data = frappe.session.data.copy()
 	try:
 		frappe.set_user(user)
 		yield
 	finally:
 		frappe.set_user(session_user)
+		frappe.session.sid = session_sid
 		frappe.session.data = session_data
 
 
@@ -66,11 +69,112 @@ class TestAccountApi(TestCase):
 			signup(email)
 		return mock_send_email
 
+	def _create_session(self, user: str, sid: str | None = None) -> str:
+		sid = sid or frappe.generate_hash(length=32)
+		sessions = frappe.qb.DocType("Sessions")
+
+		(
+			frappe.qb.into(sessions)
+			.columns(sessions.sessiondata, sessions.user, sessions.lastupdate, sessions.sid, sessions.status)
+			.insert((frappe.as_json({"user": user}), user, frappe.utils.now(), sid, "Active"))
+		).run()
+
+		return sid
+
+	def _delete_session_without_commit(self, sid=None, **_kwargs):
+		frappe.db.delete("Sessions", {"sid": sid})
+
 	def test_account_request_is_created_from_signup(self):
 		acc_req_count_before = frappe.db.count("Account Request")
 		self._fake_signup()
 		acc_req_count_after = frappe.db.count("Account Request")
 		self.assertGreater(acc_req_count_after, acc_req_count_before)
+
+	def test_logout_from_all_devices_clears_other_sessions_and_keeps_current(self):
+		user = frappe.mock("email")
+		create_test_user(user)
+		frappe.db.set_value("User", user, "simultaneous_sessions", 3)
+		current_sid = self._create_session(user)
+		other_sid = self._create_session(user)
+		another_sid = self._create_session(user)
+
+		with user_context(user), patch(
+			"frappe.sessions.delete_session", side_effect=self._delete_session_without_commit
+		):
+			frappe.session.sid = current_sid
+
+			logout_from_all_devices()
+
+			self.assertTrue(frappe.db.exists("Sessions", {"sid": current_sid}))
+			self.assertFalse(frappe.db.exists("Sessions", {"sid": other_sid}))
+			self.assertFalse(frappe.db.exists("Sessions", {"sid": another_sid}))
+			self.assertEqual(frappe.session.user, user)
+
+	def test_logout_from_all_devices_with_only_current_session_does_not_error(self):
+		user = frappe.mock("email")
+		create_test_user(user)
+		current_sid = self._create_session(user)
+
+		with user_context(user), patch(
+			"frappe.sessions.delete_session", side_effect=self._delete_session_without_commit
+		):
+			frappe.session.sid = current_sid
+
+			logout_from_all_devices()
+
+			self.assertTrue(frappe.db.exists("Sessions", {"sid": current_sid}))
+			self.assertEqual(frappe.db.count("Sessions", {"user": user}), 1)
+
+	def test_logout_from_all_devices_rejects_guest_call(self):
+		from frappe.handler import execute_cmd
+
+		request = getattr(frappe.local, "request", None)
+		form_dict = frappe.local.form_dict
+
+		try:
+			with user_context("Guest"):
+				frappe.local.request = frappe._dict(method="POST")
+				frappe.local.form_dict = frappe._dict(cmd="press.api.account.logout_from_all_devices")
+
+				with self.assertRaises(frappe.PermissionError):
+					execute_cmd(frappe.local.form_dict.cmd)
+		finally:
+			frappe.local.request = request
+			frappe.local.form_dict = form_dict
+
+	def test_accept_team_invite_with_blank_existing_member_role(self):
+		team = create_test_team()
+		existing_member = frappe.mock("email")
+		create_test_user(existing_member)
+		team.append("team_members", {"user": existing_member})
+		team.save(ignore_permissions=True)
+		member = frappe.db.get_value(
+			"Team Member",
+			{"parent": team.name, "user": existing_member},
+			"name",
+		)
+		frappe.db.set_value("Team Member", member, "role", "")
+
+		invited_member = frappe.mock("email")
+		create_test_user(invited_member)
+		key = frappe.generate_hash(length=32)
+		account_request = frappe.get_doc(
+			{
+				"doctype": "Account Request",
+				"team": team.name,
+				"email": invited_member,
+				"invited_by": team.user,
+				"request_key": key,
+				"request_key_expiration_time": frappe.utils.add_days(frappe.utils.now_datetime(), 1),
+			}
+		).insert(ignore_permissions=True)
+
+		with user_context(invited_member):
+			accept_team_invite(key)
+
+		self.assertTrue(frappe.db.exists("Team Member", {"parent": team.name, "user": invited_member}))
+		self.assertEqual(frappe.db.get_value("Team Member", member, "role"), "Member")
+		self.assertFalse(frappe.db.get_value("Account Request", account_request.name, "request_key"))
 
 	def test_invite_team_member_accepts_custom_role_by_press_role_name(self):
 		"""The invite dialog sends the Press Role document name (a hash) for

--- a/press/api/tests/test_account.py
+++ b/press/api/tests/test_account.py
@@ -98,8 +98,9 @@ class TestAccountApi(TestCase):
 		other_sid = self._create_session(user)
 		another_sid = self._create_session(user)
 
-		with user_context(user), patch(
-			"frappe.sessions.delete_session", side_effect=self._delete_session_without_commit
+		with (
+			user_context(user),
+			patch("frappe.sessions.delete_session", side_effect=self._delete_session_without_commit),
 		):
 			frappe.session.sid = current_sid
 
@@ -115,8 +116,9 @@ class TestAccountApi(TestCase):
 		create_test_user(user)
 		current_sid = self._create_session(user)
 
-		with user_context(user), patch(
-			"frappe.sessions.delete_session", side_effect=self._delete_session_without_commit
+		with (
+			user_context(user),
+			patch("frappe.sessions.delete_session", side_effect=self._delete_session_without_commit),
 		):
 			frappe.session.sid = current_sid
 


### PR DESCRIPTION
## Summary

Adds a "Log out of all active devices" action to account settings so a user can revoke every other Frappe Cloud session in one click while staying signed in on their current device. This gives users a way to recover from a lost or shared device without resorting to a password reset.

## Why this matters

Requested in #6732: users currently have no way to invalidate their account sessions on other devices, so the only recourse after signing in on a shared or lost machine is changing the password. A dedicated action mirrors the session-revocation control most account systems expose, and reuses the same `clear_sessions` helper the dashboard already runs after enabling 2FA.

## Changes

- New whitelisted `press.api.account.logout_from_all_devices` endpoint, restricted to `POST`. A state-changing endpoint callable via `GET` would be reachable through cross-site navigation, so this matches the framework's own `logout` endpoint which is also POST-only.
- The endpoint loops `clear_sessions(..., keep_current=True, force=True)` until no other sessions remain. Frappe's `get_sessions_to_clear()` pages at 100 rows even with `force=True`, so a single call would silently leave sessions active for any user above that count.
- The dashboard security section gains a confirmation dialog and a `logoutAllDevices` resource mirroring the existing disable-account pattern. The current session is preserved so the user is not signed out of the dashboard they are acting from.

## Testing

- Added coverage in `press/api/tests/test_account.py`: clearing keeps the current session while removing the others, the single-session case is a no-op, and a guest call is rejected by the whitelist guard.
- `ruff check` and `ruff format --check` pass on the touched files.

Fixes #6732
