### PR TITLE
fix(deps): Set frappe requirement to >=15.0.0,<17.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ include-package-data = true
 version = {attr = "press.__version__"}
 
 [tool.bench.frappe-dependencies]
-frappe = ">=16.0.0-dev,<17.0.0"
+frappe = ">=15.0.0,<17.0.0"
 
 [tool.bench.dev-dependencies]
 cryptography = "~=45.0" # cap below 46 which drops the GEN_EMAIL binding pyOpenSSL reads at import

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ include-package-data = true
 version = {attr = "press.__version__"}
 
 [tool.bench.frappe-dependencies]
-frappe = ">=16.0.0-dev,<=17.0.0-dev"
+frappe = ">=16.0.0-dev,<17.0.0"
 
 [tool.bench.dev-dependencies]
 cryptography = "~=45.0" # cap below 46 which drops the GEN_EMAIL binding pyOpenSSL reads at import


### PR DESCRIPTION
Follow-up to #7042. Two problems with the range it added:

**Upper bound.** `>=16.0.0-dev,<=17.0.0-dev` fails our own version range validation:

> Invalid version range: There is an inconsistency between the upper and lower bound major versions. Please ensure the version range specifies valid major versions.

`App.map_frappe_version` parses the range with `NpmSpec`, and a prerelease upper bound expands into more clauses than you'd expect:

```
>=16.0.0-dev,<=17.0.0-dev  →  <=17.0.0, >=16.0.0, >=17.0.0, >=16.0.0-dev, <=17.0.0-dev, <16.0.1
>=15.0.0,<17.0.0           →  >=15.0.0, <17.0.0
```

The first set contains both `>=17.0.0` and `<16.0.1`, so `get_lower_bound_major` finds an upper major (16) below a lower major (17) and throws ([app.py:189](https://github.com/frappe/press/blob/develop/press/press/doctype/app/app.py#L189)).

**Lower bound.** Press runs against v15 as well, so a `16.0.0-dev` floor locks out valid benches.

Tradeoff on the upper bound: bench checks with `SimpleSpec`, where `<17.0.0` rejects `17.0.0-dev` — so this will warn on `get-app` once frappe develop bumps to v17. The prerelease form that would cover it isn't expressible without changing the validator.

Master gets the same range via #7046, which also clears the conflict markers #7043 left in `pyproject.toml` there.