### PR TITLE
fix(site-plan): Don't allow Press User role to access internal plans

### DIFF
--- a/press/fixtures/site_plan.json
+++ b/press/fixtures/site_plan.json
@@ -28739,11 +28739,7 @@
 		"private_benches": 0,
 		"release_groups": [],
 		"restrict_based_on_dedicated_server_plan": 0,
-		"roles": [
-			{
-				"role": "Press User"
-			}
-		],
+		"roles": [],
 		"support_included": 0,
 		"vcpu": 0
 	}


### PR DESCRIPTION
Some plans are internal and set by admin only. There is no need to allow Press User for that.
Else it appears in site plan list.