### PR TITLE
fix(product-trial): Only hand out standby sites on the latest bench

### DIFF
--- a/press/saas/doctype/product_trial/product_trial.py
+++ b/press/saas/doctype/product_trial/product_trial.py
@@ -297,11 +297,35 @@ class ProductTrial(Document):
 		sites_without_incident = [site["name"] for site in sites_without_incident]
 		return sites_without_incident[0] if sites_without_incident else sites[0]
 
+	def get_latest_benches(self) -> list[str]:
+		"""Newest Active bench per server for this product's release group.
+
+		A standby site is only handed out if it sits on one of these benches,
+		so a user never receives a site that predates the latest deploy. Sites
+		still waiting on the async site-update job to migrate them forward are
+		excluded until they land on the current bench.
+		"""
+		benches = frappe.get_all(
+			"Bench",
+			filters={"group": self.release_group, "status": "Active"},
+			fields=["name", "server"],
+			order_by="creation desc",
+		)
+		latest_by_server: dict[str, str] = {}
+		for bench in benches:
+			latest_by_server.setdefault(bench.server, bench.name)
+		return list(latest_by_server.values())
+
 	def get_standby_site(self, cluster: str | None = None, account_request: str | None = None) -> str | None:
+		latest_benches = self.get_latest_benches()
+		if not latest_benches:
+			return None
+
 		filters = {
 			"is_standby": True,
 			"standby_for_product": self.name,
 			"status": "Active",
+			"bench": ("in", latest_benches),
 		}
 		if cluster:
 			filters["cluster"] = cluster

--- a/press/saas/doctype/product_trial/test_product_trial.py
+++ b/press/saas/doctype/product_trial/test_product_trial.py
@@ -14,6 +14,7 @@ from press.press.doctype.release_group.test_release_group import (
 	create_test_release_group,
 )
 from press.press.doctype.root_domain.test_root_domain import create_test_root_domain
+from press.press.doctype.site.test_site import create_test_bench, create_test_site
 from press.press.doctype.site_plan.test_site_plan import create_test_plan
 
 
@@ -49,4 +50,55 @@ def create_test_product_trial(
 
 
 class TestProductTrial(FrappeTestCase):
-	pass
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def _create_standby_site(self, product, bench):
+		return create_test_site(
+			bench=bench.name,
+			standby_for_product=product.name,
+			is_standby=1,
+		)
+
+	def _two_benches_on_same_server(self, product):
+		"""An old and a new Active bench for the product's group on one server."""
+		group = frappe.get_doc("Release Group", product.release_group)
+		old_bench = create_test_bench(
+			group=group,
+			creation=frappe.utils.add_to_date(None, days=-2),
+		)
+		new_bench = create_test_bench(
+			group=group,
+			server=old_bench.server,
+			creation=frappe.utils.now_datetime(),
+		)
+		return old_bench, new_bench
+
+	def test_get_latest_benches_returns_newest_active_bench_per_server(self):
+		product = create_test_product_trial(create_test_app("test_latest_bench", "Test Latest Bench"))
+		old_bench, new_bench = self._two_benches_on_same_server(product)
+
+		latest_benches = product.get_latest_benches()
+
+		self.assertIn(new_bench.name, latest_benches)
+		self.assertNotIn(old_bench.name, latest_benches)
+
+	def test_standby_site_on_older_bench_is_not_handed_out(self):
+		product = create_test_product_trial(create_test_app("test_stale_standby", "Test Stale Standby"))
+		old_bench, new_bench = self._two_benches_on_same_server(product)
+
+		stale_site = self._create_standby_site(product, old_bench)
+		fresh_site = self._create_standby_site(product, new_bench)
+
+		chosen = product.get_standby_site()
+
+		self.assertEqual(chosen, fresh_site.name)
+		self.assertNotEqual(chosen, stale_site.name)
+
+	def test_no_standby_site_handed_out_when_only_stale_sites_exist(self):
+		product = create_test_product_trial(create_test_app("test_only_stale", "Test Only Stale"))
+		old_bench, _new_bench = self._two_benches_on_same_server(product)
+
+		self._create_standby_site(product, old_bench)
+
+		self.assertIsNone(product.get_standby_site())


### PR DESCRIPTION
## Problem

Users claiming trial (standby) sites were getting sites running **out-of-date app builds**.

Standby sites are created on whatever bench is latest at creation time and then rely on the generic `schedule_updates` cron to migrate them forward as new deploys happen. That migration is:

- **asynchronous** — runs every 15 min and the actual bench move (backup → restore) takes minutes;
- **throttled** — capped per server by `auto_update_queue_size`, so the pool competes with real customer sites for update slots.

Nothing verified a standby site had caught up before it was claimed, and `get_preferred_site` deliberately picks the **oldest** site (`order_by=... creation asc`) — precisely the one most likely to predate the latest deploy.

## Fix

Add a **claim-time guard**: `get_standby_site` now only considers sites sitting on the newest `Active` bench for their release group.

- Computed **per server** (`get_latest_benches`), since standby sites are spread across servers/clusters and each server has its own current bench — a single global "latest" would wrongly reject sites on other servers' current benches.
- Reuses the codebase's existing "latest bench" definition: `{group, status: "Active"}` ordered by `creation desc` (same as `site_update.py` destination selection and `site.py` bench placement).
- Sites still waiting on the async updater are simply skipped. When no fresh standby site is available, `get_standby_site` returns `None` and the caller already falls back to creating a fresh on-demand site — so the worst case is a normal site creation instead of a stale hand-off.

## Tests

`test_product_trial.py` — using real Bench/Site records (old + new bench on the same server):

- `get_latest_benches` returns only the newest bench per server
- a standby site on the older bench is not handed out; the fresh one is
- when only stale sites exist, `get_standby_site` returns `None`

## Out of scope

This does **not** backfill apps *added* to a product after a standby site was created — a site update migrates benches but never installs new apps. If that's part of the report, it needs a separate fix (e.g. also filtering the pool on app-set match).