### PR TITLE
fix(release-group): Don't block deploy on stale bench app source

### DIFF
--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -687,6 +687,10 @@ class ReleaseGroup(Document, TagHelpers):
 		Checked on deploy (and on an explicit branch change), not on every save:
 		blocking saves meant two incompatible apps deadlocked editing, since the
 		UI changes one app at a time and could never fix or remove either.
+
+		Only the group's own sources are checked. Apps not being updated carry
+		their source over from the last deployed bench, which can be a source
+		the group has since moved off — blocking on that leaves no way out.
 		"""
 		app_source = frappe.get_doc("App Source", source)
 		if all(row.version != self.version for row in app_source.versions):
@@ -918,8 +922,8 @@ class ReleaseGroup(Document, TagHelpers):
 			self.check_auto_scales()
 
 		apps = self.get_apps_to_update(apps_to_update)
-		for app in apps:
-			self.validate_app_version(app["source"])
+		for app in self.apps:
+			self.validate_app_version(app.source)
 		if apps_to_update is None:
 			self.validate_dc_apps_against_rg(apps)
 

--- a/press/press/doctype/release_group/test_release_group.py
+++ b/press/press/doctype/release_group/test_release_group.py
@@ -228,6 +228,29 @@ class TestReleaseGroup(FrappeTestCase):
 		with self.assertRaises(frappe.ValidationError):
 			group.create_deploy_candidate()
 
+	def test_deploy_ignores_incompatible_source_carried_over_from_bench(self):
+		"""A stale source on the deployed bench must not block deploy when the
+		group has already moved the app to a compatible source."""
+		from press.press.doctype.site.test_site import create_test_bench
+
+		frappe_app = create_test_app("frappe", "Frappe Framework")
+		payments_app = create_test_app("payments", "Payments")
+		group = create_test_release_group([frappe_app, payments_app], frappe_version="Version 14")
+		bench = create_test_bench(group=group)
+
+		bench_app = find(bench.apps, lambda x: x.app == "payments")
+		stale_source = frappe.copy_doc(frappe.get_doc("App Source", bench_app.source))
+		stale_source.branch = "develop"
+		stale_source.versions = []
+		stale_source.append("versions", {"version": "Version 13"})
+		with patch.object(AppSource, "after_insert", new=Mock()):
+			stale_source.insert()
+		frappe.db.set_value("Bench App", bench_app.name, "source", stale_source.name)
+
+		group.reload()
+		# Only frappe is being updated, so payments carries its source over from the bench
+		group.create_deploy_candidate([{"app": "frappe"}])  # must not raise
+
 	def test_create_release_group_fail_with_duplicate_titles(self):
 		app = create_test_app("frappe", "Frappe Framework")
 		source = app.add_source(


### PR DESCRIPTION
## Problem

A group with payments on the `version-16` source failed every deploy with:

> Failed to create deploy candidate: payments:develop branch is no longer compatible with bench of Version 16

Apps that aren't part of the current update carry their source over from the last deployed bench. Here the running bench still held `payments:develop` (which has since dropped Version 16 from its versions), while the group had already been switched to `version-16`. The compatibility check ran on the carried-over bench source rather than on what the group configures, so nothing the user changed in the group could clear it.

## Fix

Validate the group's own app sources in `create_deploy_candidate`, not the resolved deploy list from `get_apps_to_update()`.

Regression from 26787b917, which moved the check off save (where it iterated `self.apps`) into `create_deploy_candidate` (where it iterated `get_apps_to_update()` output, i.e. bench sources included).

## Not in scope

Rewriting the carried-over source to the group's compatible one — that needs a release on the new branch and is a separate change. A branch switch still only takes effect when that app is actually updated.

## Test

`test_deploy_ignores_incompatible_source_carried_over_from_bench` reproduces the exact throw without the fix and passes with it. Full `test_release_group` module: 28 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)