### PR TITLE
fix(dashboard): Stop invoice CSV download logging out non-system users

### DIFF
--- a/dashboard/src/components/InvoiceTable.vue
+++ b/dashboard/src/components/InvoiceTable.vue
@@ -185,18 +185,17 @@ export default {
 		},
 		fetchServerName() {
 			return {
-				url: 'frappe.client.get_value',
+				url: 'press.api.client.get',
 				makeParams(snapshotName) {
 					return {
 						doctype: 'Server Snapshot',
-						filters: { name: snapshotName },
-						fieldname: 'app_server',
+						name: snapshotName,
 					}
 				},
 				onSuccess(r) {
-					const snapshotName =
-						this.$resources.fetchServerName.params.filters.name
-					this.serverSnapshotServers[snapshotName] = r.app_server
+					this.serverSnapshotServers[
+						this.$resources.fetchServerName.params.name
+					] = r?.app_server
 				},
 			}
 		},


### PR DESCRIPTION
## Problem

Customers reported being silently logged out when downloading an invoice as CSV — the session became **Guest** mid-flow and `press.api.billing.fetch_invoice_items` returned **403 PermissionError**.

## Root cause

`InvoiceTable.vue` resolved a **Server Snapshot** line item's server name via `frappe.client.get_value`. For a non-system user (a customer / Website User):

1. `press.auth.hook` (registered as `auth_hooks`) rejects any request path that isn't `press.api.*` / `press.saas.*` / `wiki.*` with `frappe.AuthenticationError`.
2. Frappe clears the session cookies on `AuthenticationError` (`frappe/app.py`), so the browser becomes **Guest**.
3. The next call — `fetch_invoice_items` for the CSV — is now unauthenticated → **403**.

System users bypass `press.auth.hook` entirely, which is why this only ever reproduced for real customers and **not** while testing as Administrator.

## Fix

Fetch the server name through the role-guarded `press.api.client.get` (which matches the `press.api.*` allow-list). Using `get` rather than `get_list` because the list query drops snapshots whose status is `Unavailable` — exactly what older invoices reference.

This was the **last** `frappe.client.*` call left in the dashboard; same bug class as c8a08d429.

## Testing

Reproduced locally as a Website User (non-system) with an invoice containing a Server Snapshot line item: before the fix the session dropped to Guest and the CSV 403'd; after the fix the CSV downloads and the session stays authenticated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)