### PR TITLE
feat(proxy): Add playbook to update ProxySQL on proxies

### DIFF
--- a/press/playbooks/roles/update_proxysql/tasks/main.yml
+++ b/press/playbooks/roles/update_proxysql/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+# Updates the ProxySQL container to a new image version. Mirrors the manual
+# procedure: stop container, archive rotated logs, back up the data dir, then
+# recreate the container from the new image reusing the same volume and config.
+
+- name: Stop ProxySQL
+  become: yes
+  become_user: frappe
+  command: docker stop proxysql
+
+- name: Archive old rotated logs
+  become: yes
+  become_user: frappe
+  # ponytail: shell glob + mv is what was done by hand; find/copy modules would
+  # need a task each for events/audit and still shell out for the wildcard.
+  shell: >
+    mkdir -p /home/frappe/proxysql-old-logs &&
+    mv /home/frappe/proxysql/events.log.000000* /home/frappe/proxysql-old-logs/ 2>/dev/null;
+    mv /home/frappe/proxysql/audit.log.0000000* /home/frappe/proxysql-old-logs/ 2>/dev/null;
+    true
+
+- name: Back up ProxySQL data directory
+  become: yes
+  become_user: frappe
+  command: cp -R /home/frappe/proxysql /home/frappe/proxysql-old
+  args:
+    creates: /home/frappe/proxysql-old
+
+- name: Remove old ProxySQL container
+  become: yes
+  become_user: frappe
+  command: docker rm proxysql
+
+- name: Start ProxySQL
+  become: yes
+  become_user: frappe
+  command: "docker run -d --name proxysql --hostname proxysql --restart always -p 3306:6033 -p 127.0.0.1:6032:6032 -p 127.0.0.1:6070:6070 -v /home/frappe/proxysql:/var/lib/proxysql -v /home/frappe/proxysql/proxysql.cnf:/etc/proxysql.cnf proxysql/proxysql:{{ proxysql_version }}"

--- a/press/playbooks/roles/update_proxysql/tasks/main.yml
+++ b/press/playbooks/roles/update_proxysql/tasks/main.yml
@@ -2,15 +2,16 @@
 # Updates the ProxySQL container to a new image version. Mirrors the manual
 # procedure: stop container, archive rotated logs, back up the data dir, then
 # recreate the container from the new image reusing the same volume and config.
+#
+# All tasks run as root (the play default). The proxysql image runs as root
+# inside the container, so its data files land on the host owned by root — a
+# `frappe` user cannot read them, so `cp -R` would fail. docker run as root
+# produces an identical container to the `frappe` invocation used at setup.
 
 - name: Stop ProxySQL
-  become: yes
-  become_user: frappe
   command: docker stop proxysql
 
 - name: Archive old rotated logs
-  become: yes
-  become_user: frappe
   # ponytail: shell glob + mv is what was done by hand; find/copy modules would
   # need a task each for events/audit and still shell out for the wildcard.
   shell: >
@@ -20,18 +21,12 @@
     true
 
 - name: Back up ProxySQL data directory
-  become: yes
-  become_user: frappe
   command: cp -R /home/frappe/proxysql /home/frappe/proxysql-old
   args:
     creates: /home/frappe/proxysql-old
 
 - name: Remove old ProxySQL container
-  become: yes
-  become_user: frappe
   command: docker rm proxysql
 
 - name: Start ProxySQL
-  become: yes
-  become_user: frappe
   command: "docker run -d --name proxysql --hostname proxysql --restart always -p 3306:6033 -p 127.0.0.1:6032:6032 -p 127.0.0.1:6070:6070 -v /home/frappe/proxysql:/var/lib/proxysql -v /home/frappe/proxysql/proxysql.cnf:/etc/proxysql.cnf proxysql/proxysql:{{ proxysql_version }}"

--- a/press/playbooks/roles/update_proxysql/tasks/main.yml
+++ b/press/playbooks/roles/update_proxysql/tasks/main.yml
@@ -11,14 +11,18 @@
 - name: Stop ProxySQL
   command: docker stop proxysql
 
-- name: Archive old rotated logs
-  # ponytail: shell glob + mv is what was done by hand; find/copy modules would
-  # need a task each for events/audit and still shell out for the wildcard.
-  shell: >
-    mkdir -p /home/frappe/proxysql-old-logs &&
-    mv /home/frappe/proxysql/events.log.* /home/frappe/proxysql-old-logs/ 2>/dev/null;
-    mv /home/frappe/proxysql/audit.log.* /home/frappe/proxysql-old-logs/ 2>/dev/null;
-    true
+- name: Create old logs directory
+  file:
+    dest: /home/frappe/proxysql-old-logs
+    state: directory
+
+# ponytail: shell glob + mv is what was done by hand; the `|| true` tolerates a
+# missing glob so the play stays re-runnable after the logs are already moved.
+- name: Archive rotated event logs
+  shell: mv /home/frappe/proxysql/events.log.* /home/frappe/proxysql-old-logs/ 2>/dev/null || true
+
+- name: Archive rotated audit logs
+  shell: mv /home/frappe/proxysql/audit.log.* /home/frappe/proxysql-old-logs/ 2>/dev/null || true
 
 - name: Back up ProxySQL data directory
   command: cp -R /home/frappe/proxysql /home/frappe/proxysql-old

--- a/press/playbooks/roles/update_proxysql/tasks/main.yml
+++ b/press/playbooks/roles/update_proxysql/tasks/main.yml
@@ -10,6 +10,9 @@
 
 - name: Stop ProxySQL
   command: docker stop proxysql
+  # Tolerate a missing container so the play is re-runnable after a partial
+  # failure that already removed it.
+  failed_when: false
 
 - name: Create old logs directory
   file:
@@ -31,6 +34,8 @@
 
 - name: Remove old ProxySQL container
   command: docker rm proxysql
+  # Tolerate a missing container on re-run (see Stop ProxySQL above).
+  failed_when: false
 
 - name: Start ProxySQL
   command: "docker run -d --name proxysql --hostname proxysql --restart always -p 3306:6033 -p 127.0.0.1:6032:6032 -p 127.0.0.1:6070:6070 -v /home/frappe/proxysql:/var/lib/proxysql -v /home/frappe/proxysql/proxysql.cnf:/etc/proxysql.cnf proxysql/proxysql:{{ proxysql_version }}"

--- a/press/playbooks/roles/update_proxysql/tasks/main.yml
+++ b/press/playbooks/roles/update_proxysql/tasks/main.yml
@@ -16,8 +16,8 @@
   # need a task each for events/audit and still shell out for the wildcard.
   shell: >
     mkdir -p /home/frappe/proxysql-old-logs &&
-    mv /home/frappe/proxysql/events.log.000000* /home/frappe/proxysql-old-logs/ 2>/dev/null;
-    mv /home/frappe/proxysql/audit.log.0000000* /home/frappe/proxysql-old-logs/ 2>/dev/null;
+    mv /home/frappe/proxysql/events.log.* /home/frappe/proxysql-old-logs/ 2>/dev/null;
+    mv /home/frappe/proxysql/audit.log.* /home/frappe/proxysql-old-logs/ 2>/dev/null;
     true
 
 - name: Back up ProxySQL data directory

--- a/press/playbooks/roles/update_proxysql/tasks/main.yml
+++ b/press/playbooks/roles/update_proxysql/tasks/main.yml
@@ -10,9 +10,6 @@
 
 - name: Stop ProxySQL
   command: docker stop proxysql
-  # Tolerate a missing container so the play is re-runnable after a partial
-  # failure that already removed it.
-  failed_when: false
 
 - name: Create old logs directory
   file:
@@ -34,8 +31,6 @@
 
 - name: Remove old ProxySQL container
   command: docker rm proxysql
-  # Tolerate a missing container on re-run (see Stop ProxySQL above).
-  failed_when: false
 
 - name: Start ProxySQL
   command: "docker run -d --name proxysql --hostname proxysql --restart always -p 3306:6033 -p 127.0.0.1:6032:6032 -p 127.0.0.1:6070:6070 -v /home/frappe/proxysql:/var/lib/proxysql -v /home/frappe/proxysql/proxysql.cnf:/etc/proxysql.cnf proxysql/proxysql:{{ proxysql_version }}"

--- a/press/playbooks/update_proxysql.yml
+++ b/press/playbooks/update_proxysql.yml
@@ -1,0 +1,8 @@
+---
+- name: Update ProxySQL
+  hosts: all
+  become: yes
+  become_user: root
+  gather_facts: no
+  roles:
+    - role: update_proxysql

--- a/press/press/doctype/proxy_server/proxy_server.py
+++ b/press/press/doctype/proxy_server/proxy_server.py
@@ -12,6 +12,10 @@ from press.runner import Ansible
 from press.security import fail2ban
 from press.utils import log_error
 
+# ProxySQL image version rolled out to all proxies. Bumped from 2.3.2 to fix
+# ProxySQL failing to serve newly issued Let's Encrypt certificates.
+PROXYSQL_VERSION = "3.0.9"
+
 
 class ProxyServer(BaseServer):
 	# begin: auto-generated types
@@ -318,6 +322,23 @@ class ProxyServer(BaseServer):
 					self.reboot()
 		except Exception:
 			log_error("ProxySQL Setup Exception", server=self.as_dict())
+
+	@frappe.whitelist()
+	def update_proxysql(self):
+		frappe.enqueue_doc(self.doctype, self.name, "_update_proxysql", queue="long", timeout=1200)
+
+	def _update_proxysql(self):
+		try:
+			ansible = Ansible(
+				playbook="update_proxysql.yml",
+				server=self,
+				user=self._ssh_user(),
+				port=self._ssh_port(),
+				variables={"proxysql_version": PROXYSQL_VERSION},
+			)
+			ansible.run()
+		except Exception:
+			log_error("ProxySQL Update Exception", server=self.as_dict())
 
 	@frappe.whitelist()
 	def setup_replication(self):


### PR DESCRIPTION
## Why

Older proxies run the ProxySQL **2.3.2** image, which fails to serve newly issued Let's Encrypt certificates. This adds an update path to move all proxies to **3.0.9**.

## What

- **`update_proxysql.yml` playbook + role** — mirrors the manual procedure already done by hand on a couple of proxies:
  1. stop the container
  2. archive rotated logs into `proxysql-old-logs/`
  3. back up the data dir to `proxysql-old/`
  4. `docker rm` the old container
  5. recreate from the new image, reusing the same volume and `proxysql.cnf`

  The backup (`creates:`) and log-archive steps are guarded so the play is re-runnable.

- **`ProxyServer.update_proxysql()`** — whitelisted method that enqueues the play on the `long` queue.

- **`PROXYSQL_VERSION` constant** in `proxy_server.py` is the single source of truth for the image tag. The playbook requires the variable to be passed and fails loud if it isn't.

## Rollout

```python
frappe.get_doc("Proxy Server", name).update_proxysql()
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)