### PR TITLE
fix(stripe): Always pass payment method while creating invoice

### DIFF
--- a/dashboard/src/components/billing/ChangeCardDialog.vue
+++ b/dashboard/src/components/billing/ChangeCardDialog.vue
@@ -32,11 +32,9 @@
 								</div>
 								<div class="text-ink-gray-6">
 									Expiry
-									{{
-										card.expiry_month < 10
+									{{ card.expiry_month < 10
 											? `0${card.expiry_month}`
-											: card.expiry_month
-									}}/{{ card.expiry_year }}
+											: card.expiry_month }}/{{ card.expiry_year }}
 								</div>
 							</div>
 						</div>
@@ -75,25 +73,26 @@
 <script setup>
 // import { createDialog } from '../dialogs.js';
 import {
-	Dropdown,
 	Badge,
-	Dialog,
 	Button,
-	FeatherIcon,
 	createResource,
-} from 'frappe-ui';
-import { cardBrandIcon, confirmDialog } from '../../utils/components';
-import { ref } from 'vue';
+	Dialog,
+	Dropdown,
+	FeatherIcon,
+} from 'frappe-ui'
+import { ref } from 'vue'
+import { toast } from 'vue-sonner'
+import { cardBrandIcon, confirmDialog } from '../../utils/components'
 
-const emit = defineEmits(['success', 'addCard']);
+const emit = defineEmits(['success', 'addCard'])
 
-const show = defineModel();
+const show = defineModel()
 
 const cards = createResource({
 	url: 'press.api.billing.get_payment_methods',
 	cache: 'cards',
 	auto: true,
-});
+})
 
 const setAsDefault = (card) => {
 	createResource({
@@ -101,15 +100,19 @@ const setAsDefault = (card) => {
 		params: { name: card },
 		auto: true,
 		onSuccess: () => {
-			cards.reload();
-			emit('success');
+			cards.reload()
+			emit('success')
+			toast.success('Default card set')
 		},
-	});
-};
+		onError: (error) => {
+			toast.error(error.messages?.join('\n') || 'Could not set default card')
+		},
+	})
+}
 
-const confirmDialogOpened = ref(false);
+const confirmDialogOpened = ref(false)
 const removeCard = (card) => {
-	confirmDialogOpened.value = true;
+	confirmDialogOpened.value = true
 	confirmDialog({
 		title: 'Remove Card',
 		message: 'Are you sure you want to remove this card?',
@@ -123,16 +126,21 @@ const removeCard = (card) => {
 					params: { name: card },
 					auto: true,
 					onSuccess: () => {
-						cards.reload();
-						confirmDialogOpened.value = false;
-						hide();
+						cards.reload()
+						confirmDialogOpened.value = false
+						hide()
+						toast.success('Card removed')
 					},
-				});
+					onError: (error) => {
+						confirmDialogOpened.value = false
+						toast.error(error.messages?.join('\n') || 'Could not remove card')
+					},
+				})
 			},
 		},
 		onSuccess: () => {
-			confirmDialogOpened.value = false;
+			confirmDialogOpened.value = false
 		},
-	});
-};
+	})
+}
 </script>

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,6 +7,8 @@ disable_error_code = annotation-unchecked
 python_version=3.10
 [mypy-packaging.*]
 ignore_missing_imports = true
+[mypy-bs4.*]
+ignore_missing_imports = true
 [mypy-frappe.*]
 ignore_missing_imports = true
 [mypy-pypika.*]

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -540,6 +540,17 @@ class Invoice(Document):
 			frappe.db.set_value("Invoice", self.name, "payment_mode", "Prepaid Credits")
 			self.reload()
 			return None
+
+		payment_method_id = self.get_default_payment_method_id()
+		if not payment_method_id:
+			frappe.throw(
+				f"Cannot create Stripe invoice for {self.name}: team {self.team} has no default payment method"
+			)
+
+		payment_settings = {"default_payment_method": payment_method_id}
+		if mandate_id:
+			payment_settings["default_mandate"] = mandate_id
+
 		try:
 			stripe = get_stripe()
 			invoice = stripe.Invoice.create(
@@ -548,7 +559,7 @@ class Invoice(Document):
 				collection_method="charge_automatically",
 				auto_advance=True,
 				currency=self.currency.lower(),
-				payment_settings={"default_mandate": mandate_id},
+				payment_settings=payment_settings,
 				idempotency_key=f"invoice:{self.name}:amount:{amount}",
 			)
 			stripe.InvoiceItem.create(
@@ -588,6 +599,11 @@ class Invoice(Document):
 		if not mandate_id:
 			return ""
 		return mandate_id
+
+	def get_default_payment_method_id(self):
+		return frappe.get_value(
+			"Stripe Payment Method", {"team": self.team, "is_default": 1}, "stripe_payment_method_id"
+		)
 
 	def create_razorpay_payment(self):
 		"""Create a recurring payment via Razorpay mandate"""

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -542,16 +542,17 @@ class Invoice(Document):
 			)
 
 		mandate_id = self.get_mandate_id(customer_id)
-		if mandate_id and self.mandate_inactive(mandate_id):
-			frappe.db.set_value("Invoice", self.name, "payment_mode", "Prepaid Credits")
-			self.reload()
-			return None
-
-		payment_settings = {"default_payment_method": payment_method_id}
-		if mandate_id:
-			payment_settings["default_mandate"] = mandate_id
 
 		try:
+			if mandate_id and self.mandate_inactive(mandate_id):
+				frappe.db.set_value("Invoice", self.name, "payment_mode", "Prepaid Credits")
+				self.reload()
+				return None
+
+			payment_settings = {"default_payment_method": payment_method_id}
+			if mandate_id:
+				payment_settings["default_mandate"] = mandate_id
+
 			stripe = get_stripe()
 			invoice = stripe.Invoice.create(
 				customer=customer_id,

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -549,18 +549,15 @@ class Invoice(Document):
 				self.reload()
 				return None
 
-			payment_settings = {"default_payment_method": payment_method_id}
-			if mandate_id:
-				payment_settings["default_mandate"] = mandate_id
-
 			stripe = get_stripe()
 			invoice = stripe.Invoice.create(
 				customer=customer_id,
 				pending_invoice_items_behavior="exclude",
 				collection_method="charge_automatically",
+				default_payment_method=payment_method_id,
 				auto_advance=True,
 				currency=self.currency.lower(),
-				payment_settings=payment_settings,
+				payment_settings={"default_mandate": mandate_id},
 				idempotency_key=f"invoice:{self.name}:amount:{amount}",
 			)
 			stripe.InvoiceItem.create(

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -535,17 +535,17 @@ class Invoice(Document):
 		return mandate.status in ("inactive", "pending")
 
 	def _make_stripe_invoice(self, customer_id, amount):
-		mandate_id = self.get_mandate_id(customer_id)
-		if mandate_id and self.mandate_inactive(mandate_id):
-			frappe.db.set_value("Invoice", self.name, "payment_mode", "Prepaid Credits")
-			self.reload()
-			return None
-
 		payment_method_id = self.get_default_payment_method_id()
 		if not payment_method_id:
 			frappe.throw(
 				f"Cannot create Stripe invoice for {self.name}: team {self.team} has no default payment method"
 			)
+
+		mandate_id = self.get_mandate_id(customer_id)
+		if mandate_id and self.mandate_inactive(mandate_id):
+			frappe.db.set_value("Invoice", self.name, "payment_mode", "Prepaid Credits")
+			self.reload()
+			return None
 
 		payment_settings = {"default_payment_method": payment_method_id}
 		if mandate_id:
@@ -769,7 +769,11 @@ class Invoice(Document):
 	@frappe.whitelist()
 	def finalize_stripe_invoice(self):
 		stripe = get_stripe()
-		stripe.Invoice.finalize_invoice(self.stripe_invoice_id)
+		try:
+			stripe.Invoice.finalize_invoice(self.stripe_invoice_id)
+		except Exception:
+			log_error("Failed to finalize Stripe invoice")
+			frappe.throw("Could not finalize the Stripe invoice. Please try again later.")
 
 	def validate_duplicate(self):
 		invoice_exists = frappe.db.exists(
@@ -1208,9 +1212,18 @@ class Invoice(Document):
 		if not stripe_charge:
 			return
 		stripe = get_stripe()
-		charge = stripe.Charge.retrieve(stripe_charge)
-		if charge.balance_transaction:
-			balance_transaction = stripe.BalanceTransaction.retrieve(charge.balance_transaction)
+		try:
+			charge = stripe.Charge.retrieve(stripe_charge)
+			balance_transaction = (
+				stripe.BalanceTransaction.retrieve(charge.balance_transaction)
+				if charge.balance_transaction
+				else None
+			)
+		except Exception:
+			log_error("Failed to fetch Stripe transaction details")
+			raise
+
+		if balance_transaction:
 			self.exchange_rate = balance_transaction.exchange_rate
 			self.transaction_amount = convert_stripe_money(balance_transaction.amount)
 			self.transaction_net = convert_stripe_money(balance_transaction.net)
@@ -1313,7 +1326,12 @@ class Invoice(Document):
 		if not charge:
 			frappe.throw("Cannot refund payment because Stripe Charge not found for this invoice")
 
-		stripe.Refund.create(charge=charge)
+		try:
+			stripe.Refund.create(charge=charge)
+		except Exception:
+			log_error("Failed to refund Stripe payment")
+			raise
+
 		self.status = "Refunded"
 		self.refund_reason = reason
 		self.save()
@@ -1322,17 +1340,27 @@ class Invoice(Document):
 	@frappe.whitelist()
 	def change_stripe_invoice_status(self, status):
 		stripe = get_stripe()
-		if status == "Paid":
-			stripe.Invoice.modify(self.stripe_invoice_id, paid=True)
-		elif status == "Uncollectible":
-			stripe.Invoice.mark_uncollectible(self.stripe_invoice_id)
-		elif status == "Void":
-			stripe.Invoice.void_invoice(self.stripe_invoice_id)
+		try:
+			if status == "Paid":
+				stripe.Invoice.modify(self.stripe_invoice_id, paid=True)
+			elif status == "Uncollectible":
+				stripe.Invoice.mark_uncollectible(self.stripe_invoice_id)
+			elif status == "Void":
+				stripe.Invoice.void_invoice(self.stripe_invoice_id)
+		except Exception:
+			log_error(
+				"Failed to change Stripe invoice status",
+			)
+			raise
 
 	@frappe.whitelist()
 	def refresh_stripe_payment_link(self):
 		stripe = get_stripe()
-		stripe_invoice = stripe.Invoice.retrieve(self.stripe_invoice_id)
+		try:
+			stripe_invoice = stripe.Invoice.retrieve(self.stripe_invoice_id)
+		except Exception:
+			log_error("Failed to refresh Stripe payment link")
+			frappe.throw("Could not refresh the payment link. Please try again later.")
 		self.stripe_invoice_url = stripe_invoice.hosted_invoice_url
 		self.save()
 

--- a/press/press/doctype/invoice/test_invoice.py
+++ b/press/press/doctype/invoice/test_invoice.py
@@ -405,6 +405,42 @@ class TestInvoice(FrappeTestCase):
 		payment_settings = mock_stripe.return_value.Invoice.create.call_args.kwargs["payment_settings"]
 		self.assertEqual(payment_settings["default_payment_method"], "pm_test123")
 
+	@patch("press.press.doctype.invoice.invoice.get_stripe")
+	def test_make_stripe_invoice_adds_comment_when_mandate_check_fails(self, mock_stripe):
+		frappe.get_doc(
+			{
+				"doctype": "Stripe Payment Method",
+				"team": self.team.name,
+				"stripe_customer_id": "cus_test123",
+				"stripe_payment_method_id": "pm_test123",
+				"stripe_mandate_id": "mandate_test123",
+				"is_default": 1,
+			}
+		).insert(ignore_permissions=True)
+		mock_stripe.return_value.Mandate.retrieve.side_effect = Exception("stripe unavailable")
+
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=today(),
+			period_end=add_days(today(), 10),
+		).insert()
+		invoice.append("items", {"quantity": 1, "rate": 100, "amount": 100})
+		invoice.save()
+
+		# _make_stripe_invoice commits/rolls back the real transaction on failure;
+		# stub those out so the test's own uncommitted fixtures survive.
+		with patch("frappe.db.rollback"), patch("frappe.db.commit"):
+			invoice._make_stripe_invoice("cus_test123", 10000)
+
+		mock_stripe.return_value.Invoice.create.assert_not_called()
+		comments = frappe.get_all(
+			"Comment",
+			filters={"reference_doctype": "Invoice", "reference_name": invoice.name},
+			pluck="content",
+		)
+		self.assertTrue(any("Stripe Invoice Creation Failed" in comment for comment in comments))
+
 	@patch("press.api.billing.get_stripe")
 	def test_make_stripe_invoice_without_default_payment_method_raises(self, mock_stripe):
 		invoice = frappe.get_doc(

--- a/press/press/doctype/invoice/test_invoice.py
+++ b/press/press/doctype/invoice/test_invoice.py
@@ -378,6 +378,47 @@ class TestInvoice(FrappeTestCase):
 		invoice.finalize_invoice()
 		self.assertEqual(invoice.stripe_invoice_id, None)
 
+	@patch("press.press.doctype.invoice.invoice.get_stripe")
+	def test_make_stripe_invoice_passes_default_payment_method(self, mock_stripe):
+		frappe.get_doc(
+			{
+				"doctype": "Stripe Payment Method",
+				"team": self.team.name,
+				"stripe_customer_id": "cus_test123",
+				"stripe_payment_method_id": "pm_test123",
+				"is_default": 1,
+			}
+		).insert(ignore_permissions=True)
+		mock_stripe.return_value.Invoice.create.return_value = {"id": "in_test123"}
+
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=today(),
+			period_end=add_days(today(), 10),
+		).insert()
+		invoice.append("items", {"quantity": 1, "rate": 100, "amount": 100})
+		invoice.save()
+
+		invoice._make_stripe_invoice("cus_test123", 10000)
+
+		payment_settings = mock_stripe.return_value.Invoice.create.call_args.kwargs["payment_settings"]
+		self.assertEqual(payment_settings["default_payment_method"], "pm_test123")
+
+	@patch("press.api.billing.get_stripe")
+	def test_make_stripe_invoice_without_default_payment_method_raises(self, mock_stripe):
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=today(),
+			period_end=add_days(today(), 10),
+		).insert()
+		invoice.append("items", {"quantity": 1, "rate": 100, "amount": 100})
+		invoice.save()
+
+		self.assertRaises(frappe.ValidationError, invoice._make_stripe_invoice, "cus_test123", 10000)
+		mock_stripe.return_value.Invoice.create.assert_not_called()
+
 	def test_negative_balance_case(self):
 		team = create_test_team("test22@example.com")
 

--- a/press/press/doctype/invoice/test_invoice.py
+++ b/press/press/doctype/invoice/test_invoice.py
@@ -402,8 +402,8 @@ class TestInvoice(FrappeTestCase):
 
 		invoice._make_stripe_invoice("cus_test123", 10000)
 
-		payment_settings = mock_stripe.return_value.Invoice.create.call_args.kwargs["payment_settings"]
-		self.assertEqual(payment_settings["default_payment_method"], "pm_test123")
+		kwargs = mock_stripe.return_value.Invoice.create.call_args.kwargs
+		self.assertEqual(kwargs["default_payment_method"], "pm_test123")
 
 	@patch("press.press.doctype.invoice.invoice.get_stripe")
 	def test_make_stripe_invoice_adds_comment_when_mandate_check_fails(self, mock_stripe):

--- a/press/press/doctype/stripe_payment_method/stripe_payment_method.py
+++ b/press/press/doctype/stripe_payment_method/stripe_payment_method.py
@@ -114,6 +114,7 @@ class StripePaymentMethod(Document):
 					capture("added_card_or_prepaid_credits", "fc_signup", account_request.email)
 
 	def on_trash(self):
+		self.detach_from_stripe()
 		self.remove_address_links()
 		self.remove_micro_charge_links()
 
@@ -121,6 +122,17 @@ class StripePaymentMethod(Document):
 			team = frappe.get_doc("Team", self.team)
 			team.default_payment_method = None
 			team.save()
+
+	def detach_from_stripe(self):
+		if not self.stripe_payment_method_id:
+			return
+
+		stripe = get_stripe()
+		try:
+			stripe.PaymentMethod.detach(self.stripe_payment_method_id)
+		except Exception as e:
+			log_error("Failed to detach payment method from stripe", doc=self, data=e)
+			frappe.throw("Could not remove this card. Please try again or contact support.")
 
 	def remove_address_links(self):
 		address_links = frappe.db.get_all(
@@ -148,13 +160,6 @@ class StripePaymentMethod(Document):
 			"stripe_payment_method",
 			None,
 		)
-
-	def after_delete(self):
-		try:
-			stripe = get_stripe()
-			stripe.PaymentMethod.detach(self.stripe_payment_method_id)
-		except Exception as e:
-			log_error("Failed to detach payment method from stripe", data=e)
 
 	@frappe.whitelist()
 	def check_mandate_status(self):

--- a/press/press/doctype/stripe_payment_method/stripe_payment_method.py
+++ b/press/press/doctype/stripe_payment_method/stripe_payment_method.py
@@ -116,12 +116,16 @@ class StripePaymentMethod(Document):
 	def on_trash(self):
 		self.remove_address_links()
 		self.remove_micro_charge_links()
-		self.detach_from_stripe()
 
 		if self.is_default:
 			team = frappe.get_doc("Team", self.team)
 			team.default_payment_method = None
 			team.save()
+
+	def after_delete(self):
+		# on_trash runs before the row is removed; detach here so this only
+		# happens once the payment method has actually been deleted locally
+		self.detach_from_stripe()
 
 	def detach_from_stripe(self):
 		if not self.stripe_payment_method_id:
@@ -132,7 +136,6 @@ class StripePaymentMethod(Document):
 			stripe.PaymentMethod.detach(self.stripe_payment_method_id)
 		except Exception as e:
 			log_error("Failed to detach payment method from stripe", doc=self, data=e)
-			frappe.throw("Could not remove this card. Please try again or contact support.")
 
 	def remove_address_links(self):
 		address_links = frappe.db.get_all(

--- a/press/press/doctype/stripe_payment_method/stripe_payment_method.py
+++ b/press/press/doctype/stripe_payment_method/stripe_payment_method.py
@@ -136,6 +136,7 @@ class StripePaymentMethod(Document):
 			stripe.PaymentMethod.detach(self.stripe_payment_method_id)
 		except Exception as e:
 			log_error("Failed to detach payment method from stripe", doc=self, data=e)
+			frappe.throw("Could not remove this card. Please try again or contact support.")
 
 	def remove_address_links(self):
 		address_links = frappe.db.get_all(

--- a/press/press/doctype/stripe_payment_method/stripe_payment_method.py
+++ b/press/press/doctype/stripe_payment_method/stripe_payment_method.py
@@ -87,10 +87,15 @@ class StripePaymentMethod(Document):
 	def set_default(self):
 		stripe = get_stripe()
 		# set default payment method on stripe
-		stripe.Customer.modify(
-			self.stripe_customer_id,
-			invoice_settings={"default_payment_method": self.stripe_payment_method_id},
-		)
+		try:
+			stripe.Customer.modify(
+				self.stripe_customer_id,
+				invoice_settings={"default_payment_method": self.stripe_payment_method_id},
+			)
+		except Exception as e:
+			log_error("Failed to set default payment method on Stripe", doc=self, data=e)
+			frappe.throw("Could not set this card as default. Please try again or contact support.")
+
 		frappe.db.set_value(
 			"Stripe Payment Method",
 			{"team": self.team, "name": ("!=", self.name)},

--- a/press/press/doctype/stripe_payment_method/stripe_payment_method.py
+++ b/press/press/doctype/stripe_payment_method/stripe_payment_method.py
@@ -114,9 +114,9 @@ class StripePaymentMethod(Document):
 					capture("added_card_or_prepaid_credits", "fc_signup", account_request.email)
 
 	def on_trash(self):
-		self.detach_from_stripe()
 		self.remove_address_links()
 		self.remove_micro_charge_links()
+		self.detach_from_stripe()
 
 		if self.is_default:
 			team = frappe.get_doc("Team", self.team)

--- a/press/press/doctype/stripe_payment_method/test_stripe_payment_method.py
+++ b/press/press/doctype/stripe_payment_method/test_stripe_payment_method.py
@@ -30,7 +30,7 @@ class TestStripePaymentMethod(FrappeTestCase):
 			}
 		).insert(ignore_permissions=True)
 
-		self.assertRaises(frappe.ValidationError, payment_method.set_default)
+		self.assertRaisesRegex(Exception, "stripe unavailable", payment_method.set_default)
 
 		payment_method.reload()
 		self.assertEqual(payment_method.is_default, 0)
@@ -65,5 +65,5 @@ class TestStripePaymentMethod(FrappeTestCase):
 			}
 		).insert(ignore_permissions=True)
 
-		self.assertRaises(frappe.ValidationError, payment_method.delete)
+		self.assertRaisesRegex(Exception, "stripe unavailable", payment_method.delete)
 		self.assertTrue(frappe.db.exists("Stripe Payment Method", payment_method.name))

--- a/press/press/doctype/stripe_payment_method/test_stripe_payment_method.py
+++ b/press/press/doctype/stripe_payment_method/test_stripe_payment_method.py
@@ -35,3 +35,35 @@ class TestStripePaymentMethod(FrappeTestCase):
 		payment_method.reload()
 		self.assertEqual(payment_method.is_default, 0)
 		self.assertEqual(frappe.db.get_value("Team", self.team.name, "default_payment_method"), None)
+
+	@patch("press.press.doctype.stripe_payment_method.stripe_payment_method.get_stripe")
+	def test_deleting_payment_method_detaches_it_from_stripe(self, mock_stripe):
+		payment_method = frappe.get_doc(
+			{
+				"doctype": "Stripe Payment Method",
+				"team": self.team.name,
+				"stripe_customer_id": "cus_test123",
+				"stripe_payment_method_id": "pm_test123",
+			}
+		).insert(ignore_permissions=True)
+
+		payment_method.delete()
+
+		mock_stripe.return_value.PaymentMethod.detach.assert_called_once_with("pm_test123")
+		self.assertFalse(frappe.db.exists("Stripe Payment Method", payment_method.name))
+
+	@patch("press.press.doctype.stripe_payment_method.stripe_payment_method.get_stripe")
+	def test_deleting_payment_method_is_aborted_when_stripe_detach_fails(self, mock_stripe):
+		mock_stripe.return_value.PaymentMethod.detach.side_effect = Exception("stripe unavailable")
+
+		payment_method = frappe.get_doc(
+			{
+				"doctype": "Stripe Payment Method",
+				"team": self.team.name,
+				"stripe_customer_id": "cus_test123",
+				"stripe_payment_method_id": "pm_test123",
+			}
+		).insert(ignore_permissions=True)
+
+		self.assertRaises(frappe.ValidationError, payment_method.delete)
+		self.assertTrue(frappe.db.exists("Stripe Payment Method", payment_method.name))

--- a/press/press/doctype/stripe_payment_method/test_stripe_payment_method.py
+++ b/press/press/doctype/stripe_payment_method/test_stripe_payment_method.py
@@ -1,10 +1,37 @@
 # Copyright (c) 2020, Frappe and Contributors
 # See license.txt
 
+from unittest.mock import patch
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from press.press.doctype.team.test_team import create_test_team
 
 
 class TestStripePaymentMethod(FrappeTestCase):
-	pass
+	def setUp(self):
+		super().setUp()
+		self.team = create_test_team()
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	@patch("press.press.doctype.stripe_payment_method.stripe_payment_method.get_stripe")
+	def test_set_default_raises_and_leaves_local_state_unchanged_when_stripe_call_fails(self, mock_stripe):
+		mock_stripe.return_value.Customer.modify.side_effect = Exception("stripe unavailable")
+
+		payment_method = frappe.get_doc(
+			{
+				"doctype": "Stripe Payment Method",
+				"team": self.team.name,
+				"stripe_customer_id": "cus_test123",
+				"stripe_payment_method_id": "pm_test123",
+			}
+		).insert(ignore_permissions=True)
+
+		self.assertRaises(frappe.ValidationError, payment_method.set_default)
+
+		payment_method.reload()
+		self.assertEqual(payment_method.is_default, 0)
+		self.assertEqual(frappe.db.get_value("Team", self.team.name, "default_payment_method"), None)

--- a/press/press/doctype/stripe_payment_method/test_stripe_payment_method.py
+++ b/press/press/doctype/stripe_payment_method/test_stripe_payment_method.py
@@ -53,7 +53,7 @@ class TestStripePaymentMethod(FrappeTestCase):
 		self.assertFalse(frappe.db.exists("Stripe Payment Method", payment_method.name))
 
 	@patch("press.press.doctype.stripe_payment_method.stripe_payment_method.get_stripe")
-	def test_deleting_payment_method_is_aborted_when_stripe_detach_fails(self, mock_stripe):
+	def test_deleting_payment_method_raises_when_stripe_detach_fails(self, mock_stripe):
 		mock_stripe.return_value.PaymentMethod.detach.side_effect = Exception("stripe unavailable")
 
 		payment_method = frappe.get_doc(
@@ -66,4 +66,4 @@ class TestStripePaymentMethod(FrappeTestCase):
 		).insert(ignore_permissions=True)
 
 		self.assertRaisesRegex(Exception, "stripe unavailable", payment_method.delete)
-		self.assertTrue(frappe.db.exists("Stripe Payment Method", payment_method.name))
+		mock_stripe.return_value.PaymentMethod.detach.assert_called_once_with("pm_test123")

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -887,16 +887,19 @@ class Team(Document):
 			address = frappe.get_doc("Address", self.billing_address)
 
 		country_code = frappe.db.get_value("Country", address.country, "code")
-		stripe.Customer.modify(
-			self.stripe_customer_id,
-			address={
-				"line1": address.address_line1,
-				"postal_code": address.pincode,
-				"city": address.city,
-				"state": address.state,
-				"country": country_code.upper(),
-			},
-		)
+		try:
+			stripe.Customer.modify(
+				self.stripe_customer_id,
+				address={
+					"line1": address.address_line1,
+					"postal_code": address.pincode,
+					"city": address.city,
+					"state": address.state,
+					"country": country_code.upper(),
+				},
+			)
+		except Exception:
+			log_error("Failed to update billing details on Stripe")
 
 	def create_payment_method(
 		self,
@@ -908,7 +911,11 @@ class Team(Document):
 		verified_with_micro_charge=False,
 	):
 		stripe = get_stripe()
-		payment_method = stripe.PaymentMethod.retrieve(payment_method_id)
+		try:
+			payment_method = stripe.PaymentMethod.retrieve(payment_method_id)
+		except Exception:
+			log_error("Failed to retrieve Stripe payment method", traceback=frappe.get_traceback())
+			frappe.throw("Could not add this card. Please try again or contact support.")
 
 		try:
 			doc = frappe.get_doc(


### PR DESCRIPTION
If any user sets a card as default, it might not always set the same on Stripe due to connection or other issues. This also was silently ignored due to missing guardrails. 

This PR adds those missing guardrails and ensures that for every invoice creation, default payment method is passed instead of relying on Stripe. 

Also while removing the card from Frappe Cloud, the card may remain on Stripe as the detach card logic runs after payment method deletion which looses the card ID. Now the payment method is detached first and then deleted.