### PR TITLE
fix(deps): Widen frappe requirement to v15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ include-package-data = true
 version = {attr = "press.__version__"}
 
 [tool.bench.frappe-dependencies]
-frappe = ">=16.0.0-dev,<=17.0.0-dev"
+frappe = ">=15.0.0,<17.0.0"
 
 [tool.bench.dev-dependencies]
 cryptography = "~=45.0" # cap below 46 which drops the GEN_EMAIL binding pyOpenSSL reads at import


### PR DESCRIPTION
Press runs against v15 as well, so pinning the floor at `16.0.0-dev` locks out valid benches. Widened to `>=15.0.0,<17.0.0` — the same range master gets in #7046.

No `backport-master` label: master is already covered by #7046, which also clears the conflict markers left there by #7043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)