### PR TITLE
fix(server): Set docker MTU before the enqueued setup plays

### DIFF
--- a/press/playbooks/roles/docker_mtu/tasks/main.yml
+++ b/press/playbooks/roles/docker_mtu/tasks/main.yml
@@ -22,3 +22,7 @@
 
 - name: Get Docker Info
   command: docker info
+  register: result
+  until: result.rc == 0
+  retries: 10
+  delay: 6

--- a/press/press/doctype/press_job/jobs/create_server.py
+++ b/press/press/doctype/press_job/jobs/create_server.py
@@ -45,13 +45,15 @@ class CreateServerJob(PressJob):
 			self.configure_mariadb_replica()
 			self.start_mariadb_replica()
 
+		# Before set_additional_config, because it reboots the server and
+		# set_additional_config only enqueues its plays (filebeat, cadvisor,
+		# wazuh, ...) - they'd still be running when the reboot lands
+		self.set_docker_mtu_hetzner()
+
 		self.set_additional_config()
 
 		if self.is_fs_server:
 			self.share_benches_over_nfs()
-
-		# Last, because it reboots the server
-		self.set_docker_mtu_hetzner()
 
 	@property
 	def is_setup_db_replication(self):


### PR DESCRIPTION
#7066 added a `Set docker MTU hetzner` step at the end of the Create Server job, on the reasoning that everything ahead of it was already finished.

It isn't. `set_additional_config` doesn't do its own work — `Server.set_additional_config()` calls `install_filebeat()`, `install_cadvisor()`, `install_wazuh_agent()`, `setup_logrotate()` and the rest, each of which is a `frappe.enqueue_doc(..., queue="long")`. The press job step returns in about a second while those ansible plays are still opening SSH connections.

`docker_mtu.yml` then reboots the machine. Filebeat's play has `retries: 5, delay: 120` on three apt tasks, so it is alive for minutes and reliably ends up with a task in **unreachable** state.

## Changes

- Move `set_docker_mtu_hetzner()` ahead of `set_additional_config()`. Everything before that point (TLS, agent, mariadb upgrade/replica, mounts) is synchronous — blocking `ansible.run()` or `now=True` — so the reboot still has nothing in flight, and the enqueued plays now start on an already-booted server.
- Retry `docker info` in the docker_mtu role. Ansible's `reboot` module returns as soon as SSH answers, which can be before dockerd is up; without a retry a slow boot fails server creation.

Chose to move the step rather than make `set_additional_config` wait on its enqueued jobs — that step has been fire-and-forget since long before this bug and nothing else needs it synchronous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)