### PR TITLE
fix(release-group): Fix branch-change tests broken

### DIFF
--- a/press/press/doctype/release_group/test_release_group.py
+++ b/press/press/doctype/release_group/test_release_group.py
@@ -29,6 +29,16 @@ if typing.TYPE_CHECKING:
 	from press.press.doctype.app.app import App
 
 
+# change_app_branch() reads frappe/__init__.py off GitHub to compare major versions.
+# Test sources point at frappe/erpnext, which has no such file, so the call 404s — and
+# tests shouldn't reach the network anyway. 14 matches create_test_release_group's
+# default frappe_version.
+mock_frappe_branch_major_version = patch(
+	"press.press.doctype.release_group.release_group.get_frappe_branch_major_version",
+	new=Mock(return_value=14),
+)
+
+
 def mock_free_space(space_required: int):
 	def wrapper(*args, **kwargs):
 		return space_required
@@ -217,6 +227,7 @@ class TestReleaseGroup(FrappeTestCase):
 		with self.assertRaises(frappe.ValidationError):
 			rg.change_app_branch("frappe", "master")
 
+	@mock_frappe_branch_major_version
 	@patch.object(AppSource, "sync_versions", new=Mock())
 	def test_branch_change_app_source_exists(self):
 		app = create_test_app()
@@ -236,6 +247,7 @@ class TestReleaseGroup(FrappeTestCase):
 		# Source must be set to the available `app_source` for `app`
 		self.assertEqual(rg.apps[0].source, app_source.name)
 
+	@mock_frappe_branch_major_version
 	@patch.object(AppSource, "sync_versions", new=Mock())
 	def test_branch_change_app_source_does_not_exist(self):
 		app = create_test_app()
@@ -253,10 +265,10 @@ class TestReleaseGroup(FrappeTestCase):
 
 	@patch.object(AppSource, "sync_versions", autospec=True)
 	def test_branch_change_syncs_versions_for_non_public_source(self, mock_sync_versions):
-		app = create_test_app()
-		rg = create_test_release_group([app])
+		app = create_test_app("erpnext", "ERPNext")
+		rg = create_test_release_group([create_test_app(), app])
 
-		current_app_source = frappe.get_doc("App Source", rg.apps[0].source)
+		current_app_source = frappe.get_doc("App Source", rg.apps[1].source)
 		app_source = create_test_app_source(
 			current_app_source.versions[0].version,
 			app,
@@ -271,10 +283,10 @@ class TestReleaseGroup(FrappeTestCase):
 
 	@patch.object(AppSource, "sync_versions", autospec=True)
 	def test_branch_change_does_not_sync_versions_for_public_source(self, mock_sync_versions):
-		app = create_test_app()
-		rg = create_test_release_group([app])
+		app = create_test_app("erpnext", "ERPNext")
+		rg = create_test_release_group([create_test_app(), app])
 
-		current_app_source = frappe.get_doc("App Source", rg.apps[0].source)
+		current_app_source = frappe.get_doc("App Source", rg.apps[1].source)
 		public_app_source = create_test_app_source(
 			current_app_source.versions[0].version,
 			app,


### PR DESCRIPTION
Fixes the `test_branch_change_*` failures on develop. Unrelated to the change itself — it's fallout from #7015.

## Two problems

**1. Tests hit the GitHub API.** d93cb760d made `change_app_branch()` read `frappe/__init__.py` off GitHub when the app is `frappe`. `create_test_app_source` defaults every source to `https://github.com/frappe/erpnext`, which has no `frappe/__init__.py`, so the call 404s and throws. Tests shouldn't reach the network anyway. Mocked the lookup for the two tests that genuinely change frappe's branch.

**2. Two tests were asserting against an unreachable branch.** `frappe` now goes down the version-check arm:

```python
if app == "frappe":
    self._validate_frappe_branch_matches_bench_version(...)
elif not required_app_source.public and required_app_source.team == get_current_team():
    frappe.get_doc("App Source", required_app_source.name).sync_versions()
```

so `sync_versions()` is never called for `frappe`. `..._syncs_versions_for_non_public_source` therefore can't pass, and `..._does_not_sync_versions_for_public_source` had started passing **vacuously**. Switched both to `erpnext`, which still takes the sync arm.

## Testing

All 25 tests in `test_release_group` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)