### PR TITLE
fix: Branch change for framework

### DIFF
--- a/press/api/github.py
+++ b/press/api/github.py
@@ -17,6 +17,7 @@ from urllib.parse import urlencode, urlparse
 import frappe
 import jwt
 import requests
+import semantic_version as sv
 import tomli
 from frappe.utils.verified_command import get_secret
 
@@ -376,11 +377,15 @@ def app(owner: str, repository: str, branch: str, installation: str | None = Non
 		tree,
 	)
 
-	frappe_version = _get_compatible_frappe_version_from_pyproject(
-		owner,
-		repository,
-		branch_info,
-		headers,
+	frappe_version = (
+		None
+		if app_name == "frappe"
+		else _get_compatible_frappe_version_from_pyproject(
+			owner,
+			repository,
+			branch_info,
+			headers,
+		)
 	)
 
 	return {"name": app_name, "title": title, "frappe_version": frappe_version}
@@ -487,6 +492,33 @@ def _get_compatible_frappe_version_from_pyproject(
 		raise  # for mypy: NoReturn
 
 	return compatible_frappe_version
+
+
+@frappe.whitelist()
+def get_frappe_branch_major_version(
+	owner: str, repository: str, branch: str, installation: str | None = None
+) -> int:
+	"""Get the major Frappe version declared in `frappe/__init__.py` of the given branch."""
+	headers = get_auth_headers(installation)
+	init_file = requests.get(
+		f"https://api.github.com/repos/{owner}/{repository}/contents/frappe/__init__.py",
+		params={"ref": branch},
+		headers=headers,
+	).json()
+
+	if "content" not in init_file:
+		frappe.throw(
+			f"We couldn't read frappe/__init__.py from branch {branch}. "
+			"Please make sure the selected branch is correct."
+		)
+
+	content = b64decode(init_file["content"]).decode()
+	match = re.search(r"""__version__\s*=\s*["']([\d.]+)""", content)
+	if not match:
+		frappe.throw(f"Could not find __version__ in frappe/__init__.py on branch {branch}.")
+		raise  # for mypy: NoReturn
+
+	return sv.Version.coerce(match.group(1)).major
 
 
 def _get_app_name_and_title_from_hooks(

--- a/press/press/doctype/app_source/app_source.py
+++ b/press/press/doctype/app_source/app_source.py
@@ -118,6 +118,8 @@ class AppSource(Document):
 	@frappe.whitelist()
 	def sync_versions(self):
 		"""Replace `versions` with the Frappe versions the repo's pyproject.toml currently supports."""
+		if self.app == "frappe":
+			return
 		app_info = get_repo_app_info(
 			owner=self.repository_owner,
 			repository=self.repository,

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -24,6 +24,7 @@ from press.access.actions import ReleaseGroupActions
 from press.access.decorators import action_guard
 from press.agent import Agent
 from press.api.client import dashboard_whitelist
+from press.api.github import get_frappe_branch_major_version
 from press.exceptions import ImageNotFoundInRegistry, InsufficientSpaceOnServer, VolumeResizeLimitError
 from press.guards import role_guard
 from press.overrides import get_permission_query_conditions_for_doctype
@@ -1718,13 +1719,32 @@ class ReleaseGroup(Document, TagHelpers):
 			required_app_source.github_installation_id = current_app_source.github_installation_id
 			required_app_source.save()
 
+		if app == "frappe":
+			# Framework is a special case we must just compare the major versions
+			self._validate_frappe_branch_matches_bench_version(current_app_source, to_branch)
 		# Skip public sources, and sources owned by other teams — the same repository
 		# and branch can have a separate App Source per team, and neither should be
 		# mutated on behalf of a different team's branch change.
-		if not required_app_source.public and required_app_source.team == get_current_team():
+		elif not required_app_source.public and required_app_source.team == get_current_team():
 			frappe.get_doc("App Source", required_app_source.name).sync_versions()
 
 		self.set_app_source(app, required_app_source.name)
+
+	def _validate_frappe_branch_matches_bench_version(
+		self, current_app_source: AppSource, to_branch: str
+	) -> None:
+		target_major_version = get_frappe_branch_major_version(
+			current_app_source.repository_owner,
+			current_app_source.repository,
+			to_branch,
+			current_app_source.github_installation_id,
+		)
+		bench_major_version = frappe.get_cached_value("Frappe Version", self.version, "number")
+		if target_major_version != bench_major_version:
+			frappe.throw(
+				f"Branch {to_branch} is Frappe version {target_major_version}, which doesn't "
+				f"match this bench's version {self.version}."
+			)
 
 	def get_app_source(self, app: str) -> AppSource:
 		source = frappe.get_all(

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -1740,6 +1740,8 @@ class ReleaseGroup(Document, TagHelpers):
 			current_app_source.github_installation_id,
 		)
 		bench_major_version = frappe.get_cached_value("Frappe Version", self.version, "number")
+		if bench_major_version is None:
+			frappe.throw(f"Could not determine major version for bench version {self.version!r}.")
 		if target_major_version != bench_major_version:
 			frappe.throw(
 				f"Branch {to_branch} is Frappe version {target_major_version}, which doesn't "


### PR DESCRIPTION
Allow changing frameworks branch if the major version of the branch matches the release groups version.