### PR TITLE
feat(server): Set docker MTU during Hetzner server creation

### DIFF
--- a/press/press/doctype/press_job/jobs/create_server.py
+++ b/press/press/doctype/press_job/jobs/create_server.py
@@ -50,6 +50,9 @@ class CreateServerJob(PressJob):
 		if self.is_fs_server:
 			self.share_benches_over_nfs()
 
+		# Last, because it reboots the server
+		self.set_docker_mtu_hetzner()
+
 	@property
 	def is_setup_db_replication(self):
 		return self.server_type == "Database Server" and self.arguments_dict.get(
@@ -237,6 +240,15 @@ class CreateServerJob(PressJob):
 			server.setup_docker(now=True)
 		elif server.doctype == "Database Server":
 			server.set_mariadb_mount_dependency(now=True)
+
+	@task(queue="long", timeout=1200)
+	def set_docker_mtu_hetzner(self):
+		# The image ships docker on MTU 1500, which breaks traffic over Hetzner's 1450 private network
+		server = self.server_doc
+		if server.provider != "Hetzner" or server.doctype != "Server":
+			return
+
+		server._set_docker_mtu(throw_on_failure=True)
 
 	@task
 	def update_tls_certificate(self):

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -2599,14 +2599,17 @@ node_filesystem_avail_bytes{{instance="{self.name}", mountpoint="{mountpoint}"}}
 	def set_docker_mtu(self):
 		frappe.enqueue_doc(self.doctype, self.name, "_set_docker_mtu", queue="long", timeout=1200)
 
-	def _set_docker_mtu(self):
+	def _set_docker_mtu(self, throw_on_failure: bool = False):
 		ansible = Ansible(
 			playbook="docker_mtu.yml",
 			server=self,
 			user=self._ssh_user(),
 			port=self._ssh_port(),
 		)
-		return ansible.run()
+		play = ansible.run()
+		if play.status != "Success" and throw_on_failure:
+			frappe.throw("Failed to set docker MTU")  # nosemgrep
+		return play
 
 	@frappe.whitelist()
 	def reload_nginx(self):

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -2606,7 +2606,7 @@ node_filesystem_avail_bytes{{instance="{self.name}", mountpoint="{mountpoint}"}}
 			user=self._ssh_user(),
 			port=self._ssh_port(),
 		)
-		ansible.run()
+		return ansible.run()
 
 	@frappe.whitelist()
 	def reload_nginx(self):


### PR DESCRIPTION
Follow-up to #7063.

Hetzner servers boot from a VM image whose `daemon.json` has no `mtu`, so a new server runs docker on 1500 over a 1450 private network ([Hetzner docs](https://docs.hetzner.com/networking/networks/troubleshooting/mtu/)). `configure_apps_for_mounts_hetzner` only calls `setup_docker()` when the server has a data volume, so that path can't be relied on.

Adds a `set_docker_mtu_hetzner` step to `CreateServerJob`. It runs **last**, because the playbook reboots — TLS, agent, mariadb and mounts all talk to the server and would race the boot. Only `on_press_job_success` follows, and that touches Press records, not the machine.

`_set_docker_mtu` gets a `throw_on_failure` flag, matching `_prune_docker_system`, so a failed play fails the job.

No-ops on non-Hetzner and database servers, and skips the reboot when the MTU is already 1450.

## Testing

Playbook was verified on f1/f2 local in #7063 (reboot path and skip path). This PR only changes where it's called from — not yet run against a real Hetzner creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)