### PR TITLE
fix: support is_standalone (self-proxy) servers and Generic unified-server provisioning

### DIFF
--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -651,6 +651,9 @@ class Bench(Document):
 	@frappe.whitelist()
 	def add_ssh_user(self):
 		proxy_server = frappe.db.get_value("Server", self.server, "proxy_server")
+		if not proxy_server:
+			# Standalone server is its own proxy; no separate Proxy Server doc to target.
+			return
 		agent = Agent(proxy_server, server_type="Proxy Server")
 		agent.add_ssh_user(self)
 

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -827,6 +827,7 @@ class BaseServer(Document, TagHelpers):
 					"mariadb_root_password": database_server_config.mariadb_root_password,
 					"mariadb_depends_on_mounts": database_server_config.mariadb_depends_on_mounts,
 					"nat_gateway_ip": self.get_nat_gateway_ip(),
+					"cloud_provider": self.provider,
 					**self.get_mount_variables(),  # Currently same as database server since no volumes
 				},
 			)

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -779,7 +779,10 @@ class Site(Document, TagHelpers):
 
 	def rename_upstream(self, new_name: str):
 		proxy_server = frappe.db.get_value("Server", self.server, "proxy_server")
-		agent = Agent(proxy_server, server_type="Proxy Server")
+		if self.is_on_standalone:
+			agent = Agent(self.server)
+		else:
+			agent = Agent(proxy_server, server_type="Proxy Server")
 		site_domains = frappe.get_all(
 			"Site Domain", {"site": self.name, "name": ("!=", self.name)}, pluck="name"
 		)
@@ -1154,7 +1157,10 @@ class Site(Document, TagHelpers):
 
 		server = frappe.get_all("Server", filters={"name": self.server}, fields=["proxy_server"], limit=1)[0]
 
-		agent = Agent(server.proxy_server, server_type="Proxy Server")
+		if self.is_on_standalone:
+			agent = Agent(self.server)
+		else:
+			agent = Agent(server.proxy_server, server_type="Proxy Server")
 		agent.new_upstream_file(server=self.server, site=self.name)
 
 	@dashboard_whitelist()
@@ -1839,7 +1845,10 @@ class Site(Document, TagHelpers):
 
 		server = frappe.get_all("Server", filters={"name": self.server}, fields=["proxy_server"], limit=1)[0]
 
-		agent = Agent(server.proxy_server, server_type="Proxy Server")
+		if self.is_on_standalone:
+			agent = Agent(self.server)
+		else:
+			agent = Agent(server.proxy_server, server_type="Proxy Server")
 		agent.remove_upstream_file(
 			server=self.server,
 			site=self.name,


### PR DESCRIPTION
### Summary

Three fixes so **`is_standalone` (self-proxy) servers** and **Generic bring-your-own unified servers** work end-to-end. All are guarded by existing `is_on_standalone` / provider checks, so there is **no behavior change for VM-backed or non-standalone setups**.

Discovered while running a self-hosted press control plane with a single Generic `is_standalone` unified server (app + db + proxy on one box).

### Fixes

**1. `server.py` — `_setup_unified_server` doesn't pass `cloud_provider`**
The `nat_iptables` role's first task evaluates `when: cloud_provider == "Hetzner"`, but `_setup_unified_server` doesn't include `cloud_provider` in the Ansible vars (the VM-backed setup paths do). On a Generic server the variable is undefined → the conditional errors → the play fails at task 1. Fix: pass `"cloud_provider": self.provider` (matches the other provisioning paths).

**2. `bench.py` — `add_ssh_user` crashes on standalone servers**
`add_ssh_user` looks up `Server.proxy_server` and dispatches an Agent Job to it as a `Proxy Server`. For `is_standalone` servers (which are their own proxy) `proxy_server` is empty → the Agent Job insert raises `MandatoryError: server`, which crashes the New-Bench success callback and leaves the bench stuck `Pending` even though the container is running. Fix: return early when there is no `proxy_server`.

**3. `site.py` — `new_upstream_file` / `remove_upstream_file` / `rename_upstream` crash on standalone**
These unconditionally target `Server.proxy_server`, which is empty for standalone servers → `MandatoryError` on site create / archive / rename. Fix: branch on `self.is_on_standalone` and use `Agent(self.server)` when standalone — mirroring the existing pattern already used in `set_redirects_in_proxy` / `unset_redirects_in_proxy`.

### Impact

`+16 / -3` across 3 files. Non-standalone and VM-provider flows are unaffected (guarded branches). With these, a Generic standalone server provisions, deploys benches, and creates/archives sites cleanly.
