### PR TITLE
chore(proxysql): Bump setup image to 3.0.9

### DIFF
--- a/press/playbooks/roles/proxysql/tasks/main.yml
+++ b/press/playbooks/roles/proxysql/tasks/main.yml
@@ -36,7 +36,7 @@
 - name: Start ProxySQL
   become: yes
   become_user: frappe
-  command: "docker run -d --name proxysql --hostname proxysql --restart always -p 3306:6033 -p 127.0.0.1:6032:6032 -p 127.0.0.1:6070:6070 -v /home/frappe/proxysql:/var/lib/proxysql -v /home/frappe/proxysql/proxysql.cnf:/etc/proxysql.cnf proxysql/proxysql:2.3.2"
+  command: "docker run -d --name proxysql --hostname proxysql --restart always -p 3306:6033 -p 127.0.0.1:6032:6032 -p 127.0.0.1:6070:6070 -v /home/frappe/proxysql:/var/lib/proxysql -v /home/frappe/proxysql/proxysql.cnf:/etc/proxysql.cnf proxysql/proxysql:3.0.9"
 
 - name: Update APT Cache
   apt:


### PR DESCRIPTION
## Change

Bump the ProxySQL setup playbook image from `proxysql/proxysql:2.3.2` to `proxysql/proxysql:3.0.9` so newly provisioned proxies run the current release.

## Note

3.x is a major version jump from 2.3 — TLS/config compatibility should be verified on a test proxy before wider rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)