### PR TITLE
feat(bench): Mark managed benches in common_site_config

### DIFF
--- a/press/press/doctype/bench/bench.py
+++ b/press/press/doctype/bench/bench.py
@@ -294,6 +294,11 @@ class Bench(Document):
 			self.port_offset = self.get_unused_port_offset()
 
 		config = {
+			# tells bench its state is owned by Press, so it can warn before
+			# commands that desync the container from the Bench/Site records.
+			# common_site_config is the only bench config bind-mounted into the
+			# container, so the marker has to live here.
+			"frappe_cloud": True,
 			"monitor": True,
 			"redis_cache": self.build_redis_uri(13000),
 			"redis_queue": self.build_redis_uri(11000),

--- a/press/press/doctype/bench/test_bench.py
+++ b/press/press/doctype/bench/test_bench.py
@@ -677,6 +677,12 @@ class TestArchiveObsoleteBenches(FrappeTestCase):
 				bench.archive()
 			bench.reload()
 
+	def test_bench_config_marks_bench_as_frappe_cloud_managed(self):
+		"""bench reads this key to warn before commands that desync the container."""
+		with fake_agent_job({"New Bench": {"status": "Success"}, "Add User to Proxy": {"status": "Success"}}):
+			bench = create_test_bench()
+			self.assertTrue(json.loads(bench.config)["frappe_cloud"])
+
 	def test_bench_and_release_group_redis_password(self):
 		with fake_agent_job({"New Bench": {"status": "Success"}, "Add User to Proxy": {"status": "Success"}}):
 			frappe.db.set_single_value("Press Settings", "set_redis_password", True)


### PR DESCRIPTION
## What

Adds `"frappe_cloud": true` to the bench's `common_site_config`.

## Why

bench reads this key to warn before commands that desync the container from the Bench and Site records it mirrors — `bench --site x install-app`, `drop-site`, `get-app`, `set-config` and friends, run by hand over SSH. See the companion PR: https://github.com/frappe/bench/pull/1728

## Why common_site_config and not bench_config

`agent/templates/bench/docker-compose.yml.jinja2` bind-mounts only `sites/` and `logs/` into the container. `config.json` (the bench config, with `is_ssh_enabled`, `docker_image`, port offsets) stays on the host and is invisible from inside. `sites/common_site_config.json` is the only bench-level config bench can actually read at the point it needs to decide, so the marker has to live there.

## Rollout

No patch, no backfill. A deploy creates a new Bench rather than mutating the current one, so benches pick the marker up naturally as their groups redeploy. Backfilling by re-saving existing benches would fire an Update Bench Config agent job per bench for a flag that arrives on its own within a deploy cycle.

Until a bench has the key, the bench-side guard is simply inert — it fails closed toward *not* prompting.

## Testing

Added `test_bench_config_marks_bench_as_frappe_cloud_managed`. No existing test asserts the shape of the config dict, so nothing else is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)