### PR TITLE
feat(dashboard): Focus and prefill the login as admin reason field

### DIFF
--- a/dashboard/src/dialogs/ConfirmDialog.vue
+++ b/dashboard/src/dialogs/ConfirmDialog.vue
@@ -3,7 +3,7 @@
 		<template #body-content>
 			<div class="space-y-4">
 				<p class="text-p-base text-ink-gray-8" v-if="message" v-html="message" />
-				<div class="space-y-4">
+				<div class="space-y-4" ref="fields">
 					<template v-for="field in fields" :key="field.fieldname">
 						<LinkControl
 							v-if="field.type == 'link'"
@@ -87,6 +87,13 @@ export default {
 		hide() {
 			this.showDialog = false;
 		},
+		focusFirstField() {
+			const field = this.$refs.fields?.querySelector('input, textarea, select');
+			if (!field) return;
+			field.focus();
+			// caret at the end so a prefilled default reads as a prefix to type after
+			field.setSelectionRange?.(field.value.length, field.value.length);
+		},
 		handleKeydown(event) {
 			if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
 				event.preventDefault();
@@ -96,6 +103,9 @@ export default {
 	},
 	mounted() {
 		document.addEventListener('keydown', this.handleKeydown);
+		// setTimeout because the dialog's focus trap grabs the close button on
+		// nextTick; we want the caret in the first field instead
+		setTimeout(() => this.focusFirstField(), 0);
 	},
 	beforeUnmount() {
 		document.removeEventListener('keydown', this.handleKeydown);

--- a/dashboard/src/objects/site.js
+++ b/dashboard/src/objects/site.js
@@ -19,6 +19,9 @@ import { getToastErrorMessage } from '../utils/toast'
 import { getUpsellBanner } from './common'
 import { getAppsTab } from './common/apps'
 
+// prefilled so only the ticket id has to be typed; on its own it is not a reason
+const LOGIN_REASON_PREFIX = 'Investigating '
+
 export default {
 	doctype: 'Site',
 	whitelistedMethods: {
@@ -1709,13 +1712,14 @@ export default {
 														label: 'Reason',
 														type: 'textarea',
 														fieldname: 'reason',
-														default: 'Investigating ',
+														default: LOGIN_REASON_PREFIX,
 													},
 												]
 											: [],
 									onSuccess: ({ hide, values }) => {
+										const reason = values.reason?.trim()
 										if (
-											!values.reason &&
+											(!reason || reason === LOGIN_REASON_PREFIX.trim()) &&
 											($team.name !== site.doc.team || $team.doc.is_desk_user)
 										) {
 											throw new Error(

--- a/dashboard/src/objects/site.js
+++ b/dashboard/src/objects/site.js
@@ -1709,6 +1709,7 @@ export default {
 														label: 'Reason',
 														type: 'textarea',
 														fieldname: 'reason',
+														default: 'Investigating ',
 													},
 												]
 											: [],

--- a/dashboard/tests-e2e/tests/dashboard/login-as-admin-dialog.test.ts
+++ b/dashboard/tests-e2e/tests/dashboard/login-as-admin-dialog.test.ts
@@ -1,0 +1,94 @@
+import { expect, test } from './coverage.fixture'
+
+const SITE_NAME = 'test-login.fc.frappe.dev'
+
+const siteMock = {
+	message: {
+		name: SITE_NAME,
+		status: 'Active',
+		// current_plan null prevents the upsell banner from appearing
+		current_plan: null,
+		group_public: 0,
+		setup_wizard_complete: 1,
+		// breadcrumbs for a desk user link to the server and bench group
+		server: 'f1.local.frappe.dev',
+		server_title: 'Server 1',
+		group: 'bench-0001',
+		group_title: 'Bench 1',
+	},
+}
+
+const emptyListMock = { message: [] }
+
+async function openLoginAsAdminDialog(page) {
+	await page.route(
+		/\/api\/method\/press\.api\.client\.get\b/,
+		async (route) => {
+			const url = new URL(route.request().url())
+			if (url.searchParams.get('doctype') === 'Site') {
+				await route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify(siteMock),
+				})
+			} else {
+				await route.continue()
+			}
+		},
+	)
+	await page.route(
+		/\/api\/method\/press\.api\.client\.get_list/,
+		async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify(emptyListMock),
+			})
+		},
+	)
+
+	await page.goto(`/dashboard/sites/${SITE_NAME}/overview`)
+	await page.getByRole('button', { name: 'Options' }).click()
+	await page.getByText('Login As Administrator').click()
+
+	return page.getByRole('dialog').getByRole('textbox')
+}
+
+test('login as admin dialog focuses the reason field with a prefilled default', async ({
+	page,
+}) => {
+	const reason = await openLoginAsAdminDialog(page)
+
+	await expect(reason).toBeFocused()
+	await expect(reason).toHaveValue('Investigating ')
+
+	// caret sits at the end, so typing appends to the default
+	await page.keyboard.type('12345')
+	await expect(reason).toHaveValue('Investigating 12345')
+})
+
+test('login as admin dialog submits on ctrl+enter from the reason field', async ({
+	page,
+}) => {
+	const reason = await openLoginAsAdminDialog(page)
+
+	const loginRequest = page.waitForRequest(
+		/\/api\/method\/press\.api\.client\.run_doc_method/,
+	)
+	await page.route(
+		/\/api\/method\/press\.api\.client\.run_doc_method/,
+		async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ message: { message: 'https://example.com' } }),
+			})
+		},
+	)
+
+	await reason.press('Control+Enter')
+
+	const body = (await loginRequest).postDataJSON()
+	expect(body.method).toBe('login_as_admin')
+	expect(body.args.reason).toBe('Investigating ')
+})

--- a/dashboard/tests-e2e/tests/dashboard/login-as-admin-dialog.test.ts
+++ b/dashboard/tests-e2e/tests/dashboard/login-as-admin-dialog.test.ts
@@ -86,9 +86,20 @@ test('login as admin dialog submits on ctrl+enter from the reason field', async 
 		},
 	)
 
+	await reason.pressSequentially('12345')
 	await reason.press('Control+Enter')
 
 	const body = (await loginRequest).postDataJSON()
 	expect(body.method).toBe('login_as_admin')
-	expect(body.args.reason).toBe('Investigating ')
+	expect(body.args.reason).toBe('Investigating 12345')
+})
+
+test('login as admin dialog rejects the untouched default as a reason', async ({
+	page,
+}) => {
+	const reason = await openLoginAsAdminDialog(page)
+
+	await reason.press('Control+Enter')
+
+	await expect(page.getByText('Reason is required.')).toBeVisible()
 })


### PR DESCRIPTION
Clicking **Login As Administrator** on a site now opens the dialog with the reason field already focused and prefilled with `Investigating `, caret at the end — so you can paste the ticket id and hit Ctrl/Cmd+Enter without touching the mouse.

- Confirm dialogs focus their first field on open (`setTimeout` rather than `nextTick`, because reka-ui's focus trap otherwise claims the close button).
- The reason field uses a `default`, not a `placeholder`, so the prefix is stored on the activity record rather than just hinted.
- Submitting the untouched prefix is still rejected as "Reason is required" — the prefix on its own is not a reason.
- Ctrl/Cmd+Enter still submits — the listener is on `document`, so it fires with the textarea focused.

Playwright tests cover focus, prefill, appending while typing, ctrl+enter submitting `login_as_admin` with the full reason, and the untouched-prefix rejection. Verified failing without the focus change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)