### PR TITLE
feat(docker): Prebundle headless Chromium in prod bench image

### DIFF
--- a/press/docker/Dockerfile
+++ b/press/docker/Dockerfile
@@ -259,6 +259,17 @@ COPY --chown=frappe:frappe redis /home/frappe/frappe-bench/redis
 COPY --chown=frappe:frappe .vimrc /home/frappe/.vimrc
 COPY --chown=frappe:frappe common_site_config.json /home/frappe/frappe-bench/sites/common_site_config.json
 
+# Prebundle headless Chromium for the Chrome-based PDF generator (frappe.utils.chromium)
+RUN --mount=type=cache,sharing=locked,id=chromium-{% if is_arm_build %}arm64{% else %}x86_64{% endif %},target=/home/frappe/chromium-cache,uid=1000,gid=1000 \
+  if [ -n "$(ls -A /home/frappe/chromium-cache 2>/dev/null)" ]; then \
+  mkdir -p /home/frappe/frappe-bench/chromium \
+  && cp -a /home/frappe/chromium-cache/. /home/frappe/frappe-bench/chromium/; \
+  elif bench setup-chrome --help > /dev/null 2>&1; then \
+  bench setup-chrome \
+  && cp -a /home/frappe/frappe-bench/chromium/. /home/frappe/chromium-cache/; \
+  else echo "bench setup-chrome unavailable on this Frappe version; skipping Chromium prebundle"; fi \
+  `#stage-setup-chromium`
+
 # Install other apps
 {% for app in doc.apps %}
 {% if app.app != "frappe"%}


### PR DESCRIPTION
Frappe's Chrome-based PDF generator (frappe.utils.chromium) downloads a headless-Chromium build on the fly the first time a PDF is generated (find_or_download_chromium_executable -> download_chromium). On a prod bench that means the first PDF request needs outbound internet access and stalls on a ~150 MB download.

Bake Chromium into the image at build time instead, right after the common_site_config.json copy (so the chromium_version / chromium_download_url escape hatches are honoured) and before the customer-apps loop (so the layer is not invalidated by app changes).

Reuse `bench setup-chrome` rather than hand-writing the download URLs: it already picks the correct build per arch (chrome-for-testing for x86_64, Playwright's CDN for linux-arm64 via distro detection) and tracks the pinned version, so there is no logic to drift from frappe/utils/chromium/download.py.

The Frappe app layer above changes on every build, so this step always re-runs; a BuildKit cache mount holds the extracted binary across builds so only the first build on a given build server hits the network. Clear the builder cache to pick up a Chromium version bump.

Older Frappe versions don't ship `bench setup-chrome`; the `--help` guard skips them so their builds don't break, while a real download failure still fails the build.