### PR TITLE
refactor(ui): Improve sites list page to make it consistent

### DIFF
--- a/dashboard/src/components/BillingAlerts.vue
+++ b/dashboard/src/components/BillingAlerts.vue
@@ -38,7 +38,7 @@ const getUnpaidInvoices = createResource({
 		order_by: 'creation desc',
 		limit: 1,
 	},
-	auto: team.doc?.payment_mode === 'Card' && isAfterFirstWeek,
+	auto: () => team.doc?.payment_mode === 'Card' && isAfterFirstWeek,
 })
 const cardPaymentFailure = computed(() => {
 	const invoices = getUnpaidInvoices.data

--- a/dashboard/src/components/BillingAlerts.vue
+++ b/dashboard/src/components/BillingAlerts.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { createResource } from 'frappe-ui'
+import { computed, defineAsyncComponent } from 'vue'
+import { getTeam } from '@/data/team'
+import dayjs from '@/utils/dayjs'
+
+withDefaults(defineProps<{ ctxType?: string }>(), { ctxType: 'List Page' })
+
+const AlertAddPaymentMode = defineAsyncComponent(() => import('./AlertAddPaymentMode.vue'))
+const AlertCardExpired = defineAsyncComponent(() => import('./AlertCardExpired.vue'))
+const AlertAddressDetails = defineAsyncComponent(() => import('./AlertAddressDetails.vue'))
+const AlertMandateInfo = defineAsyncComponent(() => import('./AlertMandateInfo.vue'))
+const AlertUnpaidInvoices = defineAsyncComponent(() => import('./AlertUnpaidInvoices.vue'))
+const AlertCardPaymentFailed = defineAsyncComponent(() => import('./AlertCardPaymentFailed.vue'))
+const AlertBudgetThreshold = defineAsyncComponent(() => import('./AlertBudgetThreshold.vue'))
+const CustomAlerts = defineAsyncComponent(() => import('./CustomAlerts.vue'))
+
+const team = getTeam()
+const isAfterFirstWeek = dayjs().date() > 6
+
+const isCardExpired = computed(() => {
+	const expiry = team.doc?.payment_method
+	if (!expiry) return false
+	if (expiry.expiry_year < dayjs().year()) return true
+	return expiry.expiry_year == dayjs().year() && expiry.expiry_month < dayjs().month() + 1
+})
+const isMandateNotSet = computed(() => !team.doc?.payment_method?.stripe_mandate_id)
+
+const getAmountDue = createResource({ url: 'press.api.billing.total_unpaid_amount', auto: true })
+const hasUnpaidInvoices = computed(() => getAmountDue.data)
+
+const getUnpaidInvoices = createResource({
+	url: 'press.api.client.get_list',
+	params: {
+		doctype: 'Invoice',
+		fields: ['name', 'stripe_invoice_url', 'stripe_payment_failed', 'stripe_payment_error'],
+		filters: { status: 'Unpaid', type: 'Subscription' },
+		order_by: 'creation desc',
+		limit: 1,
+	},
+	auto: team.doc?.payment_mode === 'Card' && isAfterFirstWeek,
+})
+const cardPaymentFailure = computed(() => {
+	const invoices = getUnpaidInvoices.data
+	if (!invoices) return null
+	return (
+		invoices.find((inv: any) => {
+			if (!inv.stripe_payment_failed || !inv.stripe_invoice_url) return false
+			const error = (inv.stripe_payment_error || '').toLowerCase()
+			return error.includes('insufficient fund') || error.includes('mandate amount')
+		}) || null
+	)
+})
+
+const getCurrentBillingAmount = createResource({
+	url: 'press.api.billing.get_current_billing_amount',
+	auto: true,
+	cache: 'Current Billing Amount',
+})
+const displayBudgetAlert = computed(() => {
+	if (
+		!team.doc?.receive_budget_alerts ||
+		!team.doc?.monthly_alert_threshold ||
+		team.doc.monthly_alert_threshold <= 0
+	)
+		return 0
+	const difference = getCurrentBillingAmount.data - team.doc.monthly_alert_threshold
+	return difference > 0 ? difference.toFixed(2) : 0
+})
+</script>
+
+<template>
+	<template v-if="team.doc">
+		<AlertAddPaymentMode class="mb-5" v-if="!team.doc.payment_mode && !team.doc.parent_team" />
+		<AlertCardExpired class="mb-5" v-if="isCardExpired && team.doc?.payment_mode == 'Card'" />
+		<AlertAddressDetails
+			class="mb-5"
+			v-if="!team.doc?.billing_details?.name && team.doc.payment_mode"
+		/>
+		<CustomAlerts :ctx_type="ctxType" />
+		<AlertMandateInfo
+			class="mb-5"
+			v-if="isMandateNotSet && team.doc.currency === 'INR' && team.doc.payment_mode == 'Card'"
+		/>
+		<AlertUnpaidInvoices
+			class="mb-5"
+			v-if="hasUnpaidInvoices > 0 && team.doc.payment_mode == 'Prepaid Credits'"
+			:amount="hasUnpaidInvoices"
+		/>
+		<AlertCardPaymentFailed
+			class="mb-5"
+			v-if="cardPaymentFailure && team.doc.payment_mode == 'Card' && isAfterFirstWeek && !isCardExpired && !isMandateNotSet"
+			:errorMessage="cardPaymentFailure.stripe_payment_error"
+			:stripeUrl="cardPaymentFailure.stripe_invoice_url"
+		/>
+		<AlertBudgetThreshold
+			class="mb-5"
+			v-if="displayBudgetAlert > 0"
+			:amount="displayBudgetAlert"
+			:currency="team.doc.currency == 'INR' ? '₹' : '$'"
+		/>
+	</template>
+</template>

--- a/dashboard/src/components/ObjectList.vue
+++ b/dashboard/src/components/ObjectList.vue
@@ -134,12 +134,15 @@
 				</div>
 			</div>
 			<div
-				class="p-2 text-right"
+				class="flex items-center justify-end gap-3 p-2"
 				:class="{
 					'bg-surface-white bottom-0 sticky': $list?.next && $list?.hasNextPage,
 				}"
 				v-if="$list"
 			>
+				<span class="text-sm text-ink-gray-5" v-if="totalCount != null">
+					{{ totalCount }} {{ countLabel }}
+				</span>
 				<Button
 					v-if="$list.next && $list.hasNextPage"
 					@click="$list.next()"
@@ -267,6 +270,13 @@ export default {
 			const listRes = this.$resources.list
 			if (listRes) void listRes.data
 			return this.options.extraResource(this.context)
+		},
+		count() {
+			if (!this.options.count) return
+			if (typeof this.options.count === 'function') {
+				return this.options.count(this.context)
+			}
+			return this.options.count
 		},
 	},
 	beforeUpdate() {
@@ -444,6 +454,12 @@ export default {
 		isLoading() {
 			if (this.options.data) return false
 			return this.$list.list?.loading || this.$list.loading
+		},
+		totalCount() {
+			return this.$resources.count?.data
+		},
+		countLabel() {
+			return (this.options.title || 'items').toLowerCase()
 		},
 		showControls() {
 			return (

--- a/dashboard/src/objects/site.js
+++ b/dashboard/src/objects/site.js
@@ -1,5 +1,4 @@
 import { Badge, createListResource, createResource, LoadingIndicator } from 'frappe-ui'
-import { unparse } from 'papaparse'
 import { defineAsyncComponent, h } from 'vue'
 import { toast } from 'vue-sonner'
 import ArrowLeftRightIcon from '~icons/lucide/arrow-left-right'
@@ -13,12 +12,11 @@ import { getRunningJobs } from '../utils/agentJob'
 import { confirmDialog, icon, renderDialog } from '../utils/components'
 import dayjs from '../utils/dayjs'
 import { isMobile } from '../utils/device'
-import { bytes, date, userCurrency } from '../utils/format'
+import { bytes, date } from '../utils/format'
 import { getQueryParam, setQueryParam } from '../utils/index'
 import { getDocResource } from '../utils/resource'
-import { getSiteStatusBadge, trialDays } from '../utils/site'
 import { getToastErrorMessage } from '../utils/toast'
-import { clusterOptions, getUpsellBanner } from './common'
+import { getUpsellBanner } from './common'
 import { getAppsTab } from './common/apps'
 
 export default {
@@ -65,209 +63,7 @@ export default {
 	list: {
 		route: '/sites',
 		title: 'Sites',
-		fields: [
-			'plan.plan_title as plan_title',
-			'plan.price_usd as price_usd',
-			'plan.price_inr as price_inr',
-			'group.title as group_title',
-			'group.public as group_public',
-			'group.team as group_team',
-			'group.version as version',
-			'cluster.image as cluster_image',
-			'cluster.title as cluster_title',
-			'trial_end_date',
-			'creation',
-			'is_monitoring_disabled',
-		],
-		orderBy: 'creation desc',
-		searchField: 'host_name',
-		count: {
-			url: 'press.api.account.get_site_count',
-			auto: true,
-		},
-		filterControls() {
-			return [
-				{
-					type: 'select',
-					label: 'Status',
-					fieldname: 'status',
-					options: [
-						'',
-						'Active',
-						'Inactive',
-						'Suspended',
-						'Broken',
-						'Archived',
-					],
-				},
-				{
-					type: 'link',
-					label: 'Version',
-					fieldname: 'group.version',
-					options: {
-						doctype: 'Frappe Version',
-					},
-				},
-				{
-					type: 'link',
-					label: 'Benches',
-					fieldname: 'group',
-					options: {
-						doctype: 'Release Group',
-					},
-				},
-				{
-					type: 'select',
-					label: 'Region',
-					fieldname: 'cluster',
-					options: clusterOptions,
-				},
-				{
-					type: 'link',
-					label: 'Tag',
-					fieldname: 'tags.tag',
-					options: {
-						doctype: 'Press Tag',
-						filters: {
-							doctype_name: 'Site',
-						},
-					},
-				},
-			]
-		},
-		columns: [
-			{
-				label: 'Site',
-				fieldname: 'host_name',
-				width: 1.5,
-				class: 'font-medium',
-				format(value, row) {
-					return value || row.name
-				},
-			},
-			{
-				label: 'Status',
-				fieldname: 'status',
-				type: 'Component',
-				width: '140px',
-				component({ row }) {
-					const badge = getSiteStatusBadge(row.status)
-					return h(
-						Badge,
-						{ variant: 'subtle', class: 'w-fit', theme: badge.theme },
-						() => [
-							h('span', {
-								class: `size-1.5 rounded-full shrink-0 mr-0.5 ${badge.dot}`,
-							}),
-							row.status,
-						],
-					)
-				},
-			},
-			{
-				label: 'Plan',
-				fieldname: 'plan',
-				width: '15rem',
-				format(value, row) {
-					if (row.trial_end_date) {
-						return trialDays(row.trial_end_date)
-					}
-					const $team = getTeam()
-					if (row.price_usd > 0) {
-						const india = $team.doc?.currency === 'INR'
-						const formattedValue = userCurrency(
-							india ? row.price_inr : row.price_usd,
-							0,
-						)
-						return `${formattedValue}/mo`
-					}
-					return row.plan_title
-				},
-			},
-			{
-				label: 'Region',
-				fieldname: 'cluster',
-				width: 1,
-				format(value, row) {
-					return row.cluster_title || value
-				},
-				prefix(row) {
-					return h('img', {
-						src: row.cluster_image,
-						class: 'w-4 h-4',
-						alt: row.cluster_title,
-					})
-				},
-			},
-			{
-				label: 'Benches',
-				fieldname: 'group',
-				width: '15rem',
-				format(value, row) {
-					return row.group_public ? 'Shared' : row.group_title || value
-				},
-			},
-			{
-				label: 'Version',
-				fieldname: 'version',
-				width: 0.5,
-			},
-		],
-		primaryAction({ listResource: sites }) {
-			return {
-				label: 'New Site',
-				variant: 'solid',
-				slots: {
-					prefix: icon('plus'),
-				},
-				onClick() {
-					router.push({ name: 'New Site' })
-				},
-			}
-		},
-		moreActions({ listResource: sites }) {
-			return [
-				{
-					label: 'Export as CSV',
-					icon: 'download',
-					onClick() {
-						const fields = [
-							'host_name',
-							'plan_title',
-							'cluster_title',
-							'group_title',
-							'tags',
-							'version',
-							'creation',
-						]
-						createListResource({
-							doctype: 'Site',
-							url: 'press.api.site.fetch_sites_data_for_export',
-							auto: true,
-							onSuccess(data) {
-								let csv = unparse({
-									fields,
-									data,
-								})
-								csv = '\uFEFF' + csv // for utf-8
-
-								// create a blob and trigger a download
-								const blob = new Blob([csv], {
-									type: 'text/csv;charset=utf-8',
-								})
-								const today = new Date().toISOString().split('T')[0]
-								const filename = `sites-${today}.csv`
-								const link = document.createElement('a')
-								link.href = URL.createObjectURL(blob)
-								link.download = filename
-								link.click()
-								URL.revokeObjectURL(link.href)
-							},
-						})
-					},
-				},
-			]
-		},
+		component: () => import('../pages/sites/list/Page.vue'),
 	},
 	detail: {
 		titleField: 'name',

--- a/dashboard/src/objects/site.js
+++ b/dashboard/src/objects/site.js
@@ -81,6 +81,10 @@ export default {
 		],
 		orderBy: 'creation desc',
 		searchField: 'host_name',
+		count: {
+			url: 'press.api.account.get_site_count',
+			auto: true,
+		},
 		filterControls() {
 			return [
 				{

--- a/dashboard/src/objects/site.js
+++ b/dashboard/src/objects/site.js
@@ -1,4 +1,4 @@
-import { createListResource, createResource, LoadingIndicator } from 'frappe-ui'
+import { Badge, createListResource, createResource, LoadingIndicator } from 'frappe-ui'
 import { unparse } from 'papaparse'
 import { defineAsyncComponent, h } from 'vue'
 import { toast } from 'vue-sonner'
@@ -16,7 +16,7 @@ import { isMobile } from '../utils/device'
 import { bytes, date, userCurrency } from '../utils/format'
 import { getQueryParam, setQueryParam } from '../utils/index'
 import { getDocResource } from '../utils/resource'
-import { trialDays } from '../utils/site'
+import { getSiteStatusBadge, trialDays } from '../utils/site'
 import { getToastErrorMessage } from '../utils/toast'
 import { clusterOptions, getUpsellBanner } from './common'
 import { getAppsTab } from './common/apps'
@@ -145,7 +145,25 @@ export default {
 					return value || row.name
 				},
 			},
-			{ label: 'Status', fieldname: 'status', type: 'Badge', width: '140px' },
+			{
+				label: 'Status',
+				fieldname: 'status',
+				type: 'Component',
+				width: '140px',
+				component({ row }) {
+					const badge = getSiteStatusBadge(row.status)
+					return h(
+						Badge,
+						{ variant: 'subtle', class: 'w-fit', theme: badge.theme },
+						() => [
+							h('span', {
+								class: `size-1.5 rounded-full shrink-0 mr-0.5 ${badge.dot}`,
+							}),
+							row.status,
+						],
+					)
+				},
+			},
 			{
 				label: 'Plan',
 				fieldname: 'plan',

--- a/dashboard/src/pages/ListPage.vue
+++ b/dashboard/src/pages/ListPage.vue
@@ -6,58 +6,7 @@
 			/>
 		</Header>
 		<div class="p-5 pb-0">
-			<AlertAddPaymentMode
-				class="mb-5"
-				v-if="$team?.doc && !$team.doc.payment_mode && !$team.doc.parent_team"
-			/>
-			<AlertCardExpired
-				class="mb-5"
-				v-if="$team?.doc && isCardExpired && $team.doc?.payment_mode == 'Card'"
-			/>
-			<AlertAddressDetails
-				class="mb-5"
-				v-if="
-					$team?.doc &&
-					!$team.doc?.billing_details?.name &&
-					$team.doc.payment_mode
-				"
-			/>
-			<CustomAlerts ctx_type="List Page" />
-			<AlertMandateInfo
-				class="mb-5"
-				v-if="
-					$team?.doc &&
-					isMandateNotSet &&
-					$team.doc.currency === 'INR' &&
-					$team.doc.payment_mode == 'Card'
-				"
-			/>
-			<AlertUnpaidInvoices
-				class="mb-5"
-				v-if="
-					hasUnpaidInvoices > 0 && $team.doc.payment_mode == 'Prepaid Credits'
-				"
-				:amount="hasUnpaidInvoices"
-			/>
-			<AlertCardPaymentFailed
-				class="mb-5"
-				v-if="
-					$team?.doc &&
-					cardPaymentFailure &&
-					$team.doc.payment_mode == 'Card' &&
-					isAfterFirstWeek &&
-					!isCardExpired &&
-					!isMandateNotSet
-				"
-				:errorMessage="cardPaymentFailure.stripe_payment_error"
-				:stripeUrl="cardPaymentFailure.stripe_invoice_url"
-			/>
-			<AlertBudgetThreshold
-				class="mb-5"
-				v-if="displayBudgetAlert > 0"
-				:amount="displayBudgetAlert"
-				:currency="$team.doc.currency == 'INR' ? '₹' : '$'"
-			/>
+			<BillingAlerts ctx-type="List Page" />
 			<ObjectList :options="listOptions" />
 		</div>
 	</div>
@@ -65,11 +14,10 @@
 
 <script>
 import { Breadcrumbs, Button, Dropdown, TextInput } from 'frappe-ui'
-import { defineAsyncComponent } from 'vue'
+import BillingAlerts from '../components/BillingAlerts.vue'
 import Header from '../components/Header.vue'
 import ObjectList from '../components/ObjectList.vue'
 import { getObject } from '../objects'
-import dayjs from '../utils/dayjs'
 
 export default {
 	components: {
@@ -79,30 +27,7 @@ export default {
 		Button,
 		Dropdown,
 		TextInput,
-		AlertAddPaymentMode: defineAsyncComponent(
-			() => import('../components/AlertAddPaymentMode.vue'),
-		),
-		AlertCardExpired: defineAsyncComponent(
-			() => import('../components/AlertCardExpired.vue'),
-		),
-		AlertAddressDetails: defineAsyncComponent(
-			() => import('../components/AlertAddressDetails.vue'),
-		),
-		AlertMandateInfo: defineAsyncComponent(
-			() => import('../components/AlertMandateInfo.vue'),
-		),
-		AlertUnpaidInvoices: defineAsyncComponent(
-			() => import('../components/AlertUnpaidInvoices.vue'),
-		),
-		AlertCardPaymentFailed: defineAsyncComponent(
-			() => import('../components/AlertCardPaymentFailed.vue'),
-		),
-		AlertBudgetThreshold: defineAsyncComponent(
-			() => import('../components/AlertBudgetThreshold.vue'),
-		),
-		CustomAlerts: defineAsyncComponent(
-			() => import('../components/CustomAlerts.vue'),
-		),
+		BillingAlerts,
 	},
 	props: {
 		objectType: {
@@ -129,90 +54,6 @@ export default {
 				...this.object.list,
 				doctype: this.object.doctype,
 				route: this.object.detail ? this.getRoute : null,
-			}
-		},
-		isCardExpired() {
-			if (this.$team.doc.payment_method?.expiry_year < dayjs().year()) {
-				return true
-			} else if (
-				this.$team.doc.payment_method?.expiry_year == dayjs().year() &&
-				this.$team.doc.payment_method?.expiry_month < dayjs().month() + 1
-			) {
-				return true
-			} else {
-				return false
-			}
-		},
-		isMandateNotSet() {
-			return !this.$team.doc?.payment_method?.stripe_mandate_id
-		},
-		hasUnpaidInvoices() {
-			return this.$resources.getAmountDue.data
-		},
-		isAfterFirstWeek() {
-			return dayjs().date() > 6
-		},
-		cardPaymentFailure() {
-			const invoices = this.$resources.getUnpaidInvoices.data
-			if (!invoices) return null
-			return (
-				invoices.find((inv) => {
-					if (!inv.stripe_payment_failed || !inv.stripe_invoice_url)
-						return false
-					const error = (inv.stripe_payment_error || '').toLowerCase()
-					return (
-						error.includes('insufficient fund') ||
-						error.includes('mandate amount')
-					)
-				}) || null
-			)
-		},
-		displayBudgetAlert() {
-			if (
-				!this.$team.doc.receive_budget_alerts ||
-				!this.$team.doc.monthly_alert_threshold ||
-				this.$team.doc.monthly_alert_threshold <= 0
-			) {
-				return 0
-			}
-
-			let difference =
-				this.$resources.getCurrentBillingAmount.data -
-				this.$team.doc.monthly_alert_threshold
-
-			return difference > 0 ? difference.toFixed(2) : 0
-		},
-	},
-	resources: {
-		getAmountDue() {
-			return {
-				url: 'press.api.billing.total_unpaid_amount',
-				auto: true,
-			}
-		},
-		getUnpaidInvoices() {
-			return {
-				url: 'press.api.client.get_list',
-				params: {
-					doctype: 'Invoice',
-					fields: [
-						'name',
-						'stripe_invoice_url',
-						'stripe_payment_failed',
-						'stripe_payment_error',
-					],
-					filters: { status: 'Unpaid', type: 'Subscription' },
-					order_by: 'creation desc',
-					limit: 1,
-				},
-				auto: this.$team?.doc?.payment_mode === 'Card' && this.isAfterFirstWeek,
-			}
-		},
-		getCurrentBillingAmount() {
-			return {
-				url: 'press.api.billing.get_current_billing_amount',
-				auto: true,
-				cache: 'Current Billing Amount',
 			}
 		},
 	},

--- a/dashboard/src/pages/benches/list/BenchRow.vue
+++ b/dashboard/src/pages/benches/list/BenchRow.vue
@@ -12,6 +12,7 @@ import { h, ref, computed, defineAsyncComponent, onBeforeUnmount, watch, reactiv
 import Collapsable from '@/components/common/Collapsable.vue'
 import { renderDialog } from '@/utils/components'
 import { dropBench } from '@/pages/servers/list/utils'
+import { getSiteStatusBadge } from '@/utils/site'
 
 interface Props {
 	data: any
@@ -188,17 +189,6 @@ const siteOptions = (site: any) => [
 	},
 ]
 
-const siteStatusBadges: Record<string, { theme: 'green' | 'red' | 'orange' | 'blue' | 'gray' | null; dot: string }> = {
-	Active: { theme: null, dot: 'bg-surface-green-3' },
-	Inactive: { theme: 'gray', dot: 'bg-surface-gray-4' },
-	Suspended: { theme: 'gray', dot: 'bg-surface-gray-4' },
-	Archived: { theme: 'gray', dot: 'bg-surface-gray-4' },
-	Broken: { theme: 'red', dot: 'bg-surface-red-5' },
-	Draft: { theme: 'orange', dot: 'bg-surface-orange-3' },
-	AwaitingApproval: { theme: 'orange', dot: 'bg-surface-orange-3' },
-	'Update Available': { theme: 'blue', dot: 'bg-surface-blue-3' },
-}
-const defaultSiteStatusBadge = { theme: 'gray' as const, dot: 'bg-surface-gray-4' }
 </script>
 
 <template>
@@ -332,11 +322,11 @@ const defaultSiteStatusBadge = { theme: 'gray' as const, dot: 'bg-surface-gray-4
 					v-else
 					variant="subtle"
 					class="w-fit"
-					:theme="(siteStatusBadges[site.status] || defaultSiteStatusBadge).theme"
+					:theme="getSiteStatusBadge(site.status).theme"
 				>
 					<span
 						class="size-1.5 rounded-full shrink-0 mr-0.5"
-						:class="(siteStatusBadges[site.status] || defaultSiteStatusBadge).dot"
+						:class="getSiteStatusBadge(site.status).dot"
 					/>
 					{{ site.status }}
 				</Badge>

--- a/dashboard/src/pages/servers/list/BenchRow.vue
+++ b/dashboard/src/pages/servers/list/BenchRow.vue
@@ -22,6 +22,7 @@ import {
 import { dropBench } from './utils'
 
 import { dayjsLocal } from '@/utils/dayjs'
+import { getSiteStatusBadge } from '@/utils/site'
 import Collapsable from '@/components/common/Collapsable.vue'
 
 interface Props {
@@ -183,24 +184,6 @@ const siteOptions = (site) => [
 		onClick: () => dropSite(site),
 	},
 ]
-
-const siteStatusBadges: Record<
-	string,
-	{ theme: 'green' | 'red' | 'orange' | 'blue' | 'gray' | null; dot: string }
-> = {
-	Active: { theme: null, dot: 'bg-surface-green-3' },
-	Inactive: { theme: 'gray', dot: 'bg-surface-gray-4' },
-	Suspended: { theme: 'gray', dot: 'bg-surface-gray-4' },
-	Archived: { theme: 'gray', dot: 'bg-surface-gray-4' },
-	Broken: { theme: 'red', dot: 'bg-surface-red-5' },
-	Draft: { theme: 'orange', dot: 'bg-surface-orange-3' },
-	AwaitingApproval: { theme: 'orange', dot: 'bg-surface-orange-3' },
-	'Update Available': { theme: 'blue', dot: 'bg-surface-blue-3' },
-}
-const defaultSiteStatusBadge = {
-	theme: 'gray' as const,
-	dot: 'bg-surface-gray-4',
-}
 
 const transientStatuses = ['Pending', 'Installing', 'Updating', 'Recovering']
 const wiredSites = reactive(new Set<string>())
@@ -396,11 +379,11 @@ onBeforeUnmount(() => {
 				v-else
 				variant="subtle"
 				class="w-fit"
-				:theme="siteStatusBadges[site.status]?.theme"
+				:theme="getSiteStatusBadge(site.status).theme"
 			>
 				<span
 					class="size-1.5 rounded-full shrink-0 mr-0.5"
-					:class="(siteStatusBadges[site.status] || defaultSiteStatusBadge).dot"
+					:class="getSiteStatusBadge(site.status).dot"
 				/>
 				{{ site.status }}
 			</Badge>

--- a/dashboard/src/pages/sites/list/Page.vue
+++ b/dashboard/src/pages/sites/list/Page.vue
@@ -1,0 +1,360 @@
+<script setup lang="ts">
+import {
+	Badge,
+	Button,
+	Combobox,
+	Dropdown,
+	MultiSelect,
+	Spinner,
+	TextInput,
+	Tooltip,
+	createDocumentResource,
+	createListResource,
+} from 'frappe-ui'
+import { unparse } from 'papaparse'
+import { defineAsyncComponent, h, ref } from 'vue'
+import BillingAlerts from '@/components/BillingAlerts.vue'
+import LinkControl from '@/components/LinkControl.vue'
+import Scrollbar from '@/components/common/Scrollbar.vue'
+import Header from '@/components/Header.vue'
+import { getTeam } from '@/data/team'
+import { clusterOptions } from '@/objects/common'
+import { renderDialog } from '@/utils/components'
+import { userCurrency } from '@/utils/format'
+import { getSiteStatusBadge, trialDays } from '@/utils/site'
+
+const sites = createListResource({
+	doctype: 'Site',
+	fields: [
+		'name',
+		'host_name',
+		'status',
+		'creation',
+		'trial_end_date',
+		'plan.plan_title as plan_title',
+		'plan.price_usd as price_usd',
+		'plan.price_inr as price_inr',
+		'group.title as group_title',
+		'group.public as group_public',
+		'group.version as version',
+		'cluster.image as cluster_image',
+		'cluster.title as cluster_title',
+	],
+	orderBy: 'creation desc',
+	pageLength: 20,
+	auto: true,
+})
+
+const statusOptions = ['Active', 'Inactive', 'Suspended', 'Broken', 'Archived'].map((label) => ({
+	label,
+	value: label,
+}))
+const regionOptions = clusterOptions.filter(Boolean)
+
+const selectedStatuses = ref<string[]>(
+	statusOptions.filter((o) => o.value !== 'Archived').map((o) => o.value),
+)
+
+function applyStatusFilter(value: string[]) {
+	selectedStatuses.value = value
+	applyFilter('status', value.length ? ['in', value] : undefined)
+}
+
+const moreActions = [{ label: 'Export as CSV', icon: 'download', onClick: () => exportCSV() }]
+
+function applyFilter(key: string, value: any) {
+	sites.update({ filters: { ...sites.filters, [key]: value || undefined }, start: 0 })
+	sites.reload()
+}
+
+function sitePlan(row: any) {
+	if (row.trial_end_date) return trialDays(row.trial_end_date)
+	const $team = getTeam()
+	if (row.price_usd > 0) {
+		const india = $team.doc?.currency === 'INR'
+		const formattedValue = userCurrency(india ? row.price_inr : row.price_usd, 0)
+		return `${formattedValue}/mo`
+	}
+	return row.plan_title
+}
+
+function dropSite(site: any) {
+	const ArchiveSiteDialog = defineAsyncComponent(
+		() => import('@/components/site/ArchiveSiteDialog.vue'),
+	)
+	const siteResource = createDocumentResource({
+		doctype: 'Site',
+		name: site.name,
+		auto: true,
+	})
+	renderDialog(
+		h(ArchiveSiteDialog, {
+			site: siteResource,
+			modelValue: true,
+			onArchived: () => sites.reload(),
+		}),
+	)
+}
+
+function siteOptions(site: any) {
+	return [
+		{
+			label: 'Site Actions',
+			route: { name: 'Site Detail Actions', params: { name: site.name } },
+			icon: LucideSlidersVertical,
+		},
+		{
+			label: 'Drop site',
+			theme: 'red',
+			variant: 'subtle',
+			icon: 'trash-2',
+			onClick: () => dropSite(site),
+		},
+	]
+}
+
+function exportCSV() {
+	const fields = [
+		'host_name',
+		'plan_title',
+		'cluster_title',
+		'group_title',
+		'tags',
+		'version',
+		'creation',
+	]
+	createListResource({
+		doctype: 'Site',
+		url: 'press.api.site.fetch_sites_data_for_export',
+		auto: true,
+		onSuccess(data: any) {
+			let csv = unparse({ fields, data })
+			csv = '﻿' + csv // for utf-8
+
+			const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+			const today = new Date().toISOString().split('T')[0]
+			const filename = `sites-${today}.csv`
+			const link = document.createElement('a')
+			link.href = URL.createObjectURL(blob)
+			link.download = filename
+			link.click()
+			URL.revokeObjectURL(link.href)
+		},
+	})
+}
+</script>
+
+<template>
+	<div class="flex flex-col h-full">
+		<Header class="bg-surface-white shrink-0">
+			<Breadcrumbs :items="[{ label: 'Sites', route: '/sites' }]" />
+			<Button class="ml-auto mr-2" :loading="sites.list?.loading" @click="sites.reload()">
+				<template #icon><lucide-refresh-ccw class="size-4" /></template>
+			</Button>
+			<Button class="mr-2" :route="{ name: 'New Site' }" variant="solid">
+				<template #prefix><lucide-plus class="size-4" /></template>
+				New Site
+			</Button>
+			<Dropdown :options="moreActions">
+				<Button>
+					Actions
+					<template #suffix><LucideChevronsUpDown class="size-4" /></template>
+				</Button>
+			</Dropdown>
+		</Header>
+
+		<div class="px-5 pt-4">
+			<BillingAlerts ctx-type="List Page" />
+		</div>
+
+		<div class="flex items-center gap-3 px-5 py-3 shrink-0">
+			<div class="flex items-center gap-2 flex-wrap">
+				<TextInput
+					placeholder="Search sites"
+					class="w-56 shrink-0"
+					:debounce="500"
+					@update:modelValue="v => applyFilter('host_name', v ? ['like', `%${v}%`] : undefined)"
+				>
+					<template #prefix>
+						<lucide-search class="size-4 text-ink-gray-5" />
+					</template>
+				</TextInput>
+
+				<MultiSelect
+					placeholder="Status"
+					class="!w-36 shrink-0"
+					:options="statusOptions"
+					:modelValue="selectedStatuses"
+					@update:modelValue="applyStatusFilter"
+				>
+					<template #option="{ item }">
+						<span class="site-status-option flex items-center gap-1.5 flex-1">
+							<span
+								class="size-3.5 rounded-sm border shrink-0 flex items-center justify-center"
+								:class="selectedStatuses.includes(item.value)
+									? 'bg-surface-gray-7 border-outline-gray-5'
+									: 'border-outline-gray-3'"
+							>
+								<lucide-check
+									v-if="selectedStatuses.includes(item.value)"
+									class="size-2 text-ink-white"
+									stroke-width="3"
+								/>
+							</span>
+							<span
+								class="size-2 rounded-full shrink-0 ml-1"
+								:class="getSiteStatusBadge(item.value).dot"
+							/>
+							{{ item.label }}
+						</span>
+					</template>
+				</MultiSelect>
+
+				<LinkControl
+					placeholder="Version"
+					class="!w-36 shrink-0"
+					:options="{ doctype: 'Frappe Version' }"
+					:modelValue="sites.filters?.['group.version']"
+					@update:modelValue="v => applyFilter('group.version', v)"
+				/>
+
+				<LinkControl
+					placeholder="Benches"
+					class="!w-36 shrink-0"
+					:options="{ doctype: 'Release Group' }"
+					:modelValue="sites.filters?.group"
+					@update:modelValue="v => applyFilter('group', v)"
+				/>
+
+				<Combobox
+					placeholder="Region"
+					class="!w-36 shrink-0"
+					:openOnFocus="true"
+					:options="regionOptions"
+					@update:modelValue="v => applyFilter('cluster', v)"
+				>
+					<template #prefix>
+						<LucideGlobe class="size-4 text-ink-gray-5" />
+					</template>
+				</Combobox>
+
+				<LinkControl
+					placeholder="Tag"
+					class="!w-32 shrink-0"
+					:options="{ doctype: 'Press Tag', filters: { doctype_name: 'Site' } }"
+					:modelValue="sites.filters?.['tags.tag']"
+					@update:modelValue="v => applyFilter('tags.tag', v)"
+				/>
+			</div>
+		</div>
+
+		<div
+			v-if="sites.list?.loading && !sites.data?.length"
+			class="flex justify-center py-10"
+		>
+			<Spinner class="size-5" />
+		</div>
+
+		<template v-else>
+			<Scrollbar class="h-[calc(100dvh-300px)] md:h-[calc(100dvh-230px)] px-5">
+				<div class="table w-full [&_.table-cell]:p-2">
+					<div class="text-ink-gray-5 text-xs sticky top-0 z-10 table-header-group [&_.table-cell]:bg-surface-gray-1">
+						<div class="table-row" role="row">
+							<div class="table-cell rounded-l">Site</div>
+							<div class="table-cell">Status</div>
+							<div class="table-cell">Plan</div>
+							<div class="table-cell">Region</div>
+							<div class="table-cell">Benches</div>
+							<div class="table-cell">Version</div>
+							<div class="table-cell rounded-r"></div>
+						</div>
+					</div>
+
+					<div class="h-3 invisible">a</div>
+
+					<div class="table-row-group text-ink-gray-8">
+						<div
+							v-for="site in sites.data"
+							:key="site.name"
+							class="table-row *:border-b"
+							role="row"
+						>
+							<div class="table-cell font-medium" role="cell">
+								<Tooltip text="Go to site dashboard">
+									<router-link
+										class="flex gap-2 w-fit items-center hover:underline"
+										:to="{ name: 'Site Detail', params: { name: site.name } }"
+									>
+										<LucideAppWindow class="size-4" />
+										{{ site.host_name || site.name }}
+									</router-link>
+								</Tooltip>
+							</div>
+
+							<div class="table-cell" role="cell">
+								<Badge
+									variant="subtle"
+									class="w-fit"
+									:theme="getSiteStatusBadge(site.status).theme"
+								>
+									<span
+										class="size-1.5 rounded-full shrink-0 mr-0.5"
+										:class="getSiteStatusBadge(site.status).dot"
+									/>
+									{{ site.status }}
+								</Badge>
+							</div>
+
+							<div class="table-cell whitespace-nowrap" role="cell">
+								{{ sitePlan(site) }}
+							</div>
+
+							<div class="table-cell" role="cell">
+								<span class="flex gap-1.5 items-center">
+									<img v-if="site.cluster_image" :src="site.cluster_image" class="size-3.5" />
+									{{ site.cluster_title }}
+								</span>
+							</div>
+
+							<div class="table-cell" role="cell">
+								{{ site.group_public ? 'Shared' : site.group_title }}
+							</div>
+
+							<div class="table-cell" role="cell">
+								{{ site.version }}
+							</div>
+
+							<div class="table-cell w-px" role="cell">
+								<div class="flex justify-end">
+									<Dropdown :options="siteOptions(site)">
+										<Button variant="ghost"><LucideEllipsis class="size-4" /></Button>
+									</Dropdown>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<div
+					v-if="!sites.list?.loading && !sites.data?.length"
+					class="py-10 text-center text-sm text-ink-gray-5"
+				>
+					No sites
+				</div>
+			</Scrollbar>
+
+			<div v-if="sites.hasNextPage" class="shrink-0 px-5 py-2 flex justify-end">
+				<Button :loading="sites.list?.loading" @click="sites.next()">Load more</Button>
+			</div>
+		</template>
+	</div>
+</template>
+
+<style>
+/* Hide MultiSelect's built-in checkmark for rows rendering our own checkbox
+   (site-status-option). Unscoped because MultiSelect's dropdown is teleported
+   outside this component's DOM subtree, so scoped/:deep() styles can't reach it. */
+.site-status-option ~ .absolute.right-2 {
+	display: none;
+}
+</style>

--- a/dashboard/src/pages/sites/list/Page.vue
+++ b/dashboard/src/pages/sites/list/Page.vue
@@ -53,7 +53,13 @@ const sitesCount = createListResource({
 	auto: true,
 })
 
-const statusOptions = ['Active', 'Inactive', 'Suspended', 'Broken', 'Archived'].map((label) => ({
+const statusOptions = [
+	'Active',
+	'Inactive',
+	'Suspended',
+	'Broken',
+	'Archived',
+].map((label) => ({
 	label,
 	value: label,
 }))
@@ -68,7 +74,9 @@ function applyStatusFilter(value: string[]) {
 	applyFilter('status', value.length ? ['in', value] : undefined)
 }
 
-const moreActions = [{ label: 'Export as CSV', icon: 'download', onClick: () => exportCSV() }]
+const moreActions = [
+	{ label: 'Export as CSV', icon: 'download', onClick: () => exportCSV() },
+]
 
 function applyFilter(key: string, value: any) {
 	const filters = { ...sites.filters, [key]: value || undefined }
@@ -83,7 +91,10 @@ function sitePlan(row: any) {
 	const $team = getTeam()
 	if (row.price_usd > 0) {
 		const india = $team.doc?.currency === 'INR'
-		const formattedValue = userCurrency(india ? row.price_inr : row.price_usd, 0)
+		const formattedValue = userCurrency(
+			india ? row.price_inr : row.price_usd,
+			0,
+		)
 		return `${formattedValue}/mo`
 	}
 	return row.plan_title
@@ -140,7 +151,7 @@ function exportCSV() {
 		auto: true,
 		onSuccess(data: any) {
 			let csv = unparse({ fields, data })
-			csv = '﻿' + csv // for utf-8
+			csv = '�' + csv // for utf-8
 
 			const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
 			const today = new Date().toISOString().split('T')[0]
@@ -159,7 +170,11 @@ function exportCSV() {
 	<div class="flex flex-col h-full">
 		<Header class="bg-surface-white shrink-0">
 			<Breadcrumbs :items="[{ label: 'Sites', route: '/sites' }]" />
-			<Button class="ml-auto mr-2" :loading="sites.list?.loading" @click="sites.reload()">
+			<Button
+				class="ml-auto mr-2"
+				:loading="sites.list?.loading"
+				@click="sites.reload()"
+			>
 				<template #icon><lucide-refresh-ccw class="size-4" /></template>
 			</Button>
 			<Button class="mr-2" :route="{ name: 'New Site' }" variant="solid">
@@ -268,29 +283,25 @@ function exportCSV() {
 
 		<template v-else>
 			<Scrollbar class="h-[calc(100dvh-300px)] md:h-[calc(100dvh-230px)] px-5">
-				<div class="table w-full [&_.table-cell]:p-2">
-					<div class="text-ink-gray-5 text-xs sticky top-0 z-10 table-header-group [&_.table-cell]:bg-surface-gray-1">
-						<div class="table-row" role="row">
-							<div class="table-cell rounded-l">Site</div>
-							<div class="table-cell">Status</div>
-							<div class="table-cell">Plan</div>
-							<div class="table-cell">Region</div>
-							<div class="table-cell">Benches</div>
-							<div class="table-cell">Version</div>
-							<div class="table-cell rounded-r"></div>
-						</div>
-					</div>
+				<table class="sites-table w-full border-separate border-spacing-0">
+					<thead class="text-ink-gray-5 text-xs">
+						<tr>
+							<th class="rounded-l">Site</th>
+							<th>Status</th>
+							<th>Plan</th>
+							<th>Region</th>
+							<th>Benches</th>
+							<th>Version</th>
+							<th class="rounded-r"></th>
+						</tr>
+						<tr aria-hidden="true">
+							<td colspan="7" class="h-3 p-0"></td>
+						</tr>
+					</thead>
 
-					<div class="h-3 invisible">a</div>
-
-					<div class="table-row-group text-ink-gray-8">
-						<div
-							v-for="site in sites.data"
-							:key="site.name"
-							class="table-row *:border-b"
-							role="row"
-						>
-							<div class="table-cell font-medium" role="cell">
+					<tbody class="text-ink-gray-8">
+						<tr v-for="site in sites.data" :key="site.name" class="*:border-b">
+							<td class="font-medium">
 								<Tooltip text="Go to site dashboard">
 									<router-link
 										class="flex gap-2 w-fit items-center hover:underline"
@@ -300,9 +311,9 @@ function exportCSV() {
 										{{ site.host_name || site.name }}
 									</router-link>
 								</Tooltip>
-							</div>
+							</td>
 
-							<div class="table-cell" role="cell">
+							<td>
 								<Badge
 									variant="subtle"
 									class="w-fit"
@@ -314,37 +325,38 @@ function exportCSV() {
 									/>
 									{{ site.status }}
 								</Badge>
-							</div>
+							</td>
 
-							<div class="table-cell whitespace-nowrap" role="cell">
-								{{ sitePlan(site) }}
-							</div>
+							<td class="whitespace-nowrap"> {{ sitePlan(site) }} </td>
 
-							<div class="table-cell" role="cell">
+							<td class="whitespace-nowrap">
 								<span class="flex gap-1.5 items-center">
-									<img v-if="site.cluster_image" :src="site.cluster_image" class="size-3.5" />
+									<img
+										v-if="site.cluster_image"
+										:src="site.cluster_image"
+										class="size-3.5"
+									/>
 									{{ site.cluster_title }}
 								</span>
-							</div>
+							</td>
 
-							<div class="table-cell" role="cell">
+							<td class="whitespace-nowrap">
 								{{ site.group_public ? 'Shared' : site.group_title }}
-							</div>
+							</td>
+							<td class="whitespace-nowrap"> {{ site.version }}</td>
 
-							<div class="table-cell" role="cell">
-								{{ site.version }}
-							</div>
-
-							<div class="table-cell w-px" role="cell">
+							<td class="w-px">
 								<div class="flex justify-end">
 									<Dropdown :options="siteOptions(site)">
-										<Button variant="ghost"><LucideEllipsis class="size-4" /></Button>
+										<Button variant="ghost"
+											><LucideEllipsis class="size-4" /></Button
+										>
 									</Dropdown>
 								</div>
-							</div>
-						</div>
-					</div>
-				</div>
+							</td>
+						</tr>
+					</tbody>
+				</table>
 
 				<div
 					v-if="!sites.list?.loading && !sites.data?.length"
@@ -356,15 +368,30 @@ function exportCSV() {
 
 			<div class="shrink-0 px-5 py-2 flex justify-end items-center gap-3">
 				<span class="text-sm text-ink-gray-5">
-					Total {{ sitesCount.data?.length ?? 0 }} {{ sitesCount.data?.length === 1 ? 'site' : 'sites' }}
+					Total {{ sitesCount.data?.length ?? 0 }}
+					{{ sitesCount.data?.length === 1 ? 'site' : 'sites' }}
 				</span>
-				<Button v-if="sites.hasNextPage" :loading="sites.list?.loading" @click="sites.next()">
+				<Button
+					v-if="sites.hasNextPage"
+					:loading="sites.list?.loading"
+					@click="sites.next()"
+				>
 					Load more
 				</Button>
 			</div>
 		</template>
 	</div>
 </template>
+
+<style scoped>
+.sites-table th {
+	@apply p-2 sticky top-0 z-10 bg-surface-gray-1 text-left font-normal;
+}
+
+.sites-table td {
+	@apply p-2;
+}
+</style>
 
 <style>
 /* add shrink-0 to multiselect chevron */

--- a/dashboard/src/pages/sites/list/Page.vue
+++ b/dashboard/src/pages/sites/list/Page.vue
@@ -45,6 +45,14 @@ const sites = createListResource({
 	auto: true,
 })
 
+const sitesCount = createListResource({
+	doctype: 'Site',
+	fields: ['name'],
+	orderBy: 'creation desc',
+	pageLength: 100000,
+	auto: true,
+})
+
 const statusOptions = ['Active', 'Inactive', 'Suspended', 'Broken', 'Archived'].map((label) => ({
 	label,
 	value: label,
@@ -63,8 +71,11 @@ function applyStatusFilter(value: string[]) {
 const moreActions = [{ label: 'Export as CSV', icon: 'download', onClick: () => exportCSV() }]
 
 function applyFilter(key: string, value: any) {
-	sites.update({ filters: { ...sites.filters, [key]: value || undefined }, start: 0 })
+	const filters = { ...sites.filters, [key]: value || undefined }
+	sites.update({ filters, start: 0 })
 	sites.reload()
+	sitesCount.update({ filters })
+	sitesCount.reload()
 }
 
 function sitePlan(row: any) {
@@ -182,7 +193,7 @@ function exportCSV() {
 
 				<MultiSelect
 					placeholder="Status"
-					class="!w-36 shrink-0"
+					class="!w-36 shrink-0 status-multiselect"
 					:options="statusOptions"
 					:modelValue="selectedStatuses"
 					@update:modelValue="applyStatusFilter"
@@ -343,17 +354,25 @@ function exportCSV() {
 				</div>
 			</Scrollbar>
 
-			<div v-if="sites.hasNextPage" class="shrink-0 px-5 py-2 flex justify-end">
-				<Button :loading="sites.list?.loading" @click="sites.next()">Load more</Button>
+			<div class="shrink-0 px-5 py-2 flex justify-end items-center gap-3">
+				<span class="text-sm text-ink-gray-5">
+					Total {{ sitesCount.data?.length ?? 0 }} {{ sitesCount.data?.length === 1 ? 'site' : 'sites' }}
+				</span>
+				<Button v-if="sites.hasNextPage" :loading="sites.list?.loading" @click="sites.next()">
+					Load more
+				</Button>
 			</div>
 		</template>
 	</div>
 </template>
 
 <style>
-/* Hide MultiSelect's built-in checkmark for rows rendering our own checkbox
-   (site-status-option). Unscoped because MultiSelect's dropdown is teleported
-   outside this component's DOM subtree, so scoped/:deep() styles can't reach it. */
+/* add shrink-0 to multiselect chevron */
+.status-multiselect svg {
+	flex-shrink: 0;
+}
+
+/* Hide MultiSelect's built-in checkmark*/
 .site-status-option ~ .absolute.right-2 {
 	display: none;
 }

--- a/dashboard/src/pages/sites/list/Page.vue
+++ b/dashboard/src/pages/sites/list/Page.vue
@@ -282,7 +282,7 @@ function exportCSV() {
 		</div>
 
 		<template v-else>
-			<Scrollbar class="h-[calc(100dvh-300px)] md:h-[calc(100dvh-230px)] px-5">
+			<Scrollbar class="flex-1 min-h-0 px-5">
 				<table class="sites-table w-full border-separate border-spacing-0">
 					<thead class="text-ink-gray-5 text-xs">
 						<tr>

--- a/dashboard/src/pages/sites/list/Page.vue
+++ b/dashboard/src/pages/sites/list/Page.vue
@@ -199,7 +199,7 @@ function exportCSV() {
 					placeholder="Search sites"
 					class="w-56 shrink-0"
 					:debounce="500"
-					@update:modelValue="v => applyFilter('host_name', v ? ['like', `%${v}%`] : undefined)"
+					@update:modelValue="v => applyFilter('_search', v || undefined)"
 				>
 					<template #prefix>
 						<lucide-search class="size-4 text-ink-gray-5" />
@@ -307,7 +307,6 @@ function exportCSV() {
 										class="flex gap-2 w-fit items-center hover:underline"
 										:to="{ name: 'Site Detail', params: { name: site.name } }"
 									>
-										<LucideAppWindow class="size-4" />
 										{{ site.host_name || site.name }}
 									</router-link>
 								</Tooltip>

--- a/dashboard/src/pages/sites/list/Page.vue
+++ b/dashboard/src/pages/sites/list/Page.vue
@@ -5,7 +5,6 @@ import {
 	Combobox,
 	Dropdown,
 	MultiSelect,
-	Spinner,
 	TextInput,
 	Tooltip,
 	createDocumentResource,
@@ -43,6 +42,7 @@ const sites = createListResource({
 	orderBy: 'creation desc',
 	pageLength: 20,
 	auto: true,
+	cache: ['Site', 'list'],
 })
 
 const sitesCount = createListResource({
@@ -69,7 +69,7 @@ const selectedStatuses = ref<string[]>(
 	statusOptions.filter((o) => o.value !== 'Archived').map((o) => o.value),
 )
 
-function applyStatusFilter(value: string[]) {
+const applyStatusFilter = (value: string[]) => {
 	selectedStatuses.value = value
 	applyFilter('status', value.length ? ['in', value] : undefined)
 }
@@ -78,7 +78,7 @@ const moreActions = [
 	{ label: 'Export as CSV', icon: 'download', onClick: () => exportCSV() },
 ]
 
-function applyFilter(key: string, value: any) {
+const applyFilter = (key: string, value: any) => {
 	const filters = { ...sites.filters, [key]: value || undefined }
 	sites.update({ filters, start: 0 })
 	sites.reload()
@@ -86,7 +86,7 @@ function applyFilter(key: string, value: any) {
 	sitesCount.reload()
 }
 
-function sitePlan(row: any) {
+const sitePlan = (row: any) => {
 	if (row.trial_end_date) return trialDays(row.trial_end_date)
 	const $team = getTeam()
 	if (row.price_usd > 0) {
@@ -100,7 +100,7 @@ function sitePlan(row: any) {
 	return row.plan_title
 }
 
-function dropSite(site: any) {
+const dropSite = (site: any) => {
 	const ArchiveSiteDialog = defineAsyncComponent(
 		() => import('@/components/site/ArchiveSiteDialog.vue'),
 	)
@@ -118,7 +118,7 @@ function dropSite(site: any) {
 	)
 }
 
-function siteOptions(site: any) {
+const siteOptions = (site: any) => {
 	return [
 		{
 			label: 'Site Actions',
@@ -135,7 +135,7 @@ function siteOptions(site: any) {
 	]
 }
 
-function exportCSV() {
+const exportCSV = () => {
 	const fields = [
 		'host_name',
 		'plan_title',
@@ -167,7 +167,7 @@ function exportCSV() {
 </script>
 
 <template>
-	<div class="flex flex-col h-full">
+	<div class="flex flex-col h-dvh">
 		<Header class="bg-surface-white shrink-0">
 			<Breadcrumbs :items="[{ label: 'Sites', route: '/sites' }]" />
 			<Button
@@ -193,192 +193,186 @@ function exportCSV() {
 			<BillingAlerts ctx-type="List Page" />
 		</div>
 
-		<div class="flex items-center gap-3 px-5 py-3 shrink-0">
-			<div class="flex items-center gap-2 flex-wrap">
-				<TextInput
-					placeholder="Search sites"
-					class="w-56 shrink-0"
-					:debounce="500"
-					@update:modelValue="v => applyFilter('_search', v || undefined)"
-				>
-					<template #prefix>
-						<lucide-search class="size-4 text-ink-gray-5" />
-					</template>
-				</TextInput>
+		<div class="flex items-center gap-2 px-5 pb-3 overflow-auto">
+			<TextInput
+				placeholder="Search sites"
+				class="w-56 shrink-0"
+				:debounce="500"
+				@update:modelValue="v => applyFilter('_search', v || undefined)"
+			>
+				<template #prefix>
+					<lucide-search class="size-4 text-ink-gray-5" />
+				</template>
+			</TextInput>
 
-				<MultiSelect
-					placeholder="Status"
-					class="!w-36 shrink-0 status-multiselect"
-					:options="statusOptions"
-					:modelValue="selectedStatuses"
-					@update:modelValue="applyStatusFilter"
-				>
-					<template #option="{ item }">
-						<span class="site-status-option flex items-center gap-1.5 flex-1">
-							<span
-								class="size-3.5 rounded-sm border shrink-0 flex items-center justify-center"
-								:class="selectedStatuses.includes(item.value)
+			<MultiSelect
+				placeholder="Status"
+				class="!w-36 shrink-0 status-multiselect *:text-ink-gray-5"
+				:options="statusOptions"
+				:modelValue="selectedStatuses"
+				@update:modelValue="applyStatusFilter"
+			>
+				<template #option="{ item }">
+					<span class="site-status-option flex items-center gap-1.5 flex-1">
+						<span
+							class="size-3.5 rounded-sm border shrink-0 flex items-center justify-center"
+							:class="selectedStatuses.includes(item.value)
 									? 'bg-surface-gray-7 border-outline-gray-5'
 									: 'border-outline-gray-3'"
-							>
-								<lucide-check
-									v-if="selectedStatuses.includes(item.value)"
-									class="size-2 text-ink-white"
-									stroke-width="3"
-								/>
-							</span>
-							<span
-								class="size-2 rounded-full shrink-0 ml-1"
-								:class="getSiteStatusBadge(item.value).dot"
+						>
+							<lucide-check
+								v-if="selectedStatuses.includes(item.value)"
+								class="size-2 text-ink-white"
+								stroke-width="3"
 							/>
-							{{ item.label }}
 						</span>
-					</template>
-				</MultiSelect>
+						<span
+							class="size-2 rounded-full shrink-0 ml-1"
+							:class="getSiteStatusBadge(item.value).dot"
+						/>
+						{{ item.label }}
+					</span>
+				</template>
+			</MultiSelect>
 
-				<LinkControl
-					placeholder="Version"
-					class="!w-36 shrink-0"
-					:options="{ doctype: 'Frappe Version' }"
-					:modelValue="sites.filters?.['group.version']"
-					@update:modelValue="v => applyFilter('group.version', v)"
-				/>
+			<LinkControl
+				placeholder="Version"
+				class="!w-36 shrink-0"
+				:options="{ doctype: 'Frappe Version' }"
+				:modelValue="sites.filters?.['group.version']"
+				@update:modelValue="v => applyFilter('group.version', v)"
+			/>
 
-				<LinkControl
-					placeholder="Benches"
-					class="!w-36 shrink-0"
-					:options="{ doctype: 'Release Group' }"
-					:modelValue="sites.filters?.group"
-					@update:modelValue="v => applyFilter('group', v)"
-				/>
+			<LinkControl
+				placeholder="Benches"
+				class="!w-36 shrink-0"
+				:options="{ doctype: 'Release Group' }"
+				:modelValue="sites.filters?.group"
+				@update:modelValue="v => applyFilter('group', v)"
+			/>
 
-				<Combobox
-					placeholder="Region"
-					class="!w-36 shrink-0"
-					:openOnFocus="true"
-					:options="regionOptions"
-					@update:modelValue="v => applyFilter('cluster', v)"
-				>
-					<template #prefix>
-						<LucideGlobe class="size-4 text-ink-gray-5" />
-					</template>
-				</Combobox>
+			<Combobox
+				placeholder="Region"
+				class="!w-36 shrink-0"
+				:openOnFocus="true"
+				:options="regionOptions"
+				@update:modelValue="v => applyFilter('cluster', v)"
+			>
+				<template #prefix>
+					<LucideGlobe class="size-4 text-ink-gray-5" />
+				</template>
+			</Combobox>
 
-				<LinkControl
-					placeholder="Tag"
-					class="!w-32 shrink-0"
-					:options="{ doctype: 'Press Tag', filters: { doctype_name: 'Site' } }"
-					:modelValue="sites.filters?.['tags.tag']"
-					@update:modelValue="v => applyFilter('tags.tag', v)"
-				/>
-			</div>
+			<LinkControl
+				placeholder="Tag"
+				class="!w-32 shrink-0"
+				:options="{ doctype: 'Press Tag', filters: { doctype_name: 'Site' } }"
+				:modelValue="sites.filters?.['tags.tag']"
+				@update:modelValue="v => applyFilter('tags.tag', v)"
+			/>
 		</div>
 
-		<div
-			v-if="sites.list?.loading && !sites.data?.length"
-			class="flex justify-center py-10"
-		>
-			<Spinner class="size-5" />
-		</div>
+		<Scrollbar class="flex-1 min-h-0 px-5">
+			<table class="sites-table w-full">
+				<thead class="text-ink-gray-5 text-sm">
+					<tr>
+						<th class="rounded-l">Site</th>
+						<th>Status</th>
+						<th>Plan</th>
+						<th>Region</th>
+						<th>Benches</th>
+						<th>Version</th>
+						<th class="rounded-r"></th>
+					</tr>
+				</thead>
 
-		<template v-else>
-			<Scrollbar class="flex-1 min-h-0 px-5">
-				<table class="sites-table w-full border-separate border-spacing-0">
-					<thead class="text-ink-gray-5 text-xs">
-						<tr>
-							<th class="rounded-l">Site</th>
-							<th>Status</th>
-							<th>Plan</th>
-							<th>Region</th>
-							<th>Benches</th>
-							<th>Version</th>
-							<th class="rounded-r"></th>
-						</tr>
-						<tr aria-hidden="true">
-							<td colspan="7" class="h-3 p-0"></td>
-						</tr>
-					</thead>
+				<tbody class="text-ink-gray-8">
+					<tr v-if="sites.list?.loading && !sites.data?.length">
+						<td colspan="7">
+							<div class="flex items-center justify-center py-20">
+								<Spinner class="size-5" />
+							</div>
+						</td>
+					</tr>
 
-					<tbody class="text-ink-gray-8">
-						<tr v-for="site in sites.data" :key="site.name" class="*:border-b">
-							<td class="font-medium">
-								<Tooltip text="Go to site dashboard">
-									<router-link
-										class="flex gap-2 w-fit items-center hover:underline"
-										:to="{ name: 'Site Detail', params: { name: site.name } }"
-									>
-										{{ site.host_name || site.name }}
-									</router-link>
-								</Tooltip>
-							</td>
-
-							<td>
-								<Badge
-									variant="subtle"
-									class="w-fit"
-									:theme="getSiteStatusBadge(site.status).theme"
+					<tr v-for="site in sites.data" :key="site.name" class="*:border-b">
+						<td class="font-medium">
+							<Tooltip text="Go to site dashboard">
+								<router-link
+									class="flex gap-2 w-fit items-center hover:underline"
+									:to="{ name: 'Site Detail', params: { name: site.name } }"
 								>
-									<span
-										class="size-1.5 rounded-full shrink-0 mr-0.5"
-										:class="getSiteStatusBadge(site.status).dot"
-									/>
-									{{ site.status }}
-								</Badge>
-							</td>
+									{{ site.host_name || site.name }}
+								</router-link>
+							</Tooltip>
+						</td>
 
-							<td class="whitespace-nowrap"> {{ sitePlan(site) }} </td>
+						<td>
+							<Badge
+								variant="subtle"
+								class="w-fit"
+								:theme="getSiteStatusBadge(site.status).theme"
+							>
+								<span
+									class="size-1.5 rounded-full shrink-0 mr-0.5"
+									:class="getSiteStatusBadge(site.status).dot"
+								/>
+								{{ site.status }}
+							</Badge>
+						</td>
 
-							<td class="whitespace-nowrap">
-								<span class="flex gap-1.5 items-center">
-									<img
-										v-if="site.cluster_image"
-										:src="site.cluster_image"
-										class="size-3.5"
-									/>
-									{{ site.cluster_title }}
-								</span>
-							</td>
+						<td> {{ sitePlan(site) }} </td>
 
-							<td class="whitespace-nowrap">
-								{{ site.group_public ? 'Shared' : site.group_title }}
-							</td>
-							<td class="whitespace-nowrap"> {{ site.version }}</td>
+						<td>
+							<span class="flex gap-1.5 items-center">
+								<img
+									v-if="site.cluster_image"
+									:src="site.cluster_image"
+									class="size-3.5"
+								/>
+								{{ site.cluster_title }}
+							</span>
+						</td>
 
-							<td class="w-px">
-								<div class="flex justify-end">
-									<Dropdown :options="siteOptions(site)">
-										<Button variant="ghost"
-											><LucideEllipsis class="size-4" /></Button
-										>
-									</Dropdown>
-								</div>
-							</td>
-						</tr>
-					</tbody>
-				</table>
+						<td>
+							{{ site.group_public ? 'Shared' : site.group_title }}
+						</td>
+						<td> {{ site.version }}</td>
 
-				<div
-					v-if="!sites.list?.loading && !sites.data?.length"
-					class="py-10 text-center text-sm text-ink-gray-5"
-				>
-					No sites
-				</div>
-			</Scrollbar>
+						<td class="w-px">
+							<div class="flex justify-end">
+								<Dropdown :options="siteOptions(site)">
+									<Button variant="ghost"
+										><LucideEllipsis class="size-4" /></Button
+									>
+								</Dropdown>
+							</div>
+						</td>
+					</tr>
+				</tbody>
+			</table>
 
-			<div class="shrink-0 px-5 py-2 flex justify-end items-center gap-3">
-				<span class="text-sm text-ink-gray-5">
-					Total {{ sitesCount.data?.length ?? 0 }}
-					{{ sitesCount.data?.length === 1 ? 'site' : 'sites' }}
-				</span>
-				<Button
-					v-if="sites.hasNextPage"
-					:loading="sites.list?.loading"
-					@click="sites.next()"
-				>
-					Load more
-				</Button>
+			<div
+				v-if="!sites.list?.loading && !sites.data?.length"
+				class="py-10 text-center text-sm text-ink-gray-5"
+			>
+				No sites
 			</div>
-		</template>
+		</Scrollbar>
+
+		<div class="shrink-0 px-5 py-2 flex justify-end items-center gap-3">
+			<span class="text-sm text-ink-gray-5">
+				Total {{ sitesCount.data?.length ?? 0 }}
+				{{ sitesCount.data?.length === 1 ? 'site' : 'sites' }}
+			</span>
+			<Button
+				v-if="sites.hasNextPage"
+				:loading="sites.list?.loading"
+				@click="sites.next()"
+			>
+				Load more
+			</Button>
+		</div>
 	</div>
 </template>
 
@@ -388,7 +382,7 @@ function exportCSV() {
 }
 
 .sites-table td {
-	@apply p-2;
+	@apply p-2 whitespace-nowrap;
 }
 </style>
 

--- a/dashboard/src/pages/sites/list/Page.vue
+++ b/dashboard/src/pages/sites/list/Page.vue
@@ -7,6 +7,7 @@ import {
 	MultiSelect,
 	TextInput,
 	Tooltip,
+  Spinner,
 	createDocumentResource,
 	createListResource,
 } from 'frappe-ui'
@@ -83,7 +84,11 @@ const moreActions = [
 ]
 
 const applyFilter = (key: string, value: any) => {
-	const filters = { ...sites.filters, [key]: value || undefined }
+	const filters = Object.fromEntries(
+		Object.entries({ ...sites.filters, [key]: value || undefined }).filter(
+			([, v]) => v !== undefined,
+		),
+	)
 	sites.update({ filters, start: 0 })
 	sites.reload()
 	sitesCount.update({ filters })

--- a/dashboard/src/pages/sites/list/Page.vue
+++ b/dashboard/src/pages/sites/list/Page.vue
@@ -22,6 +22,24 @@ import { renderDialog } from '@/utils/components'
 import { userCurrency } from '@/utils/format'
 import { getSiteStatusBadge, trialDays } from '@/utils/site'
 
+const statusOptions = [
+	'Active',
+	'Inactive',
+	'Suspended',
+	'Broken',
+	'Archived',
+].map((label) => ({
+	label,
+	value: label,
+}))
+const regionOptions = clusterOptions.filter(Boolean)
+
+const selectedStatuses = ref<string[]>(
+	statusOptions.filter((o) => o.value !== 'Archived').map((o) => o.value),
+)
+
+const initialFilters = { status: ['in', selectedStatuses.value] }
+
 const sites = createListResource({
 	doctype: 'Site',
 	fields: [
@@ -39,6 +57,7 @@ const sites = createListResource({
 		'cluster.image as cluster_image',
 		'cluster.title as cluster_title',
 	],
+	filters: initialFilters,
 	orderBy: 'creation desc',
 	pageLength: 20,
 	auto: true,
@@ -48,26 +67,11 @@ const sites = createListResource({
 const sitesCount = createListResource({
 	doctype: 'Site',
 	fields: ['name'],
+	filters: initialFilters,
 	orderBy: 'creation desc',
 	pageLength: 100000,
 	auto: true,
 })
-
-const statusOptions = [
-	'Active',
-	'Inactive',
-	'Suspended',
-	'Broken',
-	'Archived',
-].map((label) => ({
-	label,
-	value: label,
-}))
-const regionOptions = clusterOptions.filter(Boolean)
-
-const selectedStatuses = ref<string[]>(
-	statusOptions.filter((o) => o.value !== 'Archived').map((o) => o.value),
-)
 
 const applyStatusFilter = (value: string[]) => {
 	selectedStatuses.value = value
@@ -151,7 +155,7 @@ const exportCSV = () => {
 		auto: true,
 		onSuccess(data: any) {
 			let csv = unparse({ fields, data })
-			csv = '�' + csv // for utf-8
+			csv = '﻿' + csv // for utf-8
 
 			const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
 			const today = new Date().toISOString().split('T')[0]

--- a/dashboard/src/utils/site.js
+++ b/dashboard/src/utils/site.js
@@ -35,6 +35,26 @@ export function isTrialEnded(_trialEndDate) {
 	return trialEndDate.isBefore(today, 'day');
 }
 
+export const siteStatusBadges = {
+	Active: { theme: null, dot: 'bg-surface-green-3' },
+	Inactive: { theme: 'gray', dot: 'bg-surface-gray-4' },
+	Suspended: { theme: 'gray', dot: 'bg-surface-gray-4' },
+	Archived: { theme: 'gray', dot: 'bg-surface-gray-4' },
+	Broken: { theme: 'red', dot: 'bg-surface-red-5' },
+	Draft: { theme: 'orange', dot: 'bg-surface-orange-3' },
+	AwaitingApproval: { theme: 'orange', dot: 'bg-surface-orange-3' },
+	'Update Available': { theme: 'blue', dot: 'bg-surface-blue-3' },
+};
+
+export const defaultSiteStatusBadge = {
+	theme: 'gray',
+	dot: 'bg-surface-gray-4',
+};
+
+export function getSiteStatusBadge(status) {
+	return siteStatusBadges[status] || defaultSiteStatusBadge;
+}
+
 export function validateSubdomain(subdomain) {
 	if (!subdomain) {
 		return 'Subdomain cannot be empty';

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -289,8 +289,16 @@ class Site(Document, TagHelpers):
 		Site = frappe.qb.DocType("Site")
 
 		status = filters.get("status")
-		if status == "Archived":
-			sites = query.where(Site.status == status).run(as_dict=1)
+		if isinstance(status, (list, tuple)) and len(status) == 2 and str(status[0]).lower() == "in":
+			statuses = list(status[1])
+		elif status:
+			statuses = [status]
+		else:
+			statuses = []
+
+		if statuses:
+			# explicit status filter: respect it as-is, don't force-hide archived
+			sites = query.where(Site.status.isin(statuses)).run(as_dict=1)
 		else:
 			benches_with_available_update = benches_with_available_update()
 			sites = query.where(Site.status != "Archived").select(Site.bench).run(as_dict=1)

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -282,11 +282,22 @@ class Site(Document, TagHelpers):
 
 	@staticmethod
 	def get_list_query(query, filters=None, **list_args):
+		from frappe.query_builder.functions import Coalesce
+
 		from press.press.doctype.site_update.site_update import (
 			benches_with_available_update,
 		)
 
 		Site = frappe.qb.DocType("Site")
+
+		# not a real field, so validate_filters strips it before it reaches the
+		# base query; host_name is only set once a site first reaches Active, so
+		# sites that broke or are still pending before that never get one — search
+		# against whichever one the UI actually displays (host_name || name)
+		search_term = filters.get("_search")
+		if search_term:
+			like_term = f"%{search_term}%"
+			query = query.where(Coalesce(Site.host_name, Site.name).like(like_term))
 
 		status = filters.get("status")
 		if isinstance(status, (list, tuple)) and len(status) == 2 and str(status[0]).lower() == "in":


### PR DESCRIPTION
- Also allow status to have multiselect filter, before it was a select element and it was impossible to clear old value unless you use combobox or update frappe ui to latest we can't at the moment.

- Updated badge styles
- Total site count ( as per partner feedback
- Make only table rows scrollable, header & footer stay static



<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/e14f8aec-164e-4008-93fe-70fce434823b" />


## Old 

https://github.com/user-attachments/assets/4d4e227b-98b2-4e87-b770-3208396ac842






## New 
https://github.com/user-attachments/assets/16c3d7f6-2851-4f26-b1b9-c04466f8852e




### Todo for future: 

Make a better list component, `filters + list`, just use native `<table>` or `display table` https://tailwindcss.com/docs/display#table  . Current objectlist.vue is bloated and overcomplicated 

