### PR TITLE
fix(server): Give the update agent play a job timeout that fits

### DIFF
--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1007,7 +1007,8 @@ class BaseServer(Document, TagHelpers):
 
 	@frappe.whitelist()
 	def update_agent_ansible(self):
-		frappe.enqueue_doc(self.doctype, self.name, "_update_agent_ansible")
+		# ponytail: 1h, not the long queue's 1500s — a busy rq worker's warm shutdown alone is 1500s
+		frappe.enqueue_doc(self.doctype, self.name, "_update_agent_ansible", queue="long", timeout=3600)
 
 	def _update_agent_ansible(self, throw_on_failure: bool = False):
 		try:


### PR DESCRIPTION
## Problem

Updating the agent from the desk button leaves the Ansible Play stuck on `Running` — the last tasks sit `Pending` forever and no failure is ever recorded.

`update_agent_ansible` enqueued on the default queue with no timeout, so RQ's death penalty fired at **300s**. Ansible imposes no timeout on a task's command (its `timeout` setting is SSH *connect* only), and `agent update` runs `supervisorctl stop agent:worker-N`, which blocks on an rq warm shutdown — [`stopwaitsecs=1500`](https://github.com/frappe/agent/blob/master/agent/templates/agent/supervisor.conf.jinja2) in the agent's supervisor template. A worker sitting on a long job (backup, bench build, site migrate) can hold that single `stop` for up to 25 minutes.

So anything past 5 minutes was torn down mid-play. The remote `agent update` usually keeps running; Press just stops watching.

## Fix

Long queue with an explicit `timeout=3600`. Not the long queue's own 1500s default — that is exactly one worker's stopwait and leaves nothing over for the rest of the playbook.

## Scope

Only the desk button (`server.js`, `proxy_server.js`, `database_server.js`) hits this path. `create_server`, `virtual_machine_migration` and `arm_build_record` call `_update_agent_ansible` directly from press job steps that already enqueue with `timeout=18000`.

## Testing

No test — it would only assert `frappe.enqueue_doc` was called with those kwargs, which is testing the mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)