### PR TITLE
chore(deps): Declare frappe version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ include-package-data = true
 [tool.setuptools.dynamic]
 version = {attr = "press.__version__"}
 
+[tool.bench.frappe-dependencies]
+frappe = ">=16.0.0-dev,<=17.0.0-dev"
+
 [tool.bench.dev-dependencies]
 cryptography = "~=45.0" # cap below 46 which drops the GEN_EMAIL binding pyOpenSSL reads at import
 "moto[all]" = "~=5.0"


### PR DESCRIPTION
Declares `[tool.bench.frappe-dependencies]` in `pyproject.toml`:

```toml
[tool.bench.frappe-dependencies]
frappe = ">=16.0.0-dev,<=17.0.0-dev"
```

bench validates this on `get-app` ([bench/app.py](https://github.com/frappe/bench/blob/develop/bench/app.py)) and warns when the installed frappe doesn't match, so press can no longer be silently installed on an incompatible framework.

### Why `<=17.0.0-dev` and not `<17.0.0`

bench checks with `semantic_version.SimpleSpec`, where prereleases sort below the release:

| spec | 16.0.0-dev | 16.x | 17.0.0-dev | 17.0.0 |
|---|---|---|---|---|
| `>=16.0.0-dev,<=17.0.0-dev` | ✓ | ✓ | ✓ | ✗ |
| `>=16.0.0-dev,<17.0.0` | ✓ | ✓ | ✗ | ✗ |

Press only ever runs on frappe develop — prod runs a fork of it (`deployment/production.md`), currently `16.0.0-dev`. `<17.0.0` would start warning on every `get-app` the day frappe develop bumps to `17.0.0-dev`.

Ref: https://github.com/frappe/bench/issues/1524

🤖 Generated with [Claude Code](https://claude.com/claude-code)