### PR TITLE
fix(server): Use `query.run()` to get servers

### DIFF
--- a/press/api/server.py
+++ b/press/api/server.py
@@ -121,9 +121,7 @@ def all(server_filter=None):  # noqa: C901
 	else:
 		query = app_server_query + database_server_query
 
-	# union isn't supported in qb for run method
-	# https://github.com/frappe/frappe/issues/15609
-	servers = frappe.db.sql(query.get_sql(), as_dict=True)
+	servers = query.run(as_dict=True)
 	for server in servers:
 		server_plan_name = frappe.get_value("Server", server.name, "plan")
 		server["plan"] = frappe.get_doc("Server Plan", server_plan_name) if server_plan_name else None

--- a/press/api/tests/test_server.py
+++ b/press/api/tests/test_server.py
@@ -395,3 +395,11 @@ class TestAPIServerList(FrappeTestCase):
 			all(server_filter={"server_type": "", "tag": "test_tag"}),
 			[self.app_server_dict],
 		)
+
+	def test_tag_ending_in_backslash_is_treated_as_a_value(self):
+		"""A trailing backslash used to escape the closing quote and made the rest of the query run as SQL."""
+		self.assertEqual(all(server_filter={"server_type": "", "tag": "test_tag\\"}), [])
+
+	def test_tag_carrying_a_union_payload_returns_no_servers(self):
+		payload = "test_tag\\' UNION SELECT name, name, name, creation, name FROM `tabTeam` -- "
+		self.assertEqual(all(server_filter={"server_type": "", "tag": payload}), [])


### PR DESCRIPTION
SQL union support was added in early 2024 and has been available ever since.

Refs:

- https://github.com/frappe/frappe/pull/24757
- https://github.com/frappe/frappe/issues/15609