### PR TITLE
feat(site): Gate dedicated plan warranty on app + database server cost

### DIFF
--- a/press/api/site.py
+++ b/press/api/site.py
@@ -350,10 +350,21 @@ def _is_free_dedicated_plan_allowed(server: str, new_site_plan: dict) -> bool:
 		return False
 	if not new_site_plan.get("restrict_based_on_dedicated_server_plan", 0):
 		return True
-	app_server_plan = frappe.db.get_value("Server", server, "plan")
 	min_price = new_site_plan.get("minimum_server_price_usd", 0)
-	server_price = frappe.db.get_value("Server Plan", app_server_plan, "price_usd")
-	return server_price >= min_price
+	return get_dedicated_server_price(server) >= min_price
+
+
+def get_dedicated_server_price(server: str) -> float:
+	"""Combined monthly USD cost of a dedicated server: app server plan + its database server plan."""
+	app_server_plan, database_server = frappe.db.get_value("Server", server, ["plan", "database_server"])
+	app_server_price = frappe.db.get_value("Server Plan", app_server_plan, "price_usd") or 0
+
+	database_server_price = 0
+	if database_server:
+		database_server_plan = frappe.db.get_value("Database Server", database_server, "plan")
+		database_server_price = frappe.db.get_value("Server Plan", database_server_plan, "price_usd") or 0
+
+	return app_server_price + database_server_price
 
 
 @validate_argument_types
@@ -981,10 +992,14 @@ def _get_team_dedicated_server_info(for_server: str | None = None):
 			"cluster",
 			"provider",
 			"plan",
-			"plan.price_usd as price_usd",
 			"public",
 		],
 	)
+
+	for server in servers:
+		# Combined app server + database server cost, matching the gate in
+		# `_is_plan_allowed_on_server` so the UI and backend agree.
+		server["price_usd"] = get_dedicated_server_price(server["name"])
 
 	if for_server:
 		servers = attach_warranty_info_to_dedicated_servers(servers)

--- a/press/api/tests/test_site.py
+++ b/press/api/tests/test_site.py
@@ -16,6 +16,9 @@ from press.press.doctype.app.test_app import create_test_app
 from press.press.doctype.app_release.test_app_release import create_test_app_release
 from press.press.doctype.bench.test_bench import create_test_bench
 from press.press.doctype.cluster.test_cluster import create_test_cluster
+from press.press.doctype.database_server.test_database_server import (
+	create_test_database_server,
+)
 from press.press.doctype.deploy_candidate_difference.test_deploy_candidate_difference import (
 	create_test_deploy_candidate_differences,
 )
@@ -31,6 +34,7 @@ from press.press.doctype.remote_file.remote_file import RemoteFile
 from press.press.doctype.remote_file.test_remote_file import create_test_remote_file
 from press.press.doctype.root_domain.test_root_domain import create_test_root_domain
 from press.press.doctype.server.test_server import create_test_server
+from press.press.doctype.server_plan.test_server_plan import create_test_server_plan
 from press.press.doctype.site.test_site import create_test_site
 from press.press.doctype.site_backup.test_site_backup import create_test_site_backup
 from press.press.doctype.site_plan.test_site_plan import create_test_plan
@@ -1192,3 +1196,36 @@ class TestValidateWarrantyChange(FrappeTestCase):
 			new_supported=False,
 			cooldown_active=True,
 		)
+
+
+class TestDedicatedServerPrice(FrappeTestCase):
+	"""The product-warranty plan gate compares a dedicated server's cost against
+	`minimum_server_price_usd`. That cost is the app server plan plus its paired
+	database server plan, not the app server plan alone."""
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def _make_server(self, app_price, db_price=None):
+		app_plan = create_test_server_plan(server_type="Server")
+		frappe.db.set_value("Server Plan", app_plan.name, "price_usd", app_price)
+
+		database_server = create_test_database_server()
+		if db_price is not None:
+			db_plan = create_test_server_plan(server_type="Database Server")
+			frappe.db.set_value("Server Plan", db_plan.name, "price_usd", db_price)
+			frappe.db.set_value("Database Server", database_server.name, "plan", db_plan.name)
+
+		return create_test_server(plan=app_plan.name, database_server=database_server.name)
+
+	def test_price_is_sum_of_app_and_database_server_plans(self):
+		from press.api.site import get_dedicated_server_price
+
+		server = self._make_server(app_price=200, db_price=150)
+		self.assertEqual(get_dedicated_server_price(server.name), 350)
+
+	def test_price_falls_back_to_app_server_plan_when_database_has_no_plan(self):
+		from press.api.site import get_dedicated_server_price
+
+		server = self._make_server(app_price=200)
+		self.assertEqual(get_dedicated_server_price(server.name), 200)


### PR DESCRIPTION
feat(site): Gate dedicated plan warranty on app + database server cost

The product warranty plan gate (`_is_plan_allowed_on_server`) decided
whether a free, dedicated-server site plan could be used by comparing the
site plan's `minimum_server_price_usd` against the *app server's* plan
price alone. A dedicated server is really an app server plus a paired
database server, so the database server's cost was silently ignored — a
team running a small app server with a large database server could be
blocked from a plan whose minimum they actually clear.

Compare against the combined cost instead. A new `get_dedicated_server_price`
helper sums the app server plan price and the paired database server plan
price; when a server has no database server or that server has no plan, the
database portion is 0, so app-only servers behave exactly as before.

`_get_team_dedicated_server_info` now returns this combined price as
`price_usd` (it previously joined `plan.price_usd`, app-only). That value
feeds `serverPriceUsd` in NewSite.vue and the client-side
`serverPlanPrice >= minimum_server_price_usd` check in SitePlansCards.vue,
so the dashboard and the backend gate stay in agreement.

Note: existing `minimum_server_price_usd` values were likely calibrated
against the app-server-only price; since the comparison base is now larger,
those thresholds may need raising to preserve the same effective cutoff.

