### PR TITLE
fix(release-group): Enforce app-version compatibility on deploy

### DIFF
--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -258,7 +258,6 @@ class ReleaseGroup(Document, TagHelpers):
 		self.validate_title()
 		self.validate_frappe_app()
 		self.validate_duplicate_app()
-		self.validate_app_versions()
 		self.validate_servers()
 		self.validate_rq_queues()
 		self.validate_max_min_workers()
@@ -681,21 +680,16 @@ class ReleaseGroup(Document, TagHelpers):
 				frappe.throw(f"App {app.app} can be added only once", frappe.ValidationError)
 			apps.add(app_name)
 
-	def validate_app_versions(self):
-		# App Source should be compatible with Release Group's version
-		with suppress(AttributeError, RuntimeError):
-			if (
-				not frappe.flags.in_test
-				and frappe.request.path == "/api/method/press.api.bench.change_branch"
-			):
-				return  # Separate validation exists in set_app_source
-		for app in self.apps:
-			self.validate_app_version(app)
+	def validate_app_version(self, source: str):
+		"""App Source must be compatible with the release group's bench version.
 
-	def validate_app_version(self, app: "ReleaseGroupApp"):
-		source = frappe.get_doc("App Source", app.source)
-		if all(row.version != self.version for row in source.versions):
-			branch, repo = frappe.db.get_values("App Source", app.source, ("branch", "repository"))[0]
+		Checked on deploy (and on an explicit branch change), not on every save:
+		blocking saves meant two incompatible apps deadlocked editing, since the
+		UI changes one app at a time and could never fix or remove either.
+		"""
+		app_source = frappe.get_doc("App Source", source)
+		if all(row.version != self.version for row in app_source.versions):
+			branch, repo = frappe.db.get_values("App Source", source, ("branch", "repository"))[0]
 			msg = f"{repo.rsplit('/')[-1] or repo.rsplit('/')[-2]}:{branch} branch is no longer compatible with bench of {self.version}"
 			frappe.throw(msg, frappe.ValidationError)
 
@@ -923,6 +917,8 @@ class ReleaseGroup(Document, TagHelpers):
 			self.check_auto_scales()
 
 		apps = self.get_apps_to_update(apps_to_update)
+		for app in apps:
+			self.validate_app_version(app["source"])
 		if apps_to_update is None:
 			self.validate_dc_apps_against_rg(apps)
 
@@ -1747,7 +1743,7 @@ class ReleaseGroup(Document, TagHelpers):
 				app.source = source
 				app.save()
 				break
-		self.validate_app_version(app)
+		self.validate_app_version(source)
 		self.save()
 
 	def get_marketplace_app_sources(self) -> list[str]:

--- a/press/press/doctype/release_group/test_release_group.py
+++ b/press/press/doctype/release_group/test_release_group.py
@@ -171,7 +171,9 @@ class TestReleaseGroup(FrappeTestCase):
 			team=self.team,
 		)
 
-	def test_create_release_group_fail_when_version_mismatch(self):
+	def test_create_release_group_allows_version_mismatch(self):
+		# Compatibility is enforced on deploy, not on save — see
+		# test_deploy_fails_when_app_incompatible_with_bench_version.
 		app = create_test_app("frappe", "Frappe Framework")
 		source = app.add_source(
 			frappe_version="Version 12",
@@ -179,14 +181,42 @@ class TestReleaseGroup(FrappeTestCase):
 			branch="version-12",
 			team=self.team,
 		)
-		self.assertRaises(
-			frappe.ValidationError,
-			new_release_group,
+		group = new_release_group(
 			"Test Group",
 			"Version 13",
 			[{"app": source.app, "source": source.name}],
 			team=self.team,
 		)
+		self.assertEqual(group.version, "Version 13")
+
+	def test_editing_group_with_incompatible_app_is_allowed(self):
+		"""Compatibility is checked on deploy, not on save.
+
+		Blocking saves meant two incompatible apps deadlocked editing (the UI
+		changes one app at a time), so the group must save even with an
+		incompatible app present.
+		"""
+		frappe_app = create_test_app("frappe", "Frappe Framework")
+		erpnext_app = create_test_app("erpnext", "ERPNext")
+		group = create_test_release_group([frappe_app, erpnext_app], frappe_version="Version 14")
+
+		frappe.db.delete("App Source Version", {"parent": group.apps[1].source, "version": group.version})
+
+		group.reload()
+		group.title = "Renamed Group"
+		group.save()  # must not raise despite erpnext being incompatible
+
+	def test_deploy_fails_when_app_incompatible_with_bench_version(self):
+		"""An app whose source is no longer compatible with the bench version must
+		block deploy."""
+		frappe_app = create_test_app("frappe", "Frappe Framework")
+		group = create_test_release_group([frappe_app], frappe_version="Version 14")
+
+		frappe.db.delete("App Source Version", {"parent": group.apps[0].source, "version": group.version})
+
+		group.reload()
+		with self.assertRaises(frappe.ValidationError):
+			group.create_deploy_candidate()
 
 	def test_create_release_group_fail_with_duplicate_titles(self):
 		app = create_test_app("frappe", "Frappe Framework")


### PR DESCRIPTION
## Problem

App Source compatibility with the bench version was validated on **every save** (`validate_app_versions` in `validate`). When a release group had two apps that were both incompatible with its version, editing deadlocked: the UI changes one app at a time, so any save re-raised on the *other* incompatible app — neither app could be fixed or removed.

## Change

Move the check to where it actually matters:

- `create_deploy_candidate` — validates each app being deployed
- `set_app_source` — the explicit branch-change path

Saving a group with an incompatible app is now allowed; the incompatibility is caught at deploy time instead. Also drops the `frappe.request.path == change_branch` carve-out that only existed to skip the on-save validation for branch changes — no longer needed now that the save-time check is gone.

## Tests

- `test_create_release_group_allows_version_mismatch` — save with a version mismatch now succeeds (was previously asserting it raised)
- `test_editing_group_with_incompatible_app_is_allowed` — editing a group with an incompatible app saves cleanly
- `test_deploy_fails_when_app_incompatible_with_bench_version` — deploy still blocks on an incompatible app

All 27 tests in `test_release_group` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)