### PR TITLE
fix(bench): Stop fatal updates pinning benches they cannot help

### DIFF
--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -1126,13 +1126,20 @@ class Bench(Document):
 		fatal_site_updates = (
 			frappe.qb.from_(site_updates)
 			.join(sites)
-			.on(site_updates.site == sites.name)
+			.on(
+				(site_updates.site == sites.name)
+				& (
+					(sites.bench == site_updates.source_bench)
+					| (sites.bench == site_updates.destination_bench)
+				)
+			)
 			.select(site_updates.name)
 			.where((site_updates.source_bench == self.name) | (site_updates.destination_bench == self.name))
 			.where(
 				(site_updates.status == "Fatal")
 				& (site_updates.creation > frappe.utils.add_to_date(None, days=-EMPTY_BENCH_COURTESY_DAYS))
 				& (sites.status != "Archived")
+				& (site_updates.cause_of_failure_is_resolved == 0)
 			)
 			.limit(1)
 		).run()

--- a/press/press/doctype/bench/test_bench.py
+++ b/press/press/doctype/bench/test_bench.py
@@ -522,6 +522,80 @@ class TestArchiveObsoleteBenches(FrappeTestCase):
 		benches_after = frappe.db.count("Bench", {"status": "Active"})  # 1
 		self.assertEqual(benches_after, benches_before - 1)
 
+	@patch("press.press.doctype.bench.bench.frappe.enqueue", new=foreground_enqueue)
+	def test_fatal_site_update_doesnt_block_archival_when_site_left_both_benches(self):
+		version = "Version 15"
+		app = create_test_app()
+		app_source = create_test_app_source(version=version, app=app)
+		group = create_test_release_group([app], frappe_version=version)
+
+		with fake_agent_job("New Bench"):
+			bench1 = create_test_bench(group=group)
+			poll_pending_jobs()
+
+		site = create_test_site(bench=bench1.name, fake_agent_jobs=True)
+		create_test_app_release(app_source=app_source)
+
+		with fake_agent_job("New Bench"):
+			bench2 = create_test_bench(group=group, server=bench1.server)
+			poll_pending_jobs()
+
+		create_test_deploy_candidate_differences(bench2.candidate)  # for site update to be available
+
+		create_test_site_update(site.name, site.group, "Fatal")  # recent site update
+
+		with fake_agent_job("New Bench"):
+			unrelated_bench = create_test_bench(server=bench1.server)
+			poll_pending_jobs()
+		site.db_set(
+			"bench", unrelated_bench.name
+		)  # site moved out of the group, so neither bench1 nor bench2 can be rolled back to
+
+		benches_before = frappe.db.count("Bench", {"status": "Active", "group": group.name})  # 2
+
+		with fake_agent_job("Archive Bench"):
+			archive_obsolete_benches()
+			poll_pending_jobs()
+
+		# bench1 is archived despite the recent Fatal update, without waiting out the courtesy days
+		benches_after = frappe.db.count("Bench", {"status": "Active", "group": group.name})  # 1
+		self.assertEqual(benches_after, benches_before - 1)
+
+	@patch("press.press.doctype.bench.bench.frappe.enqueue", new=foreground_enqueue)
+	def test_fatal_site_update_doesnt_block_archival_once_cause_of_failure_is_resolved(self):
+		version = "Version 15"
+		app = create_test_app()
+		app_source = create_test_app_source(version=version, app=app)
+		group = create_test_release_group([app], frappe_version=version)
+
+		with fake_agent_job("New Bench"):
+			bench1 = create_test_bench(group=group)
+			poll_pending_jobs()
+
+		site = create_test_site(bench=bench1.name, fake_agent_jobs=True)
+		create_test_app_release(app_source=app_source)
+
+		with fake_agent_job("New Bench"):
+			bench2 = create_test_bench(group=group, server=bench1.server)
+			poll_pending_jobs()
+
+		create_test_deploy_candidate_differences(bench2.candidate)  # for site update to be available
+
+		update = create_test_site_update(site.name, site.group, "Fatal")  # recent site update
+		site.db_set("bench", bench2.name)  # site moved to new bench, but not rolled back
+
+		benches_before = frappe.db.count("Bench", {"status": "Active", "group": group.name})  # 2
+
+		update.set_cause_of_failure_is_resolved()
+
+		with fake_agent_job("Archive Bench"):
+			archive_obsolete_benches()
+			poll_pending_jobs()
+
+		# The rollback target is no longer needed once the operator resolves the cause
+		benches_after = frappe.db.count("Bench", {"status": "Active", "group": group.name})  # 1
+		self.assertEqual(benches_after, benches_before - 1)
+
 	@patch(
 		"press.press.doctype.bench.bench.archive_obsolete_benches_for_server",
 		wraps=archive_obsolete_benches_for_server,


### PR DESCRIPTION
## Problem

Two empty benches, the source and destination of one recent Fatal Site Update, cannot be dropped:

> There was a recent **site update which has failed**. Due to the same reason, bench cannot be archived.

The `fatal_site_updates` guard in `Bench.check_ongoing_site_updates()` holds a bench for `EMPTY_BENCH_COURTESY_DAYS` (3) whenever a recent Fatal update names it as source or destination, so the source survives as a rollback target for a site left broken on the destination. Two holes let it pin benches that cannot serve that purpose:

1. **It keys on the site's status, not on where the site lives.** #6927 skips `Archived` sites, covering the site being gone but not the site being *elsewhere*. A site fixed by moving forward to a later deploy instead of rolling back is neither `Archived` nor on either bench — nothing left to roll back to, benches pinned anyway.
2. **`cause_of_failure_is_resolved` was never read.** It is set from the desk button and auto-set in `handle_failure()` for agent-update and incident failures. Press could conclude a failure was its own fault, record it, and still pin the benches.

In the reported case either hole alone was enough to keep both benches.

## Fix

Join `Site` on the update's benches as well as its name, so only a site still parked on the source or destination holds up the archive, and skip updates whose cause is already resolved.

- Keeping `site_updates.site == sites.name` in the join matters: without it an unrelated site on the destination blocks the source.
- The flag is compared to `0` rather than negated with `not`: a pypika `Field` is always truthy, so `not field` collapses to a constant `False` at build time and disables the whole guard. That sank a9c9d1c24, reverted in 7295a081d.
- The `!= "Archived"` condition from #6927 stays — archiving a site does not clear `Site.bench`.
- `ongoing_site_updates` is untouched.

## Testing

Two new tests, one per hole, each failing on `develop`:

- `test_fatal_site_update_doesnt_block_archival_when_site_left_both_benches`
- `test_fatal_site_update_doesnt_block_archival_once_cause_of_failure_is_resolved` — site left *on* the destination, so only the flag can unblock it.

The existing `test_if_fatal_site_update_with_source_bench_blocks_archival` still passes: site on the destination with the cause unresolved, source stays blocked. Full `test_bench` (29) and `test_site_update` (11) green.