### PR TITLE
fix(database-server): Fix broken duplicate DB server actions

### DIFF
--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -362,7 +362,12 @@ class DatabaseServer(BaseServer):
 				filter(lambda action: action.get("action") != "Rename server", server_actions)
 			)
 
-		server_type = "database server" if not self.is_unified_server else "database"
+		if self.is_replication_setup:
+			# A replica is managed through its primary. The dashboard offers nothing
+			# beyond rename, reboot and change plan for it.
+			return server_actions
+
+		server_type = self.server_type_for_actions
 		actions = [
 			{
 				"action": "View Database Configuration",

--- a/press/press/doctype/database_server/test_database_server.py
+++ b/press/press/doctype/database_server/test_database_server.py
@@ -172,6 +172,35 @@ class TestDatabaseServer(FrappeTestCase):
 		mock_restart.assert_called_once()
 		self.assertEqual(call_order, ["restart", "agent"])
 
+	def test_replica_is_offered_only_the_actions_the_dashboard_supports(self):
+		"""A replica used to be offered every database action, grouped as "Database Server
+		Actions" so they merged into the primary's card. The dashboard doesn't whitelist
+		the methods behind them for a replica, so those buttons did nothing when clicked."""
+		primary = create_test_database_server()
+		replica = create_test_database_server()
+		replica.is_primary = False
+		replica.primary = primary.name
+		replica.is_replication_setup = True
+		replica.save()
+
+		actions = replica.get_actions()
+
+		self.assertEqual({action["action"] for action in actions}, {"Rename server", "Reboot server"})
+		self.assertEqual({action["group"] for action in actions}, {"Replication Server Actions"})
+
+	def test_primary_of_a_replica_is_still_offered_its_database_actions(self):
+		primary = create_test_database_server()
+		replica = create_test_database_server()
+		replica.is_primary = False
+		replica.primary = primary.name
+		replica.is_replication_setup = True
+		replica.save()
+
+		actions = primary.get_actions()
+
+		self.assertIn("Update Max DB Connections", {action["action"] for action in actions})
+		self.assertEqual({action["group"] for action in actions}, {"Database Server Actions"})
+
 	@patch("press.press.doctype.database_server.database_server.Ansible", new=Mock())
 	@patch(
 		"press.press.doctype.database_server.database_server.frappe.enqueue_doc",

--- a/press/press/doctype/database_server/test_database_server.py
+++ b/press/press/doctype/database_server/test_database_server.py
@@ -41,6 +41,19 @@ def create_test_database_server(ip=None, cluster="Default") -> DatabaseServer:
 	return server
 
 
+def create_test_database_replica(primary: DatabaseServer) -> DatabaseServer:
+	"""Create a Database Server already set up as a replica of primary"""
+	replica = create_test_database_server()
+	replica.is_primary = False
+	replica.primary = primary.name
+	# on_update forbids binlog auto purge once replication is set up, and new servers
+	# default it on
+	replica.auto_purge_binlog_based_on_size = False
+	replica.is_replication_setup = True
+	replica.save()
+	return replica
+
+
 @patch.object(Ansible, "run", new=Mock())
 class TestDatabaseServer(FrappeTestCase):
 	def tearDown(self):
@@ -176,12 +189,7 @@ class TestDatabaseServer(FrappeTestCase):
 		"""A replica used to be offered every database action, grouped as "Database Server
 		Actions" so they merged into the primary's card. The dashboard doesn't whitelist
 		the methods behind them for a replica, so those buttons did nothing when clicked."""
-		primary = create_test_database_server()
-		replica = create_test_database_server()
-		replica.is_primary = False
-		replica.primary = primary.name
-		replica.is_replication_setup = True
-		replica.save()
+		replica = create_test_database_replica(create_test_database_server())
 
 		actions = replica.get_actions()
 
@@ -190,11 +198,7 @@ class TestDatabaseServer(FrappeTestCase):
 
 	def test_primary_of_a_replica_is_still_offered_its_database_actions(self):
 		primary = create_test_database_server()
-		replica = create_test_database_server()
-		replica.is_primary = False
-		replica.primary = primary.name
-		replica.is_replication_setup = True
-		replica.save()
+		create_test_database_replica(primary)
 
 		actions = primary.get_actions()
 

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -406,17 +406,19 @@ class BaseServer(Document, TagHelpers):
 		"""Get clusters which have autoscaling enabled"""
 		return frappe.db.get_all("Cluster", {"enable_autoscaling": 1}, pluck="name")
 
-	def get_actions(self):
-		server_type = ""
+	@property
+	def server_type_for_actions(self) -> str:
+		"""What to call this server in action descriptions and action group titles."""
 		if self.doctype == "Server":
-			server_type = "application server" if not getattr(self, "is_unified_server", False) else "server"
-		elif self.doctype == "Database Server":
+			return "server" if getattr(self, "is_unified_server", False) else "application server"
+		if self.doctype == "Database Server":
 			if self.is_replication_setup:
-				server_type = "replication server"
-			else:
-				server_type = (
-					"database server" if not getattr(self, "is_unified_server", False) else "database"
-				)
+				return "replication server"
+			return "database" if getattr(self, "is_unified_server", False) else "database server"
+		return ""
+
+	def get_actions(self):
+		server_type = self.server_type_for_actions
 
 		actions = [
 			{


### PR DESCRIPTION
### Problem

On a certain server, clicking **Update Max DB Connections** on the Actions page did nothing — no dialog, no error, no toast.

The row belongs to the **replica**, not the primary. `DatabaseServer.get_actions` grouped its database actions as `"Database Server Actions"` regardless of `is_replication_setup` — unlike `BaseServer.get_actions`, which uses `"Replication Server Actions"`. So the replica's rows merged into the primary's card and every row appeared twice. Scrolled down, you're clicking the replica's copy.

And those copies can't work: `ServerActionCell` resolves the method on the cached document resource, but `$dbReplicaServer` is created with only `change_plan` / `reboot` / `rename`. Every handler hits its `if (!server.method) return` guard and bails silently. Same for Update InnoDB Buffer Pool Size, Forcefully Purge Binlogs, Enable Binlog Indexer, Enable/Disable Performance Schema and Manage Database Binlogs.

### Fix

A replica no longer emits those actions. It is managed through its primary, so rename / reboot / change plan is the right surface — dropping them is preferable to widening the dashboard whitelist for operations that aren't meant to be driven on a replica.

Also pulled the server type label into a `server_type_for_actions` property on `BaseServer`, so the two `get_actions` implementations can't disagree on it again — that drift is what produced the duplicate card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)