### PR TITLE
fix(docker): Set FRAPPE_HARD_LINK_ASSETS before installing apps

### DIFF
--- a/press/docker/Dockerfile
+++ b/press/docker/Dockerfile
@@ -234,6 +234,8 @@ RUN --mount=type=cache,target=/home/frappe/.cache,uid=1000,gid=1000 python${PYTH
 RUN git config --global advice.detachedHead false
 
 ENV PYTHONUNBUFFERED 1
+# Must be set before any bench get-app, which builds assets
+ENV FRAPPE_HARD_LINK_ASSETS True
 
 # For the sake of completing the step
 RUN `#stage-bench-env`
@@ -311,7 +313,6 @@ RUN mkdir -p {{ m.destination }} && \
 {% endfor %}
 
 ENV FRAPPE_DOCKER_BUILD=
-ENV FRAPPE_HARD_LINK_ASSETS True
 ENV HISTTIMEFORMAT "%Y-%m-%d %T "
 
 EXPOSE 8000 9000 2200 8088

--- a/press/docker/Dockerfile_Bench_5_2_1
+++ b/press/docker/Dockerfile_Bench_5_2_1
@@ -150,6 +150,8 @@ COPY --chown=frappe:frappe common_site_config.json /home/frappe/frappe-bench/sit
 RUN git config --global advice.detachedHead false
 
 ENV PYTHONUNBUFFERED 1
+# Must be set before any bench get-app, which builds assets
+ENV FRAPPE_HARD_LINK_ASSETS True
 
 # Install Frappe app
 RUN echo '["build"]' > .bench.cmd
@@ -169,8 +171,6 @@ RUN --mount=type=cache,target=/home/frappe/.cache,uid=1000,gid=1000 --mount=type
 
 COPY --chown=frappe:frappe config /home/frappe/frappe-bench/config
 COPY --chown=frappe:frappe apps.txt /home/frappe/frappe-bench/sites/apps.txt
-
-ENV FRAPPE_HARD_LINK_ASSETS True
 
 EXPOSE 8000 8088 9000 2200
 CMD ["supervisord"]


### PR DESCRIPTION
`ENV FRAPPE_HARD_LINK_ASSETS True` was the **last** instruction in both bench Dockerfiles ([`Dockerfile:314`](https://github.com/frappe/press/blob/develop/press/docker/Dockerfile#L314), [`Dockerfile_Bench_5_2_1:173`](https://github.com/frappe/press/blob/develop/press/docker/Dockerfile_Bench_5_2_1#L173)) — after every `bench get-app`.

`bench get-app` builds assets during the image build, so those builds ran with the variable unset and **symlinked** assets into the image. The variable only took effect for a later runtime `bench build` (agent's `Rebuild Bench Assets`, which goes through `docker_execute` and does inherit the image ENV). That's why benches looked inconsistent: whether a bench has hard-linked assets depended on whether a human or a job happened to rebuild them after creation.

Moved the `ENV` above the app-install block in both templates.

### Note on ordering

It now sits *above* the release group's `{% for v in doc.environment_variables %}` loop, so a group that sets `FRAPPE_HARD_LINK_ASSETS` will win. That seemed right — previously the hardcoded value silently discarded the group's. Happy to move it below the loop if Press should force it instead.

### Related

Companion fix in agent for the SSH side of the same problem: sshd strips the image ENV, so a manual `bench build` over SSH also symlinks — https://github.com/frappe/agent/pull/566

### Testing

Not verified against a real image build. Worth confirming with `docker run <new image> find sites/assets -maxdepth 1 -type l` on a fresh build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)