### PR TITLE
fix(account): Keep one-time passwords out of Account Request

### DIFF
--- a/press/api/account.py
+++ b/press/api/account.py
@@ -28,7 +28,9 @@ from press.press.doctype.team.team import (
 	get_team_members,
 )
 from press.utils import docs, get_country_info, get_current_team, is_user_part_of_team, log_error
+from press.utils import otp as otp_purpose
 from press.utils import user as user_utils
+from press.utils.otp import OneTimePassword
 from press.utils.telemetry import capture
 
 if TYPE_CHECKING:
@@ -101,17 +103,17 @@ def verify_otp(account_request: str, otp: str) -> str:
 	):
 		ip_tracker and ip_tracker.add_failure_attempt()
 		frappe.throw("Invalid OTP. Please try again.")
-	if account_request_doc.otp != otp:
+	if not account_request_doc.signup_otp.verify(otp):
 		ip_tracker and ip_tracker.add_failure_attempt()
 		frappe.throw("Invalid OTP. Please try again.")
 
 	ip_tracker and ip_tracker.add_success_attempt()
-	account_request_doc.reset_otp()
+	account_request_doc.signup_otp.clear()
 
 	if account_request_doc.product_trial:
 		capture("otp_verified", "fc_product_trial", account_request_doc.name)
 
-	return str(account_request_doc.request_key)
+	return account_request_doc.ensure_request_key()
 
 
 @frappe.whitelist(allow_guest=True)
@@ -119,35 +121,27 @@ def verify_otp(account_request: str, otp: str) -> str:
 def verify_otp_and_login(email: str, otp: str):
 	from frappe.auth import get_login_attempt_tracker
 
-	account_request = frappe.db.get_value("Account Request", {"email": email}, "name")
-
-	if not account_request:
-		frappe.throw("Please sign up first")
-
-	account_request_doc: "AccountRequest" = frappe.get_doc("Account Request", account_request)
 	ip_tracker = get_login_attempt_tracker(frappe.local.request_ip)
+	code = OneTimePassword(otp_purpose.LOGIN, email)
 
-	if account_request_doc.otp != otp:
+	# An address nobody asked for a code for has no code to match, so this also
+	# covers the caller who never signed up. Saying so would tell them which
+	# addresses have accounts.
+	if not code.verify(otp):
 		ip_tracker and ip_tracker.add_failure_attempt()
 		frappe.throw("Invalid OTP. Please try again.")
 
 	ip_tracker and ip_tracker.add_success_attempt()
-	account_request_doc.reset_otp()
+	code.clear()
 
 	return frappe.local.login_manager.login_as(email)
 
 
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=5, seconds=60)
-def resend_otp(account_request: str, for_2fa_keys: bool = False):
+def resend_otp(account_request: str):
 	account_request_doc: "AccountRequest" = frappe.get_doc("Account Request", account_request)
-
-	# if last OTP was sent less than 30 seconds ago, throw an error
-	if (
-		account_request_doc.otp_generated_at
-		and (frappe.utils.now_datetime() - account_request_doc.otp_generated_at).seconds < 30
-	):
-		frappe.throw("Please wait for 30 seconds before requesting a new OTP")
+	throttle_otp(account_request_doc.signup_otp)
 
 	# ensure no team has been created with this email
 	if (
@@ -155,29 +149,56 @@ def resend_otp(account_request: str, for_2fa_keys: bool = False):
 		and not account_request_doc.product_trial
 	):
 		frappe.throw("Invalid Email")
-	account_request_doc.reset_otp()
-	account_request_doc.send_otp_mail(for_login=not for_2fa_keys)
+
+	send_otp_mail(str(account_request_doc.email), account_request_doc.signup_otp.generate())
 
 
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=5, seconds=60)
 def send_otp(email: str, for_2fa_keys: bool = False):
-	account_request = frappe.db.get_value("Account Request", {"email": email}, "name")
-
-	if not account_request or (account_request and not frappe.db.exists("User", email)):
+	# Logging in asks whether the account exists, not how it came to. Requiring an
+	# Account Request locked out everyone whose signup record was never written or
+	# had since been cleaned up.
+	if not frappe.db.exists("User", email):
 		frappe.throw("Please sign up first")
 
-	account_request_doc: "AccountRequest" = frappe.get_doc("Account Request", account_request)
+	purpose = otp_purpose.TWO_FACTOR_RECOVERY if for_2fa_keys else otp_purpose.LOGIN
+	code = OneTimePassword(purpose, email)
+	throttle_otp(code)
 
-	# if last OTP was sent less than 30 seconds ago, throw an error
-	if (
-		account_request_doc.otp_generated_at
-		and (frappe.utils.now_datetime() - account_request_doc.otp_generated_at).seconds < 30
-	):
+	send_otp_mail(email, code.generate(), for_login=not for_2fa_keys)
+
+
+def throttle_otp(code: OneTimePassword):
+	issued_ago = code.seconds_since_generated
+	if issued_ago is not None and issued_ago < 30:
 		frappe.throw("Please wait for 30 seconds before requesting a new OTP")
 
-	account_request_doc.reset_otp()
-	account_request_doc.send_otp_mail(for_login=not for_2fa_keys)
+
+def send_otp_mail(email: str, otp: str, for_login: bool = True):
+	if frappe.conf.developer_mode and frappe.local.dev_server:
+		print(f"Login OTP for {email}:" if for_login else f"OTP to view 2FA recovery codes for {email}:")
+		print(otp)
+		print()
+		return
+
+	if frappe.flags.in_test:
+		return
+
+	if for_login:
+		template = "login_otp"
+		subject = f"{otp} - OTP for Frappe Cloud Login"
+	else:
+		template = "2fa_recovery_codes_otp"
+		subject = f"{otp} - OTP to view 2FA recovery codes for Frappe Cloud"
+
+	frappe.sendmail(
+		recipients=email,
+		subject=subject,
+		template=template,
+		args={"otp": otp},
+		now=True,
+	)
 
 
 @frappe.whitelist(allow_guest=True)
@@ -1350,12 +1371,11 @@ def get_2fa_recovery_codes(verification_code: int):
 	if not frappe.db.exists("User 2FA", {"user": frappe.session.user, "enabled": 1}):
 		frappe.throw("2FA is not enabled for this user")
 
-	account_request: "AccountRequest" = frappe.get_doc("Account Request", {"email": frappe.session.user})
-
-	if account_request.otp != verification_code:
+	code = OneTimePassword(otp_purpose.TWO_FACTOR_RECOVERY, frappe.session.user)
+	if not code.verify(verification_code):
 		frappe.throw("Invalid OTP. Please try again.")
 
-	account_request.reset_otp()
+	code.clear()
 
 	# Get the User 2FA document.
 	two_fa = frappe.get_doc("User 2FA", frappe.session.user)

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -168,9 +168,8 @@ def send_otp(email: str, for_2fa_keys: bool = False):
 
 
 def throttle_otp(code: OneTimePassword):
-	issued_ago = code.seconds_since_generated
-	if issued_ago is not None and issued_ago < 30:
-		frappe.throw("Please wait for 30 seconds before requesting a new OTP")
+	if code.issued_recently:
+		frappe.throw(f"Please wait for {otp_purpose.RESEND_AFTER} seconds before requesting a new OTP")
 
 
 def send_otp_mail(email: str, otp: str, for_login: bool = True):

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -103,12 +103,11 @@ def verify_otp(account_request: str, otp: str) -> str:
 	):
 		ip_tracker and ip_tracker.add_failure_attempt()
 		frappe.throw("Invalid OTP. Please try again.")
-	if not account_request_doc.signup_otp.verify(otp):
+	if not account_request_doc.signup_otp.consume(otp):
 		ip_tracker and ip_tracker.add_failure_attempt()
 		frappe.throw("Invalid OTP. Please try again.")
 
 	ip_tracker and ip_tracker.add_success_attempt()
-	account_request_doc.signup_otp.clear()
 
 	if account_request_doc.product_trial:
 		capture("otp_verified", "fc_product_trial", account_request_doc.name)
@@ -127,12 +126,11 @@ def verify_otp_and_login(email: str, otp: str):
 	# An address nobody asked for a code for has no code to match, so this also
 	# covers the caller who never signed up. Saying so would tell them which
 	# addresses have accounts.
-	if not code.verify(otp):
+	if not code.consume(otp):
 		ip_tracker and ip_tracker.add_failure_attempt()
 		frappe.throw("Invalid OTP. Please try again.")
 
 	ip_tracker and ip_tracker.add_success_attempt()
-	code.clear()
 
 	return frappe.local.login_manager.login_as(email)
 
@@ -1372,10 +1370,8 @@ def get_2fa_recovery_codes(verification_code: int):
 		frappe.throw("2FA is not enabled for this user")
 
 	code = OneTimePassword(otp_purpose.TWO_FACTOR_RECOVERY, frappe.session.user)
-	if not code.verify(verification_code):
+	if not code.consume(verification_code):
 		frappe.throw("Invalid OTP. Please try again.")
-
-	code.clear()
 
 	# Get the User 2FA document.
 	two_fa = frappe.get_doc("User 2FA", frappe.session.user)

--- a/press/api/tests/test_otp.py
+++ b/press/api/tests/test_otp.py
@@ -50,6 +50,16 @@ class TestOneTimePassword(FrappeTestCase):
 
 		self.assertNotIn(issued, str(frappe.cache.get_value(self.code.key)))
 
+	def test_a_signup_code_lasts_as_long_as_the_link_it_is_mailed_with(self):
+		signup = OneTimePassword(otp_purpose.SIGNUP, "some-account-request")
+
+		self.assertEqual(signup.expires_in, 24 * 60 * 60)
+		self.assertEqual(self.code.expires_in, 10 * 60)
+
+	def test_a_purpose_with_no_declared_life_is_refused(self):
+		with self.assertRaises(KeyError):
+			OneTimePassword("something-new", "someone@example.com")
+
 
 @patch("press.api.account.send_otp_mail")
 class TestLoginOtp(FrappeTestCase):

--- a/press/api/tests/test_otp.py
+++ b/press/api/tests/test_otp.py
@@ -42,6 +42,24 @@ class TestOneTimePassword(FrappeTestCase):
 
 		self.assertFalse(self.code.verify(issued))
 
+	def test_only_one_caller_can_consume_a_code(self):
+		issued = self.code.generate()
+
+		self.assertTrue(self.code.consume(issued))
+		self.assertFalse(self.code.consume(issued))
+
+	def test_the_loser_of_a_race_is_refused_even_though_the_code_read_back_fine(self):
+		"""Both racers read the same code; the one that did not remove it loses.
+
+		Redis reports how many keys a delete actually removed, so the loser gets
+		0 back and must be refused despite having verified the code.
+		"""
+		issued = self.code.generate()
+
+		with patch.object(frappe.cache, "delete", return_value=0):
+			self.assertTrue(self.code.verify(issued))
+			self.assertFalse(self.code.consume(issued))
+
 	def test_nothing_matches_when_no_code_was_issued(self):
 		self.assertFalse(OneTimePassword(otp_purpose.LOGIN, "nobody@example.com").verify("111111"))
 

--- a/press/api/tests/test_otp.py
+++ b/press/api/tests/test_otp.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from press.api.account import send_otp, verify_otp, verify_otp_and_login
+from press.press.doctype.account_request.account_request import AccountRequest
+from press.press.doctype.team.test_team import create_test_press_admin_team
+from press.utils import otp as otp_purpose
+from press.utils.otp import OneTimePassword
+
+
+def code_that_was_mailed(send_otp_mail) -> str:
+	"""`send_otp_mail(email, otp, for_login=...)` — the code is the second argument."""
+	return send_otp_mail.call_args.args[1]
+
+
+class TestOneTimePassword(FrappeTestCase):
+	def setUp(self):
+		super().setUp()
+		self.code = OneTimePassword(otp_purpose.LOGIN, "someone@example.com")
+
+	def tearDown(self):
+		self.code.clear()
+		frappe.db.rollback()
+
+	def test_a_code_only_matches_the_purpose_it_was_issued_for(self):
+		recovery = OneTimePassword(otp_purpose.TWO_FACTOR_RECOVERY, "someone@example.com")
+		issued = self.code.generate()
+
+		self.assertTrue(self.code.verify(issued))
+		self.assertFalse(recovery.verify(issued))
+
+	def test_a_cleared_code_stops_matching(self):
+		issued = self.code.generate()
+		self.code.clear()
+
+		self.assertFalse(self.code.verify(issued))
+
+	def test_nothing_matches_when_no_code_was_issued(self):
+		self.assertFalse(OneTimePassword(otp_purpose.LOGIN, "nobody@example.com").verify("111111"))
+
+	def test_the_code_itself_is_never_stored(self):
+		issued = self.code.generate()
+
+		self.assertNotIn(issued, str(frappe.cache.get_value(self.code.key)))
+
+
+@patch("press.api.account.send_otp_mail")
+class TestLoginOtp(FrappeTestCase):
+	def setUp(self):
+		super().setUp()
+		# frappe's login attempt tracker keys on the request IP, and logging in
+		# needs a login manager. Neither exists outside a request.
+		frappe.local.request_ip = "127.0.0.1"
+		frappe.local.login_manager = Mock(login_as=frappe.set_user)
+		self.team = create_test_press_admin_team()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for purpose in (otp_purpose.LOGIN, otp_purpose.TWO_FACTOR_RECOVERY):
+			OneTimePassword(purpose, self.team.user).clear()
+		frappe.db.rollback()
+
+	def test_login_works_without_an_account_request(self, send_otp_mail):
+		"""The reported failure: user and team exist, the signup record does not."""
+		frappe.db.delete("Account Request", {"email": self.team.user})
+
+		send_otp(self.team.user)
+		verify_otp_and_login(self.team.user, code_that_was_mailed(send_otp_mail))
+
+		self.assertEqual(frappe.session.user, self.team.user)
+
+	def test_send_otp_still_refuses_an_address_with_no_user(self, send_otp_mail):
+		with self.assertRaisesRegex(Exception, "Please sign up first"):
+			send_otp("no-such-person@example.com")
+
+	def test_a_second_code_within_thirty_seconds_is_refused(self, send_otp_mail):
+		send_otp(self.team.user)
+
+		with self.assertRaisesRegex(Exception, "Please wait for 30 seconds"):
+			send_otp(self.team.user)
+
+	def test_a_recovery_code_does_not_log_anyone_in(self, send_otp_mail):
+		"""Both used to be the same column, so either code worked for either flow."""
+		send_otp(self.team.user, for_2fa_keys=True)
+
+		with self.assertRaisesRegex(Exception, "Invalid OTP"):
+			verify_otp_and_login(self.team.user, code_that_was_mailed(send_otp_mail))
+
+	def test_a_signup_code_does_not_log_anyone_in(self, send_otp_mail):
+		request = frappe.get_doc(
+			{"doctype": "Account Request", "email": self.team.user, "team": self.team.name}
+		).insert(ignore_permissions=True)
+
+		with self.assertRaisesRegex(Exception, "Invalid OTP"):
+			verify_otp_and_login(self.team.user, request.signup_otp.generate())
+
+		request.signup_otp.clear()
+
+	def test_a_login_code_is_spent_once(self, send_otp_mail):
+		send_otp(self.team.user)
+		issued = code_that_was_mailed(send_otp_mail)
+
+		verify_otp_and_login(self.team.user, issued)
+		with self.assertRaisesRegex(Exception, "Invalid OTP"):
+			verify_otp_and_login(self.team.user, issued)
+
+
+class TestSignupOtp(FrappeTestCase):
+	def setUp(self):
+		super().setUp()
+		frappe.local.request_ip = "127.0.0.1"
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def create_signup(self) -> AccountRequest:
+		with patch.object(AccountRequest, "send_verification_email"):
+			return frappe.get_doc(
+				{"doctype": "Account Request", "email": frappe.mock("email"), "send_email": True}
+			).insert(ignore_permissions=True)
+
+	def test_verifying_a_signup_returns_its_request_key(self):
+		request = self.create_signup()
+		issued = request.signup_otp.generate()
+
+		key = verify_otp(request.name, issued)
+
+		self.assertEqual(key, request.reload().request_key)
+		self.assertFalse(request.signup_otp.verify(issued))
+
+	def test_a_signup_code_is_scoped_to_its_own_request(self):
+		mine = self.create_signup()
+		theirs = self.create_signup()
+		issued = mine.signup_otp.generate()
+
+		with self.assertRaisesRegex(Exception, "Invalid OTP"):
+			verify_otp(theirs.name, issued)
+
+		mine.signup_otp.clear()

--- a/press/api/tests/test_otp.py
+++ b/press/api/tests/test_otp.py
@@ -48,17 +48,20 @@ class TestOneTimePassword(FrappeTestCase):
 		self.assertTrue(self.code.consume(issued))
 		self.assertFalse(self.code.consume(issued))
 
-	def test_the_loser_of_a_race_is_refused_even_though_the_code_read_back_fine(self):
-		"""Both racers read the same code; the one that did not remove it loses.
+	def test_a_superseded_code_is_refused(self):
+		superseded = self.code.generate()
+		self.code.generate()
 
-		Redis reports how many keys a delete actually removed, so the loser gets
-		0 back and must be refused despite having verified the code.
-		"""
-		issued = self.code.generate()
+		self.assertFalse(self.code.consume(superseded))
 
-		with patch.object(frappe.cache, "delete", return_value=0):
-			self.assertTrue(self.code.verify(issued))
-			self.assertFalse(self.code.consume(issued))
+	def test_a_superseded_code_does_not_take_its_replacement_with_it(self):
+		"""A stale request must not spend the code the user was just sent."""
+		superseded = self.code.generate()
+		replacement = self.code.generate()
+
+		self.code.consume(superseded)
+
+		self.assertTrue(self.code.consume(replacement))
 
 	def test_nothing_matches_when_no_code_was_issued(self):
 		self.assertFalse(OneTimePassword(otp_purpose.LOGIN, "nobody@example.com").verify("111111"))
@@ -66,7 +69,7 @@ class TestOneTimePassword(FrappeTestCase):
 	def test_the_code_itself_is_never_stored(self):
 		issued = self.code.generate()
 
-		self.assertNotIn(issued, str(frappe.cache.get_value(self.code.key)))
+		self.assertNotIn(issued, str(frappe.cache.get(self.code.key)))
 
 	def test_a_signup_code_lasts_as_long_as_the_link_it_is_mailed_with(self):
 		signup = OneTimePassword(otp_purpose.SIGNUP, "some-account-request")

--- a/press/press/doctype/account_request/account_request.js
+++ b/press/press/doctype/account_request/account_request.js
@@ -4,7 +4,7 @@
 frappe.ui.form.on('Account Request', {
 	refresh: function (frm) {
 		frm.add_custom_button('Send verification email', () => {
-			frm.call('send_verification_email');
-		});
+			frm.call('resend_verification_email')
+		})
 	},
-});
+})

--- a/press/press/doctype/account_request/account_request.json
+++ b/press/press/doctype/account_request/account_request.json
@@ -11,8 +11,6 @@
 		"email",
 		"oauth_signup",
 		"send_email",
-		"otp",
-		"otp_generated_at",
 		"column_break_4",
 		"invited_by",
 		"ip_address",
@@ -267,18 +265,8 @@
 			"options": "Account Request Press Role"
 		},
 		{
-			"fieldname": "otp",
-			"fieldtype": "Data",
-			"label": "OTP"
-		},
-		{
 			"fieldname": "column_break_eaxp",
 			"fieldtype": "Column Break"
-		},
-		{
-			"fieldname": "otp_generated_at",
-			"fieldtype": "Datetime",
-			"label": "OTP Generated at"
 		},
 		{
 			"default": "0",

--- a/press/press/doctype/account_request/account_request.py
+++ b/press/press/doctype/account_request/account_request.py
@@ -12,7 +12,8 @@ from frappe.utils import get_url, random_string, validate_email_address
 
 from press.guards import settings
 from press.utils import disposable_emails, get_country_info, is_valid_email_address, log_error
-from press.utils.otp import generate_otp
+from press.utils import otp as otp_purpose
+from press.utils.otp import OneTimePassword
 from press.utils.telemetry import capture
 
 
@@ -49,8 +50,6 @@ class AccountRequest(Document):
 		no_of_employees: DF.Data | None
 		no_of_users: DF.Int
 		oauth_signup: DF.Check
-		otp: DF.Data | None
-		otp_generated_at: DF.Datetime | None
 		phone_number: DF.Data | None
 		plan: DF.Link | None
 		press_role: DF.Link | None
@@ -89,12 +88,6 @@ class AccountRequest(Document):
 		if not self.request_key:
 			self.request_key = random_string(32)
 			self.request_key_expiration_time = frappe.utils.add_to_date(hours=24)
-
-		if not self.otp:
-			self.otp = generate_otp()
-			self.otp_generated_at = frappe.utils.now_datetime()
-			if frappe.conf.developer_mode and frappe.local.dev_server:
-				self.otp = 111111
 
 		self.ip_address = frappe.local.request_ip
 		geo_location = self.get_country_info() or {}
@@ -175,7 +168,7 @@ class AccountRequest(Document):
 			capture("clicked_verify_link", "fc_signup", self.email)
 
 		if self.send_email:
-			self.send_verification_email()
+			self.send_verification_email(self.signup_otp.generate())
 		if self.oauth_signup:
 			# Telemetry: simulate verification email sent
 			capture("verification_email_sent", "fc_signup", self.email)
@@ -194,28 +187,37 @@ class AccountRequest(Document):
 				return True
 		return False
 
-	def reset_otp(self):
+	@property
+	def signup_otp(self) -> OneTimePassword:
+		"""Proves the address on this request. Only good for finishing this signup."""
+		return OneTimePassword(otp_purpose.SIGNUP, self.name)
+
+	def ensure_request_key(self) -> str:
+		"""The key the setup-account link is built from. Expires on its own."""
 		if not self.request_key:
 			self.request_key = random_string(32)
 			self.request_key_expiration_time = frappe.utils.add_to_date(hours=24)
-		self.otp = generate_otp()
-		if frappe.conf.developer_mode and frappe.local.dev_server:
-			self.otp = 111111
-		self.save(ignore_permissions=True)
+			self.save(ignore_permissions=True)
+
+		return self.request_key
 
 	@frappe.whitelist()
-	def send_verification_email(self):  # noqa: C901
+	def resend_verification_email(self):
+		"""Issues a fresh code. The caller doesn't get to choose what gets mailed."""
+		self.send_verification_email(self.signup_otp.generate())
+
+	def send_verification_email(self, otp: str):  # noqa: C901
 		url = self.get_verification_url()
 
 		if frappe.conf.developer_mode and frappe.local.dev_server:
 			print(f"\nSetup account URL for {self.email}:")
 			print(url)
 			print(f"\nOTP for {self.email}:")
-			print(self.otp)
+			print(otp)
 			print()
 			return
 
-		subject = f"{self.otp} - OTP for Frappe Cloud Account Verification"
+		subject = f"{otp} - OTP for Frappe Cloud Account Verification"
 		args = {}
 		sender = ""
 		inline_images = []
@@ -231,7 +233,7 @@ class AccountRequest(Document):
 				template = "product_trial_verify_account"
 				product_trial = frappe.get_doc("Product Trial", self.product_trial)
 				if product_trial.email_subject:
-					subject = product_trial.email_subject.format(otp=self.otp)
+					subject = product_trial.email_subject.format(otp=otp)
 				if product_trial.email_account:
 					sender = frappe.get_value("Email Account", product_trial.email_account, "email_id")
 				if product_trial.email_full_logo:
@@ -272,7 +274,7 @@ class AccountRequest(Document):
 				"read_pixel_path": get_url(
 					f"/api/method/press.utils.telemetry.capture_read_event?email={self.email}"
 				),
-				"otp": self.otp,
+				"otp": otp,
 			}
 		)
 		if not args.get("image_path"):
@@ -310,41 +312,6 @@ class AccountRequest(Document):
 				reference_doctype=self.doctype,
 				reference_name=self.name,
 			)
-
-	def send_otp_mail(self, for_login: bool = True):
-		if frappe.conf.developer_mode and frappe.local.dev_server:
-			print(
-				f"Login OTP for {self.email}:"
-				if for_login
-				else f"OTP to view 2FA recovery codes for {self.email}:"
-			)
-			print(self.otp)
-			print()
-			return
-
-		if hasattr(frappe.flags, "in_test") and frappe.flags.in_test:
-			return
-
-		if for_login:
-			template = "login_otp"
-			subject = f"{self.otp} - OTP for Frappe Cloud Login"
-		else:
-			template = "2fa_recovery_codes_otp"
-			subject = f"{self.otp} - OTP to view 2FA recovery codes for Frappe Cloud"
-
-		args = {
-			"otp": self.otp,
-		}
-
-		frappe.sendmail(
-			recipients=self.email,
-			subject=subject,
-			template=template,
-			args=args,
-			now=True,
-			reference_doctype=self.doctype,
-			reference_name=self.name,
-		)
 
 	def get_verification_url(self):
 		return get_url(f"/dashboard/setup-account/{self.request_key}")

--- a/press/press/doctype/balance_transaction/balance_transaction.py
+++ b/press/press/doctype/balance_transaction/balance_transaction.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import frappe
 from frappe.model.document import Document
+from frappe.query_builder.functions import Sum
 
 from press.overrides import get_permission_query_conditions_for_doctype
 
@@ -54,14 +55,16 @@ class BalanceTransaction(Document):
 			# don't update ending balance or unallocated amount for partnership fee
 			return
 
-		last_balance = frappe.db.get_all(
-			"Balance Transaction",
-			filters={"team": self.team, "docstatus": 1, "type": ("!=", "Partnership Fee")},
-			fields=["sum(amount) as ending_balance"],
-			group_by="team",
-			pluck="ending_balance",
-		)
-		last_balance = last_balance[0] if last_balance else 0
+		BalanceTransaction = frappe.qb.DocType("Balance Transaction")
+		balances = (
+			frappe.qb.from_(BalanceTransaction)
+			.select(Sum(BalanceTransaction.amount))
+			.where(BalanceTransaction.team == self.team)
+			.where(BalanceTransaction.docstatus == 1)
+			.where(BalanceTransaction.type != "Partnership Fee")
+			.groupby(BalanceTransaction.team)
+		).run(pluck=True)
+		last_balance = balances[0] if balances else 0
 		if last_balance:
 			self.ending_balance = (last_balance or 0) + self.amount
 		else:

--- a/press/tests/test_2fa.py
+++ b/press/tests/test_2fa.py
@@ -118,10 +118,10 @@ class Test2FA(FrappeTestCase):
 		secret = self.extract_secret_from_url(url)
 		code = pyotp.totp.TOTP(secret).now()
 		enable_2fa(code)
-		send_otp(self.team.user, for_2fa_keys=True)
-		verification_code = frappe.get_value(
-			"Account Request", {"email": self.team.user}, "otp", order_by="creation desc"
-		)
+		with patch("press.api.account.send_otp_mail") as send_otp_mail:
+			send_otp(self.team.user, for_2fa_keys=True)
+		# The code is no longer kept on Account Request; read what was mailed.
+		verification_code = send_otp_mail.call_args.args[1]
 		recovery_codes = get_2fa_recovery_codes(verification_code)
 		self.assertIsInstance(recovery_codes, list)
 		self.assertLessEqual(len(recovery_codes), self.recovery_codes_max)

--- a/press/utils/otp.py
+++ b/press/utils/otp.py
@@ -10,7 +10,15 @@ SIGNUP = "signup"
 LOGIN = "login"
 TWO_FACTOR_RECOVERY = "2fa-recovery"
 
-EXPIRES_IN = 10 * 60
+# How long a code stays good for. A signup code is mailed alongside the
+# setup-account link, so it lasts as long as that link does — see
+# `request_key_expiration_time`. Codes that open an account that already exists
+# get minutes, not a day.
+EXPIRES_IN = {
+	SIGNUP: 24 * 60 * 60,
+	LOGIN: 10 * 60,
+	TWO_FACTOR_RECOVERY: 10 * 60,
+}
 
 
 def generate_otp():
@@ -30,10 +38,10 @@ class OneTimePassword:
 	Account Request for verifying a signup.
 	"""
 
-	def __init__(self, purpose: str, identifier: str, expires_in: int = EXPIRES_IN):
+	def __init__(self, purpose: str, identifier: str):
 		self.purpose = purpose
 		self.identifier = identifier
-		self.expires_in = expires_in
+		self.expires_in = EXPIRES_IN[purpose]
 
 	@property
 	def key(self) -> str:

--- a/press/utils/otp.py
+++ b/press/utils/otp.py
@@ -20,6 +20,19 @@ EXPIRES_IN = {
 	TWO_FACTOR_RECOVERY: 10 * 60,
 }
 
+# How long before another code may be sent to the same inbox.
+RESEND_AFTER = 30
+
+# Spend a code, but only while it is still the code being presented. Reading,
+# comparing and deleting as three steps lets a code that has been replaced in
+# between still succeed, and take the replacement down with it.
+SPEND = """
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+	return redis.call('DEL', KEYS[1])
+end
+return 0
+"""
+
 
 def generate_otp():
 	"""Generates a cryptographically secure random OTP"""
@@ -36,6 +49,11 @@ class OneTimePassword:
 
 	The identifier is whatever the code is about: an email for logging in, an
 	Account Request for verifying a signup.
+
+	Keys are namespaced up front and only raw redis commands are used on them.
+	Frappe's cache wrappers namespace and pickle on the way past, which would
+	both double up the prefix and put a value in front of Lua that it cannot
+	compare.
 	"""
 
 	def __init__(self, purpose: str, identifier: str):
@@ -44,54 +62,45 @@ class OneTimePassword:
 		self.expires_in = EXPIRES_IN[purpose]
 
 	@property
-	def key(self) -> str:
-		return f"press_otp:{self.purpose}:{self.identifier}"
+	def key(self) -> bytes:
+		return frappe.cache.make_key(f"press_otp:{self.purpose}:{self.identifier}")
+
+	@property
+	def resend_key(self) -> bytes:
+		return frappe.cache.make_key(f"press_otp_sent:{self.purpose}:{self.identifier}")
+
+	def hashed(self, code: str | int) -> str:
+		return frappe.utils.sha256_hash(str(code))
 
 	def generate(self) -> str:
 		code = str(generate_otp())
 		if frappe.conf.developer_mode and frappe.local.dev_server:
 			code = "111111"
 
-		frappe.cache.set_value(
-			self.key,
-			{"hash": frappe.utils.sha256_hash(code), "generated_at": frappe.utils.now_datetime()},
-			expires_in_sec=self.expires_in,
-		)
+		frappe.cache.set(self.key, self.hashed(code), ex=self.expires_in)
+		frappe.cache.set(self.resend_key, 1, ex=RESEND_AFTER)
 
 		return code
 
 	def verify(self, code: str | int) -> bool:
-		issued = frappe.cache.get_value(self.key)
-		if not issued:
-			return False
+		"""Whether the code is the one currently issued. Claims nothing."""
+		issued = frappe.cache.get(self.key)
 
-		return issued["hash"] == frappe.utils.sha256_hash(str(code))
+		return issued is not None and issued.decode() == self.hashed(code)
 
 	def consume(self, code: str | int) -> bool:
-		"""Check the code and spend it, so that only one caller can use it.
+		"""Check the code and spend it, in one step, so only one caller may use it.
 
-		Requests arriving together can all read the same code before any of them
-		removes it, so reading cannot decide who wins. Removing can: Redis says
-		how many keys it actually deleted, and only the caller that deleted this
-		one gets to go on.
+		Two callers can read the same code before either removes it, and a code
+		can be replaced between being read and being removed. Neither is decided
+		by reading, so the check and the delete happen together in Redis and the
+		delete only lands on the code that was checked.
 		"""
-		if not self.verify(code):
-			return False
+		return bool(frappe.cache.eval(SPEND, 1, self.key, self.hashed(code)))
 
-		return self.clear()
-
-	def clear(self) -> bool:
-		"""Whether this call was the one that removed the code."""
-		key = frappe.cache.make_key(self.key)
-		frappe.local.cache.pop(key, None)
-
-		return bool(frappe.cache.delete(key))
+	def clear(self):
+		frappe.cache.delete(self.key)
 
 	@property
-	def seconds_since_generated(self) -> int | None:
-		"""None when nothing was issued, or what was issued has expired."""
-		issued = frappe.cache.get_value(self.key)
-		if not issued:
-			return None
-
-		return (frappe.utils.now_datetime() - issued["generated_at"]).seconds
+	def issued_recently(self) -> bool:
+		return frappe.cache.get(self.resend_key) is not None

--- a/press/utils/otp.py
+++ b/press/utils/otp.py
@@ -67,8 +67,25 @@ class OneTimePassword:
 
 		return issued["hash"] == frappe.utils.sha256_hash(str(code))
 
-	def clear(self):
-		frappe.cache.delete_value(self.key)
+	def consume(self, code: str | int) -> bool:
+		"""Check the code and spend it, so that only one caller can use it.
+
+		Requests arriving together can all read the same code before any of them
+		removes it, so reading cannot decide who wins. Removing can: Redis says
+		how many keys it actually deleted, and only the caller that deleted this
+		one gets to go on.
+		"""
+		if not self.verify(code):
+			return False
+
+		return self.clear()
+
+	def clear(self) -> bool:
+		"""Whether this call was the one that removed the code."""
+		key = frappe.cache.make_key(self.key)
+		frappe.local.cache.pop(key, None)
+
+		return bool(frappe.cache.delete(key))
 
 	@property
 	def seconds_since_generated(self) -> int | None:

--- a/press/utils/otp.py
+++ b/press/utils/otp.py
@@ -1,7 +1,72 @@
+from __future__ import annotations
+
 import os
+
+import frappe
+
+# What a code was issued for. A code handed out to verify a signup must not work
+# to log in, so each purpose gets its own key.
+SIGNUP = "signup"
+LOGIN = "login"
+TWO_FACTOR_RECOVERY = "2fa-recovery"
+
+EXPIRES_IN = 10 * 60
 
 
 def generate_otp():
 	"""Generates a cryptographically secure random OTP"""
 
 	return int.from_bytes(os.urandom(5), byteorder="big") % 900000 + 100000
+
+
+class OneTimePassword:
+	"""A one-time password held in the cache, hashed, until it expires.
+
+	These used to live on Account Request, which tied logging in to still having
+	the record written when you signed up. Accounts whose request was never
+	created, or had since been cleaned up, could not log in at all.
+
+	The identifier is whatever the code is about: an email for logging in, an
+	Account Request for verifying a signup.
+	"""
+
+	def __init__(self, purpose: str, identifier: str, expires_in: int = EXPIRES_IN):
+		self.purpose = purpose
+		self.identifier = identifier
+		self.expires_in = expires_in
+
+	@property
+	def key(self) -> str:
+		return f"press_otp:{self.purpose}:{self.identifier}"
+
+	def generate(self) -> str:
+		code = str(generate_otp())
+		if frappe.conf.developer_mode and frappe.local.dev_server:
+			code = "111111"
+
+		frappe.cache.set_value(
+			self.key,
+			{"hash": frappe.utils.sha256_hash(code), "generated_at": frappe.utils.now_datetime()},
+			expires_in_sec=self.expires_in,
+		)
+
+		return code
+
+	def verify(self, code: str | int) -> bool:
+		issued = frappe.cache.get_value(self.key)
+		if not issued:
+			return False
+
+		return issued["hash"] == frappe.utils.sha256_hash(str(code))
+
+	def clear(self):
+		frappe.cache.delete_value(self.key)
+
+	@property
+	def seconds_since_generated(self) -> int | None:
+		"""None when nothing was issued, or what was issued has expired."""
+		issued = frappe.cache.get_value(self.key)
+		if not issued:
+			return None
+
+		return (frappe.utils.now_datetime() - issued["generated_at"]).seconds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
     "pydo==0.24.0",
     "semgrep==1.159.0",
     "frappe-mcp @ git+https://github.com/frappe/mcp",
+    "setuptools==80.9.0",
 ]
 
 [project.optional-dependencies]
@@ -65,7 +66,6 @@ dev = [
     "ruff==0.14.2",
     "mypy==1.18.2",
     "ipdb==0.13.13",
-    "setuptools~=81.0",
     # typechecking
     "types-requests<2.32",
     "types-pytz~=2025.2",


### PR DESCRIPTION
Logging in read the code off the Account Request written at signup, so an account whose request was never created could not get past "Please sign up first". Nothing in press deletes those rows, so the accounts that broke are the ones that never had one: teams created outside Team.create_new, by staff in Desk or by an import.

Codes now live in the cache, hashed, under a key naming what they are for. That is the shape product_trial and developer/saas already used, so the one-time password helper grows to hold it rather than a third copy appearing. Logging in now asks only whether the user exists, which is the question it was trying to answer. Account Request keeps only its request key; the two columns holding the code and when it was made are gone.

Signup, login and viewing 2FA recovery codes shared that single column, so a code issued for one was accepted by another, and a signup code stayed valid forever. Each purpose now has its own key and its own ten minutes.

Resending during signup still sends the login template, as it did before. Worth revisiting, but not while changing what the codes are.