### PR TITLE
fix: Fix conflict, `plans` section fields got added twice

### DIFF
--- a/press/press/doctype/press_settings/press_settings.json
+++ b/press/press/doctype/press_settings/press_settings.json
@@ -197,7 +197,7 @@
 		"enable_chat",
 		"chat_base_url",
 		"chat_website_token",
-		"column_break_srse",
+		"column_break_wqtc",
 		"chat_support_start_time",
 		"chat_support_end_time",
 		"marketplace_tab",
@@ -1752,33 +1752,6 @@
 			"label": "Chat Support"
 		},
 		{
-			"fieldname": "column_break_srse",
-			"fieldtype": "Column Break"
-		},
-		{
-			"default": "30",
-			"description": "Default number of days before the site warranty setting can be changed for newly created dedicated servers",
-			"fieldname": "default_dedicated_server_site_warranty_change_cooldown",
-			"fieldtype": "Int",
-			"label": "Default Dedicated Server Site Warranty change Cooldown"
-		},
-		{
-			"default": "5",
-			"description": "Default max number of sites with product warranty for newly created dedicated servers\n",
-			"fieldname": "default_dedicated_server_site_warranty_quota",
-			"fieldtype": "Int",
-			"label": "Default Dedicated Server Supported Site Quota"
-		},
-		{
-			"fieldname": "chatwoot_section",
-			"fieldtype": "Section Break",
-			"label": "Chat Support"
-		},
-		{
-			"fieldname": "column_break_srse",
-			"fieldtype": "Column Break"
-		},
-		{
 			"default": "0",
 			"fieldname": "enable_chat",
 			"fieldtype": "Check",
@@ -1868,14 +1841,19 @@
 			"label": "Default Dedicated Server Supported Site Quota"
 		},
 		{
+			"default": "0",
 			"fieldname": "allow_patch_builds",
 			"fieldtype": "Check",
 			"label": "Allow Patch Builds"
+		},
+		{
+			"fieldname": "column_break_wqtc",
+			"fieldtype": "Column Break"
 		}
 	],
 	"issingle": 1,
 	"links": [],
-	"modified": "2026-06-02 22:46:34.584687",
+	"modified": "2026-07-16 15:15:38.007435",
 	"modified_by": "Administrator",
 	"module": "Press",
 	"name": "Press Settings",

--- a/press/press/doctype/press_settings/press_settings.py
+++ b/press/press/doctype/press_settings/press_settings.py
@@ -30,6 +30,7 @@ class PressSettings(Document):
 		agent_repository_owner: DF.Data | None
 		agent_sentry_dsn: DF.Data | None
 		allow_patch_builds: DF.Check
+		anthropic_api_key: DF.Password | None
 		app_include_script: DF.Data | None
 		asset_store_access_key: DF.Data | None
 		asset_store_bucket_name: DF.Data | None
@@ -170,6 +171,8 @@ class PressSettings(Document):
 		github_pat_token: DF.Data | None
 		github_webhook_secret: DF.Data | None
 		gst_percentage: DF.Float
+		hetzner_server_limit: DF.Int
+		hetzner_vcpu_limit: DF.Int
 		hybrid_cluster: DF.Link | None
 		hybrid_domain: DF.Link | None
 		ic_key: DF.Password | None


### PR DESCRIPTION
Conflict in press_settings.json where in fields under the`plans` section got added twice.
Likely happened while resolving conflicts when taking release