### PR TITLE
feat(site): Warn about A record domains before a region migration

### DIFF
--- a/dashboard/src/components/site/SiteMigration.vue
+++ b/dashboard/src/components/site/SiteMigration.vue
@@ -217,6 +217,13 @@
 							required
 						/>
 
+						<AlertBanner
+							v-if="customDomainWarning"
+							:type="'warning'"
+							:title="customDomainWarning"
+							:show-icon="false"
+						/>
+
 						<p
 							v-if="!$site.doc.group_public"
 							class="mt-1 text-sm text-ink-gray-6"
@@ -447,6 +454,15 @@ export default {
 			if (this.selectedMigrationMode !== 'Move Site To Different Region')
 				return [];
 			return this.selectedMigrationChoiceOptions?.available_regions ?? [];
+		},
+		customDomainWarning() {
+			if (!this.selectedMigrationChoiceOptions?.has_domain_with_a_record)
+				return '';
+			const region = this.availableRegionsToMoveSiteTo.find(
+				(e) => e.name === this.selectedRegion,
+			);
+			if (!region?.inbound_ip) return '';
+			return `This site has custom domains pointing to an A record. After the migration, update them to <strong>${region.inbound_ip}</strong>, or switch them to a CNAME record pointing to <strong>${this.site}</strong>. Until then those domains will not resolve. <a href="https://docs.frappe.io/cloud/sites/custom-domains" target="_blank" class="underline">Read more</a>`;
 		},
 		warningMessage() {
 			return {

--- a/dashboard/tests-e2e/tests/dashboard/site-migration-a-record-warning.test.ts
+++ b/dashboard/tests-e2e/tests/dashboard/site-migration-a-record-warning.test.ts
@@ -1,0 +1,139 @@
+import type { Route } from '@playwright/test'
+import { expect, test } from './coverage.fixture'
+
+const SITE_NAME = 'test-migrate.fc.frappe.dev'
+const DESTINATION_IP = '13.234.11.99'
+
+const siteMock = {
+	message: {
+		name: SITE_NAME,
+		status: 'Active',
+		// current_plan null prevents the upsell banner from appearing
+		current_plan: null,
+		group_public: 0,
+	},
+}
+
+// run_doc_method wraps twice: frappe-ui unwraps the outer `message`, the
+// component then reads `.message` off what run_doc_method itself returned
+function migrationOptions(hasDomainWithARecord: boolean) {
+	return {
+		message: {
+			message: {
+				'In-Place Migrate Site': {
+					hidden: false,
+					allow_scheduling: false,
+					button_label: 'Migrate Site',
+					options: {},
+				},
+				'Move Site To Different Region': {
+					hidden: false,
+					allow_scheduling: true,
+					button_label: 'Move Site',
+					options: {
+						available_regions: [
+							{ name: 'Mumbai', title: 'Mumbai', inbound_ip: DESTINATION_IP },
+						],
+						has_domain_with_a_record: hasDomainWithARecord,
+					},
+				},
+			},
+		},
+	}
+}
+
+const emptyListMock = { message: [] }
+
+function doctype(route: Route): string | null {
+	return route.request().postDataJSON()?.doctype ?? null
+}
+
+async function openRegionMigration(
+	page: Parameters<typeof test>[1]['page'],
+	hasDomainWithARecord: boolean,
+) {
+	await page.route(
+		/\/api\/method\/press\.api\.client\.get\b/,
+		async (route) => {
+			const url = new URL(route.request().url())
+			if (url.searchParams.get('doctype') === 'Site') {
+				await route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify(siteMock),
+				})
+			} else {
+				await route.continue()
+			}
+		},
+	)
+
+	await page.route(
+		/\/api\/method\/press\.api\.client\.get_list/,
+		async (route) => {
+			// Site Action rows are irrelevant, an empty Migrations tab is enough
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify(emptyListMock),
+			})
+		},
+	)
+
+	await page.route(
+		/\/api\/method\/press\.api\.client\.run_doc_method/,
+		async (route) => {
+			if (route.request().postDataJSON()?.method === 'get_migration_options') {
+				await route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify(migrationOptions(hasDomainWithARecord)),
+				})
+			} else {
+				await route.continue()
+			}
+		},
+	)
+
+	await page.goto(`/dashboard/sites/${SITE_NAME}/migrations`)
+	await page.getByRole('button', { name: 'Trigger Migration' }).click()
+
+	await expect(page.getByText('Select Migration Type')).toBeVisible({
+		timeout: 10000,
+	})
+
+	// frappe-ui's Select is a Reka UI listbox, not a native <select>
+	await page.getByText('Select Migration Option').click()
+	await page
+		.getByRole('option', { name: 'Move Site To Different Region' })
+		.click()
+
+	await page.getByRole('button', { name: 'Show popup' }).click()
+	await page.getByRole('option', { name: 'Mumbai' }).click()
+}
+
+test('warns about custom domains on A records with the destination IP', async ({
+	page,
+}) => {
+	await openRegionMigration(page, true)
+
+	const warning = page.getByText(
+		'This site has custom domains pointing to an A record',
+	)
+	await expect(warning).toBeVisible()
+	await expect(warning).toContainText(DESTINATION_IP)
+	await expect(warning).toContainText(SITE_NAME)
+	await expect(page.getByRole('link', { name: 'Read more' })).toHaveAttribute(
+		'href',
+		'https://docs.frappe.io/cloud/sites/custom-domains',
+	)
+})
+
+test('shows no A record warning when the site has none', async ({ page }) => {
+	await openRegionMigration(page, false)
+
+	await expect(page.getByText('Select Region')).toBeVisible()
+	await expect(
+		page.getByText('This site has custom domains pointing to an A record'),
+	).not.toBeVisible()
+})

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -2822,7 +2822,7 @@ class Site(Document, TagHelpers):
 
 	# TODO: rename to change_plan and remove the need for ignore_card_setup param
 	@dashboard_whitelist()
-	def set_plan(self, plan: None | str = None):
+	def set_plan(self, plan: str | None = None):
 		from press.api.site import validate_plan
 
 		validate_plan(self.server, self.name, plan)

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1609,6 +1609,19 @@ class Site(Document, TagHelpers):
 
 		return job
 
+	@property
+	def has_domain_with_a_record(self) -> bool:
+		return bool(
+			frappe.db.exists("Site Domain", {"site": self.name, "dns_type": "A", "domain": ("!=", self.name)})
+		)
+
+	def inbound_ip_in_cluster(self, cluster: str) -> str | None:
+		"""IP the site's custom domains must point to once it moves to this cluster"""
+		server = frappe.db.get_value(
+			"Bench", {"group": self.group, "cluster": cluster, "status": "Active"}, "server"
+		)
+		return get_inbound_ip(server) if server else None
+
 	def change_region(
 		self, cluster: str, scheduled_time: str | None = None, skip_failing_patches: bool = False
 	):
@@ -3426,17 +3439,7 @@ class Site(Document, TagHelpers):
 
 	@property
 	def inbound_ip(self):
-		server = frappe.db.get_value(
-			"Server",
-			self.server,
-			["ip", "is_standalone", "proxy_server", "team"],
-			as_dict=True,
-		)
-		if server.is_standalone:
-			ip = server.ip
-		else:
-			ip = frappe.db.get_value("Proxy Server", server.proxy_server, "ip")
-		return ip
+		return get_inbound_ip(self.server)
 
 	@property
 	def current_usage(self):
@@ -4349,6 +4352,9 @@ class Site(Document, TagHelpers):
 		group_regions = frappe.get_all(
 			"Cluster", filters={"name": ("in", cluster_names)}, fields=["name", "title", "image"]
 		)
+		regions_to_move_to = [region for region in group_regions if region.name != self.cluster]
+		for region in regions_to_move_to:
+			region.inbound_ip = self.inbound_ip_in_cluster(region.name)
 
 		return {
 			"In-Place Migrate Site": {
@@ -4373,7 +4379,8 @@ class Site(Document, TagHelpers):
 				"allow_scheduling": True,
 				"button_label": "Move Site",
 				"options": {
-					"available_regions": [region for region in group_regions if region.name != self.cluster],
+					"available_regions": regions_to_move_to,
+					"has_domain_with_a_record": self.has_domain_with_a_record,
 				},
 			},
 		}
@@ -4430,6 +4437,14 @@ class Site(Document, TagHelpers):
 		if not d:
 			return None
 		return str(timedelta(seconds=round(d.total_seconds() * 2)))
+
+
+def get_inbound_ip(server: str) -> str | None:
+	"""IP that custom domain A records for sites on this server must point to"""
+	values = frappe.db.get_value("Server", server, ["ip", "is_standalone", "proxy_server"], as_dict=True)
+	if values.is_standalone:
+		return values.ip
+	return frappe.db.get_value("Proxy Server", values.proxy_server, "ip")
 
 
 def check_allowed_actions(creation_failed, function_name, action_name_refined):

--- a/press/press/doctype/site/test_site.py
+++ b/press/press/doctype/site/test_site.py
@@ -396,6 +396,40 @@ class TestSite(FrappeTestCase):
 			config_host = site.configuration[0].value
 		self.assertEqual(config_host, f"https://{site_domain1.name}")
 
+	def test_site_without_custom_domain_has_no_domain_with_a_record(self):
+		"""The default domain is a CNAME of the site itself, so it must not count."""
+		site = create_test_site("testsubdomain")
+		self.assertFalse(site.has_domain_with_a_record)
+
+	def test_custom_domain_with_a_record_is_detected(self):
+		from press.press.doctype.site_domain.test_site_domain import create_test_site_domain
+
+		site = create_test_site("testsubdomain")
+		create_test_site_domain(site.name, "sitedomain1.com")
+		self.assertTrue(site.has_domain_with_a_record)
+
+	def test_custom_domain_with_cname_is_not_detected_as_a_record(self):
+		from press.press.doctype.site_domain.test_site_domain import create_test_site_domain
+
+		site = create_test_site("testsubdomain")
+		domain = create_test_site_domain(site.name, "sitedomain1.com")
+		frappe.db.set_value("Site Domain", domain.name, "dns_type", "CNAME")
+		self.assertFalse(site.has_domain_with_a_record)
+
+	def test_inbound_ip_in_cluster_is_of_proxy_of_destination_bench(self):
+		"""The warning shown before a region move must name the destination cluster's proxy IP."""
+		from press.press.doctype.cluster.test_cluster import create_test_cluster
+		from press.press.doctype.proxy_server.test_proxy_server import create_test_proxy_server
+		from press.press.doctype.server.test_server import create_test_server
+
+		site = create_test_site("testsubdomain")
+		cluster = create_test_cluster("Mumbai")
+		proxy_server = create_test_proxy_server(cluster=cluster.name)
+		server = create_test_server(proxy_server.name, cluster=cluster.name)
+		create_test_bench(group=frappe.get_doc("Release Group", site.group), server=server.name)
+
+		self.assertEqual(site.inbound_ip_in_cluster(cluster.name), proxy_server.ip)
+
 	@patch.object(RemoteFile, "download_link", new="http://test.com")
 	@patch.object(RemoteFile, "get_content", new=lambda x: {"a": "test"})  # type: ignore
 	def test_new_site_with_backup_files(self):


### PR DESCRIPTION
## Problem

Moving a site to a different region breaks custom domains that use an **A record** — the record points at the old cluster's proxy IP, which the site no longer sits behind. CNAME domains survive, since they resolve through the site's `*.frappe.cloud` name.

Site Migration already knows this: for a `Cluster` migration with an A-record primary domain it appends `remove_redirects_for_custom_domain_with_A_record`, which unsets the redirect and calls `site.set_host_name(self.site)` — silently demoting the customer's custom domain back to the `*.frappe.cloud` name. There is no warning before, and no notification after.

The old **Change Region** dialog did warn about this. It was dropped when migrations moved to the Site Action flow in #4890. It was also inverted — the condition was `$resources.ARecords.data?.length == 0`, so it rendered only for sites that had *no* A records — and it never said which IP to switch to.

## Change

Restores the warning in the Migrations tab dialog, with the destination IP:

> This site has custom domains pointing to an A record. After the migration, update them to **13.234.11.99**, or switch them to a CNAME record pointing to **site.frappe.cloud**. Until then those domains will not resolve. [Read more](https://docs.frappe.io/cloud/sites/custom-domains)

- `get_migration_options` now returns `has_domain_with_a_record` and an `inbound_ip` per available region.
- The destination is resolved through the same `Bench {group, cluster, status: Active}` lookup `change_region` uses, so the IP shown is the one the site actually lands behind.
- Extracted `get_inbound_ip(server)` out of `Site.inbound_ip` so it can be asked about any server, not just the site's current one.

Shows only when a Site Domain doc exists for the site with `dns_type == "A"` that isn't the default domain.

## Screenshot

<img width="576" height="578" alt="image" src="https://github.com/user-attachments/assets/b2b3c42e-bf9c-4349-bc2c-a8b9881b3788" />

_Region set to Mumbai on a site with a custom domain on an A record._

## Tests

4 backend tests (`test_site.py`) — default domain excluded, A record detected, CNAME not detected, and the destination IP resolving to the destination cluster's proxy.

2 Playwright tests (`site-migration-a-record-warning.test.ts`) — warning shown with the IP, site name and doc link; and no warning when the site has none.

## Notes

- `dns_type` is Press's recorded belief, refreshed by `update_dns_type` in `daily_long`, so it can be up to a day stale if a customer flips their DNS externally.
- The silent primary-domain demotion during migration is still unannounced. Worth a post-migration notification, but out of scope here.
