### PR TITLE
fix(billing): Warn about the draft invoice when switching payment mode

### DIFF
--- a/dashboard/src/components/billing/PaymentDetails.vue
+++ b/dashboard/src/components/billing/PaymentDetails.vue
@@ -375,6 +375,14 @@ function payUnpaidInvoices() {
 
 const showMessage = ref(false);
 function updatePaymentMode(mode) {
+	if (hasUnbilledAmountOnCurrentMode(mode)) {
+		confirmDraftInvoiceMovesToNewMode(mode);
+		return;
+	}
+	proceedWithPaymentModeChange(mode);
+}
+
+function proceedWithPaymentModeChange(mode) {
 	showMessage.value = false;
 	if (!billingDetailsSummary.value) {
 		showMessage.value = true;
@@ -388,6 +396,7 @@ function updatePaymentMode(mode) {
 	} else if (mode === 'Card' && !team.doc.payment_method) {
 		showMessage.value = true;
 		showAddCardDialog.value = true;
+		return;
 	} else if (
 		mode === 'Paid By Partner' &&
 		Boolean(unpaidInvoices.data.length > 0)
@@ -416,19 +425,19 @@ function updatePaymentMode(mode) {
 }
 
 function submitPaymentModeChange(mode) {
-	if (changePaymentMode.loading) return;
-	if (hasUnbilledAmountOnCurrentMode(mode)) {
-		confirmDraftInvoiceMovesToNewMode(mode);
-		return;
-	}
-	changePaymentMode.submit({ mode });
+	if (!changePaymentMode.loading) changePaymentMode.submit({ mode });
 }
 
 // The draft invoice for the running period is reassigned to whichever mode the
 // team ends up on (Team.update_draft_invoice_payment_mode), so usage already
 // accrued on the old mode gets billed through the new one.
+//
+// Paid By Partner is left out because the server rejects it outright while the
+// team has draft or unpaid invoices (Team.validate_billing_team), so there is
+// nothing to confirm — that mode has to finalize them first.
 function hasUnbilledAmountOnCurrentMode(mode) {
 	return (
+		mode !== 'Paid By Partner' &&
 		Boolean(team.doc.payment_mode) &&
 		mode !== team.doc.payment_mode &&
 		Number(currentBillingAmount.value) > 0
@@ -447,8 +456,8 @@ function confirmDraftInvoiceMovesToNewMode(mode) {
 			label: 'Switch anyway',
 			variant: 'solid',
 			onClick: ({ hide }) => {
-				changePaymentMode.submit({ mode });
 				hide();
+				proceedWithPaymentModeChange(mode);
 			},
 		},
 	});

--- a/dashboard/src/components/billing/PaymentDetails.vue
+++ b/dashboard/src/components/billing/PaymentDetails.vue
@@ -337,6 +337,10 @@ const paymentMode = computed(() => {
 	return paymentModeOptions.find((o) => o.value === team.doc.payment_mode);
 });
 
+function paymentModeLabel(mode) {
+	return paymentModeOptions.find((o) => o.value === mode)?.label || mode;
+}
+
 function payUnpaidInvoices() {
 	let _unpaidInvoices = unpaidInvoices.data;
 	if (_unpaidInvoices.length > 1) {
@@ -402,13 +406,52 @@ function updatePaymentMode(mode) {
 	}
 	if (mode === 'UPI Autopay') {
 		if (team.doc.default_razorpay_mandate) {
-			if (!changePaymentMode.loading) changePaymentMode.submit({ mode });
+			submitPaymentModeChange(mode);
 		} else {
 			router.push({ name: 'BillingUPIAutopay' });
 		}
 		return;
 	}
-	if (!changePaymentMode.loading) changePaymentMode.submit({ mode });
+	submitPaymentModeChange(mode);
+}
+
+function submitPaymentModeChange(mode) {
+	if (changePaymentMode.loading) return;
+	if (hasUnbilledAmountOnCurrentMode(mode)) {
+		confirmDraftInvoiceMovesToNewMode(mode);
+		return;
+	}
+	changePaymentMode.submit({ mode });
+}
+
+// The draft invoice for the running period is reassigned to whichever mode the
+// team ends up on (Team.update_draft_invoice_payment_mode), so usage already
+// accrued on the old mode gets billed through the new one.
+function hasUnbilledAmountOnCurrentMode(mode) {
+	return (
+		Boolean(team.doc.payment_mode) &&
+		mode !== team.doc.payment_mode &&
+		Number(currentBillingAmount.value) > 0
+	);
+}
+
+function confirmDraftInvoiceMovesToNewMode(mode) {
+	const currentMode = paymentModeLabel(team.doc.payment_mode);
+	const newMode = paymentModeLabel(mode);
+	const amount = `${currency.value} ${Number(currentBillingAmount.value).toFixed(2)}`;
+
+	confirmDialog({
+		title: 'Unbilled amount for this period',
+		message: `This period's invoice of <strong>${amount}</strong> is still a draft. Switching will bill it through <strong>${newMode}</strong>, including the usage you have already accrued on ${currentMode}.<br><br>To have it billed to ${currentMode} instead, settle the draft invoice from the invoices page before switching.`,
+		primaryAction: {
+			label: 'Switch anyway',
+			variant: 'solid',
+			onClick: ({ hide }) => {
+				changePaymentMode.submit({ mode });
+				hide();
+			},
+		},
+	});
 }
 
 function changeMethod() {


### PR DESCRIPTION
Closes #3308

### Problem

`Team.update_draft_invoice_payment_mode` reassigns the running period's draft invoice to whatever mode the team ends up on. So the usage already accrued under the old mode gets billed through the new one.

The painful case is Card → Prepaid Credits mid-cycle: a team with, say, $200 accrued on card tops up $10 of credits to make the switch, and the entire month's invoice is then deducted from that balance, falls short, and lands unpaid. Nothing in the dashboard says this will happen.

Only `Paid By Partner` warned about it (via `FinalizeInvoicesDialog`); the Card / Prepaid Credits / UPI Autopay switches submitted silently.

### Fix

Before submitting a mode change, if the team already has a mode set and the current period has a non-zero unbilled amount, show a confirm dialog naming the amount, the mode it is moving to, and the option to settle the draft invoice from the invoices page first. The user can still proceed with "Switch anyway".

Warned rather than blocked, since reassigning is the right default for teams whose draft invoice is still small — they just need to know before confirming.

### Testing

`yarn build` and `npx biome check` pass. No automated test: the dashboard has no unit-test setup (vitest deps are present but there is no config and no existing specs), and covering this in Playwright needs a team fixture with a mid-cycle draft invoice. Verified by reading through the branches in `updatePaymentMode` — `Paid By Partner` still returns early into `FinalizeInvoicesDialog`, so it does not get a second dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)