### PR TITLE
fix(app): Explain what makes a frappe version range invalid

### DIFF
--- a/press/press/doctype/app/app.py
+++ b/press/press/doctype/app/app.py
@@ -21,6 +21,12 @@ if typing.TYPE_CHECKING:
 	from press.press.doctype.app_source.app_source import AppSource
 
 
+VERSIONING_DOCS = (
+	"See <a href='https://docs.frappe.io/cloud/custom-apps/app-versioning/versioning'>"
+	"declaring app versions</a> for how to set this up in pyproject.toml."
+)
+
+
 class VersioningError(Exception): ...
 
 
@@ -186,11 +192,16 @@ def get_lower_bound_major(spec: sv.NpmSpec) -> int | None:
 		if getattr(c, "operator", None) in ("<", "<=") and getattr(c, "target", None) is not None
 	]
 
-	# Ensure that there is no overlap or inconsistency between upper and lower bounds
+	# Ensure that there is no overlap or inconsistency between upper and lower bounds.
+	# A prerelease bound also lands a companion clause on the opposite side here —
+	# `<=17.0.0-dev` yields `>=17.0.0`, `>=16.0.0-dev` yields `<16.0.1` — which is why a
+	# range that reads fine can still trip this. See NpmSpec.parse in semantic_version/base.py
+	# and https://github.com/npm/node-semver#prerelease-tags for the rule it implements.
 	if any(upper.major < lower.major for upper in uppers for lower in lowers):
 		frappe.throw(
-			"Invalid version range: There is an inconsistency between the upper and lower bound major versions. "
-			"Please ensure the version range specifies valid major versions."
+			f"Invalid version range '{spec}': the upper bound's major version is below the lower bound's. "
+			"Prerelease bounds cause this too — '<=17.0.0-dev' also implies '>=17.0.0'. "
+			f"Use stable versions for the bounds, e.g. '>=16.0.0-dev <17.0.0'. {VERSIONING_DOCS}"
 		)
 
 	return min(lowers).major
@@ -209,14 +220,15 @@ def map_frappe_version(
 		spec = sv.NpmSpec(version_string)
 	except ValueError:
 		frappe.throw(
-			f"Invalid version format for app '{app_title}'. Please use NPM-style semver ranges (e.g. '>=15.0.0 <16.0.0')."
+			f"Invalid version format for app '{app_title}'. Please use NPM-style semver ranges "
+			f"(e.g. '>=15.0.0 <16.0.0'). {VERSIONING_DOCS}"
 		)
 
 	if not is_bounded(spec):
 		frappe.throw(
 			f"Version range must be bounded for app '{app_title}'. "
 			"Please provide both a lower and an upper bound "
-			"(e.g. '>=15.0.0 <16.0.0')."
+			f"(e.g. '>=15.0.0 <16.0.0'). {VERSIONING_DOCS}"
 		)
 
 	highest_supported_stable_version = sv.Version(

--- a/press/press/doctype/app/app.py
+++ b/press/press/doctype/app/app.py
@@ -197,14 +197,15 @@ def get_lower_bound_major(spec: sv.NpmSpec) -> int | None:
 	# `<=17.0.0-dev` yields `>=17.0.0`, `>=16.0.0-dev` yields `<16.0.1` — which is why a
 	# range that reads fine can still trip this. See NpmSpec.parse in semantic_version/base.py
 	# and https://github.com/npm/node-semver#prerelease-tags for the rule it implements.
+	lowest = min(lowers)
 	if any(upper.major < lower.major for upper in uppers for lower in lowers):
 		frappe.throw(
 			f"Invalid version range '{spec}': the upper bound's major version is below the lower bound's. "
-			"Prerelease bounds cause this too — '<=17.0.0-dev' also implies '>=17.0.0'. "
-			f"Use stable versions for the bounds, e.g. '>=16.0.0-dev <17.0.0'. {VERSIONING_DOCS}"
+			"A prerelease upper bound does this on its own — '<=X.0.0-dev' also implies '>=X.0.0'. "
+			f"Use a stable upper bound, e.g. '>={lowest} <{lowest.major + 1}.0.0'. {VERSIONING_DOCS}"
 		)
 
-	return min(lowers).major
+	return lowest.major
 
 
 def map_frappe_version(

--- a/press/press/doctype/app/test_app.py
+++ b/press/press/doctype/app/test_app.py
@@ -176,6 +176,14 @@ class TestApp(FrappeTestCase):
 		self.assertIn(">=16.0.0-dev <=17.0.0-dev", str(context.exception))
 		self.assertIn(">=16.0.0-dev <17.0.0", str(context.exception))
 
+	def test_suggested_upper_bound_follows_the_range_that_was_rejected(self):
+		with self.assertRaises(frappe.ValidationError) as context:
+			parse_frappe_version(
+				">=14.0.0-dev,<=15.0.0-dev", app_title="test-app", ease_versioning_constrains=True
+			)
+
+		self.assertIn(">=14.0.0-dev <15.0.0", str(context.exception))
+
 	def test_version_parsing_with_ease_versioning_constrains(self):
 		"""Test version parsing with ease_versioning_constrains=True basically only lower bound major version compatibility check"""
 		accepted_custom_version_strings = [

--- a/press/press/doctype/app/test_app.py
+++ b/press/press/doctype/app/test_app.py
@@ -167,6 +167,15 @@ class TestApp(FrappeTestCase):
 			with self.assertRaises(frappe.ValidationError):
 				parse_frappe_version(invalid_custom_version_string, app_title="test-app")
 
+	def test_prerelease_upper_bound_is_rejected_with_a_message_naming_the_range(self):
+		with self.assertRaises(frappe.ValidationError) as context:
+			parse_frappe_version(
+				">=16.0.0-dev,<=17.0.0-dev", app_title="test-app", ease_versioning_constrains=True
+			)
+
+		self.assertIn(">=16.0.0-dev <=17.0.0-dev", str(context.exception))
+		self.assertIn(">=16.0.0-dev <17.0.0", str(context.exception))
+
 	def test_version_parsing_with_ease_versioning_constrains(self):
 		"""Test version parsing with ease_versioning_constrains=True basically only lower bound major version compatibility check"""
 		accepted_custom_version_strings = [


### PR DESCRIPTION
Follow-up to #7042 / #7044, where a range that reads fine got rejected with:

> Invalid version range: There is an inconsistency between the upper and lower bound major versions. Please ensure the version range specifies valid major versions.

That message names neither the range nor what to change, and the cause isn't visible in what the user wrote. `NpmSpec` pairs a prerelease bound with a companion clause on the *opposite* side — `<=17.0.0-dev` also yields `>=17.0.0`, `>=16.0.0-dev` also yields `<16.0.1` — so `get_lower_bound_major` sees an upper major (16) below a lower major (17) and throws.

**Now:**

> Invalid version range '>=16.0.0-dev <=17.0.0-dev': the upper bound's major version is below the lower bound's. Prerelease bounds cause this too — '<=17.0.0-dev' also implies '>=17.0.0'. Use stable versions for the bounds, e.g. '>=16.0.0-dev <17.0.0'. See [declaring app versions](https://docs.frappe.io/cloud/custom-apps/app-versioning/versioning) for how to set this up in pyproject.toml.

All three version errors in `map_frappe_version` now carry the docs link — an app with no `pyproject.toml` at all reaches these with nothing to go on.

Note this path only runs under `ease_versioning_constrains=True` (`app.py:243`).

Test: `test_prerelease_upper_bound_is_rejected_with_a_message_naming_the_range`. Full module passes (8 tests).

⚠️ The linked doc's own recommended example is `frappe = ">=16.0.0-dev,<=17.0.0-dev"` — the exact form that fails here. That page needs updating too.

Ref: https://github.com/npm/node-semver#prerelease-tags