### PR TITLE
feat(database): Add mariadb 11.8 related variables to fixture

### DIFF
--- a/press/fixtures/mariadb_variable.json
+++ b/press/fixtures/mariadb_variable.json
@@ -670,5 +670,19 @@
   "set_on_new_servers": 1,
   "skippable": 0,
   "title": null
+ },
+ {
+  "configurable_by_user": 0,
+  "datatype": "Int",
+  "default_value": "0",
+  "doc_section": "replication-and-binary-log",
+  "docstatus": 0,
+  "doctype": "MariaDB Variable",
+  "dynamic": 1,
+  "modified": "2026-07-02 10:03:58.148822",
+  "name": "slave_connections_needed_for_purge",
+  "set_on_new_servers": 1,
+  "skippable": 0,
+  "title": null
  }
 ]

--- a/press/fixtures/mariadb_variable.json
+++ b/press/fixtures/mariadb_variable.json
@@ -660,14 +660,14 @@
  {
   "configurable_by_user": 0,
   "datatype": "Str",
-  "default_value": null,
+  "default_value": "OFF",
   "doc_section": "innodb",
   "docstatus": 0,
   "doctype": "MariaDB Variable",
   "dynamic": 1,
-  "modified": "2026-06-30 10:00:00.000000",
+  "modified": "2026-07-02 10:02:30.861976",
   "name": "innodb_snapshot_isolation",
-  "set_on_new_servers": 0,
+  "set_on_new_servers": 1,
   "skippable": 0,
   "title": null
  }


### PR DESCRIPTION
- Keep snapshot isolation disabled by default. In mariadb 11.x, its enabled by default which is causing concurrency issue at application level. 
- Also, set slave_connections_needed_for_purge to 0 on new servers by default for auto-purging. In prod, replica usage isn't enabled by default. When, we will provison replica, we can enable it back for them.