### PR TITLE
feat(incident): Alert on Raven when phone call alerts are disabled

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -268,6 +268,7 @@ scheduler_events = {
 		"press.press.doctype.database_server.database_server.sync_binlogs_info",
 		"press.press.doctype.team.team.auto_enable_ssh_access_for_7_days_older_teams",
 		"press.press.doctype.server.server.sync_wazuh_agent_status",
+		"press.press.doctype.incident_settings.incident_settings.alert_if_phone_call_alerts_disabled",
 		# "press.press.doctype.team.team.auto_trust_teams_with_consecutive_paid_invoices",
 	],
 	"hourly_long": [

--- a/press/press/doctype/incident_settings/incident_settings.py
+++ b/press/press/doctype/incident_settings/incident_settings.py
@@ -1,10 +1,14 @@
 # Copyright (c) 2023, Frappe and contributors
 # For license information, please see license.txt
 
-# import frappe
 from __future__ import annotations
 
+import frappe
 from frappe.model.document import Document
+
+from press.utils.raven import send_raven_message
+
+RAVEN_INCIDENTS_CHANNEL = "incidents"
 
 
 class IncidentSettings(Document):
@@ -42,3 +46,16 @@ class IncidentSettings(Document):
 	# end: auto-generated types
 
 	pass
+
+
+def alert_if_phone_call_alerts_disabled():
+	"""Nobody gets paged when phone call alerts are off. Nag hourly until it's turned back on."""
+	if frappe.db.get_single_value("Incident Settings", "phone_call_alerts"):
+		return
+
+	send_raven_message(
+		"⚠️ **Phone call alerts are disabled** in "
+		f"[Incident Settings]({frappe.utils.get_url('/app/incident-settings')}). "
+		"Incidents won't call anyone.",
+		RAVEN_INCIDENTS_CHANNEL,
+	)

--- a/press/press/doctype/incident_settings/incident_settings.py
+++ b/press/press/doctype/incident_settings/incident_settings.py
@@ -8,7 +8,7 @@ from frappe.model.document import Document
 
 from press.utils.raven import send_raven_message
 
-RAVEN_INCIDENTS_CHANNEL = "incidents"
+RAVEN_INCIDENTS_CHANNEL = "frappe-cloud-incidents"
 
 
 class IncidentSettings(Document):

--- a/press/press/doctype/incident_settings/incident_settings.py
+++ b/press/press/doctype/incident_settings/incident_settings.py
@@ -8,8 +8,6 @@ from frappe.model.document import Document
 
 from press.utils.raven import send_raven_message
 
-RAVEN_INCIDENTS_CHANNEL = "frappe-cloud-incidents"
-
 
 class IncidentSettings(Document):
 	# begin: auto-generated types
@@ -57,5 +55,5 @@ def alert_if_phone_call_alerts_disabled():
 		"⚠️ **Phone call alerts are disabled** in "
 		f"[Incident Settings]({frappe.utils.get_url('/app/incident-settings')}). "
 		"Incidents won't call anyone.",
-		RAVEN_INCIDENTS_CHANNEL,
+		frappe.db.get_single_value("Press Settings", "raven_incidents_channel"),
 	)

--- a/press/press/doctype/incident_settings/test_incident_settings.py
+++ b/press/press/doctype/incident_settings/test_incident_settings.py
@@ -1,9 +1,25 @@
 # Copyright (c) 2023, Frappe and Contributors
 # See license.txt
 
-# import frappe
+from unittest.mock import patch
+
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
+from press.press.doctype.incident_settings.incident_settings import alert_if_phone_call_alerts_disabled
 
+
+@patch("press.press.doctype.incident_settings.incident_settings.send_raven_message")
 class TestIncidentSettings(FrappeTestCase):
-	pass
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_raven_alert_sent_when_phone_call_alerts_disabled(self, mock_send_raven_message):
+		frappe.db.set_single_value("Incident Settings", "phone_call_alerts", 0)
+		alert_if_phone_call_alerts_disabled()
+		self.assertIn("Phone call alerts are disabled", mock_send_raven_message.call_args[0][0])
+
+	def test_no_raven_alert_when_phone_call_alerts_enabled(self, mock_send_raven_message):
+		frappe.db.set_single_value("Incident Settings", "phone_call_alerts", 1)
+		alert_if_phone_call_alerts_disabled()
+		mock_send_raven_message.assert_not_called()

--- a/press/press/doctype/press_settings/press_settings.json
+++ b/press/press/doctype/press_settings/press_settings.json
@@ -205,6 +205,7 @@
 		"raven_url",
 		"column_break_pqic",
 		"raven_secret_access_key",
+		"raven_incidents_channel",
 		"marketplace_tab",
 		"marketplace_settings_section",
 		"max_allowed_screenshots",
@@ -1878,6 +1879,12 @@
 			"fieldname": "raven_secret_access_key",
 			"fieldtype": "Password",
 			"label": "Raven Secret Access Key"
+		},
+		{
+			"description": "Channel ID of the Raven channel incident alerts are posted to",
+			"fieldname": "raven_incidents_channel",
+			"fieldtype": "Data",
+			"label": "Raven Incidents Channel"
 		}
 	],
 	"issingle": 1,

--- a/press/press/doctype/press_settings/press_settings.py
+++ b/press/press/doctype/press_settings/press_settings.py
@@ -208,6 +208,7 @@ class PressSettings(Document):
 		pulse_api_key: DF.Data | None
 		pulse_site: DF.Data | None
 		raven_access_key_id: DF.Data | None
+		raven_incidents_channel: DF.Data | None
 		raven_secret_access_key: DF.Password | None
 		raven_url: DF.Data | None
 		razorpay_key_id: DF.Data | None

--- a/press/press/doctype/server/server_monitoring.py
+++ b/press/press/doctype/server/server_monitoring.py
@@ -12,9 +12,9 @@ import requests
 from frappe.utils.password import get_decrypted_password
 
 from press.utils import log_error
+from press.utils.raven import send_raven_message
 
 RAVEN_SERVER_ALERTS_CHANNEL = "frappe-cloud-server-alerts"
-RAVEN_BOT_ID = "Frappe Notifications"
 PROMETHEUS_REGEX_META_CHAR_PATTERN = re.compile(r"([\\.^$*+?()[\]{}|])")
 
 
@@ -350,50 +350,11 @@ def _send_public_server_pool_health_alert(server_issues: dict[str, list[str]]) -
 		issues = "<br>".join(_escape_markdown_table_cell(issue) for issue in server_issues[server])
 		table_rows.append(f"| {_escape_markdown_table_cell(server)} | {issues} |")
 
-	_send_raven_server_alert("\n".join(header_lines + table_header + table_rows).strip())
+	send_raven_message("\n".join(header_lines + table_header + table_rows).strip(), RAVEN_SERVER_ALERTS_CHANNEL)
 
 
 def _escape_markdown_table_cell(value: str) -> str:
 	return value.replace("|", "\\|").replace("\n", "<br>")
-
-
-def _send_raven_server_alert(text: str) -> None:
-	settings = frappe.get_single("Press Settings")
-	url = settings.raven_url
-	api_key = settings.raven_access_key_id
-	api_secret = settings.get_password("raven_secret_access_key", raise_exception=False)
-	if not url or not api_key or not api_secret:
-		log_error("Raven server alert settings missing")
-		return
-
-	headers = {
-		"Authorization": f"token {api_key}:{api_secret}",
-		"Content-Type": "application/json",
-	}
-
-	try:
-		response = requests.post(
-			url,
-			json={
-				"bot_id": RAVEN_BOT_ID,
-				"message": text,
-				"channel_id": RAVEN_SERVER_ALERTS_CHANNEL,
-			},
-			headers=headers,
-			timeout=30,
-		)
-	except requests.exceptions.RequestException as exc:
-		log_error("Failed to send public server pool health alert to Raven", exception=exc)
-		return
-
-	if response.ok:
-		return
-
-	log_error(
-		"Failed to send public server pool health alert to Raven",
-		status_code=response.status_code,
-		response=response.text[:1000],
-	)
 
 
 def _create_no_suitable_servers_incident(

--- a/press/press/doctype/server/server_monitoring.py
+++ b/press/press/doctype/server/server_monitoring.py
@@ -350,7 +350,9 @@ def _send_public_server_pool_health_alert(server_issues: dict[str, list[str]]) -
 		issues = "<br>".join(_escape_markdown_table_cell(issue) for issue in server_issues[server])
 		table_rows.append(f"| {_escape_markdown_table_cell(server)} | {issues} |")
 
-	send_raven_message("\n".join(header_lines + table_header + table_rows).strip(), RAVEN_SERVER_ALERTS_CHANNEL)
+	send_raven_message(
+		"\n".join(header_lines + table_header + table_rows).strip(), RAVEN_SERVER_ALERTS_CHANNEL
+	)
 
 
 def _escape_markdown_table_cell(value: str) -> str:

--- a/press/utils/raven.py
+++ b/press/utils/raven.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2025, Frappe and contributors
+# For license information, please see license.txt
+
+from __future__ import annotations
+
+import frappe
+import requests
+
+from press.utils import log_error
+
+RAVEN_BOT_ID = "Frappe Notifications"
+
+
+def send_raven_message(text: str, channel: str) -> None:
+	settings = frappe.get_single("Press Settings")
+	url = settings.raven_url
+	api_key = settings.raven_access_key_id
+	api_secret = settings.get_password("raven_secret_access_key", raise_exception=False)
+	if not url or not api_key or not api_secret:
+		log_error("Raven settings missing", channel=channel)
+		return
+
+	headers = {
+		"Authorization": f"token {api_key}:{api_secret}",
+		"Content-Type": "application/json",
+	}
+
+	try:
+		response = requests.post(
+			url,
+			json={"bot_id": RAVEN_BOT_ID, "message": text, "channel_id": channel},
+			headers=headers,
+			timeout=30,
+		)
+	except requests.exceptions.RequestException as exc:
+		log_error("Failed to send message to Raven", exception=exc, channel=channel)
+		return
+
+	if response.ok:
+		return
+
+	log_error(
+		"Failed to send message to Raven",
+		channel=channel,
+		status_code=response.status_code,
+		response=response.text[:1000],
+	)


### PR DESCRIPTION
Phone call alerts get switched off during noisy stretches and stay off, so incidents stop paging anyone and nobody notices until the next outage.

- Hourly scheduled job posts to the Raven incidents channel while `phone_call_alerts` is off in Incident Settings.
- Moved the Raven POST out of `server_monitoring.py` into `press/utils/raven.py` so both callers share it (channel is now a parameter).

No dedup/suppression state — one message an hour until someone flips it back, which is the point.

`RAVEN_INCIDENTS_CHANNEL` is hard-coded to `incidents`; change it if the real channel id differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)