### PR TITLE
refactor(invoice): Invoice finalisation flow

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -274,6 +274,7 @@ scheduler_events = {
 		"press.press.doctype.usage_record.usage_record.link_unlinked_usage_records",
 		"press.press.doctype.bench.bench.sync_benches",
 		"press.press.doctype.invoice.invoice.finalize_draft_invoices",
+		"press.press.doctype.invoice.invoice.create_invoices_for_next_month",
 		"press.press.doctype.invoice.invoice.finalize_razorpay_mandate_invoices",
 		"press.press.doctype.agent_job.agent_job.fail_old_jobs",
 		"press.press.doctype.site_update.site_update.mark_stuck_updates_as_fatal",

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -273,7 +273,6 @@ scheduler_events = {
 		"press.press.doctype.server.server.scale_workers",
 		"press.press.doctype.usage_record.usage_record.link_unlinked_usage_records",
 		"press.press.doctype.bench.bench.sync_benches",
-		"press.press.doctype.invoice.invoice.finalize_draft_invoices",
 		"press.press.doctype.invoice.invoice.create_invoices_for_next_month",
 		"press.press.doctype.invoice.invoice.finalize_razorpay_mandate_invoices",
 		"press.press.doctype.agent_job.agent_job.fail_old_jobs",
@@ -419,6 +418,9 @@ scheduler_events = {
 		"0 9 * * 2": [
 			"press.press.doctype.build_metric.build_metric.create_build_metric",
 			"press.saas.doctype.product_trial_request.product_trial_request.gather_weekly_stats",
+		],
+		"*/30 * 1 * *": [
+			"press.press.doctype.invoice.invoice.finalize_draft_invoices",
 		],
 	},
 }

--- a/press/hooks.py
+++ b/press/hooks.py
@@ -420,7 +420,7 @@ scheduler_events = {
 			"press.saas.doctype.product_trial_request.product_trial_request.gather_weekly_stats",
 		],
 		"*/30 * 1 * *": [
-			"press.press.doctype.invoice.invoice.finalize_draft_invoices",
+			"press.press.doctype.invoice.invoice.finalize_monthly_draft_invoices",
 		],
 	},
 }

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -786,14 +786,19 @@ class Invoice(Document):
 			frappe.throw("Invoice with same Stripe payment intent exists", frappe.DuplicateEntryError)
 
 		if self.type == "Subscription" and self.period_start and self.period_end and self.is_new():
-			query = (
-				f"select `name` from `tabInvoice` where team = '{self.team}' and"
-				f" status = 'Draft' and ('{self.period_start}' between `period_start` and"
-				f" `period_end` or '{self.period_end}' between `period_start` and"
-				" `period_end`)"
+			# a non-cancelled invoice (Draft, Unpaid, Paid, ...) already owns this period -
+			# not just a Draft one, otherwise a finalized invoice's period could get a duplicate
+			intersecting_invoices = frappe.db.get_all(
+				"Invoice",
+				filters={
+					"team": self.team,
+					"type": "Subscription",
+					"docstatus": ("<", 2),
+					"period_start": ("<=", self.period_end),
+					"period_end": (">=", self.period_start),
+				},
+				pluck="name",
 			)
-
-			intersecting_invoices = [x[0] for x in frappe.db.sql(query, as_list=True)]
 
 			if intersecting_invoices:
 				frappe.throw(
@@ -1092,7 +1097,13 @@ class Invoice(Document):
 		if already_exists:
 			return None
 
-		return frappe.get_doc(doctype="Invoice", team=self.team, period_start=next_start).insert()
+		try:
+			return frappe.get_doc(
+				doctype="Invoice", team=self.team, period_start=next_start, type="Subscription"
+			).insert()
+		except frappe.DuplicateEntryError:
+			# another process created it between the exists check above and this insert
+			return None
 
 	def get_pdf(self):
 		print_format = self.meta.default_print_format
@@ -1376,9 +1387,9 @@ def finalize_draft_invoices():
 	"""
 	- Runs every hour
 	- Processes 500 invoices at a time
-	- Finalizes the invoices whose
-	- period ends today and time is 6PM or later
-	- period has ended before
+	- Finalizes invoices whose period has fully ended, i.e. the previous month's
+		invoice, once the new month has started. This keeps the current month's
+		invoice untouched while usage records for it can still be created.
 	"""
 
 	today = frappe.utils.today()
@@ -1386,13 +1397,12 @@ def finalize_draft_invoices():
 	# since 'limit' returns the same set of invoices for disabled teams which are ignored
 	enabled_teams = frappe.get_all("Team", {"enabled": 1}, pluck="name")
 
-	# get draft invoices whose period has ended or ends today
 	invoices = frappe.db.get_all(
 		"Invoice",
 		filters={
 			"status": "Draft",
 			"type": "Subscription",
-			"period_end": ("<=", today),
+			"period_end": ("<", today),
 			"team": ("in", enabled_teams),
 		},
 		pluck="name",
@@ -1400,14 +1410,43 @@ def finalize_draft_invoices():
 		order_by="total desc",
 	)
 
-	current_time = frappe.utils.get_datetime().time()
-	today = frappe.utils.getdate()
+	for name in invoices:
+		finalize_draft_invoice(name)
+
+
+def create_invoices_for_next_month():
+	"""
+	- Runs every hour
+	- On the last day of the month, creates next month's Subscription invoice
+		for every enabled team so it already exists before usage records for the
+		new period start coming in
+	"""
+
+	today = frappe.utils.getdate(frappe.utils.today())
+	if today != frappe.utils.get_last_day(today):
+		return
+
+	enabled_teams = frappe.get_all("Team", {"enabled": 1}, pluck="name")
+	invoices = frappe.db.get_all(
+		"Invoice",
+		filters={
+			"type": "Subscription",
+			"period_end": today,
+			"docstatus": ("<", 2),
+			"team": ("in", enabled_teams),
+		},
+		pluck="name",
+	)
+
 	for name in invoices:
 		invoice = frappe.get_doc("Invoice", name)
-		# don't finalize if invoice ends today and time is before 6 PM
-		if invoice.period_end == today and current_time.hour < 18:
-			continue
-		finalize_draft_invoice(invoice)
+		try:
+			invoice.create_next()
+		except Exception:
+			frappe.db.rollback()
+			log_error("Invoice creation for next month failed", invoice=invoice.name)
+		finally:
+			frappe.db.commit()
 
 
 def finalize_unpaid_prepaid_credit_invoices():
@@ -1510,12 +1549,6 @@ def finalize_draft_invoice(invoice):
 		invoice.add_comment(text="Finalize Invoice Failed" + "<br><br>" + msg)
 	finally:
 		frappe.db.commit()  # For the comment
-
-	try:
-		invoice.create_next()
-	except Exception:
-		frappe.db.rollback()
-		log_error("Invoice creation for next month failed", invoice=invoice.name)
 
 
 def calculate_gst(amount):

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -1387,12 +1387,15 @@ def finalize_draft_invoices():
 	"""
 	- Runs every hour
 	- Processes 500 invoices at a time
-	- Finalizes invoices whose period has fully ended, i.e. the previous month's
-		invoice, once the new month has started. This keeps the current month's
-		invoice untouched while usage records for it can still be created.
+	- Finalizes only the previous month's Draft invoices, starting 6 AM on the
+		1st of the new month. This keeps the current month's invoice untouched
+		while usage records for it can still be created.
 	"""
 
-	today = frappe.utils.today()
+	if frappe.utils.get_datetime().hour < 6:
+		return
+
+	previous_month_end = frappe.utils.get_last_day(frappe.utils.add_months(frappe.utils.today(), -1))
 	# only finalize for enabled teams
 	# since 'limit' returns the same set of invoices for disabled teams which are ignored
 	enabled_teams = frappe.get_all("Team", {"enabled": 1}, pluck="name")
@@ -1402,7 +1405,7 @@ def finalize_draft_invoices():
 		filters={
 			"status": "Draft",
 			"type": "Subscription",
-			"period_end": ("<", today),
+			"period_end": previous_month_end,
 			"team": ("in", enabled_teams),
 		},
 		pluck="name",

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -293,7 +293,9 @@ class Invoice(Document):
 
 		if self.total == 0:
 			self.status = "Empty"
+			self.truncate_period_end_if_finalized_early()
 			self.submit()
+			self.ensure_next_invoice_exists()
 			return
 
 		team = frappe.get_doc("Team", self.team)
@@ -310,8 +312,10 @@ class Invoice(Document):
 			if invoice.status == "paid":
 				self.status = "Paid"
 				self.update_transaction_details(invoice.charge)
+				self.truncate_period_end_if_finalized_early()
 				self.submit()
 				self.unsuspend_sites_if_applicable()
+				self.ensure_next_invoice_exists()
 				return
 
 		if self.razorpay_payment_id and self.status == "Invoice Created":
@@ -321,6 +325,7 @@ class Invoice(Document):
 
 		# set as unpaid by default
 		self.status = "Unpaid"
+		self.truncate_period_end_if_finalized_early()
 		self.update_item_descriptions()
 
 		if self.amount_due > 0:
@@ -367,6 +372,8 @@ class Invoice(Document):
 		if self.status == "Paid":
 			self.submit()
 			self.unsuspend_sites_if_applicable()
+
+		self.ensure_next_invoice_exists()
 
 	def unsuspend_sites_if_applicable(self):
 		if (
@@ -1105,6 +1112,25 @@ class Invoice(Document):
 			# another process created it between the exists check above and this insert
 			return None
 
+	def truncate_period_end_if_finalized_early(self):
+		# shrink period_end to today if finalized before the period ended (e.g. account
+		# closure), so a follow-up invoice can cover the rest without a period overlap
+		if self.type != "Subscription":
+			return
+		today = frappe.utils.getdate()
+		if getdate(self.period_end) > today:
+			self.period_end = today
+
+	def ensure_next_invoice_exists(self):
+		# guarantees a Draft invoice for any not-yet-billed date, whether this invoice
+		# finalized on time or early (account closure, deletion, manual finalize)
+		if self.type != "Subscription":
+			return
+		try:
+			self.create_next()
+		except Exception:
+			log_error("Failed to create follow-up invoice after finalize", invoice=self.name)
+
 	def get_pdf(self):
 		print_format = self.meta.default_print_format
 		return frappe.utils.get_url(
@@ -1384,13 +1410,8 @@ class Invoice(Document):
 
 
 def finalize_draft_invoices():
-	"""
-	- Runs every hour
-	- Processes 500 invoices at a time
-	- Finalizes only the previous month's Draft invoices, starting 6 AM on the
-		1st of the new month. This keeps the current month's invoice untouched
-		while usage records for it can still be created.
-	"""
+	"""Runs hourly, 500 at a time. Finalizes only the previous month's Draft invoices,
+	starting 6 AM on the 1st - keeps the current month's invoice open for new usage."""
 
 	if frappe.utils.get_datetime().hour < 6:
 		return
@@ -1418,12 +1439,8 @@ def finalize_draft_invoices():
 
 
 def create_invoices_for_next_month():
-	"""
-	- Runs every hour
-	- On the last day of the month, creates next month's Subscription invoice
-		for every enabled team so it already exists before usage records for the
-		new period start coming in
-	"""
+	"""Runs hourly, 500 at a time. On the last day of the month, creates next month's
+	Draft invoice for every enabled team before usage records for it start coming in."""
 
 	today = frappe.utils.getdate(frappe.utils.today())
 	if today != frappe.utils.get_last_day(today):
@@ -1439,9 +1456,12 @@ def create_invoices_for_next_month():
 			"team": ("in", enabled_teams),
 		},
 		pluck="name",
+		limit=500,
 	)
 
 	for name in invoices:
+		if has_job_timeout_exceeded():
+			return
 		invoice = frappe.get_doc("Invoice", name)
 		try:
 			invoice.create_next()

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -1409,6 +1409,11 @@ class Invoice(Document):
 		return stripe.Invoice.retrieve(self.stripe_invoice_id)
 
 
+def finalize_monthly_draft_invoices():
+	"""Enqueue finalize_draft_invoices to run in the background. This is called from a scheduler event."""
+	frappe.enqueue(finalize_draft_invoices, queue="long", timeout=1800)
+
+
 def finalize_draft_invoices():
 	"""Runs hourly, 500 at a time. Finalizes only the previous month's Draft invoices,
 	keeps the current month's invoice open for new usage."""

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -1411,10 +1411,7 @@ class Invoice(Document):
 
 def finalize_draft_invoices():
 	"""Runs hourly, 500 at a time. Finalizes only the previous month's Draft invoices,
-	starting 6 AM on the 1st - keeps the current month's invoice open for new usage."""
-
-	if frappe.utils.get_datetime().hour < 6:
-		return
+	keeps the current month's invoice open for new usage."""
 
 	previous_month_end = frappe.utils.get_last_day(frappe.utils.add_months(frappe.utils.today(), -1))
 	# only finalize for enabled teams

--- a/press/press/doctype/invoice/test_invoice.py
+++ b/press/press/doctype/invoice/test_invoice.py
@@ -684,23 +684,6 @@ class TestInvoice(FrappeTestCase):
 
 		self.assertEqual(invoice.status, "Draft")
 
-	def test_finalize_draft_invoices_does_not_finalize_before_6am(self):
-		previous_month_start = frappe.utils.get_first_day(frappe.utils.add_months(frappe.utils.today(), -1))
-		invoice = frappe.get_doc(
-			doctype="Invoice",
-			team=self.team.name,
-			period_start=previous_month_start,
-			period_end=frappe.utils.get_last_day(previous_month_start),
-		).insert()
-		invoice.append("items", {"quantity": 1, "rate": 100, "amount": 100})
-		invoice.save()
-
-		with patch.object(frappe.utils, "get_datetime", return_value=self._at_hour(3)):
-			finalize_draft_invoices()
-		invoice.reload()
-
-		self.assertEqual(invoice.status, "Draft")
-
 	@patch("press.press.doctype.invoice.invoice.frappe.db.commit", new=MagicMock())
 	def test_finalize_draft_invoices_finalizes_previous_months_invoice_from_6am(self):
 		previous_month_start = frappe.utils.get_first_day(frappe.utils.add_months(frappe.utils.today(), -1))

--- a/press/press/doctype/invoice/test_invoice.py
+++ b/press/press/doctype/invoice/test_invoice.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 
+import datetime
 from unittest.mock import MagicMock, Mock, patch
 
 import frappe
@@ -638,49 +639,77 @@ class TestInvoice(FrappeTestCase):
 		self.assertEqual(invoice.total_discount_amount, 10)
 		self.assertEqual(invoice.amount_due, 90)
 
-	def test_finalize_draft_invoices_does_not_finalize_invoice_for_ongoing_period(self):
+	@staticmethod
+	def _at_hour(hour):
+		return datetime.datetime.combine(frappe.utils.getdate(), datetime.time(hour, 0))
+
+	def test_finalize_draft_invoices_does_not_finalize_current_months_invoice(self):
+		today_date = frappe.utils.getdate()
 		invoice = frappe.get_doc(
 			doctype="Invoice",
 			team=self.team.name,
-			period_start=add_days(today(), -10),
-			period_end=add_days(today(), 10),
+			period_start=frappe.utils.get_first_day(today_date),
+			period_end=frappe.utils.get_last_day(today_date),
 		).insert()
 		invoice.append("items", {"quantity": 1, "rate": 100, "amount": 100})
 		invoice.save()
 
-		finalize_draft_invoices()
+		with patch.object(frappe.utils, "get_datetime", return_value=self._at_hour(9)):
+			finalize_draft_invoices()
 		invoice.reload()
 
 		self.assertEqual(invoice.status, "Draft")
 
-	def test_finalize_draft_invoices_does_not_finalize_invoice_on_its_last_day(self):
-		"""Finalization now waits for the day after period_end, not a time-of-day cutoff on the last day."""
+	def test_finalize_draft_invoices_does_not_finalize_invoice_older_than_previous_month(self):
+		"""Only the previous month's invoice is finalized automatically - an older invoice
+		that's still stuck in Draft (e.g. a past finalize failure) is left alone."""
+		two_months_ago_start = frappe.utils.get_first_day(frappe.utils.add_months(frappe.utils.today(), -2))
 		invoice = frappe.get_doc(
 			doctype="Invoice",
 			team=self.team.name,
-			period_start=add_days(today(), -29),
-			period_end=today(),
+			period_start=two_months_ago_start,
+			period_end=frappe.utils.get_last_day(two_months_ago_start),
 		).insert()
 		invoice.append("items", {"quantity": 1, "rate": 100, "amount": 100})
 		invoice.save()
 
-		finalize_draft_invoices()
+		with patch.object(frappe.utils, "get_datetime", return_value=self._at_hour(9)):
+			finalize_draft_invoices()
+		invoice.reload()
+
+		self.assertEqual(invoice.status, "Draft")
+
+	def test_finalize_draft_invoices_does_not_finalize_before_6am(self):
+		previous_month_start = frappe.utils.get_first_day(frappe.utils.add_months(frappe.utils.today(), -1))
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=previous_month_start,
+			period_end=frappe.utils.get_last_day(previous_month_start),
+		).insert()
+		invoice.append("items", {"quantity": 1, "rate": 100, "amount": 100})
+		invoice.save()
+
+		with patch.object(frappe.utils, "get_datetime", return_value=self._at_hour(3)):
+			finalize_draft_invoices()
 		invoice.reload()
 
 		self.assertEqual(invoice.status, "Draft")
 
 	@patch("press.press.doctype.invoice.invoice.frappe.db.commit", new=MagicMock())
-	def test_finalize_draft_invoices_finalizes_invoice_once_period_has_fully_ended(self):
+	def test_finalize_draft_invoices_finalizes_previous_months_invoice_from_6am(self):
+		previous_month_start = frappe.utils.get_first_day(frappe.utils.add_months(frappe.utils.today(), -1))
 		invoice = frappe.get_doc(
 			doctype="Invoice",
 			team=self.team.name,
-			period_start=add_days(today(), -31),
-			period_end=add_days(today(), -1),
+			period_start=previous_month_start,
+			period_end=frappe.utils.get_last_day(previous_month_start),
 		).insert()
 		invoice.append("items", {"quantity": 1, "rate": 100, "amount": 100})
 		invoice.save()
 
-		finalize_draft_invoices()
+		with patch.object(frappe.utils, "get_datetime", return_value=self._at_hour(6)):
+			finalize_draft_invoices()
 		invoice.reload()
 
 		self.assertNotEqual(invoice.status, "Draft")
@@ -690,16 +719,18 @@ class TestInvoice(FrappeTestCase):
 		self.team.enabled = 0
 		self.team.save()
 
+		previous_month_start = frappe.utils.get_first_day(frappe.utils.add_months(frappe.utils.today(), -1))
 		invoice = frappe.get_doc(
 			doctype="Invoice",
 			team=self.team.name,
-			period_start=add_days(today(), -31),
-			period_end=add_days(today(), -1),
+			period_start=previous_month_start,
+			period_end=frappe.utils.get_last_day(previous_month_start),
 		).insert()
 		invoice.append("items", {"quantity": 1, "rate": 100, "amount": 100})
 		invoice.save()
 
-		finalize_draft_invoices()
+		with patch.object(frappe.utils, "get_datetime", return_value=self._at_hour(9)):
+			finalize_draft_invoices()
 		invoice.reload()
 
 		self.assertEqual(invoice.status, "Draft")

--- a/press/press/doctype/invoice/test_invoice.py
+++ b/press/press/doctype/invoice/test_invoice.py
@@ -168,6 +168,11 @@ class TestInvoice(FrappeTestCase):
 			{"amount": 500, "source": "Prepaid Credits"}, invoice.credit_allocations[1].as_dict()
 		)
 
+		# finalizing the invoice above also auto-creates a follow-up Draft invoice for the
+		# rest of its (now-truncated) period - drop it so it doesn't collide with the
+		# explicitly-dated second invoice this test constructs below
+		frappe.db.delete("Invoice", {"team": self.team.name, "name": ("!=", invoice.name)})
+
 		# Second Invoice
 		# Total: 700
 		# Team has 500 Credits left after the first invoice
@@ -736,8 +741,12 @@ class TestInvoice(FrappeTestCase):
 		self.assertEqual(invoice.status, "Draft")
 
 	@patch("press.press.doctype.invoice.invoice.frappe.db.commit", new=MagicMock())
-	def test_finalize_draft_invoice_does_not_create_next_months_invoice(self):
-		"""Creating next month's invoice is now a separate, last-day-of-month scheduled step."""
+	@patch("press.press.doctype.invoice.invoice.frappe.db.commit", new=MagicMock())
+	def test_finalize_draft_invoice_ensures_next_invoice_exists_as_a_safety_net(self):
+		"""create_invoices_for_next_month proactively creates next month's invoice on the
+		last day of the month, but finalize_invoice() also ensures one exists as a redundant
+		safety net - so usage always has a Draft invoice to attach to even if that proactive
+		step failed, was skipped, or this invoice was finalized early (account closure, etc)."""
 		invoice = frappe.get_doc(
 			doctype="Invoice",
 			team=self.team.name,
@@ -750,12 +759,34 @@ class TestInvoice(FrappeTestCase):
 		finalize_draft_invoice(invoice.name)
 
 		next_period_start = add_days(invoice.period_end, 1)
-		self.assertFalse(
-			frappe.db.exists(
-				"Invoice",
-				{"team": self.team.name, "period_start": next_period_start, "type": "Subscription"},
-			)
+		next_invoice = frappe.get_doc(
+			"Invoice", {"team": self.team.name, "period_start": next_period_start, "type": "Subscription"}
 		)
+		self.assertEqual(next_invoice.status, "Draft")
+
+	@patch("press.press.doctype.invoice.invoice.frappe.db.commit", new=MagicMock())
+	def test_finalize_invoice_finalized_early_leaves_a_draft_invoice_for_rest_of_period(self):
+		"""An invoice finalized before its period has ended (e.g. account closure/deletion,
+		manual 'finalize now') must leave a Draft invoice covering the remaining days of the
+		current period, starting tomorrow - not next calendar month."""
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=today(),
+			period_end=add_days(today(), 10),
+		).insert()
+		invoice.append("items", {"quantity": 1, "rate": 100, "amount": 100})
+		invoice.save()
+
+		invoice.finalize_invoice()
+
+		self.assertEqual(frappe.utils.getdate(invoice.period_end), frappe.utils.getdate(today()))
+
+		tomorrow = add_days(today(), 1)
+		continuation_invoice = frappe.get_doc(
+			"Invoice", {"team": self.team.name, "period_start": tomorrow, "type": "Subscription"}
+		)
+		self.assertEqual(continuation_invoice.status, "Draft")
 
 	def test_create_next_does_not_raise_on_race_with_concurrent_invoice_creation(self):
 		"""If another process creates next month's invoice between create_next()'s existence
@@ -878,6 +909,31 @@ class TestInvoice(FrappeTestCase):
 				{"team": self.team.name, "period_start": next_period_start, "type": "Subscription"},
 			),
 			1,
+		)
+
+	@patch("press.press.doctype.invoice.invoice.frappe.db.commit", new=MagicMock())
+	@patch("press.press.doctype.invoice.invoice.has_job_timeout_exceeded", return_value=True)
+	def test_create_invoices_for_next_month_stops_when_job_timeout_exceeded(self, mock_timeout):
+		"""A long batch must bail out cleanly instead of risking a hard kill mid-iteration."""
+		last_day = frappe.utils.get_last_day(frappe.utils.getdate())
+		period_start = frappe.utils.get_first_day(last_day)
+
+		frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=period_start,
+			period_end=last_day,
+		).insert()
+
+		with patch.object(frappe.utils, "today", return_value=last_day):
+			create_invoices_for_next_month()
+
+		next_period_start = add_days(last_day, 1)
+		self.assertFalse(
+			frappe.db.exists(
+				"Invoice",
+				{"team": self.team.name, "period_start": next_period_start, "type": "Subscription"},
+			)
 		)
 
 	def test_validate_duplicate_blocks_new_invoice_intersecting_a_finalized_invoice(self):

--- a/press/press/doctype/invoice/test_invoice.py
+++ b/press/press/doctype/invoice/test_invoice.py
@@ -2,7 +2,7 @@
 # See license.txt
 
 
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
@@ -10,7 +10,7 @@ from frappe.utils.data import add_days, today
 
 from press.press.doctype.team.test_team import create_test_team
 
-from .invoice import Invoice
+from .invoice import Invoice, create_invoices_for_next_month, finalize_draft_invoice, finalize_draft_invoices
 
 
 @patch.object(Invoice, "create_invoice_on_frappeio", new=Mock())
@@ -637,3 +637,253 @@ class TestInvoice(FrappeTestCase):
 		self.assertEqual(invoice.total_before_discount, 100)
 		self.assertEqual(invoice.total_discount_amount, 10)
 		self.assertEqual(invoice.amount_due, 90)
+
+	def test_finalize_draft_invoices_does_not_finalize_invoice_for_ongoing_period(self):
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=add_days(today(), -10),
+			period_end=add_days(today(), 10),
+		).insert()
+		invoice.append("items", {"quantity": 1, "rate": 100, "amount": 100})
+		invoice.save()
+
+		finalize_draft_invoices()
+		invoice.reload()
+
+		self.assertEqual(invoice.status, "Draft")
+
+	def test_finalize_draft_invoices_does_not_finalize_invoice_on_its_last_day(self):
+		"""Finalization now waits for the day after period_end, not a time-of-day cutoff on the last day."""
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=add_days(today(), -29),
+			period_end=today(),
+		).insert()
+		invoice.append("items", {"quantity": 1, "rate": 100, "amount": 100})
+		invoice.save()
+
+		finalize_draft_invoices()
+		invoice.reload()
+
+		self.assertEqual(invoice.status, "Draft")
+
+	@patch("press.press.doctype.invoice.invoice.frappe.db.commit", new=MagicMock())
+	def test_finalize_draft_invoices_finalizes_invoice_once_period_has_fully_ended(self):
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=add_days(today(), -31),
+			period_end=add_days(today(), -1),
+		).insert()
+		invoice.append("items", {"quantity": 1, "rate": 100, "amount": 100})
+		invoice.save()
+
+		finalize_draft_invoices()
+		invoice.reload()
+
+		self.assertNotEqual(invoice.status, "Draft")
+
+	@patch("press.press.doctype.invoice.invoice.frappe.db.commit", new=MagicMock())
+	def test_finalize_draft_invoices_skips_invoice_of_disabled_team(self):
+		self.team.enabled = 0
+		self.team.save()
+
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=add_days(today(), -31),
+			period_end=add_days(today(), -1),
+		).insert()
+		invoice.append("items", {"quantity": 1, "rate": 100, "amount": 100})
+		invoice.save()
+
+		finalize_draft_invoices()
+		invoice.reload()
+
+		self.assertEqual(invoice.status, "Draft")
+
+	@patch("press.press.doctype.invoice.invoice.frappe.db.commit", new=MagicMock())
+	def test_finalize_draft_invoice_does_not_create_next_months_invoice(self):
+		"""Creating next month's invoice is now a separate, last-day-of-month scheduled step."""
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=add_days(today(), -31),
+			period_end=add_days(today(), -1),
+		).insert()
+		invoice.append("items", {"quantity": 1, "rate": 100, "amount": 100})
+		invoice.save()
+
+		finalize_draft_invoice(invoice.name)
+
+		next_period_start = add_days(invoice.period_end, 1)
+		self.assertFalse(
+			frappe.db.exists(
+				"Invoice",
+				{"team": self.team.name, "period_start": next_period_start, "type": "Subscription"},
+			)
+		)
+
+	def test_create_next_does_not_raise_on_race_with_concurrent_invoice_creation(self):
+		"""If another process creates next month's invoice between create_next()'s existence
+		check and its insert, create_next() must not blow up with a DuplicateEntryError."""
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=add_days(today(), -31),
+			period_end=add_days(today(), -1),
+		).insert()
+
+		next_period_start = add_days(invoice.period_end, 1)
+		frappe.get_doc(
+			doctype="Invoice", team=self.team.name, period_start=next_period_start, type="Subscription"
+		).insert()
+
+		with patch("press.press.doctype.invoice.invoice.frappe.db.exists", return_value=False):
+			result = invoice.create_next()
+
+		self.assertIsNone(result)
+		self.assertEqual(
+			frappe.db.count(
+				"Invoice",
+				{"team": self.team.name, "period_start": next_period_start, "type": "Subscription"},
+			),
+			1,
+		)
+
+	@patch("press.press.doctype.invoice.invoice.frappe.db.commit", new=MagicMock())
+	def test_create_invoices_for_next_month_noop_when_not_last_day_of_month(self):
+		last_day = frappe.utils.get_last_day(frappe.utils.getdate())
+		not_last_day = add_days(last_day, -5)
+
+		frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=add_days(not_last_day, -25),
+			period_end=not_last_day,
+		).insert()
+
+		with patch.object(frappe.utils, "today", return_value=not_last_day):
+			create_invoices_for_next_month()
+
+		next_period_start = add_days(not_last_day, 1)
+		self.assertFalse(
+			frappe.db.exists(
+				"Invoice",
+				{"team": self.team.name, "period_start": next_period_start, "type": "Subscription"},
+			)
+		)
+
+	@patch("press.press.doctype.invoice.invoice.frappe.db.commit", new=MagicMock())
+	def test_create_invoices_for_next_month_creates_draft_invoice_on_last_day(self):
+		last_day = frappe.utils.get_last_day(frappe.utils.getdate())
+		period_start = frappe.utils.get_first_day(last_day)
+
+		frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=period_start,
+			period_end=last_day,
+		).insert()
+
+		with patch.object(frappe.utils, "today", return_value=last_day):
+			create_invoices_for_next_month()
+
+		next_period_start = add_days(last_day, 1)
+		next_invoice = frappe.get_doc(
+			"Invoice", {"team": self.team.name, "period_start": next_period_start, "type": "Subscription"}
+		)
+		self.assertEqual(next_invoice.status, "Draft")
+		self.assertEqual(next_invoice.period_end, frappe.utils.get_last_day(next_period_start))
+
+	@patch("press.press.doctype.invoice.invoice.frappe.db.commit", new=MagicMock())
+	def test_create_invoices_for_next_month_skips_disabled_team(self):
+		self.team.enabled = 0
+		self.team.save()
+
+		last_day = frappe.utils.get_last_day(frappe.utils.getdate())
+		period_start = frappe.utils.get_first_day(last_day)
+
+		frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=period_start,
+			period_end=last_day,
+		).insert()
+
+		with patch.object(frappe.utils, "today", return_value=last_day):
+			create_invoices_for_next_month()
+
+		next_period_start = add_days(last_day, 1)
+		self.assertFalse(
+			frappe.db.exists(
+				"Invoice",
+				{"team": self.team.name, "period_start": next_period_start, "type": "Subscription"},
+			)
+		)
+
+	@patch("press.press.doctype.invoice.invoice.frappe.db.commit", new=MagicMock())
+	def test_create_invoices_for_next_month_is_idempotent(self):
+		last_day = frappe.utils.get_last_day(frappe.utils.getdate())
+		period_start = frappe.utils.get_first_day(last_day)
+
+		frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=period_start,
+			period_end=last_day,
+		).insert()
+
+		with patch.object(frappe.utils, "today", return_value=last_day):
+			create_invoices_for_next_month()
+			create_invoices_for_next_month()
+
+		next_period_start = add_days(last_day, 1)
+		self.assertEqual(
+			frappe.db.count(
+				"Invoice",
+				{"team": self.team.name, "period_start": next_period_start, "type": "Subscription"},
+			),
+			1,
+		)
+
+	def test_validate_duplicate_blocks_new_invoice_intersecting_a_finalized_invoice(self):
+		"""A finalized (non-Draft) invoice must still block a duplicate for the same period -
+		this is the exact gap that let a late usage record spawn a second invoice."""
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=today(),
+			period_end=add_days(today(), 10),
+		).insert()
+		invoice.db_set("status", "Unpaid")
+
+		duplicate = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=today(),
+			period_end=add_days(today(), 10),
+		)
+
+		self.assertRaises(frappe.DuplicateEntryError, duplicate.insert)
+
+	def test_validate_duplicate_allows_new_invoice_after_previous_one_is_cancelled(self):
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=today(),
+			period_end=add_days(today(), 10),
+		).insert()
+		frappe.db.set_value("Invoice", invoice.name, "docstatus", 2)
+
+		new_invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=today(),
+			period_end=add_days(today(), 10),
+		)
+		new_invoice.insert()
+
+		self.assertTrue(frappe.db.exists("Invoice", new_invoice.name))

--- a/press/press/doctype/subscription/subscription.py
+++ b/press/press/doctype/subscription/subscription.py
@@ -167,8 +167,8 @@ class Subscription(Document):
 		if team.billing_team and team.payment_mode == "Paid By Partner":
 			team = frappe.get_cached_doc("Team", team.billing_team)
 
-		if not team.get_upcoming_invoice():
-			team.create_upcoming_invoice()
+		if not team.get_upcoming_invoice(date):
+			team.create_upcoming_invoice(date)
 
 		plan = frappe.get_cached_doc(self.plan_type, self.plan)
 

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -1538,17 +1538,19 @@ class Team(Document):
 			except Exception:
 				log_error("Failed to remove subscription config in trial sites")
 
-	def get_upcoming_invoice(self, for_update=False):
-		# get the current period's invoice
-		today = frappe.utils.today()
+	def get_upcoming_invoice(self, date=None, for_update=False):
+		# get the invoice covering the given date's period (defaults to today).
+		# any non-cancelled invoice counts, not just a Draft one, so a usage record
+		# doesn't spawn a duplicate once the owning invoice has been finalized
+		date = date or frappe.utils.today()
 		result = frappe.db.get_all(
 			"Invoice",
 			filters={
-				"status": "Draft",
 				"team": self.name,
 				"type": "Subscription",
-				"period_start": ("<=", today),
-				"period_end": (">=", today),
+				"docstatus": ("<", 2),
+				"period_start": ("<=", date),
+				"period_end": (">=", date),
 			},
 			order_by="creation desc",
 			limit=1,
@@ -1558,11 +1560,15 @@ class Team(Document):
 			return frappe.get_doc("Invoice", result[0], for_update=for_update)
 		return None
 
-	def create_upcoming_invoice(self):
-		today = frappe.utils.today()
-		return frappe.get_doc(
-			doctype="Invoice", team=self.name, period_start=today, type="Subscription"
-		).insert()
+	def create_upcoming_invoice(self, date=None):
+		date = date or frappe.utils.today()
+		try:
+			return frappe.get_doc(
+				doctype="Invoice", team=self.name, period_start=date, type="Subscription"
+			).insert()
+		except frappe.DuplicateEntryError:
+			# another process created the invoice for this period first
+			return self.get_upcoming_invoice(date)
 
 	@frappe.whitelist()
 	def send_telegram_alert_for_failed_payment(self, invoice):

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -1539,16 +1539,15 @@ class Team(Document):
 				log_error("Failed to remove subscription config in trial sites")
 
 	def get_upcoming_invoice(self, date=None, for_update=False):
-		# get the invoice covering the given date's period (defaults to today).
-		# any non-cancelled invoice counts, not just a Draft one, so a usage record
-		# doesn't spawn a duplicate once the owning invoice has been finalized
+		# only Draft counts - a finalized invoice may already have a Stripe/Razorpay
+		# invoice created against it and must never be mutated further
 		date = date or frappe.utils.today()
 		result = frappe.db.get_all(
 			"Invoice",
 			filters={
+				"status": "Draft",
 				"team": self.name,
 				"type": "Subscription",
-				"docstatus": ("<", 2),
 				"period_start": ("<=", date),
 				"period_end": (">=", date),
 			},
@@ -1568,7 +1567,15 @@ class Team(Document):
 			).insert()
 		except frappe.DuplicateEntryError:
 			# another process created the invoice for this period first
-			return self.get_upcoming_invoice(date)
+			invoice = self.get_upcoming_invoice(date)
+			if not invoice:
+				# the period is already owned by a finalized (no longer Draft) invoice
+				frappe.throw(
+					f"Cannot create an invoice for {self.name} on {date}: a finalized invoice "
+					"already covers this period",
+					frappe.ValidationError,
+				)
+			return invoice
 
 	@frappe.whitelist()
 	def send_telegram_alert_for_failed_payment(self, invoice):

--- a/press/press/doctype/team/test_team.py
+++ b/press/press/doctype/team/test_team.py
@@ -134,9 +134,10 @@ class TestTeam(FrappeTestCase):
 		total = team.total_subscribed_amount()
 		self.assertEqual(total, 50)
 
-	def test_get_upcoming_invoice_returns_unpaid_invoice_for_current_period(self):
-		"""An invoice that has already been finalized to Unpaid (but not yet submitted) still
-		owns its period - get_upcoming_invoice must not overlook it and cause a duplicate."""
+	def test_get_upcoming_invoice_ignores_invoice_already_finalized_to_unpaid(self):
+		"""Once an invoice is finalized to Unpaid it may already have a Stripe/Razorpay
+		invoice created against it - get_upcoming_invoice must never return it for further
+		mutation, even though it's still docstatus=0 (not yet submitted)."""
 		team = create_test_team()
 		invoice = frappe.get_doc(
 			doctype="Invoice",
@@ -145,18 +146,6 @@ class TestTeam(FrappeTestCase):
 			period_end=frappe.utils.add_days(frappe.utils.today(), 10),
 		).insert()
 		invoice.db_set("status", "Unpaid")
-
-		self.assertEqual(team.get_upcoming_invoice().name, invoice.name)
-
-	def test_get_upcoming_invoice_ignores_cancelled_invoice(self):
-		team = create_test_team()
-		invoice = frappe.get_doc(
-			doctype="Invoice",
-			team=team.name,
-			period_start=frappe.utils.add_days(frappe.utils.today(), -10),
-			period_end=frappe.utils.add_days(frappe.utils.today(), 10),
-		).insert()
-		frappe.db.set_value("Invoice", invoice.name, "docstatus", 2)
 
 		self.assertIsNone(team.get_upcoming_invoice())
 

--- a/press/press/doctype/team/test_team.py
+++ b/press/press/doctype/team/test_team.py
@@ -133,3 +133,62 @@ class TestTeam(FrappeTestCase):
 
 		total = team.total_subscribed_amount()
 		self.assertEqual(total, 50)
+
+	def test_get_upcoming_invoice_returns_unpaid_invoice_for_current_period(self):
+		"""An invoice that has already been finalized to Unpaid (but not yet submitted) still
+		owns its period - get_upcoming_invoice must not overlook it and cause a duplicate."""
+		team = create_test_team()
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=team.name,
+			period_start=frappe.utils.add_days(frappe.utils.today(), -10),
+			period_end=frappe.utils.add_days(frappe.utils.today(), 10),
+		).insert()
+		invoice.db_set("status", "Unpaid")
+
+		self.assertEqual(team.get_upcoming_invoice().name, invoice.name)
+
+	def test_get_upcoming_invoice_ignores_cancelled_invoice(self):
+		team = create_test_team()
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=team.name,
+			period_start=frappe.utils.add_days(frappe.utils.today(), -10),
+			period_end=frappe.utils.add_days(frappe.utils.today(), 10),
+		).insert()
+		frappe.db.set_value("Invoice", invoice.name, "docstatus", 2)
+
+		self.assertIsNone(team.get_upcoming_invoice())
+
+	def test_get_upcoming_invoice_matches_invoice_for_given_date_not_only_today(self):
+		team = create_test_team()
+		last_months_invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=team.name,
+			period_start=frappe.utils.add_days(frappe.utils.today(), -40),
+			period_end=frappe.utils.add_days(frappe.utils.today(), -10),
+		).insert()
+
+		backfilled_date = frappe.utils.add_days(frappe.utils.today(), -20)
+
+		self.assertEqual(team.get_upcoming_invoice(backfilled_date).name, last_months_invoice.name)
+		self.assertIsNone(team.get_upcoming_invoice())
+
+	def test_create_upcoming_invoice_uses_given_date_as_period_start(self):
+		team = create_test_team()
+		backfilled_date = frappe.utils.add_days(frappe.utils.today(), -20)
+
+		invoice = team.create_upcoming_invoice(backfilled_date)
+
+		self.assertEqual(frappe.utils.getdate(invoice.period_start), frappe.utils.getdate(backfilled_date))
+
+	def test_create_upcoming_invoice_returns_existing_invoice_on_race_duplicate(self):
+		"""If two callers race to create the invoice for the same date, the loser must get
+		back the winner's invoice instead of raising a DuplicateEntryError."""
+		team = create_test_team()
+		date = frappe.utils.today()
+		first = team.create_upcoming_invoice(date)
+
+		second = team.create_upcoming_invoice(date)
+
+		self.assertEqual(second.name, first.name)

--- a/press/press/doctype/usage_record/test_usage_record.py
+++ b/press/press/doctype/usage_record/test_usage_record.py
@@ -2,9 +2,83 @@
 # See license.txt
 
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from press.press.doctype.team.test_team import create_test_team
 
 
 class TestUsageRecord(FrappeTestCase):
-	pass
+	def setUp(self):
+		super().setUp()
+		self.team = create_test_team()
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_late_usage_record_for_past_month_attaches_to_that_months_existing_invoice(self):
+		"""A usage record created "today" but dated within an already-existing past invoice's
+		period (e.g. a backfilled/late record) must attach to that invoice, not spawn a new
+		one keyed off today's date."""
+		past_invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=frappe.utils.add_days(frappe.utils.today(), -40),
+			period_end=frappe.utils.add_days(frappe.utils.today(), -10),
+		).insert()
+
+		backfilled_date = frappe.utils.add_days(frappe.utils.today(), -20)
+		usage_record = frappe.get_doc(
+			doctype="Usage Record", team=self.team.name, amount=42, date=backfilled_date
+		)
+		usage_record.insert()
+		usage_record.submit()
+
+		self.assertEqual(usage_record.invoice, past_invoice.name)
+		self.assertFalse(
+			frappe.db.exists(
+				"Invoice",
+				{"team": self.team.name, "period_start": frappe.utils.today(), "type": "Subscription"},
+			)
+		)
+
+	def test_usage_record_creates_invoice_for_its_own_date_when_none_exists(self):
+		backfilled_date = frappe.utils.add_days(frappe.utils.today(), -20)
+		usage_record = frappe.get_doc(
+			doctype="Usage Record", team=self.team.name, amount=42, date=backfilled_date
+		)
+		usage_record.insert()
+		usage_record.submit()
+
+		invoice = frappe.get_doc("Invoice", usage_record.invoice)
+		self.assertEqual(invoice.period_start, frappe.utils.getdate(backfilled_date))
+
+	def test_cancelling_usage_record_removes_it_from_its_linked_invoice_not_a_newer_one(self):
+		"""remove_usage_from_invoice must use the usage record's own invoice link, not a
+		fresh team/date lookup that could resolve to an unrelated, newer invoice."""
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=frappe.utils.today(),
+			period_end=frappe.utils.add_days(frappe.utils.today(), 10),
+		).insert()
+
+		usage_record = frappe.get_doc(doctype="Usage Record", team=self.team.name, amount=42)
+		usage_record.insert()
+		usage_record.submit()
+		self.assertEqual(usage_record.invoice, invoice.name)
+
+		# a newer invoice also covering "today" (e.g. next period's pre-created invoice) -
+		# a naive today-based lookup in remove_usage_from_invoice would resolve to this one
+		frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=frappe.utils.add_days(frappe.utils.today(), 11),
+			period_end=frappe.utils.add_days(frappe.utils.today(), 20),
+		).insert()
+
+		usage_record.cancel()
+		invoice.reload()
+
+		self.assertEqual(len(invoice.items), 0)
+		self.assertIsNone(usage_record.invoice)

--- a/press/press/doctype/usage_record/test_usage_record.py
+++ b/press/press/doctype/usage_record/test_usage_record.py
@@ -42,6 +42,49 @@ class TestUsageRecord(FrappeTestCase):
 			)
 		)
 
+	def test_late_usage_record_against_submitted_invoice_fails_loudly_instead_of_crashing(self):
+		"""Once an invoice is submitted (Paid/Empty) it can no longer be mutated. A usage
+		record whose date falls in that period must fail with our own clear error, not
+		leak frappe's opaque UpdateAfterSubmitError from an attempted item append."""
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=frappe.utils.today(),
+			period_end=frappe.utils.add_days(frappe.utils.today(), 10),
+		).insert()
+		invoice.finalize_invoice()  # total is 0 -> status Empty, submitted (docstatus=1)
+		self.assertEqual(invoice.docstatus, 1)
+
+		usage_record = frappe.get_doc(doctype="Usage Record", team=self.team.name, amount=42)
+		usage_record.insert()
+
+		with self.assertRaises(frappe.ValidationError) as context:
+			usage_record.submit()
+		self.assertIn("already covers this period", str(context.exception))
+
+	def test_late_usage_record_against_unpaid_invoice_fails_loudly_instead_of_mutating_it(self):
+		"""An invoice finalized to Unpaid (docstatus still 0, not yet submitted) may already
+		have a Stripe/Razorpay invoice created against it. A usage record whose date falls
+		in that period must fail loudly, not silently append to and re-save it."""
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=frappe.utils.today(),
+			period_end=frappe.utils.add_days(frappe.utils.today(), 10),
+		).insert()
+		invoice.db_set("status", "Unpaid")
+		self.assertEqual(invoice.docstatus, 0)
+
+		usage_record = frappe.get_doc(doctype="Usage Record", team=self.team.name, amount=42)
+		usage_record.insert()
+
+		with self.assertRaises(frappe.ValidationError) as context:
+			usage_record.submit()
+		self.assertIn("already covers this period", str(context.exception))
+
+		invoice.reload()
+		self.assertEqual(len(invoice.items), 0)
+
 	def test_usage_record_creates_invoice_for_its_own_date_when_none_exists(self):
 		backfilled_date = frappe.utils.add_days(frappe.utils.today(), -20)
 		usage_record = frappe.get_doc(

--- a/press/press/doctype/usage_record/usage_record.py
+++ b/press/press/doctype/usage_record/usage_record.py
@@ -62,17 +62,16 @@ class UsageRecord(Document):
 			return
 		# Get a read lock on this invoice
 		# We're going to update the invoice and we don't want any other process to update it
-		invoice = team.get_upcoming_invoice(for_update=True)
+		invoice = team.get_upcoming_invoice(self.date, for_update=True)
 		if not invoice:
-			invoice = team.create_upcoming_invoice()
+			invoice = team.create_upcoming_invoice(self.date)
 
 		invoice.add_usage_record(self)
 
 	def remove_usage_from_invoice(self):
-		team = frappe.get_doc("Team", self.team)
-		invoice = team.get_upcoming_invoice()
-		if invoice:
-			invoice.remove_usage_record(self)
+		if not self.invoice:
+			return
+		frappe.get_doc("Invoice", self.invoice).remove_usage_record(self)
 
 	def validate_duplicate_usage_record(self):
 		# Can skip duplicate usage record check if this is a autoscale usage record


### PR DESCRIPTION
This PR attempts to move the invoice finalisation from last day of the month to 1st of the next month. It also increases the frequency from hourly to every 30 min running the same batch size per loop. 

Creation of new invoice for next month will still happen on the last day of the month.