### PR TITLE
fix(login): Determine post-login redirect route entirely in backend

### DIFF
--- a/dashboard/src/data/sites.js
+++ b/dashboard/src/data/sites.js
@@ -19,8 +19,7 @@ export function getActiveSites() {
 				'plan.price_usd as price_usd',
 				'plan.price_inr as price_inr',
 			],
-			// filters: { status: ['not in', ['Archived', 'Inactive']] },
-			pageLength: 5,
+			pageLength: 50,
 			auto: false,
 			cache: 'active-sites',
 		})

--- a/dashboard/src/data/sites.js
+++ b/dashboard/src/data/sites.js
@@ -13,6 +13,7 @@ export function getActiveSites() {
 				'trial_end_date',
 				'setup_wizard_complete',
 				'additional_system_user_created',
+				'standby_for_product',
 				'group.version as version',
 				'plan.plan_title as plan_title',
 				'plan.price_usd as price_usd',

--- a/dashboard/src/pages/LoginSignup.vue
+++ b/dashboard/src/pages/LoginSignup.vue
@@ -548,18 +548,12 @@ export default {
 					if (errorMessage.includes('is already registered')) {
 						localStorage.setItem('login_email', this.email);
 
-						if (this.$route.query?.product) {
-							this.$router.push({
-								name: 'Login',
-								query: {
-									redirect: `/dashboard/create-site/${this.$route.query.product}/setup`,
-								},
-							});
-						} else {
-							this.$router.push({
-								name: 'Login',
-							});
-						}
+						this.$router.push({
+							name: 'Login',
+							query: {
+								product: this.$route.query?.product,
+							},
+						});
 					}
 				},
 			};
@@ -856,7 +850,12 @@ export default {
 
 			try {
 				const route = await call('press.api.account.get_route_on_login');
-				window.location.href = `/dashboard${route || '/'}`;
+				const product = this.$route.query.product;
+				if (route === '/quickstart' && product) {
+					window.location.href = `/dashboard/quickstart?product=${product}`;
+				} else {
+					window.location.href = `/dashboard${route || '/'}`;
+				}
 			} catch (e) {
 				window.location.href = '/dashboard/';
 			}

--- a/dashboard/src/pages/LoginSignup.vue
+++ b/dashboard/src/pages/LoginSignup.vue
@@ -854,8 +854,12 @@ export default {
 				return;
 			}
 
-			const route = await call('press.api.account.get_route_on_login');
-			window.location.href = `/dashboard${route || '/'}`;
+			try {
+				const route = await call('press.api.account.get_route_on_login');
+				window.location.href = `/dashboard${route || '/'}`;
+			} catch (e) {
+				window.location.href = '/dashboard/';
+			}
 		},
 	},
 	computed: {

--- a/dashboard/src/pages/LoginSignup.vue
+++ b/dashboard/src/pages/LoginSignup.vue
@@ -444,6 +444,7 @@ import GoogleIcon from '@/components/icons/GoogleIcon.vue';
 import { toast } from 'vue-sonner';
 import { getToastErrorMessage } from '../utils/toast';
 import { h } from 'vue';
+import { call } from 'frappe-ui';
 import CustomToast from '../components/CustomToast.vue';
 
 export default {
@@ -843,20 +844,18 @@ export default {
 				},
 			);
 		},
-		afterLogin(res) {
-			let loginRoute = `/dashboard${res.dashboard_route || '/'}`;
-			// If `redirect` is present in query, redirect to that.
+		async afterLogin() {
+			localStorage.setItem('login_email', this.email);
+
 			// Restrict redirect to relative paths.
 			const redirect = this.$route.query.redirect;
 			if (redirect && redirect.startsWith('/') && !redirect.startsWith('//')) {
-				loginRoute = redirect;
+				window.location.href = redirect;
+				return;
 			}
-			localStorage.setItem('login_email', this.email);
-			if (loginRoute.includes('/welcome')) {
-				let separator = loginRoute.includes('?') ? '&' : '?';
-				loginRoute = `${loginRoute}${separator}post_login=1`;
-			}
-			window.location.href = loginRoute;
+
+			const route = await call('press.api.account.get_route_on_login');
+			window.location.href = `/dashboard${route || '/'}`;
 		},
 	},
 	computed: {

--- a/dashboard/src/pages/LoginSignup.vue
+++ b/dashboard/src/pages/LoginSignup.vue
@@ -424,14 +424,7 @@
 						</p>
 					</div>
 				</template>
-				<template v-slot:logo v-if="saasProduct">
-					<div class="flex space-x-2">
-						<img
-							class="inline-block h-[38px] w-[38px] rounded-sm"
-							:src="saasProduct?.logo"
-						/>
-					</div>
-				</template>
+
 			</LoginBox>
 		</div>
 	</div>
@@ -871,9 +864,6 @@ export default {
 				return this.$resources.resetPassword.error;
 			}
 		},
-		saasProduct() {
-			return this.$resources.signupSettings.data?.product_trial;
-		},
 		isLogin() {
 			return this.$route.name == 'Login' && !this.$route.query.forgot;
 		},
@@ -933,27 +923,18 @@ export default {
 			} else if (this.otpRequested) {
 				return 'Verify your email address';
 			} else if (this.isLogin) {
-				if (this.saasProduct) {
-					return `Log in to your account to start using ${this.saasProduct.title}`;
-				}
-				return 'Log in to your account';
-			} else {
-				if (this.saasProduct) {
-					return `Sign up for ${this.saasProduct.title}`;
-				}
-
-				return 'Create your Frappe Cloud account';
+				return 'Log in to your Frappe Cloud account';
 			}
+			return 'Signup to your Frappe Cloud account';
 		},
 		subtitle() {
 			if (this.hasForgotPassword) {
 				return 'Enter your email address to reset your password';
-			} else {
-				if (this.saasProduct) {
-					return `Get started and explore the easiest way to use ${this.saasProduct.title}`;
-				}
+			} else if (this.isLogin) {
 				return 'Get started and explore the easiest way to use all Frappe apps';
 			}
+
+			return 'Hosting platform for Frappe apps';
 		},
 	},
 };

--- a/dashboard/src/pages/Quickstart.vue
+++ b/dashboard/src/pages/Quickstart.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
-import { Spinner } from 'frappe-ui'
+import { useRoute } from 'vue-router'
+import { createResource, Spinner } from 'frappe-ui'
 import { toast } from 'vue-sonner'
 import FCLogo from '@/components/icons/FCLogo.vue'
 import { getActiveSites } from '@/data/sites'
@@ -10,6 +11,15 @@ import { getDocResource } from '@/utils/resource'
 import { getToastErrorMessage } from '@/utils/toast'
 
 defineOptions({ name: 'Quickstart' })
+
+const route = useRoute()
+const product = route.query.product
+
+const productTrial = createResource({
+	url: 'press.api.account.signup_settings',
+	params: { product },
+	auto: !!product,
+})
 
 const team = getTeam()
 const sitesResource = getActiveSites()
@@ -81,7 +91,13 @@ onMounted(() => {
 		</h2>
 
 		<p class="mt-1 text-p-base text-ink-gray-5 mb-8">
-			Select a site or continue to Frappe Cloud.
+			{{
+				sites.length
+					? 'Select a site or continue to Frappe Cloud.'
+					: product
+						? 'Continue to Frappe Cloud or create a new trial site.'
+						: 'Continue to Frappe Cloud.'
+			}}
 		</p>
 
 		<a
@@ -112,12 +128,24 @@ onMounted(() => {
 			</div>
 		</a>
 
-		<Button variant="solid" :route="{ name: 'Site List' }" class="w-full mt-2">
+		<Button :route="{ name: 'Site List' }" class="w-full mt-2">
 			Go to Cloud Dashboard
 		</Button>
 
+		<Button
+			v-if="product"
+			variant="solid"
+			class="w-full mt-3"
+			:route="{ name: 'SignupSetup', params: { productId: product } }"
+		>
+			Create a new trial site for
+			<span class="capitalize">
+				{{ productTrial.data?.product_trial?.title || product }}
+			</span>
+		</Button>
+
 		<div
-			class="flex justify-center gap-2 pt-4  text-ink-gray-6"
+			class="flex justify-center gap-2 pt-4  text-ink-gray-5"
 			:class="sites.length ? '' : 'border-t'"
 		>
 			<a

--- a/dashboard/src/pages/Quickstart.vue
+++ b/dashboard/src/pages/Quickstart.vue
@@ -25,6 +25,11 @@ const team = getTeam()
 const sitesResource = getActiveSites()
 const sites = computed(() => sitesResource.data || [])
 
+// Only one trial site is allowed per product!
+const canCreateProductTrial = computed(
+	() => product && !sites.value.some((site) => site.standby_for_product === product),
+)
+
 const sitePlan = (site) =>
 	site.trial_end_date ? trialDays(site.trial_end_date) : null
 
@@ -94,7 +99,7 @@ onMounted(() => {
 			{{
 				sites.length
 					? 'Select a site or continue to Frappe Cloud.'
-					: product
+					: canCreateProductTrial
 						? 'Continue to Frappe Cloud or create a new trial site.'
 						: 'Continue to Frappe Cloud.'
 			}}
@@ -133,7 +138,7 @@ onMounted(() => {
 		</Button>
 
 		<Button
-			v-if="product"
+			v-if="canCreateProductTrial"
 			variant="solid"
 			class="w-full mt-3"
 			:route="{ name: 'SignupSetup', params: { productId: product } }"

--- a/dashboard/src/pages/Quickstart.vue
+++ b/dashboard/src/pages/Quickstart.vue
@@ -106,7 +106,7 @@ onMounted(() => {
 		</p>
 
 		<a
-			v-for="(site, i) in sites.slice(0,3)"
+			v-for="(site, i) in sites"
 			:key="site.name"
 			class="grid grid-cols-[1fr_auto] items-center gap-1.5 mb-3 cursor-pointer"
 			@click="openSite(site)"
@@ -124,7 +124,7 @@ onMounted(() => {
 
 			<div
 				class="flex gap-2 items-center col-span-2 pb-3"
-				:class="i == sites.slice(0,3).length - 1 ? '' : 'border-b'"
+				:class="i == sites.length - 1 ? '' : 'border-b'"
 			>
 				<span class="text-ink-gray-5" v-if="sitePlan(site)">
 					{{ sitePlan(site) }}</span

--- a/dashboard/src/pages/Welcome.vue
+++ b/dashboard/src/pages/Welcome.vue
@@ -5,7 +5,6 @@
 </template>
 <script>
 import { getTeam } from '../data/team';
-import { getActiveSites } from '../data/sites';
 import Onboarding from '../components/Onboarding.vue';
 import OnboardingWithoutPayment from '../components/OnboardingWithoutPayment.vue';
 export default {
@@ -22,7 +21,7 @@ export default {
 	mounted() {
 		this.from = window.from;
 	},
-	beforeRouteEnter: async (to, from, next) => {
+	beforeRouteEnter: (to, from, next) => {
 		// adding to window object so that it can be accessed in mounted
 		// since beforeRouteEnter is called before mounted
 		window.from = from;
@@ -33,26 +32,12 @@ export default {
 			($team?.doc.onboarding.complete && $team?.doc.onboarding.site_created) ||
 			(to.query.is_redirect && $team?.doc.onboarding.site_created);
 
-		if (!onboarded) {
-			next();
-			return;
-		}
-
-		// only run the <3-sites quickstart check right after login only!!
-		if (!to.query.post_login) {
+		if (onboarded) {
 			next({ name: 'Site List' });
 			return;
 		}
 
-		let sites = getActiveSites();
-		try {
-			if (!sites.data) await sites.list.fetch();
-		} catch (e) {
-			next({ name: 'Site List' });
-			return;
-		}
-
-		next({ name: sites.data.length > 0 && sites.data.length <= 3 ? 'Quickstart' : 'Site List' });
+		next();
 	},
 	methods: {
 		routeToSourcePage() {

--- a/dashboard/tests-e2e/tests/dashboard/auth.setup.ts
+++ b/dashboard/tests-e2e/tests/dashboard/auth.setup.ts
@@ -29,8 +29,9 @@ setup('authenticate into press dashboard', async ({ page }) => {
   await page.getByRole('textbox', { name: 'Password (required)' }).fill(userPassword);
   await page.getByRole('button', { name: 'Log In' }).click();
 
-  // Wait for successful navigation
-  await page.waitForURL('**/dashboard/sites');
+  // Wait for successful navigation. Post-login route depends on how many
+  // sites the team has (e.g. /sites vs /quickstart), so match either.
+  await page.waitForURL(/\/dashboard\/(sites|quickstart)/);
 
   // Save storage state
   await page.context().storageState({ path: getSessionStorageStatePath() });

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -355,6 +355,11 @@ def login_using_key(key):
 
 
 @frappe.whitelist()
+def get_route_on_login():
+	return get_current_team(get_doc=True).get_route_on_login()
+
+
+@frappe.whitelist()
 def active_servers():
 	team = get_current_team()
 	return frappe.get_all("Server", {"team": team, "status": "Active"}, ["title", "name"])

--- a/press/api/google.py
+++ b/press/api/google.py
@@ -91,8 +91,9 @@ def callback(code: str | None = None, state: str | None = None):  # noqa: C901
 
 		# login to existing account
 		frappe.local.login_manager.login_as(email)
+		team = frappe.get_doc("Team", team_name)
 		frappe.local.response.type = "redirect"
-		frappe.local.response.location = "/dashboard?post_login=1"
+		frappe.local.response.location = f"/dashboard{team.get_route_on_login()}"
 		return None
 
 	# create account request

--- a/press/api/oauth.py
+++ b/press/api/oauth.py
@@ -117,8 +117,9 @@ def callback(code=None, state=None):
 		# login
 		else:
 			frappe.local.login_manager.login_as(email)
+			team = frappe.get_doc("Team", {"user": email})
 			frappe.local.response.type = "redirect"
-			frappe.response.location = "/dashboard?post_login=1"
+			frappe.response.location = f"/dashboard{team.get_route_on_login()}"
 
 	return None
 

--- a/press/api/oauth.py
+++ b/press/api/oauth.py
@@ -117,9 +117,10 @@ def callback(code=None, state=None):
 		# login
 		else:
 			frappe.local.login_manager.login_as(email)
-			team = frappe.get_doc("Team", {"user": email})
+			team_name = frappe.db.get_value("Team", {"user": email}, "name")
+			route = frappe.get_doc("Team", team_name).get_route_on_login() if team_name else ""
 			frappe.local.response.type = "redirect"
-			frappe.response.location = f"/dashboard{team.get_route_on_login()}"
+			frappe.response.location = f"/dashboard{route}"
 
 	return None
 

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -464,7 +464,6 @@ override_whitelisted_methods = {"upload_file": "press.overrides.upload_file"}
 
 override_doctype_class = {"User": "press.overrides.CustomUser"}
 
-on_session_creation = "press.overrides.on_session_creation"
 # on_logout = "press.overrides.on_logout"
 on_login = "press.overrides.on_login"
 

--- a/press/overrides.py
+++ b/press/overrides.py
@@ -57,23 +57,6 @@ def upload_file():
 	return ret
 
 
-def on_session_creation():
-	from press.utils import get_current_team
-
-	if (
-		not frappe.db.exists("Team", {"user": frappe.session.user})
-		and frappe.session.data.user_type == "System User"
-	):
-		return
-
-	try:
-		team = get_current_team(get_doc=True)
-		route = team.get_route_on_login()
-		frappe.local.response.update({"dashboard_route": route})
-	except Exception:
-		pass
-
-
 def on_login(login_manager):
 	if frappe.session.user and frappe.session.data and frappe.session.data.user_type == "System User":
 		return

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -1424,7 +1424,7 @@ class Team(Document):
 	def get_route_on_login(self):
 		if self.payment_mode or self.skip_onboarding:
 			site_count = frappe.db.count("Site", {"team": self.name, "status": ("!=", "Archived")})
-			if 0 < site_count <= 3:
+			if site_count <= 3:
 				return "/quickstart"
 			return "/sites"
 

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -1423,6 +1423,9 @@ class Team(Document):
 
 	def get_route_on_login(self):
 		if self.payment_mode or self.skip_onboarding:
+			site_count = frappe.db.count("Site", {"team": self.name, "status": ("!=", "Archived")})
+			if 0 < site_count <= 3:
+				return "/quickstart"
 			return "/sites"
 
 		if self.is_saas_user:


### PR DESCRIPTION
Continuation of https://github.com/frappe/press/pull/6977 

## Description 

Showing quick site list page after user login on <= 3 sites. For better onboarding. Tested 2 scenarios:

- Page will show a CTA for create site if user doesnt have that product's trial site
- Had trial site of CRM already, page will not show create site button


## Image


<img width="401" alt="image" src="https://github.com/user-attachments/assets/2740a7fd-6dbb-4a95-9e78-a251197e74e2" />


https://github.com/user-attachments/assets/e4d1741e-562a-48c6-aa36-6740aacea068

