### PR TITLE
feat(site): Add support for freemium plan

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -66,3 +66,5 @@ ignore_missing_imports = true
 ignore_missing_imports = true
 [mypy-moto.*]
 ignore_missing_imports = true
+[mypy-frappe.*]
+ignore_missing_imports = true

--- a/press/fixtures/site_plan.json
+++ b/press/fixtures/site_plan.json
@@ -28703,5 +28703,48 @@
 		"roles": [],
 		"support_included": 0,
 		"vcpu": 0
+	},
+	{
+		"allow_downgrading_from_other_plan": 1,
+		"allowed_apps": [],
+		"cloud_providers": [],
+		"cluster": null,
+		"cpu_time_per_day": 0.5,
+		"custom_hide_from_pricing_page": 0,
+		"database_access": 0,
+		"dedicated_server_plan": 0,
+		"disk": 0,
+		"docstatus": 0,
+		"doctype": "Site Plan",
+		"document_type": "Site",
+		"enabled": 1,
+		"instance_type": null,
+		"interval": "Daily",
+		"is_frappe_plan": 0,
+		"is_trial_plan": 1,
+		"legacy_plan": 0,
+		"max_database_usage": 125,
+		"max_storage_usage": 640,
+		"memory": 0,
+		"minimum_server_price_usd": 0.0,
+		"modified": "2026-07-14 10:54:20.884852",
+		"monitor_access": 0,
+		"name": "CRM Freemium",
+		"offsite_backups": 0,
+		"plan_description": null,
+		"plan_title": "CRM Freemium",
+		"price_inr": 0.0,
+		"price_usd": 0.0,
+		"private_bench_support": 0,
+		"private_benches": 0,
+		"release_groups": [],
+		"restrict_based_on_dedicated_server_plan": 0,
+		"roles": [
+			{
+				"role": "Press User"
+			}
+		],
+		"support_included": 0,
+		"vcpu": 0
 	}
 ]

--- a/press/press/doctype/site_plan/site_plan.json
+++ b/press/press/doctype/site_plan/site_plan.json
@@ -24,13 +24,14 @@
 		"max_storage_usage",
 		"column_break_13",
 		"is_trial_plan",
+		"is_frappe_plan",
+		"dedicated_server_plan",
+		"support_included",
+		"column_break_xgjo",
 		"offsite_backups",
-		"private_benches",
 		"database_access",
 		"monitor_access",
-		"support_included",
-		"dedicated_server_plan",
-		"is_frappe_plan",
+		"private_benches",
 		"private_bench_support",
 		"app_server_plan_validation",
 		"restrict_based_on_dedicated_server_plan",
@@ -57,7 +58,10 @@
 			"fieldtype": "Check",
 			"label": "Enabled"
 		},
-		{ "fieldname": "section_break_2", "fieldtype": "Section Break" },
+		{
+			"fieldname": "section_break_2",
+			"fieldtype": "Section Break"
+		},
 		{
 			"fieldname": "document_type",
 			"fieldtype": "Link",
@@ -65,14 +69,21 @@
 			"options": "DocType",
 			"reqd": 1
 		},
-		{ "fieldname": "plan_title", "fieldtype": "Data", "label": "Plan Title" },
+		{
+			"fieldname": "plan_title",
+			"fieldtype": "Data",
+			"label": "Plan Title"
+		},
 		{
 			"fieldname": "interval",
 			"fieldtype": "Select",
 			"label": "Interval",
 			"options": "Daily\nMonthly\nAnnually"
 		},
-		{ "fieldname": "column_break_5", "fieldtype": "Column Break" },
+		{
+			"fieldname": "column_break_5",
+			"fieldtype": "Column Break"
+		},
 		{
 			"fieldname": "price_inr",
 			"fieldtype": "Currency",
@@ -111,7 +122,10 @@
 			"fieldtype": "Int",
 			"label": "Max Storage Usage (MiB)"
 		},
-		{ "fieldname": "column_break_13", "fieldtype": "Column Break" },
+		{
+			"fieldname": "column_break_13",
+			"fieldtype": "Column Break"
+		},
 		{
 			"default": "0",
 			"fieldname": "is_trial_plan",
@@ -178,10 +192,25 @@
 			"fieldtype": "Data",
 			"label": "Instance Type"
 		},
-		{ "fieldname": "column_break_21", "fieldtype": "Column Break" },
-		{ "fieldname": "vcpu", "fieldtype": "Int", "label": "vCPU" },
-		{ "fieldname": "memory", "fieldtype": "Int", "label": "Memory" },
-		{ "fieldname": "disk", "fieldtype": "Int", "label": "Disk" },
+		{
+			"fieldname": "column_break_21",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "vcpu",
+			"fieldtype": "Int",
+			"label": "vCPU"
+		},
+		{
+			"fieldname": "memory",
+			"fieldtype": "Int",
+			"label": "Memory"
+		},
+		{
+			"fieldname": "disk",
+			"fieldtype": "Int",
+			"label": "Disk"
+		},
 		{
 			"fieldname": "roles_section",
 			"fieldtype": "Section Break",
@@ -267,12 +296,16 @@
 			"fieldname": "app_server_plan_validation",
 			"fieldtype": "Section Break",
 			"label": "App Server Plan validation"
+		},
+		{
+			"fieldname": "column_break_xgjo",
+			"fieldtype": "Column Break"
 		}
 	],
 	"grid_page_length": 50,
 	"index_web_pages_for_search": 1,
 	"links": [],
-	"modified": "2026-04-05 17:52:09.248191",
+	"modified": "2026-07-14 10:29:13.886035",
 	"modified_by": "Administrator",
 	"module": "Press",
 	"name": "Site Plan",

--- a/press/saas/doctype/product_trial/product_trial.json
+++ b/press/saas/doctype/product_trial/product_trial.json
@@ -53,14 +53,20 @@
 			"label": "Title",
 			"reqd": 1
 		},
-		{ "fieldname": "column_break_bqrh", "fieldtype": "Column Break" },
+		{
+			"fieldname": "column_break_bqrh",
+			"fieldtype": "Column Break"
+		},
 		{
 			"default": "0",
 			"fieldname": "published",
 			"fieldtype": "Check",
 			"label": "Published"
 		},
-		{ "fieldname": "section_break_ipmu", "fieldtype": "Section Break" },
+		{
+			"fieldname": "section_break_ipmu",
+			"fieldtype": "Section Break"
+		},
 		{
 			"fieldname": "apps",
 			"fieldtype": "Table",
@@ -68,8 +74,15 @@
 			"options": "Product Trial App",
 			"reqd": 1
 		},
-		{ "fieldname": "logo", "fieldtype": "Attach Image", "label": "Logo" },
-		{ "fieldname": "section_break_rvnt", "fieldtype": "Section Break" },
+		{
+			"fieldname": "logo",
+			"fieldtype": "Attach Image",
+			"label": "Logo"
+		},
+		{
+			"fieldname": "section_break_rvnt",
+			"fieldtype": "Section Break"
+		},
 		{
 			"fieldname": "domain",
 			"fieldtype": "Link",
@@ -78,7 +91,10 @@
 			"options": "Root Domain",
 			"reqd": 1
 		},
-		{ "fieldname": "column_break_cpkv", "fieldtype": "Column Break" },
+		{
+			"fieldname": "column_break_cpkv",
+			"fieldtype": "Column Break"
+		},
 		{
 			"fieldname": "release_group",
 			"fieldtype": "Link",
@@ -86,7 +102,10 @@
 			"options": "Release Group",
 			"reqd": 1
 		},
-		{ "fieldname": "site_pool_section", "fieldtype": "Section Break" },
+		{
+			"fieldname": "site_pool_section",
+			"fieldtype": "Section Break"
+		},
 		{
 			"default": "0",
 			"fieldname": "enable_pooling",
@@ -128,6 +147,7 @@
 		},
 		{
 			"default": "14",
+			"description": "Put -1 to set no trial end date",
 			"fieldname": "trial_days",
 			"fieldtype": "Int",
 			"label": "Trial Duration (Days)"
@@ -155,7 +175,10 @@
 			"label": "Account",
 			"options": "Email Account"
 		},
-		{ "fieldname": "column_break_gokr", "fieldtype": "Column Break" },
+		{
+			"fieldname": "column_break_gokr",
+			"fieldtype": "Column Break"
+		},
 		{
 			"fieldname": "email_subject",
 			"fieldtype": "Data",
@@ -221,19 +244,25 @@
 			"fieldtype": "Check",
 			"label": "Enable Hybrid Pooling"
 		},
-		{ "fieldname": "section_break_cszv", "fieldtype": "Section Break" }
+		{
+			"fieldname": "section_break_cszv",
+			"fieldtype": "Section Break"
+		}
 	],
 	"grid_page_length": 50,
 	"image_field": "logo",
 	"index_web_pages_for_search": 1,
 	"links": [
-		{ "link_doctype": "Site", "link_fieldname": "standby_for_product" },
+		{
+			"link_doctype": "Site",
+			"link_fieldname": "standby_for_product"
+		},
 		{
 			"link_doctype": "Product Trial Request",
 			"link_fieldname": "product_trial"
 		}
 	],
-	"modified": "2026-02-23 10:28:53.892118",
+	"modified": "2026-07-14 10:38:02.060593",
 	"modified_by": "Administrator",
 	"module": "SaaS",
 	"name": "Product Trial",

--- a/press/saas/doctype/product_trial/product_trial.py
+++ b/press/saas/doctype/product_trial/product_trial.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import frappe
 import frappe.utils
@@ -14,6 +14,9 @@ from frappe.utils.data import get_url
 from press.utils import log_error
 from press.utils.jobs import has_job_timeout_exceeded
 from press.utils.unique_name_generator import generate as generate_random_name
+
+if TYPE_CHECKING:
+	from press.press.doctype.site.site import Site
 
 
 class ProductTrial(Document):
@@ -25,7 +28,6 @@ class ProductTrial(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		from press.press.doctype.site.site import Site
 		from press.saas.doctype.hybrid_pool_item.hybrid_pool_item import HybridPoolItem
 		from press.saas.doctype.product_trial_app.product_trial_app import ProductTrialApp
 		from press.saas.doctype.product_trial_help_text.product_trial_help_text import ProductTrialHelpText
@@ -107,7 +109,7 @@ class ProductTrial(Document):
 
 		standby_site = self.get_standby_site(cluster, account_request)
 
-		trial_end_date = frappe.utils.add_days(None, self.trial_days or 14)
+		trial_end_date = None if self.trial_days == -1 else frappe.utils.add_days(None, self.trial_days or 14)
 		agent_jobs = []
 		plan = self.trial_plan
 


### PR DESCRIPTION
We want to provide users lifetime free subscriptions sometime.
So, adding support for that. In product trial, if we set trial days to -1, it will avoid setting any trial date for the site.

The plan will be still trial plan, we have handled logic for `is_trial_plan` at many places, so not introducing a new flag.