### PR TITLE
fix(deps): Remove conflict markers from frappe version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,11 +89,7 @@ include-package-data = true
 version = {attr = "press.__version__"}
 
 [tool.bench.frappe-dependencies]
-<<<<<<< HEAD
 frappe = ">=15.0.0,<17.0.0"
-=======
-frappe = ">=16.0.0-dev,<=17.0.0-dev"
->>>>>>> c019a7b45 (chore(deps): Declare frappe version requirement)
 
 [tool.bench.dev-dependencies]
 cryptography = "~=45.0" # cap below 46 which drops the GEN_EMAIL binding pyOpenSSL reads at import


### PR DESCRIPTION
The backport merge in #7043 committed unresolved conflict markers into `pyproject.toml`, so the file no longer parses as TOML and bench can't read the dependency at all.

Kept the master side (`>=15.0.0,<17.0.0`) — master runs on v15. The v16-dev range belongs to develop, which already has it, so no matching PR is needed there.

Broken by e753dae7c (#7043).

🤖 Generated with [Claude Code](https://claude.com/claude-code)