### PR TITLE
fix(site): Improve app-mismatch error when moving a site

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,18 @@ npx playwright test tests-e2e/tests/dashboard/site-update-banner.test.ts --heade
 ```
 
 Requires a running bench (`bench start`) and `dashboard/tests-e2e/.env` with credentials.
+
+## Finding docs.frappe.io/cloud URLs
+
+Error messages and dialogs often link to Frappe Cloud docs. Don't guess slugs —
+they 404 (the uninstall page is `how-to-uninstall-an-app-from-the-site`, not
+`sites/uninstall-an-app`). Search the wiki API instead:
+
+```bash
+curl -s "https://docs.frappe.io/api/method/wiki.frappe_wiki.doctype.wiki_document.search.search?query=<TERM>&space=0uh9cfn2fk"
+```
+
+Returns `{message:{results:[{title, route, content, score}], total}}`. Take the
+top result's `route` and prepend `https://docs.frappe.io/`. `space=0uh9cfn2fk`
+scopes results to the **Cloud** space (all routes start with `cloud/`); omit
+`space` to search all of docs.frappe.io (framework, etc.).

--- a/press/press/doctype/site_action/site_action.py
+++ b/press/press/doctype/site_action/site_action.py
@@ -827,8 +827,11 @@ class SiteAction(Document):
 		rg_apps.discard("frappe")
 		site_apps.discard("frappe")
 		if diff := site_apps - rg_apps:
+			apps = ", ".join(frappe.bold(app) for app in diff)
+			install = "<a class='underline' href='https://docs.frappe.io/cloud/installing-an-app#bench-group'>install</a>"
+			remove = "<a class='underline' href='https://docs.frappe.io/cloud/how-to-uninstall-an-app-from-the-site'>remove</a>"
 			frappe.throw(
-				f"Site has following apps {', '.join(diff)} which are not present in the destination release group. Please install those apps in the destination release group or remove them from the site before moving.",
+				f"Site has following apps: {apps} which are not present in the destination release group. Please {install} those apps in the destination release group or {remove} them from the site before moving.",
 				frappe.ValidationError,
 			)
 


### PR DESCRIPTION
## Why

When moving a site to another bench group, if the site has apps that aren't in the destination group, the error was hard to parse — app names were inline plain text and the "install / remove" steps were undirected.

## What

- **Bold** the offending app names (`frappe.bold`).
- Add a colon after "following apps:".
- Link **install** → [installing an app to a bench group](https://docs.frappe.io/cloud/installing-an-app#bench-group).
- Link **remove** → [uninstalling an app from a site](https://docs.frappe.io/cloud/how-to-uninstall-an-app-from-the-site).

Also documents in `AGENTS.md` how to find `docs.frappe.io/cloud` URLs via the wiki search API (guessed slugs 404), so future doc links point to real pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)