### PR TITLE
fix(cluster): Revert VPC flow logs to bare-bucket S3 ARN

### DIFF
--- a/press/press/doctype/cluster/cluster.py
+++ b/press/press/doctype/cluster/cluster.py
@@ -1306,7 +1306,7 @@ class Cluster(Document):
 			ResourceIds=[self.vpc_id],
 			TrafficType="ALL",
 			LogDestinationType="s3",
-			LogDestination=f"arn:aws:s3:::{self.vpc_flow_logs_s3_bucket}/flow-logs/{self.name.lower()}/",
+			LogDestination=f"arn:aws:s3:::{self.vpc_flow_logs_s3_bucket}",
 			TagSpecifications=[
 				{
 					"ResourceType": "vpc-flow-log",

--- a/press/press/doctype/cluster/test_cluster.py
+++ b/press/press/doctype/cluster/test_cluster.py
@@ -265,8 +265,7 @@ class TestClusterVPCFlowLogs(TestCluster):
 
 	@mock_aws
 	def test_setup_vpc_flow_logs_creates_flow_log_and_enables_flag(self):
-		# moto can't validate an S3 ARN that carries a key prefix (valid on real AWS),
-		# so stub the EC2 client and assert we call create_flow_logs correctly.
+		# Stub the EC2 client and assert we call create_flow_logs correctly.
 		cluster = self._active_aws_cluster_with_vpc()
 		client = MagicMock()
 		client.create_flow_logs.return_value = {"FlowLogIds": ["fl-123"], "Unsuccessful": []}
@@ -280,7 +279,7 @@ class TestClusterVPCFlowLogs(TestCluster):
 		self.assertEqual(kwargs["ResourceIds"], [cluster.vpc_id])
 		self.assertEqual(kwargs["TrafficType"], "ALL")
 		self.assertEqual(kwargs["LogDestinationType"], "s3")
-		self.assertEqual(kwargs["LogDestination"], "arn:aws:s3:::flow-logs-bucket/flow-logs/mumbai/")
+		self.assertEqual(kwargs["LogDestination"], "arn:aws:s3:::flow-logs-bucket")
 
 	@mock_aws
 	def test_setup_vpc_flow_logs_throws_when_bucket_not_set(self):


### PR DESCRIPTION
### Why

`create_flow_logs` was originally written (69907f86b, PR #6817) to send the **bare bucket ARN** `arn:aws:s3:::<bucket>` as the flow-log destination, but the test shipped in the same commit asserted a per-cluster key prefix `arn:aws:s3:::<bucket>/flow-logs/<cluster>/`. The test had been red on develop ever since.

PR #6657 (2f7c99cb9) read that mismatch as a code bug and added the prefix to make the test pass. That was the wrong side: the destination format was changed to the bare bucket at the last minute, so the **code** was correct and the **stale test** should have been updated.

### What

- Revert `cluster.py` `LogDestination` to the bare bucket ARN.
- Update `test_cluster.py` assertion to expect the bare bucket ARN, and drop the now-inaccurate comment about moto rejecting key-prefixed ARNs.

All 10 cluster tests pass.

Ref: 69907f86b · #6817 · 2f7c99cb9 (#6657)

🤖 Generated with [Claude Code](https://claude.com/claude-code)