### PR TITLE
fix(site-domain): Sync upstream-added domains to site config

### DIFF
--- a/press/press/doctype/site_domain/site_domain.py
+++ b/press/press/doctype/site_domain/site_domain.py
@@ -247,6 +247,12 @@ def process_add_domain_to_upstream_job_update(job):
 	if updated_status != domain_status:
 		frappe.db.set_value("Site Domain", domain, "status", updated_status)
 
+		# Domains activated via this path must also land in the site's `domains`
+		# config (same as `process_new_host_job_update`), else they're missing from
+		# `frappe.conf.domains` and reports opened on them fail PDF generation.
+		if updated_status == "Active":
+			frappe.get_doc("Site", job.site).add_domain_to_config(domain)
+
 	if updated_status == "Active" and job.site:
 		_set_product_trial_site_host_name(job.site, domain)
 


### PR DESCRIPTION
Backport of #6769 to `master`.

A domain can be activated via two paths: `process_new_host_job_update` (create TLS cert → new host) and `process_add_domain_to_upstream_job_update` (when a root/wildcard TLS cert already exists). Only the former called `add_domain_to_config`, so domains activated via the upstream path were routed by nginx but never written to the site's `domains` config (`frappe.conf.domains`).

That breaks report PDF generation on those domains: frappe's `report_to_pdf` lets wkhtmltopdf fetch assets only from the canonical host plus `frappe.conf.domains`, so a report opened on such a domain fails every asset fetch with `UnknownNetworkError`. See frappe/frappe#40199.

Mirror the new-host path: add the domain to the site config when it becomes Active. Removal already covers all paths via `on_trash` → `remove_domain_from_config`.

### Backport notes
`process_add_domain_to_upstream_job_update` has diverged between `develop` and `master` (master carries `_set_product_trial_site_host_name`, which develop doesn't), so the cherry-pick conflicted. Resolved by placing the fix in the same spot as the original commit — inside the `if updated_status != domain_status:` block, guarded by `if updated_status == "Active":` — so it fires only on the status transition to Active. Master's product-trial host-name logic is preserved unchanged. Net change is identical to the original 6-line addition.
