### PR TITLE
fix(site-backup): Derive timeout from previous backup duration

### DIFF
--- a/press/agent.py
+++ b/press/agent.py
@@ -568,9 +568,11 @@ class Agent:
 		)
 
 	def backup_site(self, site, site_backup: SiteBackup):
+		from press.press.doctype.site_backup.site_backup import get_dynamic_backup_timeout
+
 		data = {
 			"with_files": site_backup.with_files,
-			"agent_job_timeout": site.backup_timeout,
+			"agent_job_timeout": get_dynamic_backup_timeout(site, site_backup.with_files),
 		}
 		if site_backup.offsite:
 			backups_path = os.path.join(site.name, str(date.today()))

--- a/press/press/doctype/site/site.json
+++ b/press/press/doctype/site/site.json
@@ -19,7 +19,6 @@
 		"cluster",
 		"admin_password",
 		"additional_system_user_created",
-		"backup_timeout",
 		"section_break_aokd",
 		"creation_failed",
 		"column_break_tfvn",
@@ -700,12 +699,6 @@
 			"fieldtype": "Datetime",
 			"label": "Creation Failed",
 			"read_only": 1
-		},
-		{
-			"default": "18000",
-			"fieldname": "backup_timeout",
-			"fieldtype": "Int",
-			"label": "Backup Timeout"
 		},
 		{
 			"fieldname": "fatal_site_update",

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -167,7 +167,6 @@ class Site(Document, TagHelpers):
 		apps: DF.Table[SiteApp]
 		archive_failed: DF.Check
 		auto_update_last_triggered_on: DF.Datetime | None
-		backup_timeout: DF.Int
 		bench: DF.Link
 		cluster: DF.Link
 		communication_infos: DF.Table[CommunicationInfo]

--- a/press/press/doctype/site_backup/site_backup.py
+++ b/press/press/doctype/site_backup/site_backup.py
@@ -935,3 +935,38 @@ def _has_reached_max_failed_backup_attempts(site_name: str) -> bool:
 	)
 
 	return backup_failures == max_backup_attempts
+
+
+def get_dynamic_backup_timeout(site, with_files: bool) -> int:
+	"""Return a backup timeout in seconds based on the last successful backup's duration.
+
+	Uses a 50% buffer over the previous duration. Falls back to 4 hours if no
+	prior successful backup exists.
+	"""
+	MINIMUM_TIMEOUT = 4 * 3600
+	BUFFER_MULTIPLIER = 1.5
+
+	last_backup_job = frappe.db.get_value(
+		"Site Backup",
+		filters={
+			"site": site.name,
+			"status": "Success",
+			"physical": 0,
+			"with_files": with_files,
+		},
+		fieldname="job",
+		order_by="creation desc",
+	)
+	if last_backup_job:
+		times = frappe.db.get_value(
+			"Agent Job",
+			last_backup_job,
+			["start", "end"],
+			as_dict=True,
+		)
+		if times and times.start and times.end:
+			last_duration = (times.end - times.start).total_seconds()
+			if last_duration > 0:
+				return max(int(last_duration * BUFFER_MULTIPLIER), MINIMUM_TIMEOUT)
+
+	return MINIMUM_TIMEOUT


### PR DESCRIPTION
## Problem

The `backup_timeout` field on Site (static default: 18000 s / 5 h) caused backup jobs to time out on larger sites whose backups took longer than that fixed ceiling. The minimum system-level agent job timeout is 4 hours, so any site that grew past ~2.5 h of backup time was at risk of hitting the wall.

## Solution

- **Removes** the `backup_timeout` field from the Site doctype entirely.
- **Adds** `get_dynamic_backup_timeout(site, with_files)` in `site_backup.py` that:
  - Queries the most recent *successful* logical backup for the site of the same type (`with_files` matched, so DB-only and full backups are estimated separately).
  - Computes `previous_duration × 1.5` — a 50% buffer to absorb normal data growth between runs.
  - Floors the result at 4 hours so new sites (no prior backup) always get a safe minimum.
- **Updates** `Agent.backup_site()` in `agent.py` to call `get_dynamic_backup_timeout` instead of reading the now-removed static field.

## Test plan

- [ ] Trigger a backup on a site that has a successful previous backup — confirm `agent_job_timeout` in the agent request is `previous_duration × 1.5` (minimum 14400 s).
- [ ] Trigger a backup on a brand-new site with no prior backup — confirm `agent_job_timeout` is 14400 s (4 h).
- [ ] Trigger a `with_files=True` backup — confirm it uses the last `with_files` backup's duration, not a DB-only one.
- [ ] Confirm no references to `backup_timeout` remain in Site records or API responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)