### PR TITLE
fix(server): show remaining wait time instead of elapsed time for disk resize

### DIFF
--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1161,7 +1161,8 @@ class BaseServer(Document, TagHelpers):
 			return 0
 
 		diff = frappe.utils.now_datetime() - last_updated_at
-		return diff if diff < timedelta(hours=6) else 0
+		remaining = timedelta(hours=6) - diff
+		return remaining if remaining > timedelta(0) else 0
 
 	@frappe.whitelist()
 	def increase_disk_size(self, increment=50, mountpoint=None, log: str | None = None):


### PR DESCRIPTION
## Summary
- `time_to_wait_before_updating_volume` returned the elapsed time since the last volume update instead of the remaining cooldown before the next resize is allowed.
- This made the "Please wait X" error message grow over successive attempts (e.g. "wait 30 minutes", then "wait 35 minutes") instead of counting down toward the 6 hour limit (e.g. "wait 5h30m", then "wait 5h25m").
- Fix: compute `remaining = timedelta(hours=6) - diff` and return that (or `0` once elapsed).

## Test plan
- [ ] Trigger a disk resize on an AWS EC2 server, then immediately retry and confirm the error message shows a decreasing remaining time on subsequent attempts within the 6 hour window.