### PR TITLE
perf(analytics): Split advanced site analytics into per-chart requests

### DIFF
--- a/dashboard/src/components/site/SiteAnalytics.vue
+++ b/dashboard/src/components/site/SiteAnalytics.vue
@@ -66,9 +66,7 @@
 
 	<div class="space-y-4 p-5">
 		<ErrorMessage
-			:message="
-				$resources.analytics.error || $resources.advancedAnalytics.error
-			"
+			:message="$resources.analytics.error || advancedAnalyticsError"
 		/>
 
 		<div class="grid grid-cols-1 gap-5 sm:grid-cols-2">
@@ -159,7 +157,7 @@
 					:data="jobCountData"
 					unit="jobs"
 					:chartTheme="[$theme.colors.red[500]]"
-					:loading="$resources.advancedAnalytics.loading"
+					:loading="$resources.backgroundJobUsage.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
 				/>
@@ -176,7 +174,7 @@
 					:data="jobTimeData"
 					unit="seconds"
 					:chartTheme="[$theme.colors.blue[500]]"
-					:loading="$resources.advancedAnalytics.loading"
+					:loading="$resources.backgroundJobUsage.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
 				/>
@@ -193,7 +191,7 @@
 					:data="requestCountByPathData"
 					unit="requests"
 					:chartTheme="requestChartColors"
-					:loading="$resources.advancedAnalytics.loading"
+					:loading="$resources.requestCountByPath.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
 					@datazoom="handleDataZoom"
@@ -210,7 +208,7 @@
 					:data="requestDurationByPathData"
 					unit="seconds"
 					:chartTheme="requestChartColors"
-					:loading="$resources.advancedAnalytics.loading"
+					:loading="$resources.requestDurationByPath.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
 					@datazoom="handleDataZoom"
@@ -233,7 +231,7 @@
 					:data="queryReportRunReportsData"
 					unit="seconds"
 					:chartTheme="requestChartColors"
-					:loading="$resources.advancedAnalytics.loading"
+					:loading="$resources.requestDurationByPath.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
 					@datazoom="handleDataZoom"
@@ -256,7 +254,7 @@
 					:data="runDocMethodMethodnamesData"
 					unit="seconds"
 					:chartTheme="requestChartColors"
-					:loading="$resources.advancedAnalytics.loading"
+					:loading="$resources.requestDurationByPath.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
 					@datazoom="handleDataZoom"
@@ -278,7 +276,7 @@
 					:data="saveDocsDoctypesData"
 					unit="seconds"
 					:chartTheme="requestChartColors"
-					:loading="$resources.advancedAnalytics.loading"
+					:loading="$resources.requestDurationByPath.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
 				/>
@@ -299,7 +297,7 @@
 					:data="saveDocsActionData"
 					unit="seconds"
 					:chartTheme="requestChartColors"
-					:loading="$resources.advancedAnalytics.loading"
+					:loading="$resources.requestDurationByPath.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
 				/>
@@ -315,7 +313,7 @@
 					:data="averageRequestDurationByPathData"
 					unit="seconds"
 					:chartTheme="requestChartColors"
-					:loading="$resources.advancedAnalytics.loading"
+					:loading="$resources.averageRequestDurationByPath.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
 					@datazoom="handleDataZoom"
@@ -331,7 +329,7 @@
 					:data="requestCountByIPData"
 					unit="requests"
 					:chartTheme="requestChartColors"
-					:loading="$resources.advancedAnalytics.loading"
+					:loading="$resources.requestCountByIp.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
 					@datazoom="handleDataZoom"
@@ -348,7 +346,7 @@
 					:data="backgroundJobCountByMethodData"
 					unit="jobs"
 					:chartTheme="requestChartColors"
-					:loading="$resources.advancedAnalytics.loading"
+					:loading="$resources.backgroundJobCountByMethod.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
 					@datazoom="handleDataZoom"
@@ -365,7 +363,7 @@
 					:data="backgroundJobDurationByMethodData"
 					unit="seconds"
 					:chartTheme="requestChartColors"
-					:loading="$resources.advancedAnalytics.loading"
+					:loading="$resources.backgroundJobDurationByMethod.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
 					@datazoom="handleDataZoom"
@@ -388,7 +386,7 @@
 					:data="generateReportReportsData"
 					unit="seconds"
 					:chartTheme="requestChartColors"
-					:loading="$resources.advancedAnalytics.loading"
+					:loading="$resources.backgroundJobDurationByMethod.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
 					@datazoom="handleDataZoom"
@@ -405,7 +403,7 @@
 					:data="averageBackgroundJobDurationByMethodData"
 					unit="seconds"
 					:chartTheme="requestChartColors"
-					:loading="$resources.advancedAnalytics.loading"
+					:loading="$resources.averageBackgroundJobDurationByMethod.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
 					@datazoom="handleDataZoom"
@@ -478,16 +476,16 @@
 </template>
 
 <script>
-import { TabButtons, DateTimePicker, Button, Tooltip } from 'frappe-ui';
-import { toast } from 'vue-sonner';
-import dayjs, { dayjsFloorToMinutes } from '../../utils/dayjs';
-import LineChart from '@/components/charts/LineChart.vue';
-import BarChart from '@/components/charts/BarChart.vue';
-import SiteUptime from './SiteUptime.vue';
-import AlertBanner from '../AlertBanner.vue';
-import AnalyticsCard from './AnalyticsCard.vue';
-import ActionButton from '../ActionButton.vue';
-import { h } from 'vue';
+import { Button, DateTimePicker, TabButtons, Tooltip } from 'frappe-ui'
+import { h } from 'vue'
+import { toast } from 'vue-sonner'
+import BarChart from '@/components/charts/BarChart.vue'
+import LineChart from '@/components/charts/LineChart.vue'
+import dayjs, { dayjsFloorToMinutes } from '../../utils/dayjs'
+import ActionButton from '../ActionButton.vue'
+import AlertBanner from '../AlertBanner.vue'
+import AnalyticsCard from './AnalyticsCard.vue'
+import SiteUptime from './SiteUptime.vue'
 
 export default {
 	name: 'SiteAnalytics',
@@ -529,23 +527,23 @@ export default {
 				{ label: 'Last 7 days', value: '7d' },
 				{ label: 'Last 15 days', value: '15d' },
 			],
-		};
+		}
 	},
 	mounted() {
 		// Initialize date range from URL if present
-		const start = dayjs(this.$route.query.start);
-		const end = dayjs(this.$route.query.end);
+		const start = dayjs(this.$route.query.start)
+		const end = dayjs(this.$route.query.end)
 		if (start.isValid && end.isValid && start.isBefore(end)) {
-			this.updateStartDate(start);
-			this.updateEndDate(end);
+			this.updateStartDate(start)
+			this.updateEndDate(end)
 		} else {
-			this.applyDefaultDateRange();
+			this.applyDefaultDateRange()
 		}
 
 		// Highlight card if element hash found in URL
 		if (typeof this.$route.hash === 'string') {
-			const slug = this.$route.hash.replace('#', '');
-			this.highlightCard(slug);
+			const slug = this.$route.hash.replace('#', '')
+			this.highlightCard(slug)
 		}
 	},
 	resources: {
@@ -559,22 +557,47 @@ export default {
 					end: this.logicalEndDate,
 				},
 				auto: this.logicalStartDate && this.logicalEndDate,
-			};
+			}
 		},
-		advancedAnalytics() {
-			return {
-				url: 'press.api.analytics.get_advanced_analytics',
-				params: {
-					name: this.name,
-					timezone: this.localTimezone,
-					start: this.logicalStartDate,
-					end: this.logicalEndDate,
-				},
-				auto:
-					this.showAdvancedAnalytics &&
-					this.logicalStartDate &&
-					this.logicalEndDate,
-			};
+		requestCountByPath() {
+			return this.advancedAnalyticsResource(
+				'press.api.analytics.get_request_count_by_path',
+			)
+		},
+		requestDurationByPath() {
+			return this.advancedAnalyticsResource(
+				'press.api.analytics.get_request_duration_by_path',
+			)
+		},
+		averageRequestDurationByPath() {
+			return this.advancedAnalyticsResource(
+				'press.api.analytics.get_average_request_duration_by_path',
+			)
+		},
+		requestCountByIp() {
+			return this.advancedAnalyticsResource(
+				'press.api.analytics.get_request_count_by_ip',
+			)
+		},
+		backgroundJobCountByMethod() {
+			return this.advancedAnalyticsResource(
+				'press.api.analytics.get_background_job_count_by_method',
+			)
+		},
+		backgroundJobDurationByMethod() {
+			return this.advancedAnalyticsResource(
+				'press.api.analytics.get_background_job_duration_by_method',
+			)
+		},
+		averageBackgroundJobDurationByMethod() {
+			return this.advancedAnalyticsResource(
+				'press.api.analytics.get_average_background_job_duration_by_method',
+			)
+		},
+		backgroundJobUsage() {
+			return this.advancedAnalyticsResource(
+				'press.api.analytics.get_background_job_usage',
+			)
 		},
 		slowLogsCount() {
 			return {
@@ -591,7 +614,7 @@ export default {
 					this.showAdvancedAnalytics &&
 					this.logicalStartDate &&
 					this.logicalEndDate,
-			};
+			}
 		},
 		slowLogsDuration() {
 			return {
@@ -608,10 +631,22 @@ export default {
 					this.showAdvancedAnalytics &&
 					this.logicalStartDate &&
 					this.logicalEndDate,
-			};
+			}
 		},
 	},
 	computed: {
+		advancedAnalyticsError() {
+			return [
+				this.$resources.requestCountByPath,
+				this.$resources.requestDurationByPath,
+				this.$resources.averageRequestDurationByPath,
+				this.$resources.requestCountByIp,
+				this.$resources.backgroundJobCountByMethod,
+				this.$resources.backgroundJobDurationByMethod,
+				this.$resources.averageBackgroundJobDurationByMethod,
+				this.$resources.backgroundJobUsage,
+			].find((resource) => resource.error)?.error
+		},
 		requestChartColors() {
 			return [
 				this.$theme.colors.green[500],
@@ -624,13 +659,13 @@ export default {
 				this.$theme.colors.cyan[500],
 				this.$theme.colors.gray[500],
 				this.$theme.colors.orange[500],
-			];
+			]
 		},
 		usageCounterData() {
-			let data = this.$resources.analytics.data?.usage_counter;
-			if (!data) return;
+			let data = this.$resources.analytics.data?.usage_counter
+			if (!data) return
 
-			let plan_limit = this.$resources.analytics.data?.plan_limit;
+			let plan_limit = this.$resources.analytics.data?.plan_limit
 
 			return {
 				datasets: [data.map((d) => [+new Date(d.date), d.value / 1000000])],
@@ -651,188 +686,207 @@ export default {
 					],
 					symbol: ['none', 'none'],
 				},
-			};
+			}
 		},
 		requestCountData() {
-			let requestCount = this.$resources.analytics.data?.request_count;
-			if (!requestCount) return;
+			let requestCount = this.$resources.analytics.data?.request_count
+			if (!requestCount) return
 
 			return {
 				datasets: [requestCount.map((d) => [+new Date(d.date), d.value])],
-			};
+			}
 		},
 		requestCountByPathData() {
 			let requestCountByPath =
-				this.$resources.advancedAnalytics.data?.request_count_by_path;
-			if (!requestCountByPath) return;
+				this.$resources.requestCountByPath.data?.request_count_by_path
+			if (!requestCountByPath) return
 
-			return requestCountByPath;
+			return requestCountByPath
 		},
 		requestDurationByPathData() {
 			let requestDurationByPath =
-				this.$resources.advancedAnalytics.data?.request_duration_by_path;
-			if (!requestDurationByPath) return;
+				this.$resources.requestDurationByPath.data?.request_duration_by_path
+			if (!requestDurationByPath) return
 
-			return requestDurationByPath;
+			return requestDurationByPath
 		},
 		queryReportRunReportsData() {
 			let queryReportRunReports =
-				this.$resources.advancedAnalytics.data?.query_report_run_reports;
-			if (!queryReportRunReports) return;
+				this.$resources.requestDurationByPath.data?.query_report_run_reports
+			if (!queryReportRunReports) return
 
-			return queryReportRunReports;
+			return queryReportRunReports
 		},
 		runDocMethodMethodnamesData() {
 			let runDocMethodMethodnames =
-				this.$resources.advancedAnalytics.data?.run_doc_method_methodnames;
-			if (!runDocMethodMethodnames) return;
+				this.$resources.requestDurationByPath.data?.run_doc_method_methodnames
+			if (!runDocMethodMethodnames) return
 
-			return runDocMethodMethodnames;
+			return runDocMethodMethodnames
 		},
 		saveDocsDoctypesData() {
 			let saveDocDoctypes =
-				this.$resources.advancedAnalytics.data?.save_docs_doctypes;
-			if (!saveDocDoctypes) return;
+				this.$resources.requestDurationByPath.data?.save_docs_doctypes
+			if (!saveDocDoctypes) return
 
-			return saveDocDoctypes;
+			return saveDocDoctypes
 		},
 		saveDocsActionData() {
 			let saveDocActions =
-				this.$resources.advancedAnalytics.data?.save_docs_actions;
-			if (!saveDocActions) return;
+				this.$resources.requestDurationByPath.data?.save_docs_actions
+			if (!saveDocActions) return
 
-			return saveDocActions;
+			return saveDocActions
 		},
 		generateReportReportsData() {
 			let generateReportReports =
-				this.$resources.advancedAnalytics.data?.generate_report_reports;
-			if (!generateReportReports) return;
+				this.$resources.backgroundJobDurationByMethod.data
+					?.generate_report_reports
+			if (!generateReportReports) return
 
-			return generateReportReports;
+			return generateReportReports
 		},
 		averageRequestDurationByPathData() {
 			let averageRequestDurationByPath =
-				this.$resources.advancedAnalytics.data
-					?.average_request_duration_by_path;
-			if (!averageRequestDurationByPath) return;
+				this.$resources.averageRequestDurationByPath.data
+					?.average_request_duration_by_path
+			if (!averageRequestDurationByPath) return
 
-			return averageRequestDurationByPath;
+			return averageRequestDurationByPath
 		},
 		requestCountByIPData() {
 			let requestCountByIP =
-				this.$resources.advancedAnalytics.data?.request_count_by_ip;
-			if (!requestCountByIP) return;
+				this.$resources.requestCountByIp.data?.request_count_by_ip
+			if (!requestCountByIP) return
 
-			return requestCountByIP;
+			return requestCountByIP
 		},
 		backgroundJobCountByMethodData() {
 			let backgroundJobCountByMethod =
-				this.$resources.advancedAnalytics.data?.background_job_count_by_method;
-			if (!backgroundJobCountByMethod) return;
+				this.$resources.backgroundJobCountByMethod.data
+					?.background_job_count_by_method
+			if (!backgroundJobCountByMethod) return
 
-			return backgroundJobCountByMethod;
+			return backgroundJobCountByMethod
 		},
 		backgroundJobDurationByMethodData() {
 			let backgroundJobDurationByMethod =
-				this.$resources.advancedAnalytics.data
-					?.background_job_duration_by_method;
-			if (!backgroundJobDurationByMethod) return;
+				this.$resources.backgroundJobDurationByMethod.data
+					?.background_job_duration_by_method
+			if (!backgroundJobDurationByMethod) return
 
-			return backgroundJobDurationByMethod;
+			return backgroundJobDurationByMethod
 		},
 		averageBackgroundJobDurationByMethodData() {
 			let averageBackgroundJobDurationByMethod =
-				this.$resources.advancedAnalytics.data
-					?.average_background_job_duration_by_method;
-			if (!averageBackgroundJobDurationByMethod) return;
+				this.$resources.averageBackgroundJobDurationByMethod.data
+					?.average_background_job_duration_by_method
+			if (!averageBackgroundJobDurationByMethod) return
 
-			return averageBackgroundJobDurationByMethod;
+			return averageBackgroundJobDurationByMethod
 		},
 		slowLogsDurationData() {
-			const slowLogs = this.$resources.slowLogsDuration.data;
-			if (!slowLogs) return;
+			const slowLogs = this.$resources.slowLogsDuration.data
+			if (!slowLogs) return
 
-			return slowLogs;
+			return slowLogs
 		},
 		slowLogsCountData() {
-			const slowLogs = this.$resources.slowLogsCount.data;
-			if (!slowLogs) return;
+			const slowLogs = this.$resources.slowLogsCount.data
+			if (!slowLogs) return
 
-			return slowLogs;
+			return slowLogs
 		},
 		requestTimeData() {
-			let requestCpuTime = this.$resources.analytics.data?.request_cpu_time;
-			if (!requestCpuTime) return;
+			let requestCpuTime = this.$resources.analytics.data?.request_cpu_time
+			if (!requestCpuTime) return
 
 			return {
 				datasets: [
 					requestCpuTime.map((d) => [+new Date(d.date), d.value / 1000000]),
 				],
-			};
+			}
 		},
 		jobCountData() {
-			let jobCount = this.$resources.advancedAnalytics.data?.job_count;
-			if (!jobCount) return;
+			let jobCount = this.$resources.backgroundJobUsage.data?.job_count
+			if (!jobCount) return
 
 			return {
 				datasets: [jobCount.map((d) => [+new Date(d.date), d.value])],
-			};
+			}
 		},
 		jobTimeData() {
-			let jobCpuTime = this.$resources.advancedAnalytics.data?.job_cpu_time;
-			if (!jobCpuTime) return;
+			let jobCpuTime = this.$resources.backgroundJobUsage.data?.job_cpu_time
+			if (!jobCpuTime) return
 
 			return {
 				datasets: [
 					jobCpuTime.map((d) => [+new Date(d.date), d.value / 1000000]),
 				],
-			};
+			}
 		},
 		shareDashboardActionPrefix() {
-			return () => h(LucideLink, { class: 'size-3.5' });
+			return () => h(LucideLink, { class: 'size-3.5' })
 		},
 	},
 	methods: {
+		advancedAnalyticsResource(url) {
+			// Each advanced-analytics chart is its own request so they run in
+			// parallel across workers instead of serially in one handler.
+			return {
+				url,
+				params: {
+					name: this.name,
+					timezone: this.localTimezone,
+					start: this.logicalStartDate,
+					end: this.logicalEndDate,
+				},
+				auto:
+					this.showAdvancedAnalytics &&
+					this.logicalStartDate &&
+					this.logicalEndDate,
+			}
+		},
 		toggleAdvancedAnalytics() {
-			this.showAdvancedAnalytics = !this.showAdvancedAnalytics;
+			this.showAdvancedAnalytics = !this.showAdvancedAnalytics
 		},
 		handleDataZoom(evt) {
-			clearTimeout(this._zoomTimeout);
+			clearTimeout(this._zoomTimeout)
 
 			this._zoomTimeout = setTimeout(() => {
-				const { startDate, endDate } = evt;
-				this.updateStartDate(startDate);
-				this.updateEndDate(endDate);
-			}, 500); // debounce
+				const { startDate, endDate } = evt
+				this.updateStartDate(startDate)
+				this.updateEndDate(endDate)
+			}, 500) // debounce
 		},
 		dateFormatter(dateString) {
 			return dayjs(dateString, 'YYYY-MM-DD HH:mm:ss').format(
 				'MMM D, YYYY h:mm A',
-			);
+			)
 		},
 		resetDateRangeError(msg = null) {
-			this.dateRangeError = msg;
+			this.dateRangeError = msg
 		},
 		resetDurationField(value = null) {
-			this.duration = value;
+			this.duration = value
 		},
 		applyDefaultDateRange() {
-			this.duration = this.defaultDuration;
+			this.duration = this.defaultDuration
 		},
 		syncLogicalDateRange() {
-			this.logicalStartDate = this.inputStartDate;
-			this.logicalEndDate = this.inputEndDate;
+			this.logicalStartDate = this.inputStartDate
+			this.logicalEndDate = this.inputEndDate
 		},
 		validateDateRange(start = this.inputStartDate, end = this.inputEndDate) {
-			return dayjs(start).isBefore(dayjs(end));
+			return dayjs(start).isBefore(dayjs(end))
 		},
 		updateStartDate(newStartDate, resetDuration = true) {
-			this.resetDateRangeError();
+			this.resetDateRangeError()
 			if (resetDuration) {
-				this.resetDurationField();
+				this.resetDurationField()
 			}
 
-			this.inputStartDate = dayjs(newStartDate);
+			this.inputStartDate = dayjs(newStartDate)
 
 			if (this.allowTimestampSyncToUrl) {
 				// Update the query params
@@ -842,22 +896,22 @@ export default {
 						start: this.inputStartDate?.toISOString(),
 						end: this.inputEndDate?.toISOString(),
 					},
-				});
+				})
 			}
 
 			if (!this.validateDateRange()) {
-				this.dateRangeError = 'Invalid date range';
+				this.dateRangeError = 'Invalid date range'
 			} else {
-				this.syncLogicalDateRange();
+				this.syncLogicalDateRange()
 			}
 		},
 		updateEndDate(newEndDate, resetDuration = true) {
-			this.resetDateRangeError();
+			this.resetDateRangeError()
 			if (resetDuration) {
-				this.resetDurationField();
+				this.resetDurationField()
 			}
 
-			this.inputEndDate = dayjs(newEndDate);
+			this.inputEndDate = dayjs(newEndDate)
 
 			if (this.allowTimestampSyncToUrl) {
 				// Update the query params
@@ -867,54 +921,54 @@ export default {
 						start: this.inputStartDate?.toISOString(),
 						end: this.inputEndDate?.toISOString(),
 					},
-				});
+				})
 			}
 
 			if (!this.validateDateRange()) {
-				this.dateRangeError = 'Invalid date range';
+				this.dateRangeError = 'Invalid date range'
 			} else {
-				this.syncLogicalDateRange();
+				this.syncLogicalDateRange()
 			}
 		},
 		highlightCard(slug) {
-			if (!slug) return;
+			if (!slug) return
 
 			document.getElementById(slug)?.scrollIntoView({
 				behavior: 'smooth',
 				block: 'center',
-			});
+			})
 		},
 		shareDashboard(evt, context = 'card') {
 			if (!['card', 'global'].includes(context))
-				throw new Error('Invalid share context');
+				throw new Error('Invalid share context')
 
 			if (context === 'card') {
 				const url = new URL(
 					`${window.location.href}?start=${this.inputStartDate}&end=${this.inputEndDate}`,
-				);
-				url.hash = `#${evt}`;
-				navigator.clipboard?.writeText(url.toString());
-				toast.success('Card link copied to clipboard!');
+				)
+				url.hash = `#${evt}`
+				navigator.clipboard?.writeText(url.toString())
+				toast.success('Card link copied to clipboard!')
 			} else if (context === 'global') {
 				const url = new URL(
 					`${window.location.href}?start=${this.inputStartDate}&end=${this.inputEndDate}`,
-				);
-				navigator.clipboard?.writeText(url.toString());
-				toast.success('Dashboard link copied to clipboard!');
+				)
+				navigator.clipboard?.writeText(url.toString())
+				toast.success('Dashboard link copied to clipboard!')
 			}
 		},
 	},
 	watch: {
 		duration(newValue) {
-			if (!newValue) return;
-			this.now = dayjs();
+			if (!newValue) return
+			this.now = dayjs()
 			// floor to 15 minutes to avoid issues with caching
-			const flooredEndDate = dayjsFloorToMinutes(this.now, 15);
-			this.updateEndDate(flooredEndDate, false);
-			const int = parseInt(newValue.slice(0, -1));
-			const unit = newValue.slice(-1);
-			this.updateStartDate(dayjs(this.inputEndDate).subtract(int, unit), false);
+			const flooredEndDate = dayjsFloorToMinutes(this.now, 15)
+			this.updateEndDate(flooredEndDate, false)
+			const int = parseInt(newValue.slice(0, -1))
+			const unit = newValue.slice(-1)
+			this.updateStartDate(dayjs(this.inputEndDate).subtract(int, unit), false)
 		},
 	},
-};
+}
 </script>

--- a/press/api/analytics.py
+++ b/press/api/analytics.py
@@ -794,114 +794,151 @@ def get_additional_duration_reports(
 
 @frappe.whitelist()
 @protected("Site")
-def get_advanced_analytics(
+def get_request_count_by_path(
 	name: str, timezone: str, start: str, end: str, max_no_of_paths: int = MAX_NO_OF_PATHS
 ):
 	start_dt = parse_iso_datetime(start)
 	end_dt = parse_iso_datetime(end)
 	timespan, timegrain = auto_timespan_timegrain(start_dt, end_dt)
+	return {
+		"request_count_by_path": get_request_by_(
+			name, "count", timezone, start_dt, end_dt, timespan, timegrain, ResourceType.SITE, max_no_of_paths
+		)
+	}
 
-	job_data = get_usage(name, "job", timezone, start_dt, end_dt, timegrain)
 
+@frappe.whitelist()
+@protected("Site")
+def get_request_duration_by_path(
+	name: str, timezone: str, start: str, end: str, max_no_of_paths: int = MAX_NO_OF_PATHS
+):
+	start_dt = parse_iso_datetime(start)
+	end_dt = parse_iso_datetime(end)
+	timespan, timegrain = auto_timespan_timegrain(start_dt, end_dt)
 	request_duration_by_path = get_request_by_(
-		name,
-		"duration",
-		timezone,
-		start_dt,
-		end_dt,
-		timespan,
-		timegrain,
-		ResourceType.SITE,
-		max_no_of_paths,
+		name, "duration", timezone, start_dt, end_dt, timespan, timegrain, ResourceType.SITE, max_no_of_paths
+	)
+	# The slow-path breakdowns depend on the top paths of this chart, so they are
+	# computed here (in this worker) rather than as a dependent second request.
+	return {"request_duration_by_path": request_duration_by_path} | get_additional_duration_reports(
+		request_duration_by_path, name, timezone, start_dt, end_dt, timespan, timegrain, max_no_of_paths
 	)
 
+
+@frappe.whitelist()
+@protected("Site")
+def get_average_request_duration_by_path(
+	name: str, timezone: str, start: str, end: str, max_no_of_paths: int = MAX_NO_OF_PATHS
+):
+	start_dt = parse_iso_datetime(start)
+	end_dt = parse_iso_datetime(end)
+	timespan, timegrain = auto_timespan_timegrain(start_dt, end_dt)
+	return {
+		"average_request_duration_by_path": get_request_by_(
+			name,
+			"average_duration",
+			timezone,
+			start_dt,
+			end_dt,
+			timespan,
+			timegrain,
+			ResourceType.SITE,
+			max_no_of_paths,
+		)
+	}
+
+
+@frappe.whitelist()
+@protected("Site")
+def get_request_count_by_ip(
+	name: str, timezone: str, start: str, end: str, max_no_of_paths: int = MAX_NO_OF_PATHS
+):
+	start_dt = parse_iso_datetime(start)
+	end_dt = parse_iso_datetime(end)
+	timespan, timegrain = auto_timespan_timegrain(start_dt, end_dt)
+	return {
+		"request_count_by_ip": get_nginx_request_by_(
+			name, "count", timezone, start_dt, end_dt, timespan, timegrain, max_no_of_paths
+		)
+	}
+
+
+@frappe.whitelist()
+@protected("Site")
+def get_background_job_count_by_method(
+	name: str, timezone: str, start: str, end: str, max_no_of_paths: int = MAX_NO_OF_PATHS
+):
+	start_dt = parse_iso_datetime(start)
+	end_dt = parse_iso_datetime(end)
+	timespan, timegrain = auto_timespan_timegrain(start_dt, end_dt)
+	return {
+		"background_job_count_by_method": get_background_job_by_(
+			name, "count", timezone, start_dt, end_dt, timespan, timegrain, ResourceType.SITE, max_no_of_paths
+		)
+	}
+
+
+@frappe.whitelist()
+@protected("Site")
+def get_background_job_duration_by_method(
+	name: str, timezone: str, start: str, end: str, max_no_of_paths: int = MAX_NO_OF_PATHS
+):
+	start_dt = parse_iso_datetime(start)
+	end_dt = parse_iso_datetime(end)
+	timespan, timegrain = auto_timespan_timegrain(start_dt, end_dt)
 	background_job_duration_by_method = get_background_job_by_(
+		name, "duration", timezone, start_dt, end_dt, timespan, timegrain, ResourceType.SITE, max_no_of_paths
+	)
+	# The slow-job breakdowns depend on the top methods of this chart, so they are
+	# computed here (in this worker) rather than as a dependent second request.
+	return {
+		"background_job_duration_by_method": background_job_duration_by_method
+	} | get_additional_duration_reports(
+		background_job_duration_by_method,
 		name,
-		"duration",
 		timezone,
 		start_dt,
 		end_dt,
 		timespan,
 		timegrain,
-		ResourceType.SITE,
 		max_no_of_paths,
 	)
 
-	return (
-		{
-			"request_count_by_path": get_request_by_(
-				name,
-				"count",
-				timezone,
-				start_dt,
-				end_dt,
-				timespan,
-				timegrain,
-				ResourceType.SITE,
-				max_no_of_paths,
-			),
-			"request_duration_by_path": request_duration_by_path,
-			"average_request_duration_by_path": get_request_by_(
-				name,
-				"average_duration",
-				timezone,
-				start_dt,
-				end_dt,
-				timespan,
-				timegrain,
-				ResourceType.SITE,
-				max_no_of_paths,
-			),
-			"request_count_by_ip": get_nginx_request_by_(
-				name, "count", timezone, start_dt, end_dt, timespan, timegrain, max_no_of_paths
-			),
-			"background_job_count_by_method": get_background_job_by_(
-				name,
-				"count",
-				timezone,
-				start_dt,
-				end_dt,
-				timespan,
-				timegrain,
-				ResourceType.SITE,
-				max_no_of_paths,
-			),
-			"background_job_duration_by_method": background_job_duration_by_method,
-			"average_background_job_duration_by_method": get_background_job_by_(
-				name,
-				"average_duration",
-				timezone,
-				start_dt,
-				end_dt,
-				timespan,
-				timegrain,
-				ResourceType.SITE,
-				max_no_of_paths,
-			),
-			"job_count": [{"value": r.count, "date": r.date} for r in job_data],
-			"job_cpu_time": [{"value": r.duration, "date": r.date} for r in job_data],
-		}
-		| get_additional_duration_reports(
-			request_duration_by_path,
+
+@frappe.whitelist()
+@protected("Site")
+def get_average_background_job_duration_by_method(
+	name: str, timezone: str, start: str, end: str, max_no_of_paths: int = MAX_NO_OF_PATHS
+):
+	start_dt = parse_iso_datetime(start)
+	end_dt = parse_iso_datetime(end)
+	timespan, timegrain = auto_timespan_timegrain(start_dt, end_dt)
+	return {
+		"average_background_job_duration_by_method": get_background_job_by_(
 			name,
+			"average_duration",
 			timezone,
 			start_dt,
 			end_dt,
 			timespan,
 			timegrain,
+			ResourceType.SITE,
 			max_no_of_paths,
 		)
-		| get_additional_duration_reports(
-			background_job_duration_by_method,
-			name,
-			timezone,
-			start_dt,
-			end_dt,
-			timespan,
-			timegrain,
-			max_no_of_paths,
-		)
-	)
+	}
+
+
+@frappe.whitelist()
+@protected("Site")
+def get_background_job_usage(name: str, timezone: str, start: str, end: str):
+	start_dt = parse_iso_datetime(start)
+	end_dt = parse_iso_datetime(end)
+	_, timegrain = auto_timespan_timegrain(start_dt, end_dt)
+	job_data = get_usage(name, "job", timezone, start_dt, end_dt, timegrain)
+	return {
+		"job_count": [{"value": r.count, "date": r.date} for r in job_data],
+		"job_cpu_time": [{"value": r.duration, "date": r.date} for r in job_data],
+	}
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Problem

The site insights **Advanced Analytics** section (`sites/<name>/insights/analytics`) loads slowly. `press.api.analytics.get_advanced_analytics` runs ~11 Elasticsearch queries **sequentially** inside a single request handler, so the section blocks on the **sum** of every query's latency — the whole panel only renders once the slowest-accumulated chain finishes.

## Change

Split `get_advanced_analytics` into **eight whitelisted endpoints**, one per chart:

- `get_request_count_by_path`
- `get_request_duration_by_path` (bundles its slow-path breakdowns)
- `get_average_request_duration_by_path`
- `get_request_count_by_ip`
- `get_background_job_count_by_method`
- `get_background_job_duration_by_method` (bundles its report breakdowns)
- `get_average_background_job_duration_by_method`
- `get_background_job_usage` (job count + CPU time)

`SiteAnalytics.vue` now fires these as **independent parallel resources**, each landing on its own worker. Wall-clock time drops from *sum of all queries* to roughly the *slowest single chart*, and each card shows/clears its own loading spinner as its data arrives.

## Notes

- The underlying group-by helpers are already `@redis_cache`-wrapped, so the split adds **no duplicate computation**.
- The slow-path / slow-job breakdowns genuinely depend on the top paths of their parent duration chart, so they stay **bundled inside** the request / background-job duration endpoints rather than becoming a dependent second wave of requests.
- Only consumer of the old endpoint was `SiteAnalytics.vue`; no other callers.