### PR TITLE
fix(versioning): Skip Frappe version check when a branch declares none

### DIFF
--- a/press/press/doctype/app/app.py
+++ b/press/press/doctype/app/app.py
@@ -219,7 +219,7 @@ def map_frappe_version(
 	try:
 		version_string = version_string.replace(" ", "").replace(",", " ")
 		spec = sv.NpmSpec(version_string)
-	except ValueError:
+	except (AttributeError, TypeError, ValueError):
 		frappe.throw(
 			f"Invalid version format for app '{app_title}'. Please use NPM-style semver ranges "
 			f"(e.g. '>=15.0.0 <16.0.0'). {VERSIONING_DOCS}"

--- a/press/press/doctype/app/test_app.py
+++ b/press/press/doctype/app/test_app.py
@@ -167,6 +167,13 @@ class TestApp(FrappeTestCase):
 			with self.assertRaises(frappe.ValidationError):
 				parse_frappe_version(invalid_custom_version_string, app_title="test-app")
 
+	def test_version_parsing_rejects_a_missing_version_string_with_a_readable_error(self):
+		"""Regression: a None version string used to raise AttributeError from str.replace."""
+		with self.assertRaises(frappe.ValidationError) as context:
+			parse_frappe_version(None, app_title="test-app")
+
+		self.assertIn("Invalid version format for app 'test-app'", str(context.exception))
+
 	def test_prerelease_upper_bound_is_rejected_with_a_message_naming_the_range(self):
 		with self.assertRaises(frappe.ValidationError) as context:
 			parse_frappe_version(

--- a/press/press/doctype/marketplace_app/marketplace_app.py
+++ b/press/press/doctype/marketplace_app/marketplace_app.py
@@ -807,8 +807,15 @@ def validate_frappe_version_for_branch(
 		else frappe.get_value("Press Settings", None, "github_access_token"),
 	)
 	frappe_version = app_info.get("frappe_version")
-	frappe_version = parse_frappe_version(frappe_version, app_info.get("title"), ease_versioning_constrains)
-	if version not in frappe_version:
+	if frappe_version is None:
+		# The framework doesn't declare a supported range of itself. Its branches are
+		# checked against the bench version in ReleaseGroup.change_app_branch instead.
+		return
+
+	supported_versions = parse_frappe_version(
+		frappe_version, app_info.get("title"), ease_versioning_constrains
+	)
+	if version not in supported_versions:
 		frappe.throw(f"{version} is not supported by branch {branch} for app {app_name}", VersioningError)
 
 

--- a/press/press/doctype/marketplace_app/test_marketplace_app.py
+++ b/press/press/doctype/marketplace_app/test_marketplace_app.py
@@ -9,9 +9,11 @@ import frappe
 from frappe.tests.ui_test_helpers import create_test_user
 from frappe.tests.utils import FrappeTestCase
 
+from press.press.doctype.app.app import VersioningError
 from press.press.doctype.app.test_app import create_test_app
 from press.press.doctype.app_source.app_source import AppSource
 from press.press.doctype.app_source.test_app_source import create_test_app_source
+from press.press.doctype.marketplace_app.marketplace_app import validate_frappe_version_for_branch
 from press.press.doctype.marketplace_app.utils import (
 	get_rating_percentage_distribution,
 	number_k_format,
@@ -101,6 +103,41 @@ class TestMarketplaceApp(FrappeTestCase):
 				version="Version 15", repo_owner="frappe", repo_name="erpnext", branch="version-15"
 			)
 		self.assertIn("No app source found for frappe/erpnext", str(context.exception))
+
+	@patch("press.press.doctype.marketplace_app.marketplace_app.app")
+	def test_validate_frappe_version_skips_a_branch_that_declares_no_frappe_version(self, github_app: Mock):
+		"""Regression: `api.github.app` returns frappe_version=None for the framework itself,
+		which used to crash with AttributeError inside map_frappe_version."""
+		github_app.return_value = {"name": "frappe", "title": "Frappe Framework", "frappe_version": None}
+
+		self.assertIsNone(
+			validate_frappe_version_for_branch(
+				app_name="frappe",
+				owner="frappe",
+				repository="frappe",
+				branch="version-16",
+				version="Version 16",
+			)
+		)
+
+	@patch("press.press.doctype.marketplace_app.marketplace_app.app")
+	def test_validate_frappe_version_rejects_a_branch_that_does_not_support_the_version(
+		self, github_app: Mock
+	):
+		github_app.return_value = {
+			"name": "erpnext",
+			"title": "ERPNext",
+			"frappe_version": ">=15.0.0,<16.0.0",
+		}
+
+		with self.assertRaises(VersioningError):
+			validate_frappe_version_for_branch(
+				app_name="erpnext",
+				owner="frappe",
+				repository="erpnext",
+				branch="version-15",
+				version="Version 16",
+			)
 
 	def create_marketplace_app_for_team(self, team):
 		app_name = f"perm_app_{frappe.generate_hash(length=8).lower()}"


### PR DESCRIPTION
## Problem

Adding or re-pointing the **frappe** app on a release group crashes:

```
File "apps/press/press/press/doctype/release_group/release_group.py", line 1928, in add_app
  validate_frappe_version_for_branch(
File "apps/press/press/press/doctype/marketplace_app/marketplace_app.py", line 811, in validate_frappe_version_for_branch
  frappe_version = parse_frappe_version(frappe_version, app_info.get("title"), ease_versioning_constrains)
File "apps/press/press/press/doctype/app/app.py", line 220, in map_frappe_version
  version_string = version_string.replace(" ", "").replace(",", " ")
AttributeError: 'NoneType' object has no attribute 'replace'
```

Reproduced with `run_doc_method` on `Release Group` / `add_app` for a frappe fork (`diamorafaela/frappe_v16`, branch `diamoerp`), which is what the dashboard's app-update dialog sends.

## Cause

d93cb760d ("Allow framework branch switch if major versions match") made `api.github.app` return `frappe_version=None` when the repository resolves to the framework itself, and added `_validate_frappe_branch_matches_bench_version` to `ReleaseGroup.change_app_branch` to cover that case. The `add_app` path still went through the pyproject-based check, and `validate_frappe_version_for_branch` passes `app_info["frappe_version"]` straight into `parse_frappe_version` with no `None` guard, so `map_frappe_version` calls `.replace` on `None`.

Two things made it worse: the `with suppress(frappe.ValidationError)` around the call in `add_app` was meant to make this validation non-fatal, but `AttributeError` isn't a `ValidationError` so it escaped and killed the whole `add_app`; and `map_frappe_version`'s `try` only catches `ValueError`, so a non-string spec never became the intended user-facing error.

## Fix

- Return early from `validate_frappe_version_for_branch` when the branch declares no Frappe version.
- Catch `AttributeError` and `TypeError` alongside `ValueError` in `map_frappe_version`, so any other non-string spec surfaces as the intended "Invalid version format" message instead of a traceback.

I skipped the check rather than reusing `get_frappe_branch_major_version` here, because that would be a new restriction rather than a fix: before d93cb760d, frappe's own `pyproject.toml` has no `[tool.bench.frappe-dependencies]`, so this path already threw a `ValidationError` that `add_app` suppressed — the framework was never actually version-checked on the `add_app` path. Worth deciding separately whether `add_app` should enforce the same major-version match that `change_app_branch` now does; happy to follow up if we want that.

## Tests

Added regression tests for both the skip and the readable error, plus one asserting a genuine mismatch still raises `VersioningError` so the guard didn't quietly disable validation for normal apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)