### PR TITLE
fix(bench): Exclude archived sites' updates from archive block

### DIFF
--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -1122,13 +1122,17 @@ class Bench(Document):
 				ArchiveBenchError,
 			)
 
+		sites = frappe.qb.DocType("Site")
 		fatal_site_updates = (
 			frappe.qb.from_(site_updates)
+			.join(sites)
+			.on(site_updates.site == sites.name)
 			.select(site_updates.name)
 			.where((site_updates.source_bench == self.name) | (site_updates.destination_bench == self.name))
 			.where(
 				(site_updates.status == "Fatal")
 				& (site_updates.creation > frappe.utils.add_to_date(None, days=-EMPTY_BENCH_COURTESY_DAYS))
+				& (sites.status != "Archived")
 			)
 			.limit(1)
 		).run()


### PR DESCRIPTION
## Problem

When archiving a bench, `Bench.check_ongoing_site_updates()` throws:

> There was a recent **site update which has failed**. Due to the same reason, bench cannot be archived.

This comes from the `fatal_site_updates` guard in `bench.py`. It blocks archival for `EMPTY_BENCH_COURTESY_DAYS` (3 days) whenever a **Fatal** Site Update exists where the bench is the `source_bench` or `destination_bench`.

The check is bench-scoped and never considered whether the update's site still lives on the bench. So a failed update belonging to an **already-archived site** keeps the bench stuck for 3 days, with a vague message that points at a site the operator can no longer act on.

## Fix

Join **Site Update** to **Site** and skip updates whose site is `Archived`, so only failures for live sites hold up the archive.

```python
sites = frappe.qb.DocType("Site")
fatal_site_updates = (
    frappe.qb.from_(site_updates)
    .join(sites)
    .on(site_updates.site == sites.name)
    ...
    & (sites.status != "Archived")
    ...
)
```

## Notes

- Only the `fatal_site_updates` guard is changed. The `ongoing_site_updates` guard (Pending/Running/Recovering/…) is left as-is, since an in-progress update on an archived site is unlikely and should still block.