### PR TITLE
fix(site-update): Block updates on sites with database over 100 GB

### DIFF
--- a/press/press/doctype/site_update/site_update.py
+++ b/press/press/doctype/site_update/site_update.py
@@ -38,6 +38,9 @@ if TYPE_CHECKING:
 	)
 	from press.press.doctype.site.site import Site
 
+# Site Usage stores sizes in MB
+LARGE_DATABASE_SIZE_MB = 100 * 1024
+
 
 class SiteUpdate(Document):
 	# begin: auto-generated types
@@ -151,6 +154,7 @@ class SiteUpdate(Document):
 		self.validate_past_failed_updates()
 		self.set_physical_backup_mode_if_eligible()
 		self.set_logical_replication_backup_mode_if_eligible()
+		self.validate_backup_type_for_large_database()
 
 	def validate_destination_bench(self, differences):
 		if not self.destination_bench:
@@ -241,6 +245,29 @@ class SiteUpdate(Document):
 	def after_insert(self):
 		if not self.scheduled_time:
 			self.start()
+
+	@property
+	def database_size(self):
+		"""Database size in MB, as last reported by the site's server."""
+		site: "Site" = frappe.get_doc("Site", self.site)
+		return cint(site.get_disk_usages()["database"])
+
+	def validate_backup_type_for_large_database(self):
+		"""A logical backup of a huge database takes too long and often fails mid-update.
+
+		Physical and Logical Replication backups don't take a full dump, so they're fine.
+		"""
+		if self.skipped_backups or self.backup_type in ("Physical", "Logical Replication"):
+			return
+
+		if self.database_size <= LARGE_DATABASE_SIZE_MB:
+			return
+
+		frappe.throw(
+			f"Database of site {self.site} is too large to update without a physical backup. "
+			"Please <a href='/support'>contact support</a> to get this update done.",
+			frappe.ValidationError,
+		)
 
 	def set_physical_backup_mode_if_eligible(self):  # noqa: C901
 		if self.skipped_backups:

--- a/press/press/doctype/site_update/test_site_update.py
+++ b/press/press/doctype/site_update/test_site_update.py
@@ -385,3 +385,47 @@ class TestSiteUpdate(FrappeTestCase):
 
 		self.assertEqual(frappe.get_value("Site Update", site_update_name, "status"), "Cancelled")
 		self.assertTrue(frappe.db.exists("Press Notification", {"type": "Site Update", "team": site.team}))
+
+	@patch.object(AgentJob, "enqueue_http_request", new=Mock())
+	def test_site_update_is_blocked_on_site_with_database_larger_than_100_gb(self):
+		group = create_test_release_group([create_test_app()])
+		bench1 = create_test_bench(group=group)
+		bench2 = create_test_bench(group=group, server=bench1.server)
+		create_test_deploy_candidate_differences(bench2.candidate)
+
+		site = create_test_site(bench=bench1.name)
+		# Site Usage sizes are in MB
+		frappe.get_doc(doctype="Site Usage", site=site.name, database=101 * 1024).insert()
+
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"too large to update without a physical backup",
+			site.schedule_update,
+		)
+
+	@patch.object(AgentJob, "enqueue_http_request", new=Mock())
+	def test_site_update_is_allowed_on_site_with_database_smaller_than_100_gb(self):
+		group = create_test_release_group([create_test_app()])
+		bench1 = create_test_bench(group=group)
+		bench2 = create_test_bench(group=group, server=bench1.server)
+		create_test_deploy_candidate_differences(bench2.candidate)
+
+		site = create_test_site(bench=bench1.name)
+		frappe.get_doc(doctype="Site Usage", site=site.name, database=99 * 1024).insert()
+
+		self.assertTrue(site.schedule_update())
+
+	def test_site_update_with_logical_replication_backup_is_allowed_on_large_site(self):
+		"""Logical Replication doesn't take a full dump, so the size limit shouldn't apply."""
+		site = create_test_site()
+		frappe.get_doc(doctype="Site Usage", site=site.name, database=101 * 1024).insert()
+
+		site_update = frappe.new_doc("Site Update", site=site.name, backup_type="Logical Replication")
+		site_update.validate_backup_type_for_large_database()  # shouldn't raise
+
+		site_update.backup_type = "Logical"
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"too large to update without a physical backup",
+			site_update.validate_backup_type_for_large_database,
+		)


### PR DESCRIPTION
## Problem

A logical backup of a very large database takes hours and often fails or times out midway through a site update, leaving the site in a bad state that needs manual recovery. Sites over ~100 GB are the ones that hurt.

## Fix

Block these updates in `SiteUpdate.validate` unless the update avoids the full dump, and point the customer at support so we can do the update by hand instead of failing halfway through.

Details worth noting:

- The size comes from the newest **Site Usage** record — the same source the dashboard shows on the site overview page (`Site.current_usage`). Site Usage sizes are in **MB, not bytes**: `SiteOverview.vue` renders them with `$format.bytes(v, 2, 2)`, where the third argument shifts the unit label up by two. Hence the threshold is `100 * 1024`. (Note `Site.current_database_usage` is *not* this number — it's a percentage of the plan limit.)
- **Physical and Logical Replication are both allowed through.** Neither takes a full dump — Logical Replication goes down the `create_logical_replication_backup_record` path, built on snapshots and replication. Only plain `Logical` does the slow dump this guards against.
- The check runs after the backup mode setters so it sees the final `backup_type`. `set_logical_replication_backup_mode_if_eligible` runs last and overwrites `backup_type` unconditionally, so checking any earlier would read a value that's about to change.
- It skips when `skipped_backups` is set — that's a deliberate operator override, not something to block.
- `Pull` updates are blocked too, not just `Migrate`. They also take a logical backup, which is the slow and failure-prone part.

## Tests

Three new tests using real Site Usage records (no mocks): 101 GB is blocked, 99 GB goes through, and a 101 GB site with a Logical Replication backup is allowed. Full `test_site_update` module passes (14 tests).

## Open question

`LARGE_DATABASE_SIZE_MB` is a hardcoded constant. If support needs to tune it per-site or turn it off without a deploy, it should be a Press Settings field instead — happy to change it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)