### PR TITLE
fix(client): Derive document ownership from a declared table

### DIFF
--- a/press/access/ownership.py
+++ b/press/access/ownership.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+"""Which team owns a document reached through the dashboard API.
+
+`press.api.client` acts for exactly one team, so before it reads or writes a
+document it has to name the team that owns it. Doctypes carrying a `team` field
+answer that themselves. Every other doctype in `ALLOWED_DOCTYPES` declares its
+answer here, and an undeclared doctype is refused.
+
+Defaulting to "allow" is what let any signed-in user read and edit every other
+team's Support Access, Partner Lead and SSH keys — frappe/security#183.
+"""
+
+from __future__ import annotations
+
+import frappe
+from frappe.query_builder import Criterion
+
+# Reference data. The same rows for every team, so any signed-in user may read
+# them and nobody may write them from the dashboard. Nothing derived from a
+# single team's data belongs here.
+GLOBAL_DOCTYPES = frozenset(
+	{
+		"Agent Job Type",
+		"Frappe Version",
+		"Partner Lead Origin",
+		"Partner Lead Type",
+		"Partner Tier",
+		"Press Settings",
+		"Product Trial",
+		"Server Plan",
+		"Site Plan",
+	}
+)
+
+# Doctypes that name their owning team in fields other than `team`. The document
+# belongs to every team those fields point at.
+TEAM_FIELDS: dict[str, tuple[str, ...]] = {
+	"Partner Approval Request": ("requested_by", "partner"),
+	"Partner Audit": ("partner_team",),
+	"Partner Lead": ("partner_team",),
+	"Partner Non Conformance": ("partner_team",),
+	"Partner Payment Payout": ("partner",),
+	"Support Access": ("requested_team", "target_team"),
+	"Team": ("name", "parent_team"),
+}
+
+# Doctypes owned by a user instead of a team.
+USER_FIELDS: dict[str, str] = {
+	"User SSH Key": "user",
+}
+
+# Doctypes owned through a link to a document that carries a `team` field.
+LINKED_OWNERS: dict[str, tuple[str, str]] = {
+	"Agent Job": ("bench", "Bench"),
+	"Auto Scale Record": ("primary_server", "Server"),
+	"Marketplace App Plan": ("app", "Marketplace App"),
+	"New Bench Queue": ("group", "Release Group"),
+	"Server Firewall": ("server_id", "Server"),
+}
+
+# Doctypes owned through a dynamic link, where another field names the doctype
+# being linked to.
+DYNAMICALLY_LINKED_OWNERS: dict[str, tuple[str, str]] = {
+	"Ansible Play": ("server", "server_type"),
+}
+
+# Doctypes whose `get_list_query` does the scoping itself, because a job or play
+# can hang off a site, a bench, a group or a server and no single join covers
+# all four. Both refuse to list anything unless the caller names one it owns.
+SELF_SCOPED_DOCTYPES = frozenset({"Agent Job", "Ansible Play"})
+
+
+def current_team() -> str:
+	return frappe.local.team().name
+
+
+def has_document_access(doctype: str, name: str, doc=None) -> bool:
+	"""Whether the current team owns this document."""
+	if doctype in GLOBAL_DOCTYPES:
+		return True
+
+	meta = frappe.get_meta(doctype)
+	if meta.istable:
+		return has_parent_access(doctype, name)
+
+	if meta.has_field("team"):
+		team = doc.team if doc else frappe.db.get_value(doctype, name, "team")
+		return bool(team) and team == current_team()
+
+	if doctype in TEAM_FIELDS:
+		return current_team() in owning_teams(doctype, name)
+
+	if doctype in USER_FIELDS:
+		return frappe.db.get_value(doctype, name, USER_FIELDS[doctype]) == frappe.session.user
+
+	if doctype in LINKED_OWNERS:
+		return has_linked_access(doctype, name)
+
+	if doctype in DYNAMICALLY_LINKED_OWNERS:
+		return has_dynamically_linked_access(doctype, name)
+
+	return False
+
+
+def owning_teams(doctype: str, name: str) -> set[str]:
+	values = frappe.db.get_value(doctype, name, TEAM_FIELDS[doctype], as_dict=True) or {}
+	return {team for team in values.values() if team}
+
+
+def has_parent_access(doctype: str, name: str) -> bool:
+	"""A child row belongs to whoever owns the row it hangs off."""
+	parent = frappe.db.get_value(doctype, name, ["parenttype", "parent"], as_dict=True)
+	if not (parent and parent.parenttype and parent.parent):
+		return False
+
+	return has_document_access(parent.parenttype, parent.parent)
+
+
+def has_linked_access(doctype: str, name: str) -> bool:
+	link_field, linked_doctype = LINKED_OWNERS[doctype]
+	linked_name = frappe.db.get_value(doctype, name, link_field)
+
+	return bool(linked_name) and has_document_access(linked_doctype, linked_name)
+
+
+def has_dynamically_linked_access(doctype: str, name: str) -> bool:
+	link_field, doctype_field = DYNAMICALLY_LINKED_OWNERS[doctype]
+	link = frappe.db.get_value(doctype, name, [link_field, doctype_field], as_dict=True)
+	if not (link and link[link_field] and link[doctype_field]):
+		return False
+
+	return has_document_access(link[doctype_field], link[link_field])
+
+
+def team_condition(doctype: str, table):
+	"""Condition matching rows of `doctype` that the current team owns."""
+	fieldnames: tuple[str, ...] = TEAM_FIELDS.get(doctype, ())
+	if frappe.get_meta(doctype).has_field("team"):
+		fieldnames = ("team",)
+
+	if not fieldnames:
+		return None
+
+	return Criterion.any([table[fieldname] == current_team() for fieldname in fieldnames])
+
+
+def scope_query(doctype: str, meta, filters: dict, query):
+	"""Restrict a list query to the documents the current team owns.
+
+	Doctypes with a `team` field are scoped by the caller, which has its own
+	opt-out for system users and support agents. Everything else is scoped here,
+	and a doctype nothing can scope is not listable at all.
+	"""
+	if meta.has_field("team") or doctype in GLOBAL_DOCTYPES or doctype in SELF_SCOPED_DOCTYPES:
+		return query
+
+	if frappe.local.system_user():
+		return query
+
+	if meta.istable:
+		return scope_by_parent(doctype, filters, query)
+
+	if doctype in TEAM_FIELDS:
+		return query.where(team_condition(doctype, frappe.qb.DocType(doctype)))
+
+	if doctype in USER_FIELDS:
+		return query.where(frappe.qb.DocType(doctype)[USER_FIELDS[doctype]] == frappe.session.user)
+
+	if doctype in LINKED_OWNERS:
+		return scope_by_link(doctype, query)
+
+	refuse_to_list(doctype)
+	return None
+
+
+def refuse_to_list(doctype: str):
+	frappe.throw(f"{doctype} cannot be listed from the dashboard", frappe.PermissionError)
+
+
+def scope_by_parent(doctype: str, filters: dict, query):
+	parenttype = str((filters or {}).get("parenttype") or "")
+	if not parenttype:
+		refuse_to_list(doctype)
+
+	ParentDocType = frappe.qb.DocType(parenttype)
+	ChildDocType = frappe.qb.DocType(doctype)
+
+	condition = team_condition(parenttype, ParentDocType)
+	if condition is None:
+		refuse_to_list(doctype)
+
+	return query.join(ParentDocType).on(ParentDocType.name == ChildDocType.parent).where(condition)
+
+
+def scope_by_link(doctype: str, query):
+	link_field, linked_doctype = LINKED_OWNERS[doctype]
+	DocType = frappe.qb.DocType(doctype)
+	LinkedDocType = frappe.qb.DocType(linked_doctype)
+
+	return (
+		query.inner_join(LinkedDocType)
+		.on(LinkedDocType.name == DocType[link_field])
+		.where(LinkedDocType.team == current_team())
+	)

--- a/press/access/ownership.py
+++ b/press/access/ownership.py
@@ -180,6 +180,13 @@ def refuse_to_list(doctype: str):
 
 
 def scope_by_parent(doctype: str, filters: dict, query):
+	"""Join the parent the caller named and keep only the rows its team owns.
+
+	The caller picks `parenttype`, so the join is only sound as long as the rows
+	it authorizes actually hang off that doctype. `get_list` already filters on
+	the stored `parenttype`, but the join repeats it rather than trusting a
+	filter built three functions away.
+	"""
 	parenttype = str((filters or {}).get("parenttype") or "")
 	if not parenttype:
 		refuse_to_list(doctype)
@@ -191,7 +198,12 @@ def scope_by_parent(doctype: str, filters: dict, query):
 	if condition is None:
 		refuse_to_list(doctype)
 
-	return query.join(ParentDocType).on(ParentDocType.name == ChildDocType.parent).where(condition)
+	return (
+		query.join(ParentDocType)
+		.on(ParentDocType.name == ChildDocType.parent)
+		.where(ChildDocType.parenttype == parenttype)
+		.where(condition)
+	)
 
 
 def scope_by_link(doctype: str, query):

--- a/press/api/client.py
+++ b/press/api/client.py
@@ -16,7 +16,7 @@ from frappe.query_builder.terms import ValueWrapper
 from frappe.utils import cstr
 from pypika.queries import QueryBuilder
 
-from press.access import dashboard_access_rules
+from press.access import dashboard_access_rules, ownership
 from press.access.support_access import has_support_access
 from press.exceptions import TeamHeaderNotInRequestError
 from press.guards import role_guard
@@ -130,10 +130,6 @@ def get_list(
 	if filters is None:
 		filters = {}
 
-	# these doctypes doesn't have a team field to filter by but are used in get or run_doc_method
-	if doctype in ["Team", "User SSH Key"]:
-		return []
-
 	context_data = {
 		"doctype": doctype,
 		"fields": fields,
@@ -210,15 +206,7 @@ def get_list_query(
 		doctype, filters=valid_filters, fields=valid_fields, offset=start, limit=limit, order_by=order_by
 	)
 
-	if meta.istable and frappe.get_meta(filters.get("parenttype")).has_field("team"):
-		ParentDocType = frappe.qb.DocType(filters.get("parenttype"))
-		ChildDocType = frappe.qb.DocType(doctype)
-
-		query = (
-			query.join(ParentDocType)
-			.on(ParentDocType.name == ChildDocType.parent)
-			.where(ParentDocType.team == frappe.local.team().name)
-		)
+	query = ownership.scope_query(doctype, meta, filters, query)
 
 	restricted_doctypes = ("Site", "Release Group", "Server")
 	if doctype in restricted_doctypes and role_guard.is_restricted() and not has_user_permission(doctype):
@@ -305,9 +293,7 @@ def insert(doc=None):
 
 		# inserting a child record
 		parent = frappe.get_doc(doc.parenttype, doc.parent)
-
-		if frappe.get_meta(parent.doctype).has_field("team") and parent.team != frappe.local.team().name:
-			raise_not_permitted()
+		check_document_write_access(parent.doctype, parent.name)
 
 		parent.append(doc.parentfield, doc)
 		parent.save()
@@ -339,7 +325,7 @@ def set_value(doctype: str, name: str, fieldname: dict | str, value: str | None 
 	sentry.set_context("press_client", {"method": "set_value", "data": context_data})
 	check_permissions(doctype)
 	if not has_support_access(doctype, name):
-		check_document_access(doctype, name)
+		check_document_write_access(doctype, name)
 
 	for field in fieldname:
 		# fields mentioned in dashboard_fields are allowed to be set via set_value
@@ -357,7 +343,7 @@ def delete(doctype: str, name: str):
 
 	check_permissions(doctype)
 	if not has_support_access(doctype, name):
-		check_document_access(doctype, name)
+		check_document_write_access(doctype, name)
 	check_dashboard_actions(doctype, name, method)
 
 	_run_doc_method(dt=doctype, dn=name, method=method, args=None)
@@ -376,7 +362,7 @@ def run_doc_method(dt: str, dn: str, method: str, args: dict | None = None):
 
 	check_permissions(dt)
 	if not has_support_access(dt, dn):
-		check_document_access(dt, dn)
+		check_document_write_access(dt, dn)
 	check_dashboard_actions(dt, dn, method)
 
 	_run_doc_method(
@@ -447,23 +433,16 @@ def check_document_access(doctype: str, name: str, doc=None):
 	if frappe.local.system_user():
 		return
 
-	team = ""
-	meta = frappe.get_meta(doctype)
-	if meta.has_field("team"):
-		team = doc.team if doc else frappe.db.get_value(doctype, name, "team")
-	elif meta.has_field("bench"):
-		bench = frappe.db.get_value(doctype, name, "bench")
-		team = frappe.db.get_value("Bench", bench, "team")
-	elif meta.has_field("group"):
-		group = frappe.db.get_value(doctype, name, "group")
-		team = frappe.db.get_value("Release Group", group, "team")
-	else:
-		return
+	if not ownership.has_document_access(doctype, name, doc=doc):
+		raise_not_permitted()
 
-	if team == frappe.local.team().name:
-		return
 
-	raise_not_permitted()
+def check_document_write_access(doctype: str, name: str):
+	# Reference data is the same for every team, so no team gets to change it.
+	if doctype in ownership.GLOBAL_DOCTYPES and not frappe.local.system_user():
+		raise_not_permitted()
+
+	check_document_access(doctype, name)
 
 
 def check_dashboard_actions(doctype, name, method):

--- a/press/api/tests/test_client.py
+++ b/press/api/tests/test_client.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from press.access import ownership
+from press.api.client import (
+	ALLOWED_DOCTYPES,
+	check_document_access,
+	check_document_write_access,
+	get,
+	get_list,
+	set_value,
+)
+from press.overrides import before_request
+from press.press.doctype.site.test_site import create_test_site
+from press.press.doctype.team.test_team import create_test_press_admin_team
+
+
+def sign_in_as(team):
+	"""Put the request-scoped team in place the way `before_request` does."""
+	frappe.set_user(team.user)
+	before_request()
+
+
+class TestOwnershipPolicy(FrappeTestCase):
+	"""Every doctype the dashboard can reach has to say who owns it."""
+
+	def test_every_allowed_doctype_says_who_owns_it(self):
+		undeclared = []
+		for doctype in set(ALLOWED_DOCTYPES):
+			meta = frappe.get_meta(doctype)
+			if meta.istable or meta.has_field("team"):
+				continue
+			if (
+				doctype in ownership.GLOBAL_DOCTYPES
+				or doctype in ownership.TEAM_FIELDS
+				or doctype in ownership.USER_FIELDS
+				or doctype in ownership.LINKED_OWNERS
+				or doctype in ownership.DYNAMICALLY_LINKED_OWNERS
+			):
+				continue
+			undeclared.append(doctype)
+
+		self.assertEqual(
+			undeclared,
+			[],
+			f"Add {undeclared} to press.access.ownership or drop them from ALLOWED_DOCTYPES",
+		)
+
+	def test_declared_owner_fields_exist(self):
+		for doctype, fieldnames in ownership.TEAM_FIELDS.items():
+			meta = frappe.get_meta(doctype)
+			for fieldname in fieldnames:
+				self.assertTrue(
+					fieldname == "name" or meta.has_field(fieldname),
+					f"{doctype} has no field {fieldname}",
+				)
+
+		for doctype, fieldname in ownership.USER_FIELDS.items():
+			self.assertTrue(frappe.get_meta(doctype).has_field(fieldname))
+
+	def test_linked_owners_point_at_doctypes_that_carry_a_team(self):
+		for doctype, (link_field, linked_doctype) in ownership.LINKED_OWNERS.items():
+			self.assertTrue(frappe.get_meta(doctype).has_field(link_field))
+			self.assertTrue(
+				frappe.get_meta(linked_doctype).has_field("team"),
+				f"{linked_doctype} has no team field, so {doctype} cannot be scoped through it",
+			)
+
+	def test_global_doctypes_are_reference_data_only(self):
+		"""Nothing a team owns may be declared global."""
+		for doctype in ownership.GLOBAL_DOCTYPES:
+			self.assertFalse(
+				frappe.get_meta(doctype).has_field("team"),
+				f"{doctype} has a team field, so it is not global reference data",
+			)
+
+
+# Support Access mails the target team on insert and on every status change.
+@patch("frappe.sendmail", new=Mock())
+class TestDocumentAccess(FrappeTestCase):
+	def setUp(self):
+		super().setUp()
+		self.team = create_test_press_admin_team()
+		self.other_team = create_test_press_admin_team()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.rollback()
+
+	def create_support_access(self, requested_team, target_team):
+		"""`target_team` is derived from the resources the request asks for."""
+		site = create_test_site(team=target_team.name)
+		return frappe.get_doc(
+			{
+				"doctype": "Support Access",
+				"requested_by": requested_team.user,
+				"requested_team": requested_team.name,
+				"reason": "Debugging",
+				"status": "Pending",
+				"resources": [{"document_type": "Site", "document_name": site.name}],
+			}
+		).insert(ignore_permissions=True)
+
+	def test_get_list_hides_support_access_of_other_teams(self):
+		mine = self.create_support_access(self.team, self.other_team)
+		self.create_support_access(self.other_team, self.other_team)
+
+		sign_in_as(self.team)
+		names = [row.name for row in get_list("Support Access", limit=100)]
+
+		self.assertEqual(names, [mine.name])
+
+	def test_get_denies_support_access_of_another_team(self):
+		theirs = self.create_support_access(self.other_team, self.other_team)
+
+		sign_in_as(self.team)
+		with self.assertRaises(frappe.PermissionError):
+			get("Support Access", theirs.name)
+
+	def test_check_document_access_denies_a_document_with_no_owning_team(self):
+		theirs = self.create_support_access(self.other_team, self.other_team)
+
+		sign_in_as(self.team)
+		with self.assertRaises(frappe.PermissionError):
+			check_document_access("Support Access", theirs.name)
+
+	def test_check_document_access_allows_the_owning_team(self):
+		mine = self.create_support_access(self.team, self.other_team)
+
+		sign_in_as(self.team)
+		check_document_access("Support Access", mine.name)
+
+	def test_reference_data_is_readable_but_not_writable(self):
+		plan = frappe.get_all("Site Plan", limit=1, pluck="name")
+		if not plan:
+			self.skipTest("no Site Plan on this site")
+
+		sign_in_as(self.team)
+		check_document_access("Site Plan", plan[0])
+		with self.assertRaises(frappe.PermissionError):
+			check_document_write_access("Site Plan", plan[0])
+
+	def test_set_value_cannot_change_reference_data(self):
+		sign_in_as(self.team)
+		with self.assertRaises(frappe.PermissionError):
+			set_value("Press Settings", "Press Settings", {"partnership_fee_inr": 1})
+
+	def test_ssh_key_belongs_to_the_user_that_added_it(self):
+		key = frappe.get_doc(
+			{
+				"doctype": "User SSH Key",
+				"user": self.other_team.user,
+				"ssh_public_key": "ssh-ed25519 AAAA test",
+				"is_removed": 1,
+			}
+		).insert(ignore_permissions=True)
+
+		sign_in_as(self.team)
+		self.assertFalse(ownership.has_document_access("User SSH Key", key.name))
+
+		sign_in_as(self.other_team)
+		self.assertTrue(ownership.has_document_access("User SSH Key", key.name))
+
+	def test_child_row_is_owned_by_whoever_owns_its_parent(self):
+		site = create_test_site(team=self.other_team.name)
+		site.append("configuration", {"key": "test_key", "value": "test_value", "type": "String"})
+		site.save(ignore_permissions=True)
+		row = site.configuration[-1]
+
+		sign_in_as(self.team)
+		self.assertFalse(ownership.has_document_access("Site Config", row.name))
+
+		sign_in_as(self.other_team)
+		self.assertTrue(ownership.has_document_access("Site Config", row.name))

--- a/press/api/tests/test_client.py
+++ b/press/api/tests/test_client.py
@@ -179,3 +179,28 @@ class TestDocumentAccess(FrappeTestCase):
 
 		sign_in_as(self.other_team)
 		self.assertTrue(ownership.has_document_access("Site Config", row.name))
+
+	def test_child_rows_are_bound_to_the_parent_doctype_the_caller_named(self):
+		"""A caller naming a parent doctype it owns must not reach other children.
+
+		The team check runs against whichever parent table `parenttype` picks, so
+		the query also has to require that the rows really hang off that doctype.
+		"""
+		site = create_test_site(team=self.team.name)
+		site.append("configuration", {"key": "test_key", "value": "test_value", "type": "String"})
+		site.save(ignore_permissions=True)
+
+		sign_in_as(self.team)
+		mine = get_list(
+			"Site Config",
+			fields=["name", "key"],
+			filters={"parenttype": "Site", "parent": site.name},
+		)
+		self.assertIn("test_key", [row.key for row in mine])
+
+		lying = get_list(
+			"Lead Followup",
+			fields=["name"],
+			filters={"parenttype": "Site", "parent": site.name},
+		)
+		self.assertEqual(lying, [])

--- a/press/partner/doctype/partner_audit/partner_audit.py
+++ b/press/partner/doctype/partner_audit/partner_audit.py
@@ -5,6 +5,8 @@ import frappe
 from frappe.model.document import Document
 from frappe.query_builder.functions import Count
 
+from press.utils import get_current_team
+
 
 class PartnerAudit(Document):
 	# begin: auto-generated types
@@ -73,7 +75,13 @@ class PartnerAudit(Document):
 			.offset(list_args["start"])
 			.orderby(PartnerAudit.modified, order=frappe.qb.desc)
 		)
-		if filters.get("team"):
+
+		# This query is built from scratch, so the scoping `press.api.client`
+		# applied to the query it handed over is gone. Reapply it. A partner
+		# picking their own team in `filters` is redundant but harmless.
+		if not frappe.local.system_user():
+			query = query.where(PartnerAudit.partner_team == get_current_team())
+		elif filters.get("team"):
 			query = query.where(PartnerAudit.partner_team == filters["team"])
 		if filters.get("status") and filters["status"] != "All":
 			query = query.where(PartnerAudit.status == filters["status"])

--- a/press/partner/doctype/partner_lead/partner_lead.py
+++ b/press/partner/doctype/partner_lead/partner_lead.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import frappe
 from frappe.model.document import Document
 
+from press.utils import get_current_team
+
 
 class PartnerLead(Document):
 	# begin: auto-generated types
@@ -156,6 +158,11 @@ class PartnerLead(Document):
 			.offset(list_args["start"])
 			.orderby(PartnerLead.modified, order=frappe.qb.desc)
 		)
+
+		# This query is built from scratch, so the scoping `press.api.client`
+		# applied to the query it handed over is gone. Reapply it.
+		if not frappe.local.system_user():
+			query = query.where(PartnerLead.partner_team == get_current_team())
 
 		if filters:
 			if filters.get("source") and filters.get("source") != "All":

--- a/press/press/doctype/server_firewall/server_firewall.py
+++ b/press/press/doctype/server_firewall/server_firewall.py
@@ -10,7 +10,7 @@ from frappe.model.document import Document
 from press.overrides import has_permission as has_press_permission
 from press.press.doctype.server.server import Server
 from press.runner import Ansible
-from press.utils import get_current_team, log_error
+from press.utils import log_error
 
 
 class ServerFirewall(Document):
@@ -35,16 +35,6 @@ class ServerFirewall(Document):
 		"enabled",
 		"rules",
 	)
-
-	@staticmethod
-	def get_list_query(query):
-		"""Filter list query to only show firewalls belonging to the current team."""
-		Server = frappe.qb.DocType("Server")
-		Firewall = frappe.qb.DocType("Server Firewall")
-		current_team = get_current_team()
-		return (
-			query.inner_join(Server).on(Server.name == Firewall.server_id).where(Server.team == current_team)
-		)
 
 	def before_validate(self):
 		self.deduplicate_rules()


### PR DESCRIPTION
Ownership was inferred from whichever of `team`, `bench` or `group` a doctype happened to carry, and there was nothing to say about the ones carrying none. `get_list` had its own hardcoded pair of doctypes it knew it could not scope.

The rules now live in press/access/ownership.py, one entry per doctype, covering what the field sniffing missed: partner records keyed on `partner_team`, SSH keys keyed on `user`, firewalls and app plans reached through a link, child rows through their parent. Both `check_document_access` and `get_list` read from it, so fetching and listing agree on who owns what, and a doctype with no entry gets nothing rather than everything. A test keeps the table in step with ALLOWED_DOCTYPES.

Reference data such as plans, versions and tiers is declared global: every team reads the same rows and no team writes them.

Partner Lead and Partner Audit build their list query from scratch and so drop whatever the caller applied; they reapply it themselves. Server Firewall's get_list_query duplicated the central join and is gone.