### PR TITLE
fix(database): Handle zero or none value in maridab variable

### DIFF
--- a/press/press/doctype/database_server_mariadb_variable/database_server_mariadb_variable.py
+++ b/press/press/doctype/database_server_mariadb_variable/database_server_mariadb_variable.py
@@ -41,16 +41,19 @@ class DatabaseServerMariaDBVariable(Document):
 
 	@property
 	def value_field(self) -> str | None:
-		"""Return the first value field that has a value"""
-		for f in self.value_fields:
-			if self.get(f) is not None:
-				return f
+		"""Return the value field matching this variable's datatype, if it holds a value"""
+		if not self.mariadb_variable:
+			return None
 
-		return None
+		field = f"value_{self.datatype.lower()}"
+		if self.get(field) in (None, ""):
+			return None
+
+		return field
 
 	@property
 	def value(self) -> Any:
-		"""Return the value of the first value field that has a value"""
+		"""Return the value held in the value field matching this variable's datatype"""
 		v = self.get(self.value_field)
 		if self.value_field == "value_int":
 			v = v * 1024 * 1024  # Convert MB to bytes

--- a/press/press/doctype/database_server_mariadb_variable/test_database_server_mariadb_variable.py
+++ b/press/press/doctype/database_server_mariadb_variable/test_database_server_mariadb_variable.py
@@ -78,6 +78,22 @@ class TestDatabaseServerMariaDBVariable(FrappeTestCase):
 		with self.assertRaises(frappe.ValidationError):
 			server.save()
 
+	def test_str_variable_survives_resave_after_value_int_is_hydrated_from_db(self):
+		"""Test that a Str variable's default value_str isn't shadowed by value_int's DB default of 0 on re-save"""
+		server = create_test_database_server()
+		server.append(
+			"mariadb_system_variables",
+			{"mariadb_variable": "local_infile"},
+		)
+		server.save()
+		server.reload()  # value_int is now hydrated to 0 from the DB, not None
+
+		server.mariadb_system_variables[0].persist = True
+		try:
+			server.save()
+		except frappe.ValidationError:
+			self.fail("Re-saving a Str variable should not fail after value_int loads as 0 from the DB")
+
 	def test_only_skippable_variables_can_be_skipped(self):
 		"""Test that only skippable variables can be skipped"""
 		server = create_test_database_server()


### PR DESCRIPTION
For integer types, the zero value is conted as no value
and throw weird errors