### PR TITLE
fix(agent): Record failure when agent returns a non-JSON body

### DIFF
--- a/press/agent.py
+++ b/press/agent.py
@@ -975,19 +975,27 @@ class Agent:
 					response=response,
 				)
 			return json_response
+		except requests.JSONDecodeError as exc:
+			# Non-JSON body, e.g. nginx's 502 page when agent is down. Must come before
+			# the ValueError clause below, which would otherwise swallow it.
+			if response.status_code in (502, 503, 504):
+				# nginx couldn't reach agent at all. Record the failure so we stop hitting it.
+				self.log_request_failure(exc)
+				self.handle_exception(agent_job, exc)
+			else:
+				# One endpoint misbehaved (e.g. Flask's HTML 500 page). The server is still
+				# up, so don't block every other job on it.
+				self.handle_request_failure(agent_job, response)
+			log_error(
+				title="Agent Request Exception",
+				result=getattr(response, "text", None),
+			)
 		except (HTTPError, TypeError, ValueError):
 			self.handle_request_failure(agent_job, response)
 			log_error(
 				title="Agent Request Result Exception",
 				result=json_response or getattr(response, "text", None),
 			)
-		except requests.JSONDecodeError as exc:
-			if response and response.status_code >= 500:
-				self.log_request_failure(exc)
-				self.handle_exception(agent_job, exc)
-				log_error(
-					title="Agent Request Exception",
-				)
 		except Exception as exc:
 			self.log_request_failure(exc)
 			self.handle_exception(agent_job, exc)

--- a/press/tests/test_agent.py
+++ b/press/tests/test_agent.py
@@ -67,6 +67,44 @@ class TestAgent(FrappeTestCase):
 		self.assertEqual(failure.failure_count, 1)
 
 	@responses.activate
+	def test_non_json_response_creates_failure_record(self):
+		server = create_test_server()
+
+		responses.add(
+			responses.GET,
+			f"https://{server.name}:443/agent/ping",
+			status=502,
+			body="<html><body><h1>502 Bad Gateway</h1></body></html>",
+		)
+
+		agent = Agent(server.name, server.doctype)
+		self.assertRaises(requests.JSONDecodeError, agent.request, "GET", "ping")
+
+		failure = frappe.get_last_doc("Agent Request Failure")
+		self.assertEqual(failure.server, server.name)
+		self.assertEqual(agent.should_skip_requests(), True)
+
+	@responses.activate
+	def test_non_json_endpoint_error_doesnt_create_failure_record(self):
+		"""A broken endpoint shouldn't block every other job on the server."""
+		for status in (417, 500):
+			with self.subTest(status=status):
+				server = create_test_server()
+
+				responses.add(
+					responses.GET,
+					f"https://{server.name}:443/agent/ping",
+					status=status,
+					body="<html><body><h1>Error</h1></body></html>",
+				)
+
+				agent = Agent(server.name, server.doctype)
+				self.assertRaises(requests.JSONDecodeError, agent.request, "GET", "ping")
+
+				self.assertEqual(frappe.db.count("Agent Request Failure", {"server": server.name}), 0)
+				self.assertEqual(agent.should_skip_requests(), False)
+
+	@responses.activate
 	def test_request_skips_after_past_failure(self):
 		server = create_test_server()
 


### PR DESCRIPTION
### Problem

`poll_pending_jobs_server` was crashing repeatedly with:

```
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
  File "press/agent.py", line 968, in request
    json_response = response.json()
```

The agent was down, nginx returned a 502 HTML page, and `response.json()` blew up.

### Cause

`requests.JSONDecodeError` subclasses `ValueError`, so `except (HTTPError, TypeError, ValueError)` caught it before the handler written for it further down — that handler was dead code. The clause that did catch it calls `handle_request_failure`, which bare-`raise`s when there is no agent job (polling has none) and never calls `log_request_failure`. So no Agent Request Failure record was created, `should_skip_requests()` stayed False, and every 5-second poll crashed again.

The dead handler couldn't have worked either: its guard was `if response and response.status_code >= 500`, and `Response.__bool__` is False for any status >= 400.

### Fix

Move the `JSONDecodeError` handler above the `ValueError` clause, and only trip the circuit breaker on 502/503/504 — the codes nginx returns when it can't reach the agent. A non-JSON 500 is more likely a single broken endpoint (Flask's HTML error page) than a dead agent, and halting every job on the server for that is worse than the noise.

| Status, non-JSON body | Failure record / breaker |
|---|---|
| 502 / 503 / 504 | yes |
| any other (417, 500, …) | no — job gets the status code and body |

JSON-bodied error responses are untouched; they still go down the `HTTPError` path.

### Tests

`press/tests/test_agent.py` — 8 tests pass, including two new ones covering both rows of the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)