### PR TITLE
feat(support-agent): Add incident time and confirm noisy neighbours

### DIFF
--- a/press/incident_management/doctype/support_agent_investigation/support_agent_investigation.json
+++ b/press/incident_management/doctype/support_agent_investigation/support_agent_investigation.json
@@ -6,6 +6,7 @@
 	"engine": "InnoDB",
 	"field_order": [
 		"site",
+		"incident_time",
 		"status",
 		"requested_by",
 		"column_break_status",
@@ -38,6 +39,12 @@
 			"options": "Site",
 			"read_only": 1,
 			"reqd": 1
+		},
+		{
+			"description": "Optional",
+			"fieldname": "incident_time",
+			"fieldtype": "Datetime",
+			"label": "Incident Time"
 		},
 		{
 			"default": "Queued",

--- a/press/incident_management/doctype/support_agent_investigation/support_agent_investigation.py
+++ b/press/incident_management/doctype/support_agent_investigation/support_agent_investigation.py
@@ -27,6 +27,7 @@ class SupportAgentInvestigation(Document):
 		errors_json: DF.JSON | None
 		evidence_json: DF.JSON | None
 		failure_reason: DF.SmallText | None
+		incident_time: DF.Datetime | None
 		likely_cause: DF.SmallText | None
 		llm_model: DF.Data | None
 		llm_response: DF.LongText | None
@@ -44,6 +45,8 @@ class SupportAgentInvestigation(Document):
 	def before_insert(self):
 		self.status = self.status or "Queued"
 		self.requested_by = self.requested_by or frappe.session.user
+		# No time given means the site is having problems right now.
+		self.incident_time = self.incident_time or frappe.utils.now_datetime()
 
 	@frappe.whitelist(methods=["POST"])
 	def start(self):
@@ -89,7 +92,7 @@ class SupportAgentInvestigation(Document):
 		frappe.db.commit()
 
 		try:
-			payload = redact(collect_site_context(self.site))
+			payload = redact(collect_site_context(self.site, self.incident_time))
 			report = generate_report(payload)
 			self.status = "Completed"
 			self.completed_at = frappe.utils.now_datetime()
@@ -117,12 +120,13 @@ class SupportAgentInvestigation(Document):
 
 
 @frappe.whitelist(methods=["POST"])
-def create_investigation(site: str, run_now: bool = True) -> str:
+def create_investigation(site: str, run_now: bool = True, incident_time: str | None = None) -> str:
 	site = validate_site_access(site)
 	doc = frappe.get_doc(
 		{
 			"doctype": "Support Agent Investigation",
 			"site": site,
+			"incident_time": incident_time,
 			"status": "Queued",
 			"requested_by": frappe.session.user,
 		}
@@ -141,6 +145,7 @@ def get_investigation(name: str) -> dict:
 	return {
 		"name": doc.name,
 		"site": doc.site,
+		"incident_time": doc.incident_time,
 		"status": doc.status,
 		"summary": doc.summary,
 		"likely_cause": doc.likely_cause,

--- a/press/incident_management/support_agent/collectors.py
+++ b/press/incident_management/support_agent/collectors.py
@@ -2,14 +2,20 @@ from __future__ import annotations
 
 import math
 import re
-import time
 from collections import Counter
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import frappe
+from frappe.utils import get_system_timezone
+
+from press.utils import convert_user_timezone_to_utc
+
+if TYPE_CHECKING:
+	from collections.abc import Iterable
+	from datetime import datetime
 
 RECENT_LIMIT = 10
-_PROM_TIMESPAN = 24 * 60 * 60  # seconds of history to fetch from Prometheus
+_WINDOW_HALF_HOURS = 12  # investigation looks this far either side of the time of interest
 _PROM_STEP = 30 * 60  # Prometheus step size in seconds
 _SPIKE_CPU_THRESHOLD = 70.0  # flag CPU spike only above this percent
 _SPIKE_RATIO = 1.5  # peak must be this many times the mean to count as a spike
@@ -18,6 +24,10 @@ _SLOW_ENDPOINT_THRESHOLD_S = 1.0  # average duration above which an endpoint is 
 _PERF_SPIKE_PEAK_THRESHOLD_S = 2.0  # peak must exceed this to register as a performance spike
 _PERF_SPIKE_RATIO = 3.0  # peak must be this many times the mean to count as a spike
 _PERF_MAX_PATHS = 20  # fetch up to this many endpoints for anomaly analysis
+_SLOW_QUERY_MAX_LOGS = 500  # slow log rows to fetch before normalizing
+_SLOW_QUERY_TOP = 5  # normalized queries to keep in the payload
+_DQL_STATEMENTS = ("select", "update", "delete", "insert")
+_PROCESSLIST_MAX = 10  # longest-running connections to keep from a live processlist
 _WEB_ERROR_TAIL_LINES = 500  # scan only the tail of the log to bound processing time
 _WEB_ERROR_MAX_ERRORS = 10  # return at most this many recent error blocks
 _WEB_ERROR_LOG_REGEX = re.compile(
@@ -25,13 +35,44 @@ _WEB_ERROR_LOG_REGEX = re.compile(
 )
 
 
-def collect_site_context(site_name: str) -> dict[str, Any]:
+class TimeWindow:
+	"""
+	The stretch of time an investigation looks at, centred on the time of interest.
+
+	Support tickets name a moment ("the site was down around 3pm"), so the window
+	spans _WINDOW_HALF_HOURS either side of it rather than trailing from now.
+	"""
+
+	def __init__(self, centre: datetime | str | None = None):
+		self.centre = frappe.utils.get_datetime(centre) if centre else frappe.utils.now_datetime()
+		self.start = frappe.utils.add_to_date(self.centre, hours=-_WINDOW_HALF_HOURS)
+		self.end = frappe.utils.add_to_date(self.centre, hours=_WINDOW_HALF_HOURS)
+		self.hours = _WINDOW_HALF_HOURS * 2
+
+	def utc_range(self) -> tuple[str, str]:
+		"""ISO strings for Elasticsearch @timestamp ranges, which are always UTC."""
+		return convert_user_timezone_to_utc(self.start), convert_user_timezone_to_utc(self.end)
+
+	def covers_now(self) -> bool:
+		"""Whether the investigation is about a problem that is still happening."""
+		return self.start <= frappe.utils.now_datetime() <= self.end
+
+	def epoch_range(self) -> tuple[int, int]:
+		"""Unix timestamps for Prometheus range queries."""
+		start, end = self.utc_range()
+		return int(frappe.utils.get_datetime(start).timestamp()), int(
+			frappe.utils.get_datetime(end).timestamp()
+		)
+
+
+def collect_site_context(site_name: str, centre: datetime | str | None = None) -> dict[str, Any]:
+	window = TimeWindow(centre)
 	site = _get_site(site_name)
 	bench = get_bench_health(site.get("bench"))
 	db_server = bench.get("database_server") if bench else None
 
-	app_server_metrics = get_server_metrics(site.get("server"))
-	db_server_metrics = get_server_metrics(db_server, is_db_server=True)
+	app_server_metrics = get_server_metrics(site.get("server"), window)
+	db_server_metrics = get_server_metrics(db_server, window, is_db_server=True)
 
 	server_advanced_analytics = (
 		get_server_advanced_analytics(site.get("server"), site_name)
@@ -40,21 +81,30 @@ def collect_site_context(site_name: str) -> dict[str, Any]:
 	)
 
 	return {
+		"window": {"centre": window.centre, "start": window.start, "end": window.end},
 		"site": get_site_health(site),
 		"bench": bench,
 		"apps": get_app_versions(site.get("bench")),
 		"deployments": get_deployment_timeline(site_name),
-		"background_jobs": get_background_job_summary(site_name),
+		"background_jobs": get_background_job_summary(site_name, window),
 		"backups": get_backup_status(site_name),
 		"domains": get_domain_status(site_name),
 		"incidents": get_platform_incidents(site),
-		"errors": get_redacted_error_summary(site_name),
+		"errors": get_redacted_error_summary(site_name, window),
 		"app_server_metrics": app_server_metrics,
 		"db_server_metrics": db_server_metrics,
 		"server_advanced_analytics": server_advanced_analytics,
 		"bench_processes": get_bench_process_status(site.get("bench")),
 		"site_uptime": get_site_uptime(site_name),
-		"site_performance": get_site_performance_summary(site_name, site.get("bench")),
+		"site_performance": get_site_performance_summary(site_name, site.get("bench"), window),
+		"slow_queries": get_slow_queries(site_name, window),
+		"database_processes": get_database_processes(site_name, window, db_server_metrics),
+		"database_slow_query_share": get_database_tenant_share(
+			db_server, site_name, window, db_server_metrics
+		),
+		"app_server_request_share": get_app_server_tenant_share(
+			site.get("server"), site_name, site.get("bench"), window, app_server_metrics
+		),
 		"web_error_log": get_web_error_log(site.get("bench")),
 	}
 
@@ -208,11 +258,10 @@ def get_deployment_timeline(site_name: str) -> list[dict[str, Any]]:
 	)
 
 
-def get_background_job_summary(site_name: str) -> dict[str, Any]:
-	since = frappe.utils.add_to_date(frappe.utils.now_datetime(), hours=-24)
+def get_background_job_summary(site_name: str, window: TimeWindow) -> dict[str, Any]:
 	jobs = frappe.get_all(
 		"Agent Job",
-		filters={"site": site_name, "creation": (">", since)},
+		filters={"site": site_name, "creation": ("between", [window.start, window.end])},
 		fields=[
 			"name",
 			"creation",
@@ -230,7 +279,7 @@ def get_background_job_summary(site_name: str) -> dict[str, Any]:
 	)
 
 	return {
-		"window_hours": 24,
+		"window_hours": window.hours,
 		"counts_by_status": dict(Counter(job.status for job in jobs)),
 		"recent": jobs,
 	}
@@ -299,14 +348,13 @@ def get_platform_incidents(site: frappe._dict) -> list[dict[str, Any]]:
 	)
 
 
-def get_redacted_error_summary(site_name: str) -> dict[str, Any]:
-	since = frappe.utils.add_to_date(frappe.utils.now_datetime(), hours=-24)
+def get_redacted_error_summary(site_name: str, window: TimeWindow) -> dict[str, Any]:
 	failed_jobs = frappe.get_all(
 		"Agent Job",
 		filters={
 			"site": site_name,
 			"status": ("in", ["Failure", "Delivery Failure"]),
-			"creation": (">", since),
+			"creation": ("between", [window.start, window.end]),
 		},
 		fields=["job_type", "reference_doctype", "retry_count", "creation"],
 		order_by="creation desc",
@@ -315,14 +363,16 @@ def get_redacted_error_summary(site_name: str) -> dict[str, Any]:
 
 	by_job_type = Counter(job.job_type for job in failed_jobs)
 	return {
-		"window_hours": 24,
+		"window_hours": window.hours,
 		"failed_job_count": len(failed_jobs),
 		"failed_jobs_by_type": dict(by_job_type),
 		"recent_failed_jobs": failed_jobs[:RECENT_LIMIT],
 	}
 
 
-def get_server_metrics(server_name: str | None, is_db_server: bool = False) -> dict[str, Any] | None:
+def get_server_metrics(
+	server_name: str | None, window: TimeWindow, is_db_server: bool = False
+) -> dict[str, Any] | None:
 	if not server_name:
 		return None
 
@@ -335,7 +385,8 @@ def get_server_metrics(server_name: str | None, is_db_server: bool = False) -> d
 		cpu_response = prometheus_get(
 			"query_range",
 			_prom_params(
-				f'(1 - avg(rate(node_cpu_seconds_total{{instance="{server_name}",job="node",mode="idle"}}[{_PROM_STEP}s]))) * 100'
+				f'(1 - avg(rate(node_cpu_seconds_total{{instance="{server_name}",job="node",mode="idle"}}[{_PROM_STEP}s]))) * 100',
+				window,
 			),
 		)
 	except Exception:
@@ -352,7 +403,8 @@ def get_server_metrics(server_name: str | None, is_db_server: bool = False) -> d
 				"query_range",
 				_prom_params(
 					f'sum(rate(node_disk_reads_completed_total{{instance="{server_name}",job="node"}}[{_PROM_STEP}s])'
-					f' + rate(node_disk_writes_completed_total{{instance="{server_name}",job="node"}}[{_PROM_STEP}s]))'
+					f' + rate(node_disk_writes_completed_total{{instance="{server_name}",job="node"}}[{_PROM_STEP}s]))',
+					window,
 				),
 			)
 			result["iops"] = _summarise_series(_prom_values(iops_response), ratio_threshold=_IOPS_SPIKE_RATIO)
@@ -397,14 +449,16 @@ def get_server_advanced_analytics(server_name: str | None, target_site: str) -> 
 	}
 
 
-def get_site_performance_summary(site_name: str, bench_name: str | None = None) -> dict[str, Any]:
+def get_site_performance_summary(
+	site_name: str, bench_name: str | None = None, window: TimeWindow | None = None
+) -> dict[str, Any]:
 	if not frappe.db.get_single_value("Press Settings", "log_server"):
 		return {"available": False}
 
 	from press.mcp.tools.telemetry.clients import elasticsearch_post
 
 	try:
-		response = elasticsearch_post(_slow_endpoint_query(site_name))
+		response = elasticsearch_post(_slow_endpoint_query(site_name, window or TimeWindow()))
 	except Exception:
 		return {"available": False}
 
@@ -416,7 +470,8 @@ def get_site_performance_summary(site_name: str, bench_name: str | None = None) 
 	}
 
 
-def _slow_endpoint_query(site_name: str) -> dict:
+def _slow_endpoint_query(site_name: str, window: TimeWindow) -> dict:
+	start, end = window.utc_range()
 	return {
 		"size": 0,
 		"query": {
@@ -424,7 +479,7 @@ def _slow_endpoint_query(site_name: str) -> dict:
 				"filter": [
 					{"match_phrase": {"json.site": site_name}},
 					{"match_phrase": {"json.transaction_type": "request"}},
-					{"range": {"@timestamp": {"gte": "now-24h", "lte": "now"}}},
+					{"range": {"@timestamp": {"gte": start, "lte": end}}},
 				]
 			}
 		},
@@ -505,6 +560,221 @@ def _endpoint_module(path: str) -> str | None:
 	return rest.split(".")[0] or None
 
 
+def get_slow_queries(site_name: str, window: TimeWindow) -> dict[str, Any]:
+	"""
+	Top MariaDB slow queries for the site's database in the investigation window, normalized.
+
+	Normalization replaces literals with `?` so the same query with different
+	values collapses into one entry. Only the normalized form is kept — the
+	example query carries customer data.
+	"""
+	if not frappe.db.get_single_value("Press Settings", "log_server"):
+		return {"available": False}
+
+	database = frappe.db.get_value("Site", site_name, "database_name")
+	if not database:
+		return {"available": False}
+
+	from press.press.report.mariadb_slow_queries.mariadb_slow_queries import (
+		get_slow_query_logs,
+		summarize_by_query,
+	)
+
+	start, end = window.utc_range()
+	try:
+		rows = get_slow_query_logs(database, start, end, None, _SLOW_QUERY_MAX_LOGS)
+	except Exception:
+		return {"available": False}
+
+	rows = [row for row in rows if row["query"].lower().lstrip().startswith(_DQL_STATEMENTS)]
+	summaries = summarize_by_query(rows)[:_SLOW_QUERY_TOP]
+
+	return {
+		"available": True,
+		"window_hours": window.hours,
+		"log_count": len(rows),
+		"top_queries": [_slow_query_summary(summary) for summary in summaries],
+	}
+
+
+def _slow_query_summary(summary: dict) -> dict[str, Any]:
+	count = int(summary["count"])
+	return {
+		"query": summary["query"],
+		"count": count,
+		"total_duration_s": round(summary["duration"], 3),
+		"avg_duration_s": round(summary["duration"] / count, 3),
+		"rows_examined": int(summary["rows_examined"]),
+		"rows_sent": int(summary["rows_sent"]),
+	}
+
+
+def get_app_server_tenant_share(
+	server_name: str | None,
+	site_name: str,
+	bench_name: str | None,
+	window: TimeWindow,
+	app_metrics: dict[str, Any] | None,
+) -> dict[str, Any]:
+	"""
+	Request time on the app server split by site, collected when its CPU spiked.
+
+	Bench containers on shared app servers have no CPU limits, so a busy neighbor
+	can crowd this site out. A neighbor on the same bench is worse still — it eats
+	the same gunicorn workers this site serves requests with.
+	"""
+	if not server_name or not (app_metrics or {}).get("cpu", {}).get("spike_detected"):
+		return {"available": False}
+
+	from press.api.analytics import AggType, ResourceType, auto_timespan_timegrain, get_request_by_
+
+	timespan, timegrain = auto_timespan_timegrain(window.start, window.end)
+	try:
+		chart = get_request_by_(
+			server_name,
+			AggType.DURATION.value,
+			get_system_timezone(),
+			window.start,
+			window.end,
+			timespan,
+			timegrain,
+			ResourceType.SERVER,
+		)
+	except Exception:
+		return {"available": False}
+
+	share = _tenant_share(chart["datasets"], site_name, window)
+	if share["available"] and not share["busiest_site_is_target"]:
+		share["busiest_site_shares_bench"] = (
+			frappe.db.get_value("Site", share["busiest_site"], "bench") == bench_name
+		)
+	return share
+
+
+def get_database_tenant_share(
+	db_server_name: str | None, site_name: str, window: TimeWindow, db_metrics: dict[str, Any] | None
+) -> dict[str, Any]:
+	"""
+	Slow-query time on the database server, split between this site and its neighbors.
+
+	The processlist can only confirm a noisy neighbor while the problem is still
+	happening; for an incident that has passed, the slow log is the record of who
+	was working the database. Grouping slow logs by site already exists for the
+	server analytics page, so this reuses it.
+	"""
+	if not db_server_name or not (db_metrics or {}).get("cpu", {}).get("spike_detected"):
+		return {"available": False}
+
+	from press.api.analytics import AggType, ResourceType, auto_timespan_timegrain, get_slow_logs
+
+	timespan, timegrain = auto_timespan_timegrain(window.start, window.end)
+	try:
+		chart = get_slow_logs(
+			db_server_name,
+			AggType.DURATION.value,
+			get_system_timezone(),
+			window.start,
+			window.end,
+			timespan,
+			timegrain,
+			ResourceType.SERVER,
+		)
+	except Exception:
+		return {"available": False}
+
+	return _tenant_share(chart["datasets"], site_name, window)
+
+
+def _tenant_share(datasets: list[dict], site_name: str, window: TimeWindow) -> dict[str, Any]:
+	seconds_by_site = {
+		dataset["path"]: sum(value for value in dataset["values"] if value) for dataset in datasets
+	}
+	seconds_by_site.pop("Other", None)  # the chart's catch-all bucket is not a tenant
+	total = sum(seconds_by_site.values())
+	if not total:
+		return {"available": False}
+
+	busiest_site = max(seconds_by_site, key=lambda site: seconds_by_site[site])
+	return {
+		"available": True,
+		"window_hours": window.hours,
+		"target_site_share_percent": round(seconds_by_site.get(site_name, 0) / total * 100, 1),
+		"busiest_site": busiest_site,
+		"busiest_site_share_percent": round(seconds_by_site[busiest_site] / total * 100, 1),
+		"busiest_site_is_target": busiest_site == site_name,
+	}
+
+
+def get_database_processes(
+	site_name: str, window: TimeWindow, db_metrics: dict[str, Any] | None
+) -> dict[str, Any]:
+	"""
+	Live SHOW PROCESSLIST, dumped only when the database CPU is busy right now.
+
+	The processlist reflects the current moment, so it says nothing about an
+	incident that has already passed. Queries are normalized and connection
+	identity (user, host, database) is dropped at the collector.
+	"""
+	if not window.covers_now() or not (db_metrics or {}).get("cpu", {}).get("spike_detected"):
+		return {"available": False}
+
+	from press.agent import Agent
+
+	site = frappe.get_doc("Site", site_name)
+	try:
+		rows = Agent(site.server).fetch_database_processes(site)
+	except Exception:
+		return {"available": False}
+
+	if not rows:
+		return {"available": True, "count": 0, "processes": []}
+
+	rows.sort(key=lambda row: row.get("time") or 0, reverse=True)
+	sites_by_database = _sites_by_database(row.get("db") for row in rows)
+	connections = Counter(sites_by_database.get(row.get("db")) for row in rows)
+	busiest_site, busiest_connections = connections.most_common(1)[0]
+
+	return {
+		"available": True,
+		"count": len(rows),
+		"target_site_connections": connections.get(site_name, 0),
+		"busiest_site_connections": busiest_connections,
+		"busiest_site_is_target": busiest_site == site_name,
+		"processes": [
+			_database_process(row, sites_by_database, site_name) for row in rows[:_PROCESSLIST_MAX]
+		],
+	}
+
+
+def _sites_by_database(databases: Iterable[str]) -> dict[str, str]:
+	"""Database names in MariaDB output are opaque; map them back to sites."""
+	databases = {database for database in databases if database}
+	if not databases:
+		return {}
+
+	sites = frappe.get_all(
+		"Site",
+		filters={"database_name": ("in", list(databases))},
+		fields=["name", "database_name"],
+	)
+	return {site.database_name: site.name for site in sites}
+
+
+def _database_process(row: dict, sites_by_database: dict[str, str], target_site: str) -> dict[str, Any]:
+	from press.press.report.mariadb_slow_queries.mariadb_slow_queries import normalize_query
+
+	query = (row.get("query") or "").strip()
+	site = sites_by_database.get(row.get("db") or "")
+	return {
+		"site": site,
+		"is_target_site": site == target_site,
+		"command": row.get("command"),
+		"seconds": row.get("time"),
+		"state": (row.get("state") or "").capitalize(),
+		"query": normalize_query(query) if query else "",
+	}
+
+
 def get_web_error_log(bench_name: str) -> dict[str, Any]:
 	"""
 	Recent ERROR/CRITICAL entries from the bench-level gunicorn web.error.log.
@@ -567,9 +837,9 @@ def _parse_web_error_blocks(lines: list[str]) -> list[dict[str, Any]]:
 	return blocks
 
 
-def _prom_params(query: str) -> dict:
-	end = int(time.time())
-	return {"query": query, "start": end - _PROM_TIMESPAN, "end": end, "step": f"{_PROM_STEP}s"}
+def _prom_params(query: str, window: TimeWindow) -> dict:
+	start, end = window.epoch_range()
+	return {"query": query, "start": start, "end": end, "step": f"{_PROM_STEP}s"}
 
 
 def _prom_values(response: dict) -> list[float]:

--- a/press/incident_management/support_agent/llm.py
+++ b/press/incident_management/support_agent/llm.py
@@ -35,7 +35,25 @@ def _anonymise(payload: dict[str, Any]) -> dict[str, Any]:
 	if isinstance(p.get("bench"), dict):
 		for field in _BENCH_IDENTITY_FIELDS:
 			p["bench"].pop(field, None)
+	_anonymise_database_processes(p.get("database_processes"))
+	_anonymise_tenant_share(p.get("database_slow_query_share"))
+	_anonymise_tenant_share(p.get("app_server_request_share"))
 	return p
+
+
+def _anonymise_tenant_share(share: Any) -> None:
+	"""The busiest tenant on the database server is named only if it is this site."""
+	if isinstance(share, dict) and not share.get("busiest_site_is_target"):
+		share["busiest_site"] = None
+
+
+def _anonymise_database_processes(database_processes: Any) -> None:
+	"""Processlist rows name the site behind each connection; other tenants stay unnamed."""
+	if not isinstance(database_processes, dict):
+		return
+	for process in database_processes.get("processes") or []:
+		if not process.get("is_target_site"):
+			process["site"] = None
 
 
 def _build_prompt(payload: dict[str, Any], report: dict[str, Any]) -> str:
@@ -61,6 +79,10 @@ Review the payload and findings. Respond with:
 1. Whether you agree with the likely cause, or a refined diagnosis if you see something different.
 2. Any additional signals the deterministic analysis may have missed.
 3. Your recommended next steps for the support agent.
+
+Failing agent jobs are almost always a symptom, not the cause — a job fails because the bench
+is down, the disk is full, or a deploy went bad. Use them to narrow down when and where to look,
+but do not present them as the diagnosis.
 
 Be concise and actionable. Cite only evidence present in the payload. Do not invent information."""
 

--- a/press/incident_management/support_agent/report.py
+++ b/press/incident_management/support_agent/report.py
@@ -24,6 +24,10 @@ def generate_report(payload: dict[str, Any]) -> dict[str, Any]:
 	bench_processes = payload.get("bench_processes") or {}
 	site_uptime = payload.get("site_uptime") or {}
 	site_performance = payload.get("site_performance") or {}
+	slow_queries = payload.get("slow_queries") or {}
+	database_processes = payload.get("database_processes") or {}
+	slow_query_share = payload.get("database_slow_query_share") or {}
+	request_share = payload.get("app_server_request_share") or {}
 	web_error_log = payload.get("web_error_log") or {}
 
 	_add_site_evidence(site, evidence, causes, next_steps)
@@ -36,13 +40,23 @@ def generate_report(payload: dict[str, Any]) -> dict[str, Any]:
 	_add_bench_process_evidence(bench_processes, evidence, causes, next_steps)
 	_add_uptime_evidence(site_uptime, evidence, causes, next_steps)
 	_add_server_metrics_evidence(
-		app_server_metrics, db_server_metrics, server_advanced_analytics, evidence, causes, next_steps
+		app_server_metrics,
+		db_server_metrics,
+		server_advanced_analytics,
+		slow_queries,
+		evidence,
+		causes,
+		next_steps,
 	)
 	_add_performance_evidence(site_performance, evidence, causes, next_steps)
+	_add_slow_query_evidence(slow_queries, evidence, causes, next_steps)
+	_add_database_process_evidence(database_processes, evidence, causes, next_steps)
+	_add_slow_query_share_evidence(slow_query_share, evidence, causes, next_steps)
+	_add_request_share_evidence(request_share, app_server_metrics, evidence, causes, next_steps)
 	_add_web_error_evidence(web_error_log, evidence, causes, next_steps)
 
 	if causes:
-		confidence = "High" if _has_blocking_signal(site, bench, deployments, errors, incidents) else "Medium"
+		confidence = "High" if _has_blocking_signal(site, bench, deployments, incidents) else "Medium"
 	else:
 		causes.append("No obvious platform-side issue found from the read-only checks.")
 		next_steps.append(
@@ -202,12 +216,14 @@ def _add_job_evidence(jobs, errors, evidence, timeline, causes, next_steps):
 			}
 		)
 
+	# Failed agent jobs are recorded as evidence but never as a cause — a job fails
+	# because of something else (bench down, disk full, bad deploy), so treating it
+	# as the cause just restates the symptom.
 	failed_count = errors.get("failed_job_count") or 0
 	if failed_count:
-		evidence.append(f"{failed_count} agent jobs failed in the last {errors.get('window_hours')} hours.")
-		causes.append("Recent platform agent jobs are failing for this site.")
-		next_steps.append(
-			"Inspect the failed Agent Job records and retry only after confirming the failure is transient."
+		evidence.append(
+			f"{failed_count} agent jobs failed in the last {errors.get('window_hours')} hours "
+			"(symptom — look for the underlying cause)."
 		)
 
 	running_count = (jobs.get("counts_by_status") or {}).get("Running", 0)
@@ -271,19 +287,20 @@ def _summary(site, causes, evidence):
 	return f"Investigation for {site.get('name')} found no obvious platform-side issue."
 
 
-def _has_blocking_signal(site, bench, deployments, errors, incidents):
+def _has_blocking_signal(site, bench, deployments, incidents):
 	return bool(
 		site.get("status") != "Active"
 		or bench.get("status") not in {None, "Active"}
 		or (deployments and deployments[0].get("status") in {"Fatal", "Cancelled"})
-		or errors.get("failed_job_count")
 		or incidents
 	)
 
 
-def _add_server_metrics_evidence(app_metrics, db_metrics, advanced_analytics, evidence, causes, next_steps):
+def _add_server_metrics_evidence(
+	app_metrics, db_metrics, advanced_analytics, slow_queries, evidence, causes, next_steps
+):
 	_add_app_server_evidence(app_metrics, advanced_analytics, evidence, causes, next_steps)
-	_add_db_server_evidence(db_metrics, evidence, causes, next_steps)
+	_add_db_server_evidence(db_metrics, slow_queries, evidence, causes, next_steps)
 
 
 def _add_app_server_evidence(app_metrics, advanced_analytics, evidence, causes, next_steps):
@@ -293,7 +310,7 @@ def _add_app_server_evidence(app_metrics, advanced_analytics, evidence, causes, 
 	cpu = app_metrics.get("cpu") or {}
 	if cpu.get("spike_detected"):
 		evidence.append(
-			f"App server CPU peaked at {cpu['peak']}% (mean {cpu['mean']}%) over the last 24 hours."
+			f"App server CPU peaked at {cpu['peak']}% (mean {cpu['mean']}%) in the investigation window."
 		)
 		causes.append(
 			"App server CPU spiked. Bench containers on shared servers have no CPU limits; "
@@ -315,7 +332,7 @@ def _add_app_server_evidence(app_metrics, advanced_analytics, evidence, causes, 
 			)
 
 
-def _add_db_server_evidence(db_metrics, evidence, causes, next_steps):
+def _add_db_server_evidence(db_metrics, slow_queries, evidence, causes, next_steps):
 	if not db_metrics.get("available"):
 		return
 
@@ -324,12 +341,13 @@ def _add_db_server_evidence(db_metrics, evidence, causes, next_steps):
 
 	if db_cpu.get("spike_detected"):
 		evidence.append(
-			f"Database server CPU peaked at {db_cpu['peak']}% (mean {db_cpu['mean']}%) over the last 24 hours."
+			f"Database server CPU peaked at {db_cpu['peak']}% (mean {db_cpu['mean']}%) in the investigation window."
 		)
 		causes.append(
 			"Database server CPU spiked. Shared database servers have no container-level isolation; "
 			"there is no automatic fix."
 		)
+		_add_busy_db_cpu_query_shape(slow_queries, evidence, next_steps)
 		next_steps.append(
 			"Use database server advanced analytics to identify the tenant driving CPU. "
 			"Remediation requires manually moving the site or the heavy tenant to a dedicated server."
@@ -338,13 +356,43 @@ def _add_db_server_evidence(db_metrics, evidence, causes, next_steps):
 	if db_iops.get("spike_detected"):
 		evidence.append(
 			f"Database server disk I/O peaked at {db_iops['peak']} IOPS "
-			f"(mean {db_iops['mean']}) over the last 24 hours."
+			f"(mean {db_iops['mean']}) in the investigation window."
 		)
 		if not db_cpu.get("spike_detected"):
 			causes.append("Database server disk I/O spiked.")
 			next_steps.append(
 				"Check database server advanced analytics to identify which tenant is driving heavy disk I/O."
 			)
+
+
+_HEAVY_QUERY_AVG_S = 1.0  # a query averaging this long is heavy by itself, not merely frequent
+
+
+def _add_busy_db_cpu_query_shape(slow_queries, evidence, next_steps):
+	"""
+	Busy database CPU comes from either too many queries or a few too-slow ones.
+
+	It is the latter most of the time, so point the support agent at the slow
+	queries before they go looking for a noisy neighbor.
+	"""
+	top = slow_queries.get("top_queries") or []
+	if not slow_queries.get("available") or not top:
+		next_steps.append(
+			"Check the site's slow queries — busy database CPU is usually a few too-slow queries."
+		)
+		return
+
+	worst = top[0]
+	if worst["avg_duration_s"] >= _HEAVY_QUERY_AVG_S:
+		evidence.append(
+			f"Database CPU is busy and the slowest query averages {worst['avg_duration_s']}s — "
+			"a few too-slow queries rather than query volume."
+		)
+	else:
+		evidence.append(
+			f"Database CPU is busy and the slowest query ran {worst['count']} times averaging only "
+			f"{worst['avg_duration_s']}s — query volume rather than a few too-slow queries."
+		)
 
 
 def _add_performance_evidence(performance, evidence, causes, next_steps):
@@ -372,7 +420,7 @@ def _add_slow_endpoint_evidence(slow, evidence, causes, next_steps):
 	slowest = slow[0]
 	evidence.append(
 		f"Slowest endpoint '{slowest['path']}' averaged {slowest['avg_duration_s']}s per request "
-		f"over the last 24 hours (peak {slowest['peak_duration_s']}s)."
+		f"in the investigation window (peak {slowest['peak_duration_s']}s)."
 	)
 
 	custom = [e for e in slow if e.get("is_custom")]
@@ -392,7 +440,7 @@ def _add_slow_endpoint_evidence(slow, evidence, causes, next_steps):
 
 	if len(slow) > 1:
 		others = ", ".join(f"'{e['path']}'" for e in slow[1:3])
-		evidence.append(f"Other slow endpoints in the last 24 hours: {others}.")
+		evidence.append(f"Other slow endpoints in the investigation window: {others}.")
 
 
 def _add_spiky_endpoint_evidence(spiky, evidence, next_steps):
@@ -408,6 +456,164 @@ def _add_spiky_endpoint_evidence(spiky, evidence, next_steps):
 		"Spiky endpoints suggest a specific document type or operation triggers the slowness. "
 		"Use Frappe Recorder to capture the slow request in context."
 	)
+
+
+_SLOW_QUERY_TOTAL_DURATION_S = 10.0  # DB time a query family must burn in 24h to be a cause
+_FULL_SCAN_ROW_RATIO = 100  # rows examined per row sent above which an index is likely missing
+
+
+def _add_slow_query_evidence(slow_queries, evidence, causes, next_steps):
+	top = slow_queries.get("top_queries") or []
+	if not slow_queries.get("available") or not top:
+		return
+
+	worst = top[0]
+	evidence.append(
+		f"Slowest database query ran {worst['count']} time(s) in the investigation window, "
+		f"{worst['total_duration_s']}s total ({worst['avg_duration_s']}s average): {worst['query']}"
+	)
+
+	if _scans_too_many_rows(worst):
+		evidence.append(
+			f"It examined {worst['rows_examined']} rows to return {worst['rows_sent']} — likely a missing index."
+		)
+		causes.append("A slow database query is scanning far more rows than it returns; an index is missing.")
+		next_steps.append(
+			"Run the MariaDB Slow Queries report for the site and add an index for the scanned column."
+		)
+	elif worst["total_duration_s"] >= _SLOW_QUERY_TOTAL_DURATION_S:
+		causes.append("Slow database queries are consuming significant database time for this site.")
+		next_steps.append(
+			"Run the MariaDB Slow Queries report for the site to see the full query list with examples."
+		)
+
+
+_QUERY_SNIPPET_CHARS = 200  # keep evidence readable; the full query is in the payload
+_VERY_HIGH_CPU_PERCENT = 90.0  # below this the app server still had headroom for every bench
+_NOISY_NEIGHBOR_CAUSE = "Another tenant on the shared database server is driving the load, not this site."
+_NOISY_NEIGHBOR_NEXT_STEP = (
+	"Move the heavy tenant or this site to a dedicated database server — shared database "
+	"servers have no isolation and there is no automatic fix."
+)
+
+
+def _add_database_process_evidence(database_processes, evidence, causes, next_steps):
+	processes = database_processes.get("processes") or []
+	if not database_processes.get("available") or not processes:
+		return
+
+	_add_longest_connection_evidence(database_processes, evidence, next_steps)
+	_add_noisy_neighbor_evidence(database_processes, evidence, causes, next_steps)
+
+
+def _add_noisy_neighbor_evidence(database_processes, evidence, causes, next_steps):
+	"""The processlist is what settles whether the site is the culprit or the victim."""
+	total = database_processes["count"]
+	target = database_processes.get("target_site_connections") or 0
+
+	if database_processes.get("busiest_site_is_target"):
+		evidence.append(
+			f"The site holds {target} of {total} database connections — the load is its own, "
+			"not a noisy neighbor."
+		)
+		return
+
+	busiest = database_processes.get("busiest_site_connections") or 0
+	evidence.append(
+		f"Another site on the database server holds {busiest} of {total} connections against this "
+		f"site's {target} — noisy neighbor confirmed."
+	)
+	causes.append(_NOISY_NEIGHBOR_CAUSE)
+	next_steps.append(_NOISY_NEIGHBOR_NEXT_STEP)
+
+
+def _add_request_share_evidence(share, app_metrics, evidence, causes, next_steps):
+	"""
+	The same question on the app server: is this site's own traffic the load?
+
+	A busy neighbor only hurts if it is on this site's bench, where the two share
+	gunicorn workers, or if the server's CPU was high enough that there was nothing
+	left to go around.
+	"""
+	if not share.get("available"):
+		return
+
+	target = share.get("target_site_share_percent")
+	if share.get("busiest_site_is_target"):
+		evidence.append(
+			f"This site accounts for {target}% of request time on the app server — "
+			"the load is its own, not a noisy neighbor."
+		)
+		return
+
+	busiest = share["busiest_site_share_percent"]
+	if share.get("busiest_site_shares_bench"):
+		evidence.append(
+			f"Another site on the same bench accounts for {busiest}% of request time on the app "
+			f"server against this site's {target}%."
+		)
+		causes.append("Another site on the same bench is consuming the gunicorn workers this site shares.")
+		next_steps.append(
+			"Move one of the two sites to its own bench — sites on a bench share gunicorn workers."
+		)
+		return
+
+	peak = (app_metrics.get("cpu") or {}).get("peak") or 0
+	if peak < _VERY_HIGH_CPU_PERCENT:
+		evidence.append(
+			f"Another site on the app server accounts for {busiest}% of request time against this "
+			f"site's {target}%, but the server only peaked at {peak}% CPU on a different bench — "
+			"it had headroom, so this is not a noisy neighbor."
+		)
+		return
+
+	evidence.append(
+		f"Another site on the app server accounts for {busiest}% of request time against this "
+		f"site's {target}%, with the server at {peak}% CPU — noisy neighbor confirmed."
+	)
+	causes.append("Another tenant on the shared app server is consuming the CPU, not this site.")
+	next_steps.append(
+		"Bench containers on shared app servers have no CPU limits — move the heavy tenant or "
+		"this site to another server."
+	)
+
+
+def _add_slow_query_share_evidence(share, evidence, causes, next_steps):
+	"""What the processlist does for a live problem, the slow log does for a past one."""
+	if not share.get("available"):
+		return
+
+	target = share.get("target_site_share_percent")
+	if share.get("busiest_site_is_target"):
+		evidence.append(
+			f"This site accounts for {target}% of slow-query time on the database server — "
+			"the load is its own, not a noisy neighbor."
+		)
+		return
+
+	evidence.append(
+		f"Another site accounts for {share['busiest_site_share_percent']}% of slow-query time on the "
+		f"database server against this site's {target}% — noisy neighbor confirmed."
+	)
+	causes.append(_NOISY_NEIGHBOR_CAUSE)
+	next_steps.append(_NOISY_NEIGHBOR_NEXT_STEP)
+
+
+def _add_longest_connection_evidence(database_processes, evidence, next_steps):
+	longest = database_processes["processes"][0]
+	evidence.append(
+		f"{database_processes['count']} database connections are open right now; the longest has run "
+		f"for {longest['seconds']}s in state '{longest['state']}': "
+		f"{longest['query'][:_QUERY_SNIPPET_CHARS]}"
+	)
+	next_steps.append(
+		"Read the live processlist in this investigation's payload to see what the database is "
+		"busy with before killing or optimizing anything."
+	)
+
+
+def _scans_too_many_rows(query):
+	return query["rows_sent"] > 0 and query["rows_examined"] >= query["rows_sent"] * _FULL_SCAN_ROW_RATIO
 
 
 def _add_web_error_evidence(web_error_log, evidence, causes, next_steps):

--- a/press/incident_management/support_agent/spec.md
+++ b/press/incident_management/support_agent/spec.md
@@ -31,6 +31,7 @@ The only required input is a site name or site domain.
 Important fields:
 
 - `site`: Link to `Site`.
+- `incident_time`: Optional. When the site was having problems. Defaults to the time the investigation is created. See Investigation Window.
 - `status`: `Queued`, `Running`, `Completed`, `Failed`.
 - `requested_by`: User who created the investigation.
 - `started_at`, `completed_at`: Execution timestamps.
@@ -52,14 +53,14 @@ The feature exposes three narrow whitelisted entrypoints.
 
 Module-level functions (not controller methods):
 
-- `create_investigation(site: str, run_now: bool = True) -> str`
+- `create_investigation(site: str, run_now: bool = True, incident_time: str | None = None) -> str`
 - `get_investigation(name: str) -> dict`
 
 Controller method:
 
 - `SupportAgentInvestigation.start()`
 
-`get_investigation` returns: `name`, `site`, `status`, `summary`, `likely_cause`, `recommended_next_steps`, `confidence`, `evidence`, `timeline`, `errors`, `failure_reason`, `started_at`, `completed_at`.
+`get_investigation` returns: `name`, `site`, `incident_time`, `status`, `summary`, `likely_cause`, `recommended_next_steps`, `confidence`, `evidence`, `timeline`, `errors`, `failure_reason`, `started_at`, `completed_at`.
 
 All entrypoints validate site access before returning data or starting work.
 
@@ -73,6 +74,22 @@ A site can be investigated if:
 
 Site domains are resolved to their owning site before access validation.
 
+## Investigation Window
+
+Support tickets name a moment ("the site was down around 3pm"), not a trailing period, so the
+investigation window is centred on `incident_time` — 12 hours either side of it, 24 hours in total.
+`incident_time` is optional; leaving it empty means the site is having problems right now and the
+window is centred on the current time.
+
+`TimeWindow` in `collectors.py` owns the window and converts it for each backend: naive
+system-timezone datetimes for Frappe DB filters, UTC ISO strings for Elasticsearch `@timestamp`
+ranges, and Unix timestamps for Prometheus range queries. The window is included in the payload
+as `window` (`centre`, `start`, `end`).
+
+Three collectors can only report the present: site uptime (an instant Prometheus probe), bench
+process status (a live supervisor call), and the database processlist. The processlist is
+therefore skipped unless the window covers the present — see Collectors.
+
 ## Collectors
 
 Collectors return structured facts only. They intentionally avoid raw logs, raw agent output, request data, traceback, site database access, and customer-owned records.
@@ -83,14 +100,18 @@ Current collectors:
 - **Bench health**: bench status, worker configuration, deploy candidate/build, queue-related flags (`merge_all_rq_queues`, `merge_default_and_short_rq_queues`, `use_rq_workerpool`), and failure markers (`last_inplace_update_failed`, `resetting_bench`).
 - **App versions**: bench app, source, release, hash. Up to all apps on the bench, ordered by index.
 - **Deployment timeline**: 5 most recent `Site Update` records — safe status/timing fields only (`status`, `deploy_type`, `scheduled_time`, `update_start`, `update_end`, `update_duration`, `backup_type`, `skipped_backups`, `skipped_failing_patches`).
-- **Background jobs**: up to 10 recent `Agent Job` records in the last 24 hours, counts by status, excluding output/request/traceback fields.
+- **Background jobs**: up to 10 recent `Agent Job` records in the investigation window, counts by status, excluding output/request/traceback fields.
 - **Backups**: 5 most recent backup status and safe size/status metadata, excluding URLs.
 - **Domains**: total count, counts by status, and per-record `status`/`dns_type`/`redirect_to_primary` — no domain names or DNS response bodies.
 - **Platform incidents**: up to 5 active incident records matching the site's server or cluster (or-filter), excluding resolved/auto-resolved/press-resolved incidents.
-- **Error summary**: 24-hour window, aggregated failed job counts by job type, up to 10 recent failed jobs listed, excluding raw output and stack traces.
+- **Error summary**: investigation window, aggregated failed job counts by job type, up to 10 recent failed jobs listed, excluding raw output and stack traces.
 - **Bench process status**: Supervisor process list for the site's bench. Each entry records the process name, status, and message. Processes not in `Running` or `Starting` state are collected as `stopped_processes`. Collected via `Bench.supervisorctl_status()` — an agent call to the app server.
 - **Web error log**: Recent ERROR and CRITICAL entries from `web.error.log` on the site's app server. Only the gunicorn-level description and the final exception message line are captured — not full stack frames with local variables. All entries are redacted before being stored. Collects at most 10 error blocks from the last 500 log lines.
-- **Site performance summary**: Up to 20 slowest endpoints from Elasticsearch over the last 24 hours. Each endpoint includes average and peak duration, a `spike_detected` flag (peak ≥ 3× mean and peak > 2 s), and an `is_custom` flag indicating whether the endpoint belongs to a non-Frappe app. App origin is determined by checking `repository_owner` on the AppSource record — any owner other than `frappe` is treated as custom. Also includes a `has_custom_apps` flag indicating whether any non-Frappe apps are installed on the bench.
+- **Site performance summary**: Up to 20 slowest endpoints from Elasticsearch in the investigation window. Each endpoint includes average and peak duration, a `spike_detected` flag (peak ≥ 3× mean and peak > 2 s), and an `is_custom` flag indicating whether the endpoint belongs to a non-Frappe app. App origin is determined by checking `repository_owner` on the AppSource record — any owner other than `frappe` is treated as custom. Also includes a `has_custom_apps` flag indicating whether any non-Frappe apps are installed on the bench.
+- **Slow queries**: Top 5 normalized MariaDB slow queries for the site's database in the investigation window, from up to 500 slow log rows in Elasticsearch. Reuses `get_slow_query_logs` and `summarize_by_query` from the MariaDB Slow Queries report. Normalization replaces literals with `?` so the same query with different values collapses into one entry; only the normalized form is kept — the example query carries customer data and is dropped at the collector. Each entry has `count`, `total_duration_s`, `avg_duration_s`, `rows_examined`, `rows_sent`. Non-DQL statements (e.g. `SET`) are filtered out.
+- **Database processes** (conditional): Live `SHOW PROCESSLIST` for the site, fetched through `Agent.fetch_database_processes`. Collected only when the database server CPU spike is happening right now — that is, when a spike was detected *and* the investigation window covers the present. The processlist reflects the current moment, so it says nothing about an incident that has already passed. The 10 longest-running connections are kept, each with `command`, `seconds`, `state`, and a normalized `query`; connection identity (user, host, database) is dropped at the collector.
+- **App server request share** (conditional): Request time on the site's app server split by site, collected whenever an app-server CPU spike is detected. Reuses `get_request_by_(..., ResourceType.SERVER)` from `press/api/analytics.py`, which already groups requests by `json.site`. Returns the same shape as the database share plus `busiest_site_shares_bench` — whether the busiest site sits on this site's bench.
+- **Database slow-query share** (conditional): Slow-query time on the site's database server split by tenant, collected whenever a database CPU spike is detected. Reuses `get_slow_logs(..., ResourceType.SERVER)` from `press/api/analytics.py`, which already groups the slow log by `mysql.slowlog.current_user` and maps each database name back to a site. Durations are summed per site over the window; the chart's catch-all `Other` bucket is not counted as a tenant. Returns `target_site_share_percent`, `busiest_site`, `busiest_site_share_percent`, and `busiest_site_is_target`. This is the past-incident counterpart to the processlist.
 - **Site uptime**: Instant probe result from the Prometheus blackbox exporter — `probe_success` (up/down) and `probe_http_status_code` (most recent HTTP status code from the external probe). Collected only when a monitor server is configured.
 
 ## Performance Investigation
@@ -105,11 +126,44 @@ Performance tickets require a structured escalation path through platform-observ
 
 3. **If a spike is observed, check server advanced analytics.** Advanced analytics break down resource usage across all tenants sharing the server. This is the mechanism for ruling in or ruling out a noisy neighbor.
 
+4. **If the database server is the busy one, look at slow queries.** Busy database CPU comes from either too many queries or a few too-slow ones. It is the latter most of the time, so read the slow queries before concluding noisy neighbor.
+
+```mermaid
+flowchart TD
+	A[Performance ticket] --> B{Active incident on the server or cluster?}
+	B -- yes --> B1[Incident is the likely cause]
+	B -- no --> C{Spike on server charts?}
+	C -- none --> C1[Not infrastructure: check slow endpoints and slow queries]
+	C -- app server CPU --> D{Busiest site on this server}
+	D -- this site --> D1[The site's own traffic]
+	D -- neighbor on the same bench --> D2[Worker contention: split the bench]
+	D -- "neighbor, CPU 90%+" --> D3[Noisy neighbor confirmed]
+	D -- "neighbor, CPU under 90%" --> D4[Server had headroom: not a noisy neighbor]
+	C -- database server CPU --> E{Slowest query average}
+	E -- "1s or more" --> E1[A few too-slow queries: the usual case]
+	E -- "under 1s" --> E2[Query volume, not one heavy query]
+	E1 --> F[Advanced analytics to identify the tenant; remediation is manual]
+	E2 --> F
+	C -- "database server CPU, happening now" --> G[Dump the live processlist]
+	C -- "database server CPU, already over" --> H[Group slow-query time by site]
+	G --> I{Do the connections belong to this site?}
+	H --> I
+	I -- no --> I1[Noisy neighbor confirmed: move a tenant to a dedicated server]
+	I -- yes --> I2[The site's own workload]
+```
+
 ### Noisy neighbor context
 
 **App server — memory:** Bench containers on shared app servers run with memory limits enforced. Memory pressure from one tenant cannot directly starve another. Memory is not a useful noisy-neighbor signal on app servers.
 
 **App server — CPU:** Bench containers on shared app servers have no CPU limits. A CPU-heavy tenant can crowd out others. If app-server CPU charts show a spike and the site's own usage does not explain it, advanced analytics should be checked for other benches on the same server consuming the burst.
+
+A busier neighbor on the app server is only a problem in two cases, so the report only calls it a cause in those:
+
+1. **The neighbor is on this site's bench.** The two share gunicorn workers, so the contention is direct regardless of server CPU. Remediation is moving one site to its own bench.
+2. **The server CPU was very high (≥ 90 % peak).** Below that the server had headroom and every bench got served, so a larger neighbor is not the explanation — the report says so explicitly rather than staying silent.
+
+**Confirming a noisy neighbor on the database server:** Two collectors settle it. While the problem is happening, the live processlist names the site behind every connection (database names map to `Site.database_name`). Once it has passed, the slow log grouped by site says who was working the database over the window. Either way, if the busiest tenant is not this site, the site is the victim rather than the cause.
 
 **Database server:** MariaDB instances on shared database servers have no container-level CPU or memory isolation. There is currently no platform-side solution to noisy-neighbor problems on shared database servers. If DB-server CPU or I/O charts show a spike, advanced analytics can identify the contributing tenant, but remediation requires a manual decision (e.g. moving the site or the noisy tenant to a dedicated server).
 
@@ -122,7 +176,7 @@ Performance tickets require a structured escalation path through platform-observ
 ### Report signals to add
 
 - Spike on app-server CPU with no matching incident → suggest checking advanced analytics for noisy neighbor.
-- Spike on database-server CPU or I/O → note that shared DB servers have no isolation; advanced analytics can identify the tenant but there is no automatic fix.
+- Spike on database-server CPU or I/O → note that shared DB servers have no isolation; advanced analytics can identify the tenant but there is no automatic fix. Also report the shape of the slow queries: an average of 1 s or more on the slowest query means a few too-slow queries (the usual case), below that means query volume.
 - No spike on either server during the reported window → platform infrastructure is not the cause; redirect investigation to app-level slow queries or the customer's workload.
 
 ## Error Code Investigation Patterns
@@ -224,13 +278,20 @@ It flags signals such as:
 - inactive/broken/suspended site status,
 - non-active bench status,
 - fatally failed or cancelled site updates (`Fatal`, `Cancelled` are terminal failure states; `Failure` is transient — a recovery job is created shortly after and the update moves to `Recovering` → `Recovered` or `Fatal`),
-- recent failed agent jobs,
 - critical disk/database/CPU usage (≥120% flagged as a cause; ≥90% flagged as evidence),
 - broken site domains,
 - latest failed backup,
 - matching active platform incidents.
 
-Confidence is `High` if any blocking signal is present (non-Active site or bench, fatal deployment, failed jobs, or active incidents), `Medium` if other causes were found, and `Low` if no causes were found.
+Failed agent jobs are recorded as evidence but never as a likely cause, and they do not raise
+confidence. A job fails because of something else — the bench is down, the disk is full, a deploy
+went bad — so naming it as the cause just restates the symptom. The same instruction is given to
+the model in the AI analysis prompt.
+
+Slow queries are flagged as a cause when the top query examines at least 100 rows per row returned
+(a likely missing index) or burns at least 10 seconds of database time in the window.
+
+Confidence is `High` if any blocking signal is present (non-Active site or bench, fatal deployment, or active incidents), `Medium` if other causes were found, and `Low` if no causes were found.
 
 The report generator returns:
 
@@ -252,6 +313,11 @@ The model receives `payload_json` (already redacted) plus the deterministic repo
 Fields stripped from `site`: `name`, `bench`, `server`, `database_server`, `cluster`, `group`.
 
 Fields stripped from `bench`: `name`, `server`, `database_server`, `cluster`, `candidate`, `build`.
+
+Neighboring tenants are never named to the model: processlist rows keep `site` only when
+`is_target_site` is set, and `database_slow_query_share.busiest_site` is cleared unless the busiest
+tenant is the investigated site. The support agent still sees the real names on the investigation
+record — only the LLM payload is anonymized.
 
 No raw logs, no PII, and no customer documents are ever included. The redaction pipeline is the primary gate; the site name strip is an additional anonymizing step.
 

--- a/press/incident_management/support_agent/test_investigation.py
+++ b/press/incident_management/support_agent/test_investigation.py
@@ -11,7 +11,11 @@ sys.modules.setdefault("frappe_mcp", MagicMock())
 import frappe  # noqa: E402
 from frappe.tests.utils import FrappeTestCase  # noqa: E402
 
-from press.incident_management.support_agent.collectors import collect_site_context  # noqa: E402
+from press.incident_management.support_agent.collectors import (  # noqa: E402
+	TimeWindow,
+	_tenant_share,
+	collect_site_context,
+)
 from press.incident_management.support_agent.report import generate_report  # noqa: E402
 
 _SITE_NAME = "test.frappe.cloud"
@@ -109,15 +113,26 @@ class TestSupportAgentInvestigation(FrappeTestCase):
 		elasticsearch=None,
 		processes=None,
 		web_log="",
+		centre=None,
+		processlist=None,
+		sites=None,
 	) -> dict:
 		bench_doc = MagicMock()
 		bench_doc.supervisorctl_status.return_value = processes if processes is not None else []
 		bench_doc.get_server_log.return_value = {"web.error.log": web_log}
 
+		agent = MagicMock()
+		agent.return_value.fetch_database_processes.return_value = processlist or []
+
 		def _mock_get_doc(doctype, name):
 			if doctype == "Bench":
 				return bench_doc
 			return MagicMock()
+
+		def _mock_get_all(doctype, *args, **kwargs):
+			if doctype == "Site" and sites:
+				return [frappe._dict(site) for site in sites]
+			return []
 
 		def _gsv(doctype, fieldname, *args, **kwargs):
 			if doctype == "Press Settings" and fieldname == "monitor_server":
@@ -139,8 +154,9 @@ class TestSupportAgentInvestigation(FrappeTestCase):
 					return_value=_BENCH_DATA,
 				)
 			)
-			stack.enter_context(patch("frappe.get_all", return_value=[]))
+			stack.enter_context(patch("frappe.get_all", side_effect=_mock_get_all))
 			stack.enter_context(patch("frappe.get_doc", side_effect=_mock_get_doc))
+			stack.enter_context(patch("press.agent.Agent", agent))
 			stack.enter_context(patch.object(frappe.db, "get_single_value", side_effect=_gsv))
 			stack.enter_context(
 				patch(
@@ -160,9 +176,68 @@ class TestSupportAgentInvestigation(FrappeTestCase):
 					return_value={},
 				)
 			)
-			payload = collect_site_context(_SITE_NAME)
+			self.payload = collect_site_context(_SITE_NAME, centre)
 
-		return generate_report(payload)
+		return generate_report(self.payload)
+
+	def test_window_is_centred_on_the_given_incident_time(self):
+		self._run(centre="2026-06-08 12:00:00")
+
+		window = self.payload["window"]
+		self.assertEqual(str(window["centre"]), "2026-06-08 12:00:00")
+		self.assertEqual(str(window["start"]), "2026-06-08 00:00:00")
+		self.assertEqual(str(window["end"]), "2026-06-09 00:00:00")
+
+	def test_processlist_maps_databases_to_sites_and_flags_the_target(self):
+		self._run(
+			prometheus=_prometheus_series([40.0] * 40 + [95.0]),
+			processlist=[
+				{
+					"db": "_noisy",
+					"command": "Query",
+					"time": 300,
+					"state": "sending data",
+					"query": "SELECT 1",
+				},
+				{
+					"db": "_target",
+					"command": "Query",
+					"time": 2,
+					"state": "sending data",
+					"query": "SELECT 2",
+				},
+			],
+			sites=[
+				{"name": "noisy.frappe.cloud", "database_name": "_noisy"},
+				{"name": _SITE_NAME, "database_name": "_target"},
+			],
+		)
+
+		processes = self.payload["database_processes"]
+		self.assertEqual(processes["count"], 2)
+		self.assertEqual(processes["target_site_connections"], 1)
+		self.assertFalse(processes["busiest_site_is_target"])
+		# Sorted longest-first, so the noisy site's 300s connection leads.
+		self.assertEqual(processes["processes"][0]["site"], "noisy.frappe.cloud")
+		self.assertFalse(processes["processes"][0]["is_target_site"])
+		self.assertTrue(processes["processes"][1]["is_target_site"])
+
+	def test_processlist_is_skipped_when_the_incident_has_already_passed(self):
+		self._run(
+			prometheus=_prometheus_series([40.0] * 40 + [95.0]),
+			centre="2020-01-01 12:00:00",
+			processlist=[{"db": "_target", "command": "Query", "time": 9, "state": "", "query": "SELECT 1"}],
+		)
+
+		self.assertFalse(self.payload["database_processes"]["available"])
+
+	def test_processlist_is_skipped_when_database_cpu_is_not_busy(self):
+		self._run(
+			prometheus=_prometheus_series([30.0] * 48),
+			processlist=[{"db": "_target", "command": "Query", "time": 9, "state": "", "query": "SELECT 1"}],
+		)
+
+		self.assertFalse(self.payload["database_processes"]["available"])
 
 	def test_prometheus_cpu_spike_surfaces_app_server_cpu_cause(self):
 		# Mean ~41%, peak 95% — ratio 2.3x > 1.5x threshold; peak > 70% threshold
@@ -247,3 +322,37 @@ class TestSupportAgentInvestigation(FrappeTestCase):
 			any("database server" in step for step in report["recommended_next_steps"]),
 			report["recommended_next_steps"],
 		)
+
+
+class TestSlowQueryShare(FrappeTestCase):
+	"""Slow-query time per tenant, as charted by the server analytics page."""
+
+	def _share(self, datasets):
+		return _tenant_share(datasets, _SITE_NAME, TimeWindow())
+
+	def test_neighbor_with_most_slow_query_time_is_reported_as_busiest(self):
+		share = self._share(
+			[
+				{"path": "noisy.frappe.cloud", "values": [10.0, None, 70.0]},
+				{"path": _SITE_NAME, "values": [None, 20.0, None]},
+			]
+		)
+
+		self.assertEqual(share["busiest_site"], "noisy.frappe.cloud")
+		self.assertFalse(share["busiest_site_is_target"])
+		self.assertEqual(share["busiest_site_share_percent"], 80.0)
+		self.assertEqual(share["target_site_share_percent"], 20.0)
+
+	def test_catch_all_other_bucket_is_not_treated_as_a_tenant(self):
+		share = self._share(
+			[
+				{"path": "Other", "values": [900.0]},
+				{"path": _SITE_NAME, "values": [100.0]},
+			]
+		)
+
+		self.assertTrue(share["busiest_site_is_target"])
+		self.assertEqual(share["target_site_share_percent"], 100.0)
+
+	def test_no_slow_query_time_makes_the_share_unavailable(self):
+		self.assertFalse(self._share([{"path": _SITE_NAME, "values": [None, 0]}])["available"])

--- a/press/incident_management/support_agent/test_redaction.py
+++ b/press/incident_management/support_agent/test_redaction.py
@@ -1,6 +1,24 @@
 from frappe.tests.utils import FrappeTestCase
 
+from press.incident_management.support_agent.llm import _anonymise
 from press.incident_management.support_agent.redaction import redact, redact_text
+
+
+class TestSupportAgentAnonymisation(FrappeTestCase):
+	def test_processlist_keeps_the_target_site_but_drops_other_tenants(self):
+		payload = {
+			"database_processes": {
+				"processes": [
+					{"site": "noisy.frappe.cloud", "is_target_site": False},
+					{"site": "test.frappe.cloud", "is_target_site": True},
+				]
+			}
+		}
+
+		processes = _anonymise(payload)["database_processes"]["processes"]
+
+		self.assertIsNone(processes[0]["site"])
+		self.assertEqual(processes[1]["site"], "test.frappe.cloud")
 
 
 class TestSupportAgentRedaction(FrappeTestCase):
@@ -15,6 +33,9 @@ class TestSupportAgentRedaction(FrappeTestCase):
 		self.assertNotIn("10.0.0.1", redacted)
 
 	def test_redacts_secret_dict_keys_recursively(self):
-		payload = {"site": "test.frappe.cloud", "nested": {"password": "admin"}}
+		payload = {
+			"site": "test.frappe.cloud",
+			"nested": {"password": "admin"},  # pragma: allowlist secret
+		}
 
 		self.assertEqual(redact(payload)["nested"]["password"], "[REDACTED]")

--- a/press/incident_management/support_agent/test_report.py
+++ b/press/incident_management/support_agent/test_report.py
@@ -118,6 +118,185 @@ class TestSupportAgentReport(FrappeTestCase):
 		self.assertIn("Database server CPU spiked", report["likely_cause"])
 		self.assertTrue(any("dedicated server" in step for step in report["recommended_next_steps"]))
 
+	def test_busy_db_cpu_with_heavy_query_points_at_slow_queries_not_volume(self):
+		report = generate_report(
+			{
+				"site": {"name": "test.frappe.cloud", "status": "Active", "usage_percent": {}},
+				"bench": {"status": "Active"},
+				"deployments": [],
+				"background_jobs": {},
+				"backups": {},
+				"domains": {},
+				"incidents": [],
+				"errors": {},
+				"db_server_metrics": {
+					"available": True,
+					"cpu": {"available": True, "peak": 92.0, "mean": 40.0, "spike_detected": True},
+				},
+				"slow_queries": {
+					"available": True,
+					"window_hours": 24,
+					"log_count": 30,
+					"top_queries": [
+						{
+							"query": "SELECT `name` FROM `tabToDo` WHERE `owner` = ?",
+							"count": 6,
+							"total_duration_s": 24.0,
+							"avg_duration_s": 4.0,
+							"rows_examined": 900,
+							"rows_sent": 90,
+						}
+					],
+				},
+			}
+		)
+
+		self.assertTrue(
+			any("too-slow queries rather than query volume" in e for e in report["evidence"]),
+			report["evidence"],
+		)
+
+	def test_busy_db_cpu_with_many_fast_queries_points_at_volume(self):
+		report = generate_report(
+			{
+				"site": {"name": "test.frappe.cloud", "status": "Active", "usage_percent": {}},
+				"bench": {"status": "Active"},
+				"deployments": [],
+				"background_jobs": {},
+				"backups": {},
+				"domains": {},
+				"incidents": [],
+				"errors": {},
+				"db_server_metrics": {
+					"available": True,
+					"cpu": {"available": True, "peak": 92.0, "mean": 40.0, "spike_detected": True},
+				},
+				"slow_queries": {
+					"available": True,
+					"window_hours": 24,
+					"log_count": 400,
+					"top_queries": [
+						{
+							"query": "SELECT `name` FROM `tabToDo` WHERE `owner` = ?",
+							"count": 380,
+							"total_duration_s": 190.0,
+							"avg_duration_s": 0.5,
+							"rows_examined": 900,
+							"rows_sent": 90,
+						}
+					],
+				},
+			}
+		)
+
+		self.assertTrue(
+			any("query volume rather than a few too-slow queries" in e for e in report["evidence"]),
+			report["evidence"],
+		)
+
+	def test_live_processlist_surfaces_longest_running_connection(self):
+		report = generate_report(
+			{
+				"site": {"name": "test.frappe.cloud", "status": "Active", "usage_percent": {}},
+				"bench": {"status": "Active"},
+				"deployments": [],
+				"background_jobs": {},
+				"backups": {},
+				"domains": {},
+				"incidents": [],
+				"errors": {},
+				"database_processes": {
+					"available": True,
+					"count": 42,
+					"target_site_connections": 40,
+					"busiest_site_connections": 40,
+					"busiest_site_is_target": True,
+					"processes": [
+						{
+							"site": "test.frappe.cloud",
+							"is_target_site": True,
+							"command": "Query",
+							"seconds": 310,
+							"state": "Sending data",
+							"query": "SELECT `name` FROM `tabToDo` WHERE `owner` = ?",
+						}
+					],
+				},
+			}
+		)
+
+		self.assertTrue(any("310s in state 'Sending data'" in e for e in report["evidence"]))
+		self.assertTrue(any("processlist" in step for step in report["recommended_next_steps"]))
+
+	def test_processlist_dominated_by_another_site_confirms_noisy_neighbor(self):
+		report = generate_report(
+			{
+				"site": {"name": "test.frappe.cloud", "status": "Active", "usage_percent": {}},
+				"bench": {"status": "Active"},
+				"deployments": [],
+				"background_jobs": {},
+				"backups": {},
+				"domains": {},
+				"incidents": [],
+				"errors": {},
+				"database_processes": {
+					"available": True,
+					"count": 50,
+					"target_site_connections": 2,
+					"busiest_site_connections": 44,
+					"busiest_site_is_target": False,
+					"processes": [
+						{
+							"site": "noisy.frappe.cloud",
+							"is_target_site": False,
+							"command": "Query",
+							"seconds": 500,
+							"state": "Sending data",
+							"query": "SELECT `name` FROM `tabToDo` WHERE `owner` = ?",
+						}
+					],
+				},
+			}
+		)
+
+		self.assertIn("Another tenant", report["likely_cause"])
+		self.assertTrue(any("noisy neighbor confirmed" in e for e in report["evidence"]))
+		self.assertTrue(any("dedicated database server" in step for step in report["recommended_next_steps"]))
+
+	def test_processlist_dominated_by_the_site_itself_rules_out_noisy_neighbor(self):
+		report = generate_report(
+			{
+				"site": {"name": "test.frappe.cloud", "status": "Active", "usage_percent": {}},
+				"bench": {"status": "Active"},
+				"deployments": [],
+				"background_jobs": {},
+				"backups": {},
+				"domains": {},
+				"incidents": [],
+				"errors": {},
+				"database_processes": {
+					"available": True,
+					"count": 50,
+					"target_site_connections": 46,
+					"busiest_site_connections": 46,
+					"busiest_site_is_target": True,
+					"processes": [
+						{
+							"site": "test.frappe.cloud",
+							"is_target_site": True,
+							"command": "Query",
+							"seconds": 500,
+							"state": "Sending data",
+							"query": "SELECT `name` FROM `tabToDo` WHERE `owner` = ?",
+						}
+					],
+				},
+			}
+		)
+
+		self.assertNotIn("Another tenant", report["likely_cause"])
+		self.assertTrue(any("the load is its own" in e for e in report["evidence"]))
+
 	def test_slow_endpoint_flags_web_worker_cause(self):
 		report = generate_report(
 			{
@@ -419,3 +598,246 @@ class TestSupportAgentReport(FrappeTestCase):
 		)
 
 		self.assertFalse(any("Gunicorn" in c for c in [report["likely_cause"]]))
+
+	def test_failed_agent_jobs_are_evidence_but_never_the_likely_cause(self):
+		report = generate_report(
+			{
+				"site": {"name": "test.frappe.cloud", "status": "Active", "usage_percent": {}},
+				"bench": {"status": "Active"},
+				"deployments": [],
+				"background_jobs": {},
+				"backups": {},
+				"domains": {},
+				"incidents": [],
+				"errors": {"window_hours": 24, "failed_job_count": 7},
+			}
+		)
+
+		self.assertTrue(any("7 agent jobs failed" in e for e in report["evidence"]))
+		self.assertIn("No obvious platform-side issue", report["likely_cause"])
+		self.assertEqual(report["confidence"], "Low")
+
+	def test_slow_query_scanning_too_many_rows_flags_missing_index(self):
+		report = generate_report(
+			{
+				"site": {"name": "test.frappe.cloud", "status": "Active", "usage_percent": {}},
+				"bench": {"status": "Active"},
+				"deployments": [],
+				"background_jobs": {},
+				"backups": {},
+				"domains": {},
+				"incidents": [],
+				"errors": {},
+				"slow_queries": {
+					"available": True,
+					"window_hours": 24,
+					"log_count": 40,
+					"top_queries": [
+						{
+							"query": "SELECT `name` FROM `tabToDo` WHERE `owner` = ?",
+							"count": 20,
+							"total_duration_s": 60.0,
+							"avg_duration_s": 3.0,
+							"rows_examined": 500000,
+							"rows_sent": 12,
+						}
+					],
+				},
+			}
+		)
+
+		self.assertIn("index is missing", report["likely_cause"])
+		self.assertTrue(any("tabToDo" in e for e in report["evidence"]))
+
+	def test_slow_query_below_duration_threshold_produces_no_cause(self):
+		report = generate_report(
+			{
+				"site": {"name": "test.frappe.cloud", "status": "Active", "usage_percent": {}},
+				"bench": {"status": "Active"},
+				"deployments": [],
+				"background_jobs": {},
+				"backups": {},
+				"domains": {},
+				"incidents": [],
+				"errors": {},
+				"slow_queries": {
+					"available": True,
+					"window_hours": 24,
+					"log_count": 2,
+					"top_queries": [
+						{
+							"query": "SELECT `name` FROM `tabToDo` WHERE `owner` = ?",
+							"count": 2,
+							"total_duration_s": 2.4,
+							"avg_duration_s": 1.2,
+							"rows_examined": 100,
+							"rows_sent": 40,
+						}
+					],
+				},
+			}
+		)
+
+		self.assertEqual(report["confidence"], "Low")
+		self.assertTrue(any("Slowest database query" in e for e in report["evidence"]))
+
+	def test_slow_query_share_dominated_by_another_site_confirms_noisy_neighbor(self):
+		report = generate_report(
+			{
+				"site": {"name": "test.frappe.cloud", "status": "Active", "usage_percent": {}},
+				"bench": {"status": "Active"},
+				"deployments": [],
+				"background_jobs": {},
+				"backups": {},
+				"domains": {},
+				"incidents": [],
+				"errors": {},
+				"database_slow_query_share": {
+					"available": True,
+					"window_hours": 24,
+					"target_site_share_percent": 4.0,
+					"busiest_site": "noisy.frappe.cloud",
+					"busiest_site_share_percent": 81.0,
+					"busiest_site_is_target": False,
+				},
+			}
+		)
+
+		self.assertIn("Another tenant", report["likely_cause"])
+		self.assertTrue(any("81.0% of slow-query time" in e for e in report["evidence"]))
+
+	def test_slow_query_share_dominated_by_the_site_itself_rules_out_noisy_neighbor(self):
+		report = generate_report(
+			{
+				"site": {"name": "test.frappe.cloud", "status": "Active", "usage_percent": {}},
+				"bench": {"status": "Active"},
+				"deployments": [],
+				"background_jobs": {},
+				"backups": {},
+				"domains": {},
+				"incidents": [],
+				"errors": {},
+				"database_slow_query_share": {
+					"available": True,
+					"window_hours": 24,
+					"target_site_share_percent": 88.0,
+					"busiest_site": "test.frappe.cloud",
+					"busiest_site_share_percent": 88.0,
+					"busiest_site_is_target": True,
+				},
+			}
+		)
+
+		self.assertNotIn("Another tenant", report["likely_cause"])
+		self.assertTrue(any("the load is its own" in e for e in report["evidence"]))
+
+	def test_request_share_dominated_by_a_site_on_the_same_bench_flags_shared_workers(self):
+		report = generate_report(
+			{
+				"site": {"name": "test.frappe.cloud", "status": "Active", "usage_percent": {}},
+				"bench": {"status": "Active"},
+				"deployments": [],
+				"background_jobs": {},
+				"backups": {},
+				"domains": {},
+				"incidents": [],
+				"errors": {},
+				"app_server_request_share": {
+					"available": True,
+					"window_hours": 24,
+					"target_site_share_percent": 5.0,
+					"busiest_site": "noisy.frappe.cloud",
+					"busiest_site_share_percent": 76.0,
+					"busiest_site_is_target": False,
+					"busiest_site_shares_bench": True,
+				},
+			}
+		)
+
+		self.assertIn("same bench", report["likely_cause"])
+		self.assertTrue(any("share gunicorn workers" in s for s in report["recommended_next_steps"]))
+
+	def test_request_share_dominated_by_a_site_on_another_bench_flags_noisy_neighbor(self):
+		report = generate_report(
+			{
+				"site": {"name": "test.frappe.cloud", "status": "Active", "usage_percent": {}},
+				"bench": {"status": "Active"},
+				"deployments": [],
+				"background_jobs": {},
+				"backups": {},
+				"domains": {},
+				"incidents": [],
+				"errors": {},
+				"app_server_metrics": {
+					"available": True,
+					"cpu": {"available": True, "peak": 97.0, "mean": 40.0, "spike_detected": True},
+				},
+				"app_server_request_share": {
+					"available": True,
+					"window_hours": 24,
+					"target_site_share_percent": 5.0,
+					"busiest_site": "noisy.frappe.cloud",
+					"busiest_site_share_percent": 76.0,
+					"busiest_site_is_target": False,
+					"busiest_site_shares_bench": False,
+				},
+			}
+		)
+
+		self.assertTrue(any("noisy neighbor confirmed" in e for e in report["evidence"]))
+		self.assertTrue(any("move the heavy tenant" in step for step in report["recommended_next_steps"]))
+
+	def test_request_share_dominated_by_the_site_itself_rules_out_noisy_neighbor(self):
+		report = generate_report(
+			{
+				"site": {"name": "test.frappe.cloud", "status": "Active", "usage_percent": {}},
+				"bench": {"status": "Active"},
+				"deployments": [],
+				"background_jobs": {},
+				"backups": {},
+				"domains": {},
+				"incidents": [],
+				"errors": {},
+				"app_server_request_share": {
+					"available": True,
+					"window_hours": 24,
+					"target_site_share_percent": 91.0,
+					"busiest_site": "test.frappe.cloud",
+					"busiest_site_share_percent": 91.0,
+					"busiest_site_is_target": True,
+				},
+			}
+		)
+
+		self.assertNotIn("Another", report["likely_cause"])
+		self.assertTrue(any("request time on the app server" in e for e in report["evidence"]))
+
+	def test_busier_neighbor_on_another_bench_is_not_noisy_when_the_server_had_headroom(self):
+		report = generate_report(
+			{
+				"site": {"name": "test.frappe.cloud", "status": "Active", "usage_percent": {}},
+				"bench": {"status": "Active"},
+				"deployments": [],
+				"background_jobs": {},
+				"backups": {},
+				"domains": {},
+				"incidents": [],
+				"errors": {},
+				"app_server_metrics": {
+					"available": True,
+					"cpu": {"available": True, "peak": 74.0, "mean": 30.0, "spike_detected": True},
+				},
+				"app_server_request_share": {
+					"available": True,
+					"window_hours": 24,
+					"target_site_share_percent": 5.0,
+					"busiest_site": "noisy.frappe.cloud",
+					"busiest_site_share_percent": 76.0,
+					"busiest_site_is_target": False,
+					"busiest_site_shares_bench": False,
+				},
+			}
+		)
+
+		self.assertTrue(any("it had headroom" in e for e in report["evidence"]))
+		self.assertFalse(any("move the heavy tenant" in step for step in report["recommended_next_steps"]))

--- a/press/incident_management/support_agent/test_report.py
+++ b/press/incident_management/support_agent/test_report.py
@@ -841,3 +841,47 @@ class TestSupportAgentReport(FrappeTestCase):
 
 		self.assertTrue(any("it had headroom" in e for e in report["evidence"]))
 		self.assertFalse(any("move the heavy tenant" in step for step in report["recommended_next_steps"]))
+
+	def test_live_and_past_noisy_neighbor_signals_do_not_double_report(self):
+		"""Both database collectors run during a live spike and share their wording."""
+		report = generate_report(
+			{
+				"site": {"name": "test.frappe.cloud", "status": "Active", "usage_percent": {}},
+				"bench": {"status": "Active"},
+				"deployments": [],
+				"background_jobs": {},
+				"backups": {},
+				"domains": {},
+				"incidents": [],
+				"errors": {},
+				"database_processes": {
+					"available": True,
+					"count": 50,
+					"target_site_connections": 2,
+					"busiest_site_connections": 44,
+					"busiest_site_is_target": False,
+					"processes": [
+						{
+							"site": "noisy.frappe.cloud",
+							"is_target_site": False,
+							"command": "Query",
+							"seconds": 500,
+							"state": "Sending data",
+							"query": "SELECT 1",
+						}
+					],
+				},
+				"database_slow_query_share": {
+					"available": True,
+					"window_hours": 24,
+					"target_site_share_percent": 4.0,
+					"busiest_site": "noisy.frappe.cloud",
+					"busiest_site_share_percent": 81.0,
+					"busiest_site_is_target": False,
+				},
+			}
+		)
+
+		steps = report["recommended_next_steps"]
+		self.assertEqual(len(steps), len(set(steps)), steps)
+		self.assertIn("Another tenant", report["likely_cause"])

--- a/press/press/doctype/site/site.js
+++ b/press/press/doctype/site/site.js
@@ -223,15 +223,31 @@ frappe.ui.form.on('Site', {
 		frm.add_custom_button(
 			__('Investigate'),
 			() => {
-				frappe
-					.call({
-						method:
-							'press.incident_management.doctype.support_agent_investigation.support_agent_investigation.create_investigation',
-						args: { site: frm.doc.name },
-					})
-					.then((r) => {
-						frappe.set_route('Form', 'Support Agent Investigation', r.message)
-					})
+				frappe.prompt(
+					{
+						fieldname: 'incident_time',
+						fieldtype: 'Datetime',
+						label: __('Incident Time'),
+						description: __('Optional'),
+					},
+					({ incident_time }) => {
+						frappe
+							.call({
+								method:
+									'press.incident_management.doctype.support_agent_investigation.support_agent_investigation.create_investigation',
+								args: { site: frm.doc.name, incident_time },
+							})
+							.then((r) => {
+								frappe.set_route(
+									'Form',
+									'Support Agent Investigation',
+									r.message,
+								)
+							})
+					},
+					__('Investigate Site'),
+					__('Investigate'),
+				)
 			},
 			__('Actions'),
 		)


### PR DESCRIPTION
## What

**Incident Time.** The investigation takes an optional `incident_time` and looks 12 hours either side of it, instead of trailing 24 hours from now. Support tickets name a moment ("the site was slow around 3pm"), and a trailing window misses it. Empty means now. Exposed on the Site form's **Investigate** button and on the doctype.

`TimeWindow` owns the window and converts itself per backend — naive datetimes for DB filters, UTC ISO for Elasticsearch, epoch for Prometheus.

**Noisy neighbours are confirmed, not guessed.** All three reuse groupings the analytics pages already implement:

| Collector | Source | When |
|---|---|---|
| `app_server_request_share` | `get_request_by_(..., ResourceType.SERVER)`, grouped by `json.site` | app CPU spike |
| `database_slow_query_share` | `get_slow_logs(..., ResourceType.SERVER)`, grouped by tenant | DB CPU spike |
| `database_processes` | live `SHOW PROCESSLIST`, database names mapped via `Site.database_name` | DB CPU spike **and** the window covers now |

A busier neighbour on the app server is only called a cause when it shares this site's bench (gunicorn worker contention) or the server peaked over 90% CPU — below that the server had headroom, and the report says so rather than staying silent.

The processlist is skipped for past incidents; a live dump says nothing about a problem that already ended. The slow-log share covers that case instead.

**Failed agent jobs demoted to evidence.** A job fails because the bench is down, the disk is full, or a deploy went bad. Naming it as the likely cause restates the symptom. They no longer raise confidence either.

**Normalized slow queries** for the site, reusing the MariaDB Slow Queries report's normalizer so literals collapse into `?`. Flags a likely missing index at 100+ rows examined per row returned.

## Privacy

Example queries are dropped at the collector — they carry customer data. Neighbouring tenants are named on the investigation record but cleared in `llm._anonymise` before anything reaches the model.

## Tests

47 tests pass; `ruff`, `mypy` and `compileall` clean.

```
bench --site <site> run-tests --app press --module press.incident_management.support_agent.test_report
bench --site <site> run-tests --app press --module press.incident_management.support_agent.test_investigation
bench --site <site> run-tests --app press --module press.incident_management.support_agent.test_redaction
```

`spec.md` is updated throughout, including the performance-investigation decision chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)