### PR TITLE
feat(ui): Add quickstart page for new onboarders

### DIFF
--- a/dashboard/src/App.vue
+++ b/dashboard/src/App.vue
@@ -64,6 +64,7 @@ const isHideSidebar = computed(() => {
 		'Site Login',
 		'SignupLoginToSite',
 		'SignupSetup',
+		'Quickstart',
 	]
 	const alwaysHideSidebarPaths = ['/dashboard/site-login']
 

--- a/dashboard/src/components/FilterControl.vue
+++ b/dashboard/src/components/FilterControl.vue
@@ -3,6 +3,7 @@
 		v-if="$attrs.type === 'link'"
 		v-bind="$attrs"
 		class="min-w-[6rem]"
+    :openOnClick="true"
 	/>
 	<TabButtons
 		v-else-if="$attrs.type === 'tab'"

--- a/dashboard/src/data/sites.js
+++ b/dashboard/src/data/sites.js
@@ -6,7 +6,18 @@ export function getActiveSites() {
 	if (!sites) {
 		sites = createListResource({
 			doctype: 'Site',
-			fields: ['name', 'host_name', 'status'],
+			fields: [
+				'name',
+				'host_name',
+				'status',
+				'trial_end_date',
+				'setup_wizard_complete',
+				'additional_system_user_created',
+				'group.version as version',
+				'plan.plan_title as plan_title',
+				'plan.price_usd as price_usd',
+				'plan.price_inr as price_inr',
+			],
 			pageLength: 5,
 			auto: false,
 			cache: 'active-sites',

--- a/dashboard/src/data/sites.js
+++ b/dashboard/src/data/sites.js
@@ -18,6 +18,7 @@ export function getActiveSites() {
 				'plan.price_usd as price_usd',
 				'plan.price_inr as price_inr',
 			],
+			filters: { status: ['not in', ['Archived', 'Inactive']] },
 			pageLength: 5,
 			auto: false,
 			cache: 'active-sites',

--- a/dashboard/src/data/sites.js
+++ b/dashboard/src/data/sites.js
@@ -1,0 +1,16 @@
+import { createListResource } from 'frappe-ui'
+
+let sites
+
+export function getActiveSites() {
+	if (!sites) {
+		sites = createListResource({
+			doctype: 'Site',
+			fields: ['name', 'host_name', 'status'],
+			pageLength: 5,
+			auto: false,
+			cache: 'active-sites',
+		})
+	}
+	return sites
+}

--- a/dashboard/src/main.js
+++ b/dashboard/src/main.js
@@ -170,7 +170,7 @@ getInitialData().then(() => {
 	}
 
 	importGlobals().then(() => {
-		app.mount('#app');
+		router.isReady().then(() => app.mount('#app'));
 	});
 
 	if (workingHours()) {

--- a/dashboard/src/pages/LoginSignup.vue
+++ b/dashboard/src/pages/LoginSignup.vue
@@ -852,7 +852,8 @@ export default {
 				loginRoute = redirect;
 			}
 			localStorage.setItem('login_email', this.email);
-			window.location.href = loginRoute;
+			let separator = loginRoute.includes('?') ? '&' : '?';
+			window.location.href = `${loginRoute}${separator}post_login=1`;
 		},
 	},
 	computed: {

--- a/dashboard/src/pages/Quickstart.vue
+++ b/dashboard/src/pages/Quickstart.vue
@@ -2,14 +2,13 @@
 import { computed, onMounted, ref } from 'vue'
 import { Spinner } from 'frappe-ui'
 import { toast } from 'vue-sonner'
-import FCLogo from '../components/icons/FCLogo.vue'
-import { getActiveSites } from '../data/sites'
-import { getTeam } from '../data/team'
-import { session } from '../data/session'
-import { trialDays } from '../utils/site'
-import { planTitle } from '../utils/format'
-import { getDocResource } from '../utils/resource'
-import { getToastErrorMessage } from '../utils/toast'
+import FCLogo from '@/components/icons/FCLogo.vue'
+import { getActiveSites } from '@/data/sites'
+import { getTeam } from '@/data/team'
+import { trialDays } from '@/utils/site'
+import { planTitle, userCurrency } from '@/utils/format'
+import { getDocResource } from '@/utils/resource'
+import { getToastErrorMessage } from '@/utils/toast'
 
 defineOptions({ name: 'Quickstart' })
 
@@ -17,8 +16,22 @@ const team = getTeam()
 const sitesResource = getActiveSites()
 const sites = computed(() => sitesResource.data || [])
 
-const sitePlan = (site) =>
-	site.trial_end_date ? trialDays(site.trial_end_date) : planTitle(site)
+const sitePlan = (site) => {
+	if (site.trial_end_date) return trialDays(site.trial_end_date)
+
+	let plan = planTitle(site)
+
+	if (site.price_usd > 0) {
+		const india = team.doc?.currency === 'INR'
+		const formattedValue = userCurrency(
+			india ? site.price_inr : site.price_usd,
+			0,
+		)
+		plan = `${formattedValue}/mo`
+	}
+
+	return `You're on ${plan} plan`
+}
 
 const siteLoginMethods = {
 	loginAsAdmin: 'login_as_admin',
@@ -69,107 +82,60 @@ onMounted(() => {
 </script>
 
 <template>
-	<div class="mx-auto max-w-2xl px-5 py-10 min-h-screen" v-if="team?.doc">
+	<div class="mx-auto max-w-sm px-5 py-20 min-h-screen" v-if="team?.doc">
 		<!-- header -->
-		<div class="flex items-center gap-2">
-			<FCLogo class="size-8 rounded" />
-			<div class="flex flex-col gap-0.5 mr-auto">
-				<div class="text-base font-medium text-ink-gray-9">Frappe Cloud</div>
-				<div class="text-sm text-ink-gray-5">Account</div>
-			</div>
+		<div class="flex items-center gap-2"></div>
 
-			<Button class="!text-ink-gray-7">
-				<template #prefix>
-					<Avatar
-						:label="team.doc.user_info.first_name"
-						:image="team.doc.user_info.user_image"
-						size="sm"
-						class="[&>*]:bg-surface-gray-4"
-					/>
-				</template>
-				{{ team.doc.user_info.email }}
-			</Button>
+		<FCLogo class="size-10 rounded mb-6" />
 
-			<Button @click="session.logout.submit">
-				<template #prefix>
-					<LucideLogOut class="size-4" />
-				</template>
-				Sign out</Button
+		<h2 class="text-2xl font-semibold text-ink-gray-9">
+			Where do you want to go?
+		</h2>
+
+		<p class="mt-1 text-p-base text-ink-gray-5 mb-8">
+			Select a site or continue to Frappe Cloud.
+		</p>
+
+		<template v-if="sites.length">
+			<a
+				v-for="(site, i) in sites.slice(0,3)"
+				:key="site.name"
+				class="grid grid-cols-[auto_1fr_auto] items-center gap-1.5 mb-3 cursor-pointer"
+				@click="openSite(site)"
 			>
-		</div>
+				<LucideGlobe class="size-4 text-ink-gray-6 mt-1 mr-1" />
+				<span class="text-base text-ink-gray-9">
+					{{ site.host_name || site.name }}
+				</span>
 
-		<div class="flex items-start justify-between mt-10">
-			<div>
-				<h2 class="text-2xl font-semibold text-ink-gray-9">
-					Where do you want to go?
-				</h2>
-				<p class="mt-1 text-p-base text-ink-gray-5">
-					Select a site or continue to Frappe Cloud.
-				</p>
-			</div>
+				<Spinner
+					v-if="loadingSite === site.name"
+					class="size-4 text-ink-gray-4"
+				/>
+				<LucideArrowRight v-else class="size-4 text-ink-gray-6" />
 
-			<Button variant="solid" :route="{ name: 'Site List' }">
-				Go to Dashboard
-				<template #suffix>
-					<lucide-arrow-right class="size-4" />
-				</template>
-			</Button>
-		</div>
+				<span />
 
-		<table class="mt-8 w-full text-sm" v-if="sites.length">
-			<thead>
-				<tr class="border-b">
-					<th class="pb-3 text-left font-medium text-ink-gray-9">Your sites</th>
-					<th class="pb-3 text-right font-normal text-ink-gray-5">Plan</th>
-					<th class="pb-3 text-right font-normal text-ink-gray-5">
-						{{ sites.length }}
-						sites
-					</th>
-				</tr>
-			</thead>
-
-			<tbody>
-				<tr
-					class="border-b cursor-pointer"
-					v-for="site in sites"
-					:key="site.name"
-					@click="openSite(site)"
+				<div
+					class="flex gap-2 items-center col-span-2 pb-3"
+					:class="i == sites.slice(0,3).length - 1 ? '' : 'border-b'"
 				>
-					<td class="py-3">
-						<div class="flex items-center gap-3">
-							<Avatar
-								:label="site.host_name || site.name"
-								shape="square"
-								size="lg"
-							/>
-							<span class="text-base text-ink-gray-9">
-								{{ site.host_name || site.name }}
-							</span>
-						</div>
-					</td>
-					<td class="py-3 text-right text-ink-gray-5">
-						{{ sitePlan(site) }}
-					</td>
-					<td class="py-3">
-						<div class="flex items-center gap-2 justify-end">
-							<Badge :label="site.status" />
-							<Spinner
-								v-if="loadingSite === site.name"
-								class="size-4 text-ink-gray-4"
-							/>
-							<LucideChevronRight v-else class="size-4 text-ink-gray-4" />
-						</div>
-					</td>
-				</tr>
-			</tbody>
-		</table>
+					<span class="text-ink-gray-5"> {{ sitePlan(site) }}</span>
+					<Badge :label="site.status" />
+				</div>
+			</a>
+		</template>
 
 		<p class="mt-2 flex flex-col items-center gap-3 py-8 text-center" v-else>
 			You don't have any sites yet.
 		</p>
 
+		<Button variant="solid" :route="{ name: 'Site List' }" class="w-full mt-2">
+			Go to Dashboard
+		</Button>
+
 		<div
-			class="flex justify-center gap-2 pt-4 text-sm text-ink-gray-6"
+			class="flex justify-center gap-2 pt-4  text-ink-gray-6"
 			:class="sites.length ? '' : 'border-t'"
 		>
 			<a
@@ -186,14 +152,6 @@ onMounted(() => {
 				target="_blank"
 			>
 				Support
-			</a>
-			<span>·</span>
-			<a
-				class="hover:text-ink-gray-8"
-				href="https://frappecloud.com/policies"
-				target="_blank"
-			>
-				Terms
 			</a>
 		</div>
 	</div>

--- a/dashboard/src/pages/Quickstart.vue
+++ b/dashboard/src/pages/Quickstart.vue
@@ -26,9 +26,9 @@ const siteLoginMethods = {
 const loadingSite = ref(null)
 
 const openSite = (site) => {
-	if (site.status !== 'Archived' && site.setup_wizard_complete) {
+	if (site.status === 'Active' && site.setup_wizard_complete) {
 		let siteURL = `https://${site.name}`
-		if (site.version === 'Nightly' || Number(site.version?.split(' ')[1]) >= 15)
+		if (site.version === 'Nightly' || Number(site.version?.split(' ')?.[1]) >= 15)
 			siteURL += '/apps'
 		window.open(siteURL, '_blank')
 		return

--- a/dashboard/src/pages/Quickstart.vue
+++ b/dashboard/src/pages/Quickstart.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { Spinner } from 'frappe-ui'
+import { toast } from 'vue-sonner'
 import FCLogo from '../components/icons/FCLogo.vue'
 import { getActiveSites } from '../data/sites'
 import { getTeam } from '../data/team'
@@ -8,6 +9,7 @@ import { session } from '../data/session'
 import { trialDays } from '../utils/site'
 import { planTitle } from '../utils/format'
 import { getDocResource } from '../utils/resource'
+import { getToastErrorMessage } from '../utils/toast'
 
 defineOptions({ name: 'Quickstart' })
 
@@ -49,10 +51,16 @@ const openSite = (site) => {
 		login
 			.submit({ reason: '' })
 			.then((url) => window.open(url, '_blank'))
+			.catch((e) => {
+				toast.error(getToastErrorMessage(e, 'Failed to set up site'))
+			})
 			.finally(() => {
 				loadingSite.value = null
 			})
+		return
 	}
+
+	toast.error(`${site.host_name || site.name} isn't ready yet`)
 }
 
 onMounted(() => {

--- a/dashboard/src/pages/Quickstart.vue
+++ b/dashboard/src/pages/Quickstart.vue
@@ -30,22 +30,24 @@ onMounted(() => {
 				<div class="text-sm text-ink-gray-5">Account</div>
 			</div>
 
-			<Dropdown :options="accountDropdownOptions">
-				<Button class="text-sm !text-ink-gray-6">
-					<template #prefix>
-						<Avatar
-							:label="team.doc.user_info.first_name"
-							:image="team.doc.user_info.user_image"
-							size="sm"
-							class="[&>*]:bg-surface-gray-4"
-						/>
-					</template>
-					{{ team.doc.user_info.email }}
-					<template #suffix>
-						<LucideChevronDown class="size-4 shrink-0 text-ink-gray-6" />
-					</template>
-				</Button>
-			</Dropdown>
+			<Button class='!text-ink-gray-7'>
+				<template #prefix>
+					<Avatar
+						:label="team.doc.user_info.first_name"
+						:image="team.doc.user_info.user_image"
+						size="sm"
+						class="[&>*]:bg-surface-gray-4"
+					/>
+				</template>
+				{{ team.doc.user_info.email }}
+			</Button>
+
+			<Button>
+				<template #prefix>
+					<LucideLogOut class="size-4" />
+				</template>
+				Sign out</Button
+			>
 		</div>
 
 		<div class="flex items-start justify-between mt-10">
@@ -73,10 +75,10 @@ onMounted(() => {
 
 		<template v-if="sites.length">
 			<a
-				class="flex items-center justify-between py-3 border-b" 
+				class="flex items-center justify-between py-3 border-b"
 				v-for="site in sites"
 				:key="site.name"
-        :href="'https://' + site.name"
+				:href="'https://' + site.name"
 			>
 				<div class="flex items-center gap-3">
 					<Avatar
@@ -95,20 +97,17 @@ onMounted(() => {
 			</a>
 		</template>
 
-		<p
-			class="mt-2 flex flex-col items-center gap-3 py-8 text-center"
-			v-else
-		>
+		<p class="mt-2 flex flex-col items-center gap-3 py-8 text-center" v-else>
 			You don't have any sites yet.
 		</p>
 
 		<div
 			class="flex justify-center gap-2 pt-4 text-sm text-ink-gray-6"
-      :class="sites.length ? '' : 'border-t'"
+			:class="sites.length ? '' : 'border-t'"
 		>
 			<a
 				class="hover:text-ink-gray-8"
-				href="https://frappecloud.com/contact"
+				href="https://frappe.io/contact-us"
 				target="_blank"
 			>
 				Contact us

--- a/dashboard/src/pages/Quickstart.vue
+++ b/dashboard/src/pages/Quickstart.vue
@@ -116,7 +116,7 @@ onMounted(() => {
 		</p>
 
 		<Button variant="solid" :route="{ name: 'Site List' }" class="w-full mt-2">
-			Go to Dashboard
+			Go to Cloud Dashboard
 		</Button>
 
 		<div

--- a/dashboard/src/pages/Quickstart.vue
+++ b/dashboard/src/pages/Quickstart.vue
@@ -4,6 +4,9 @@ import FCLogo from '../components/icons/FCLogo.vue'
 import { getActiveSites } from '../data/sites'
 import { getTeam } from '../data/team'
 import { session } from '../data/session'
+import { trialDays } from '../utils/site'
+import { planTitle } from '../utils/format'
+import { getDocResource } from '../utils/resource'
 
 defineOptions({ name: 'Quickstart' })
 
@@ -11,9 +14,37 @@ const team = getTeam()
 const sitesResource = getActiveSites()
 const sites = computed(() => sitesResource.data || [])
 
-const accountDropdownOptions = [
-	{ label: 'Logout', icon: 'log-out', onClick: session.logout.submit },
-]
+const sitePlan = (site) =>
+	site.trial_end_date ? trialDays(site.trial_end_date) : planTitle(site)
+
+const siteLoginMethods = {
+	loginAsAdmin: 'login_as_admin',
+	loginAsTeam: 'login_as_team',
+}
+
+const openSite = (site) => {
+	if (site.status !== 'Archived' && site.setup_wizard_complete) {
+		let siteURL = `https://${site.name}`
+		if (site.version === 'Nightly' || Number(site.version?.split(' ')[1]) >= 15)
+			siteURL += '/apps'
+		window.open(siteURL, '_blank')
+		return
+	}
+
+	if (site.status === 'Active' && !site.setup_wizard_complete) {
+		const doc = getDocResource({
+			doctype: 'Site',
+			name: site.name,
+			whitelistedMethods: siteLoginMethods,
+		})
+
+		const login = site.additional_system_user_created
+			? doc.loginAsTeam
+			: doc.loginAsAdmin
+
+		login.submit({ reason: '' }).then((url) => window.open(url, '_blank'))
+	}
+}
 
 onMounted(() => {
 	if (!sitesResource.data) sitesResource.list.fetch()
@@ -30,7 +61,7 @@ onMounted(() => {
 				<div class="text-sm text-ink-gray-5">Account</div>
 			</div>
 
-			<Button class='!text-ink-gray-7'>
+			<Button class="!text-ink-gray-7">
 				<template #prefix>
 					<Avatar
 						:label="team.doc.user_info.first_name"
@@ -42,7 +73,7 @@ onMounted(() => {
 				{{ team.doc.user_info.email }}
 			</Button>
 
-			<Button>
+			<Button @click="session.logout.submit">
 				<template #prefix>
 					<LucideLogOut class="size-4" />
 				</template>
@@ -68,34 +99,49 @@ onMounted(() => {
 			</Button>
 		</div>
 
-		<div class="mt-8 flex items-center justify-between text-sm border-b pb-3">
-			<span class="font-medium text-ink-gray-9">Your sites</span>
-			<span class="text-ink-gray-5">{{ sites.length }} sites</span>
-		</div>
+		<table class="mt-8 w-full text-sm" v-if="sites.length">
+			<thead>
+				<tr class="border-b">
+					<th class="pb-3 text-left font-medium text-ink-gray-9">Your sites</th>
+					<th class="pb-3 text-right font-normal text-ink-gray-5">Plan</th>
+					<th class="pb-3 text-right font-normal text-ink-gray-5">
+						{{ sites.length }}
+						sites
+					</th>
+				</tr>
+			</thead>
 
-		<template v-if="sites.length">
-			<a
-				class="flex items-center justify-between py-3 border-b"
-				v-for="site in sites"
-				:key="site.name"
-				:href="'https://' + site.name"
-			>
-				<div class="flex items-center gap-3">
-					<Avatar
-						:label="site.host_name || site.name"
-						shape="square"
-						size="lg"
-					/>
-					<span class="text-base text-ink-gray-9">
-						{{ site.host_name || site.name }}
-					</span>
-				</div>
-				<div class="flex items-center gap-2">
-					<Badge :label="site.status" />
-					<LucideChevronRight class="size-4 text-ink-gray-4" />
-				</div>
-			</a>
-		</template>
+			<tbody>
+				<tr
+					class="border-b cursor-pointer"
+					v-for="site in sites"
+					:key="site.name"
+					@click="openSite(site)"
+				>
+					<td class="py-3">
+						<div class="flex items-center gap-3">
+							<Avatar
+								:label="site.host_name || site.name"
+								shape="square"
+								size="lg"
+							/>
+							<span class="text-base text-ink-gray-9">
+								{{ site.host_name || site.name }}
+							</span>
+						</div>
+					</td>
+					<td class="py-3 text-right text-ink-gray-5">
+						{{ sitePlan(site) }}
+					</td>
+					<td class="py-3">
+						<div class="flex items-center gap-2 justify-end">
+							<Badge :label="site.status" />
+							<LucideChevronRight class="size-4 text-ink-gray-4" />
+						</div>
+					</td>
+				</tr>
+			</tbody>
+		</table>
 
 		<p class="mt-2 flex flex-col items-center gap-3 py-8 text-center" v-else>
 			You don't have any sites yet.

--- a/dashboard/src/pages/Quickstart.vue
+++ b/dashboard/src/pages/Quickstart.vue
@@ -1,0 +1,134 @@
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import FCLogo from '../components/icons/FCLogo.vue'
+import { getActiveSites } from '../data/sites'
+import { getTeam } from '../data/team'
+import { session } from '../data/session'
+
+defineOptions({ name: 'Quickstart' })
+
+const team = getTeam()
+const sitesResource = getActiveSites()
+const sites = computed(() => sitesResource.data || [])
+
+const accountDropdownOptions = [
+	{ label: 'Logout', icon: 'log-out', onClick: session.logout.submit },
+]
+
+onMounted(() => {
+	if (!sitesResource.data) sitesResource.list.fetch()
+})
+</script>
+
+<template>
+	<div class="mx-auto max-w-2xl px-5 py-10 min-h-screen" v-if="team?.doc">
+		<!-- header -->
+		<div class="flex items-center gap-2">
+			<FCLogo class="size-8 rounded" />
+			<div class="flex flex-col gap-0.5 mr-auto">
+				<div class="text-base font-medium text-ink-gray-9">Frappe Cloud</div>
+				<div class="text-sm text-ink-gray-5">Account</div>
+			</div>
+
+			<Dropdown :options="accountDropdownOptions">
+				<Button class="text-sm !text-ink-gray-6">
+					<template #prefix>
+						<Avatar
+							:label="team.doc.user_info.first_name"
+							:image="team.doc.user_info.user_image"
+							size="sm"
+							class="[&>*]:bg-surface-gray-4"
+						/>
+					</template>
+					{{ team.doc.user_info.email }}
+					<template #suffix>
+						<LucideChevronDown class="size-4 shrink-0 text-ink-gray-6" />
+					</template>
+				</Button>
+			</Dropdown>
+		</div>
+
+		<div class="flex items-start justify-between mt-10">
+			<div>
+				<h2 class="text-2xl font-semibold text-ink-gray-9">
+					Where do you want to go?
+				</h2>
+				<p class="mt-1 text-p-base text-ink-gray-5">
+					Select a site or continue to Frappe Cloud.
+				</p>
+			</div>
+
+			<Button variant="solid" :route="{ name: 'Site List' }">
+				Go to Dashboard
+				<template #suffix>
+					<lucide-arrow-right class="size-4" />
+				</template>
+			</Button>
+		</div>
+
+		<div class="mt-8 flex items-center justify-between text-sm border-b pb-3">
+			<span class="font-medium text-ink-gray-9">Your sites</span>
+			<span class="text-ink-gray-5">{{ sites.length }} sites</span>
+		</div>
+
+		<template v-if="sites.length">
+			<a
+				class="flex items-center justify-between py-3 border-b" 
+				v-for="site in sites"
+				:key="site.name"
+        :href="'https://' + site.name"
+			>
+				<div class="flex items-center gap-3">
+					<Avatar
+						:label="site.host_name || site.name"
+						shape="square"
+						size="lg"
+					/>
+					<span class="text-base text-ink-gray-9">
+						{{ site.host_name || site.name }}
+					</span>
+				</div>
+				<div class="flex items-center gap-2">
+					<Badge :label="site.status" />
+					<LucideChevronRight class="size-4 text-ink-gray-4" />
+				</div>
+			</a>
+		</template>
+
+		<p
+			class="mt-2 flex flex-col items-center gap-3 py-8 text-center"
+			v-else
+		>
+			You don't have any sites yet.
+		</p>
+
+		<div
+			class="flex justify-center gap-2 pt-4 text-sm text-ink-gray-6"
+      :class="sites.length ? '' : 'border-t'"
+		>
+			<a
+				class="hover:text-ink-gray-8"
+				href="https://frappecloud.com/contact"
+				target="_blank"
+			>
+				Contact us
+			</a>
+			<span>·</span>
+			<a
+				class="hover:text-ink-gray-8"
+				href="https://support.frappe.io/helpdesk/my-tickets/new"
+				target="_blank"
+			>
+				Support
+			</a>
+			<span>·</span>
+			<a
+				class="hover:text-ink-gray-8"
+				href="https://frappecloud.com/policies"
+				target="_blank"
+			>
+				Terms
+			</a>
+		</div>
+	</div>
+</template>

--- a/dashboard/src/pages/Quickstart.vue
+++ b/dashboard/src/pages/Quickstart.vue
@@ -6,7 +6,6 @@ import FCLogo from '@/components/icons/FCLogo.vue'
 import { getActiveSites } from '@/data/sites'
 import { getTeam } from '@/data/team'
 import { trialDays } from '@/utils/site'
-import { planTitle, userCurrency } from '@/utils/format'
 import { getDocResource } from '@/utils/resource'
 import { getToastErrorMessage } from '@/utils/toast'
 
@@ -16,22 +15,8 @@ const team = getTeam()
 const sitesResource = getActiveSites()
 const sites = computed(() => sitesResource.data || [])
 
-const sitePlan = (site) => {
-	if (site.trial_end_date) return trialDays(site.trial_end_date)
-
-	let plan = planTitle(site)
-
-	if (site.price_usd > 0) {
-		const india = team.doc?.currency === 'INR'
-		const formattedValue = userCurrency(
-			india ? site.price_inr : site.price_usd,
-			0,
-		)
-		plan = `${formattedValue}/mo`
-	}
-
-	return `You're on ${plan} plan`
-}
+const sitePlan = (site) =>
+	site.trial_end_date ? trialDays(site.trial_end_date) : null
 
 const siteLoginMethods = {
 	loginAsAdmin: 'login_as_admin',
@@ -120,8 +105,10 @@ onMounted(() => {
 					class="flex gap-2 items-center col-span-2 pb-3"
 					:class="i == sites.slice(0,3).length - 1 ? '' : 'border-b'"
 				>
-					<span class="text-ink-gray-5"> {{ sitePlan(site) }}</span>
-					<Badge :label="site.status" />
+					<span class="text-ink-gray-5" v-if="sitePlan(site)">
+						{{ sitePlan(site) }}</span
+					>
+					<Badge :label="site.status" variant='outline' />
 				</div>
 			</a>
 		</template>

--- a/dashboard/src/pages/Quickstart.vue
+++ b/dashboard/src/pages/Quickstart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
+import { Spinner } from 'frappe-ui'
 import FCLogo from '../components/icons/FCLogo.vue'
 import { getActiveSites } from '../data/sites'
 import { getTeam } from '../data/team'
@@ -22,6 +23,8 @@ const siteLoginMethods = {
 	loginAsTeam: 'login_as_team',
 }
 
+const loadingSite = ref(null)
+
 const openSite = (site) => {
 	if (site.status !== 'Archived' && site.setup_wizard_complete) {
 		let siteURL = `https://${site.name}`
@@ -42,7 +45,13 @@ const openSite = (site) => {
 			? doc.loginAsTeam
 			: doc.loginAsAdmin
 
-		login.submit({ reason: '' }).then((url) => window.open(url, '_blank'))
+		loadingSite.value = site.name
+		login
+			.submit({ reason: '' })
+			.then((url) => window.open(url, '_blank'))
+			.finally(() => {
+				loadingSite.value = null
+			})
 	}
 }
 
@@ -136,7 +145,11 @@ onMounted(() => {
 					<td class="py-3">
 						<div class="flex items-center gap-2 justify-end">
 							<Badge :label="site.status" />
-							<LucideChevronRight class="size-4 text-ink-gray-4" />
+							<Spinner
+								v-if="loadingSite === site.name"
+								class="size-4 text-ink-gray-4"
+							/>
+							<LucideChevronRight v-else class="size-4 text-ink-gray-4" />
 						</div>
 					</td>
 				</tr>

--- a/dashboard/src/pages/Quickstart.vue
+++ b/dashboard/src/pages/Quickstart.vue
@@ -85,11 +85,11 @@ onMounted(() => {
 			<a
 				v-for="(site, i) in sites.slice(0,3)"
 				:key="site.name"
-				class="grid grid-cols-[auto_1fr_auto] items-center gap-1.5 mb-3 cursor-pointer"
+				class="grid grid-cols-[1fr_auto] items-center gap-1.5 mb-3 cursor-pointer"
 				@click="openSite(site)"
 			>
-				<LucideGlobe class="size-4 text-ink-gray-6 mt-1 mr-1" />
-				<span class="text-base text-ink-gray-9">
+				<span class="relative text-base text-ink-gray-8">
+					<LucideGlobe class="absolute -left-6 size-4 text-ink-gray-6 mt-0.5" />
 					{{ site.host_name || site.name }}
 				</span>
 
@@ -98,8 +98,6 @@ onMounted(() => {
 					class="size-4 text-ink-gray-4"
 				/>
 				<LucideArrowRight v-else class="size-4 text-ink-gray-6" />
-
-				<span />
 
 				<div
 					class="flex gap-2 items-center col-span-2 pb-3"

--- a/dashboard/src/pages/Welcome.vue
+++ b/dashboard/src/pages/Welcome.vue
@@ -5,6 +5,7 @@
 </template>
 <script>
 import { getTeam } from '../data/team';
+import { getActiveSites } from '../data/sites';
 import Onboarding from '../components/Onboarding.vue';
 import OnboardingWithoutPayment from '../components/OnboardingWithoutPayment.vue';
 export default {
@@ -21,20 +22,31 @@ export default {
 	mounted() {
 		this.from = window.from;
 	},
-	beforeRouteEnter: (to, from, next) => {
+	beforeRouteEnter: async (to, from, next) => {
 		// adding to window object so that it can be accessed in mounted
 		// since beforeRouteEnter is called before mounted
 		window.from = from;
 
 		let $team = getTeam();
 		window.$team = $team;
-		if ($team?.doc.onboarding.complete && $team?.doc.onboarding.site_created) {
-			next({ name: 'Site List' });
-		} else if (to.query.is_redirect && $team?.doc.onboarding.site_created) {
-			next({ name: 'Site List' });
-		} else {
+		let onboarded =
+			($team?.doc.onboarding.complete && $team?.doc.onboarding.site_created) ||
+			(to.query.is_redirect && $team?.doc.onboarding.site_created);
+
+		if (!onboarded) {
 			next();
+			return;
 		}
+
+		// only run the <3-sites quickstart check right after login only!!
+		if (!to.query.post_login) {
+			next({ name: 'Site List' });
+			return;
+		}
+
+		let sites = getActiveSites();
+		if (!sites.data) await sites.list.fetch();
+		next({ name: sites.data.length < 3 ? 'Quickstart' : 'Site List' });
 	},
 	methods: {
 		routeToSourcePage() {

--- a/dashboard/src/pages/Welcome.vue
+++ b/dashboard/src/pages/Welcome.vue
@@ -45,8 +45,13 @@ export default {
 		}
 
 		let sites = getActiveSites();
-		if (!sites.data) await sites.list.fetch();
-		next({ name: sites.data.length < 3 ? 'Quickstart' : 'Site List' });
+		try {
+			if (!sites.data) await sites.list.fetch();
+		} catch (e) {
+			next({ name: 'Site List' });
+			return;
+		}
+		next({ name: sites.data.length <= 3 ? 'Quickstart' : 'Site List' });
 	},
 	methods: {
 		routeToSourcePage() {

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -14,6 +14,7 @@ let router = createRouter({
 				next({
 					name: 'Welcome',
 					query: {
+						...to.query,
 						is_redirect: true,
 					},
 				})
@@ -23,6 +24,12 @@ let router = createRouter({
 			path: '/welcome',
 			name: 'Welcome',
 			component: () => import('./pages/Welcome.vue'),
+			meta: { hideSidebar: true },
+		},
+		{
+			path: '/quickstart',
+			name: 'Quickstart',
+			component: () => import('./pages/Quickstart.vue'),
 			meta: { hideSidebar: true },
 		},
 		{


### PR DESCRIPTION
## Description 

Showing quick site list page after user login on <= 3 sites. For better onboarding. Tested 2 scenarios:

- Page will show a CTA for create site if user doesnt have that product's trial site
- Had trial site of CRM already, page will not show create site button


## Image


<img width="401" alt="image" src="https://github.com/user-attachments/assets/2740a7fd-6dbb-4a95-9e78-a251197e74e2" />


https://github.com/user-attachments/assets/e4d1741e-562a-48c6-aa36-6740aacea068

