### PR TITLE
feat(telemetry): add signup-method and create-site-failed funnel events

### DIFF
--- a/dashboard/src/pages/LoginSignup.vue
+++ b/dashboard/src/pages/LoginSignup.vue
@@ -35,7 +35,7 @@
 								</Button>
 								<Button
 									:loading="$resources.googleLogin.loading"
-									@click="$resources.googleLogin.submit()"
+									@click="continueWithGoogle"
 								>
 									<div class="flex items-center">
 										<GoogleIcon class="w-4" />
@@ -729,7 +729,19 @@ export default {
 			} else if (this.hasForgotPassword) {
 				await this.checkTwoFactorAndResetPassword();
 			} else {
+				this.capturePulseSignupMethod('email');
 				this.$resources.signup.submit();
+			}
+		},
+		continueWithGoogle() {
+			this.capturePulseSignupMethod('google');
+			this.$resources.googleLogin.submit();
+		},
+		capturePulseSignupMethod(method) {
+			if (this.$route.name === 'Signup' && this.$route.query.product) {
+				this.$pulse?.capture(`signup_via_${method}`, {
+					product: this.$route.query.product,
+				});
 			}
 		},
 

--- a/dashboard/src/pages/signup/SetupSite.vue
+++ b/dashboard/src/pages/signup/SetupSite.vue
@@ -146,6 +146,12 @@ export default {
 						},
 					});
 				},
+				onError: (error) => {
+					this.$pulse?.capture('trial_create_site_failed', {
+						product: this.productId,
+						error: error?.messages?.join('\n') || error?.message,
+					});
+				},
 			};
 		},
 	},


### PR DESCRIPTION
Extends the SaaS signup funnel (Pulse) with the client-side signals the backend can't see:

- signup_via_email / signup_via_google — the method chosen at the top of the funnel, captured on the signup screen (gated to product signup, like signup_viewed). The Google button also serves login, so the shared helper only fires on the Signup route.
- trial_create_site_failed — a create-site attempt that errored (subdomain taken, provisioning kickoff failure). The Pending phase previously only showed "reached setup" vs "created"; this distinguishes "tried and failed" from "never tried".

Capture is no-op safe (this.$pulse?.) and can't affect the signup flow.