### PR TITLE
feat(nat): Extend NAT server into DigitalOcean (backport #6789)

### DIFF
--- a/press/playbooks/roles/nat_iptables/tasks/main.yml
+++ b/press/playbooks/roles/nat_iptables/tasks/main.yml
@@ -17,7 +17,7 @@
   when:
     - nat_gateway_ip is defined
     - nat_gateway_ip
-    - cloud_provider in ["AWS EC2", "Frappe Compute"]
+    - cloud_provider in ["AWS EC2", "Frappe Compute", "DigitalOcean"]
 
 - name: Configure Hetzner private networking
   copy:
@@ -62,3 +62,4 @@
   when:
     - nat_gateway_ip is defined and nat_gateway_ip
       or cloud_provider == "Hetzner"
+      or cloud_provider == "DigitalOcean"

--- a/press/playbooks/roles/nat_iptables/tasks/main.yml
+++ b/press/playbooks/roles/nat_iptables/tasks/main.yml
@@ -4,6 +4,7 @@
     primary_interface: "{{ ansible_interfaces | difference(['lo']) | first }}"
   when: cloud_provider == "Hetzner"
 
+# AWS / Frappe Compute
 - name: Add NAT gateway
   copy:
     dest: /etc/netplan/99-custom-gateway.yaml
@@ -17,8 +18,27 @@
   when:
     - nat_gateway_ip is defined
     - nat_gateway_ip
-    - cloud_provider in ["AWS EC2", "Frappe Compute", "DigitalOcean"]
+    - cloud_provider in ["AWS EC2", "Frappe Compute"]
 
+# DigitalOcean
+- name: Add NAT override routes
+  copy:
+    dest: /etc/netplan/99-custom-gateway.yaml
+    content: |
+      network:
+        ethernets:
+          {{ ansible_default_ipv4.interface }}:
+            routes:
+              - to: 0.0.0.0/1
+                via: {{ nat_gateway_ip }}
+              - to: 128.0.0.0/1
+                via: {{ nat_gateway_ip }}
+  when:
+    - nat_gateway_ip is defined
+    - nat_gateway_ip
+    - cloud_provider == "DigitalOcean"
+
+# Hetzner
 - name: Configure Hetzner private networking
   copy:
     dest: /etc/netplan/99-custom-gateway.yaml
@@ -39,6 +59,7 @@
     - network_gateway is defined
     - network_gateway
 
+# Frappe Compute specific
 - name: Configure private interface (Frappe Compute specific)
   copy:
     dest: /etc/netplan/51-private-interface.yaml
@@ -51,15 +72,18 @@
               addresses:
                 - 8.8.8.8
                 - 4.4.4.4
-  when: is_frappe_compute is defined and is_frappe_compute
+  when:
+    - is_frappe_compute is defined
+    - is_frappe_compute
 
 - name: Move original netplan (Frappe Compute specific)
   command: mv /etc/netplan/50-cloud-init.yaml /etc/netplan/50-cloud-init.yaml.bkp
-  when: is_frappe_compute is defined and is_frappe_compute
+  when:
+    - is_frappe_compute is defined
+    - is_frappe_compute
 
 - name: Apply Netplan
   command: netplan apply
-  when:
-    - nat_gateway_ip is defined and nat_gateway_ip
-      or cloud_provider == "Hetzner"
-      or cloud_provider == "DigitalOcean"
+  when: >
+    (nat_gateway_ip is defined and nat_gateway_ip)
+    or cloud_provider == "Hetzner"

--- a/press/press/doctype/cluster/cluster.py
+++ b/press/press/doctype/cluster/cluster.py
@@ -2170,7 +2170,12 @@ class Cluster(Document):
 		return None
 
 	def get_nat_server_if_supported(self):
-		if self.disable_public_ips_for_servers and self.cloud_provider in ("AWS EC2", "Frappe Compute"):
+		if self.disable_public_ips_for_servers and self.cloud_provider in (
+			"AWS EC2",
+			"Frappe Compute",
+			"Hetzner",
+			"DigitalOcean",
+		):
 			nat_server = frappe.db.get_value(
 				"NAT Server",
 				{"status": "Active", "cluster": self.name, "secondary_private_ip": ("is", "set")},

--- a/press/press/doctype/cluster/cluster.py
+++ b/press/press/doctype/cluster/cluster.py
@@ -401,12 +401,6 @@ class Cluster(Document):
 				}
 			)
 
-			if "id" not in firewall.get("firewall", {}):
-				frappe.throw(
-					"Failed to create NAT Firewall on Digital Ocean. "
-					"Please check your Digital Ocean account and ensure that you have the necessary permissions to create firewalls."
-				)
-
 			self.nat_security_group_id = firewall["firewall"]["id"]
 
 		except Exception as e:

--- a/press/press/doctype/cluster/cluster.py
+++ b/press/press/doctype/cluster/cluster.py
@@ -402,7 +402,10 @@ class Cluster(Document):
 			)
 
 			if "id" not in firewall.get("firewall", {}):
-				frappe.throw("Failed to create NAT Firewall on Digital Ocean.")
+				frappe.throw(
+					"Failed to create NAT Firewall on Digital Ocean. "
+					"Please check your Digital Ocean account and ensure that you have the necessary permissions to create firewalls."
+				)
 
 			self.nat_security_group_id = firewall["firewall"]["id"]
 

--- a/press/press/doctype/cluster/cluster.py
+++ b/press/press/doctype/cluster/cluster.py
@@ -280,6 +280,8 @@ class Cluster(Document):
 		self._add_digital_ocean_firewall(client=client)
 		# Add proxy firewall to digital ocean, if it doesn't already exist
 		self._add_digital_ocean_proxy_firewall(client=client)
+		# Add NAT firewall to digital ocean, if it doesn't already exist
+		self._add_digital_ocean_nat_security_group(client=client)
 
 		self.save()
 
@@ -343,6 +345,69 @@ class Cluster(Document):
 			self.proxy_security_group_id = firewall["firewall"]["id"]
 		except Exception as e:
 			frappe.throw(f"Failed to create Proxy Firewall on Digital Ocean: {e!s}")
+
+	def _add_digital_ocean_nat_security_group(self, client):
+		"""Adds the NAT firewall to Digital Ocean if it doesn't already exist"""
+
+		firewalls = client.firewalls.list()
+		firewalls = firewalls.get("firewalls", [])
+
+		firewall_name = f"Frappe Cloud - {self.name} - NAT - Security Group".replace(" ", "")
+
+		existing_firewalls = [fw for fw in firewalls if fw["name"] == firewall_name]
+
+		if existing_firewalls:
+			self.nat_security_group_id = existing_firewalls[0]["id"]
+			return
+
+		try:
+			firewall = client.firewalls.create(
+				{
+					"name": firewall_name,
+					"inbound_rules": [
+						{
+							"protocol": "tcp",
+							"ports": "1-65535",
+							"sources": {"addresses": [self.subnet_cidr_block]},
+						},
+						{
+							"protocol": "udp",
+							"ports": "1-65535",
+							"sources": {"addresses": [self.subnet_cidr_block]},
+						},
+						{
+							"protocol": "icmp",
+							"ports": "0",
+							"sources": {"addresses": [self.subnet_cidr_block]},
+						},
+					],
+					"outbound_rules": [
+						{
+							"protocol": "tcp",
+							"ports": "0",
+							"destinations": {"addresses": ["0.0.0.0/0"]},
+						},
+						{
+							"protocol": "udp",
+							"ports": "0",
+							"destinations": {"addresses": ["0.0.0.0/0"]},
+						},
+						{
+							"protocol": "icmp",
+							"ports": "0",
+							"destinations": {"addresses": ["0.0.0.0/0"]},
+						},
+					],
+				}
+			)
+
+			if "id" not in firewall.get("firewall", {}):
+				frappe.throw("Failed to create NAT Firewall on Digital Ocean.")
+
+			self.nat_security_group_id = firewall["firewall"]["id"]
+
+		except Exception as e:
+			frappe.throw(f"Failed to create NAT Firewall on Digital Ocean: {e!s}")
 
 	def _add_digital_ocean_firewall(self, client):
 		"""Adds the firewall to Digital Ocean if it doesn't already exist"""

--- a/press/press/doctype/nat_server/nat_server.json
+++ b/press/press/doctype/nat_server/nat_server.json
@@ -65,7 +65,7 @@
 			"fieldname": "provider",
 			"fieldtype": "Select",
 			"label": "Provider",
-			"options": "AWS EC2\nFrappe Compute\nHetzner",
+			"options": "AWS EC2\nFrappe Compute\nHetzner\nDigitalOcean",
 			"set_only_once": 1
 		},
 		{
@@ -172,7 +172,7 @@
 			"link_fieldname": "server"
 		}
 	],
-	"modified": "2026-06-15 10:37:38.581971",
+	"modified": "2026-06-23 20:01:38.633666",
 	"modified_by": "Administrator",
 	"module": "Press",
 	"name": "NAT Server",

--- a/press/press/doctype/nat_server/nat_server.py
+++ b/press/press/doctype/nat_server/nat_server.py
@@ -26,7 +26,7 @@ class NATServer(BaseServer):
 		is_server_setup: DF.Check
 		is_static_ip: DF.Check
 		private_ip: DF.Data | None
-		provider: DF.Literal["AWS EC2", "Frappe Compute", "Hetzner"]
+		provider: DF.Literal["AWS EC2", "Frappe Compute", "Hetzner", "DigitalOcean"]
 		root_public_key: DF.Code | None
 		secondary_private_ip: DF.Data | None
 		ssh_port: DF.Data | None

--- a/press/press/doctype/virtual_machine/virtual_machine.py
+++ b/press/press/doctype/virtual_machine/virtual_machine.py
@@ -225,9 +225,14 @@ class VirtualMachine(Document):
 
 		self.validate_data_disk_snapshot()
 
-		if self.series == "nat" and self.cloud_provider not in ("AWS EC2", "Frappe Compute", "Hetzner"):
+		if self.series == "nat" and self.cloud_provider not in (
+			"AWS EC2",
+			"Frappe Compute",
+			"Hetzner",
+			"DigitalOcean",
+		):
 			frappe.throw(
-				"NAT Servers are only supported on AWS EC2, Frappe Compute, and Hetzner. "
+				"NAT Servers are only supported on AWS EC2, Frappe Compute, Hetzner, and DigitalOcean. "
 				f"Change the cloud provider from {self.cloud_provider} to a supported provider."
 			)
 
@@ -533,6 +538,7 @@ class VirtualMachine(Document):
 					"vpc_uuid": cluster.vpc_id,
 					"tags": [droplet_tag],
 					"user_data": self.get_cloud_init() if self.virtual_machine_image else "",
+					"public_networking": bool(self.assign_public_ip),
 				}
 			)
 			self.instance_id = droplet["droplet"]["id"]


### PR DESCRIPTION
- Previously, NAT servers were only implemented in AWS, Hetzner and Frappe Compute
- This PR extends that into DigitalOcean.