### PR TITLE
fix(ui): Make billing overview page responsive

### DIFF
--- a/dashboard/src/components/billing/BillingSummary.vue
+++ b/dashboard/src/components/billing/BillingSummary.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="flex flex-col gap-4">
-		<div class="flex flex-col rounded-lg text-base text-ink-gray-9 shadow">
+		<div class="flex flex-col rounded-lg text-base text-ink-gray-9 shadow dark:border">
 			<div class="flex flex-col gap-2.5 px-4 py-3">
 				<div class="flex items-center justify-between">
 					<div class="flex flex-col gap-1.5">

--- a/dashboard/src/pages/BillingOverview.vue
+++ b/dashboard/src/pages/BillingOverview.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		v-if="team.doc"
-		class="flex flex-1 flex-col gap-8 overflow-y-auto px-60 pt-6"
+		class="flex flex-1 flex-col gap-8 overflow-y-auto px-5 pt-6 md:px-10 lg:px-60"
 	>
 		<BillingSummary />
 		<PaymentDetails />


### PR DESCRIPTION
## Before 

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/38073ad8-ca80-4545-bb08-1251f7aa9e02" />

## Now
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/4815eb54-e26e-4eaa-a560-914fb05ea12c" />

