### PR TITLE
feat(site): Let users pick backup times from the dashboard

### DIFF
--- a/dashboard/src/components/site/SiteBackupScheduleDialog.vue
+++ b/dashboard/src/components/site/SiteBackupScheduleDialog.vue
@@ -15,47 +15,62 @@
 	>
 		<template #body-content>
 			<div class="flex flex-col gap-4">
-				<Switch
-					v-model="custom"
-					label="Pick backup times"
-					description="Move backups off your working hours instead of leaving them to the default schedule"
-				/>
+				<div class="rounded-md bg-surface-gray-1 p-3">
+					<Switch
+						v-model="custom"
+						label="Choose when backups run"
+						:description="
+							custom
+								? 'Backups run only at the times below'
+								: 'Backups run every 6 hours, whenever that falls'
+						"
+					/>
+				</div>
 
-				<p v-if="!custom" class="text-base text-ink-gray-6">
-					Backups are taken automatically every 6 hours.
-				</p>
+				<div v-if="custom" class="flex flex-col gap-3">
+					<div class="flex items-baseline justify-between">
+						<span class="text-base font-medium text-ink-gray-8">
+							Backup times
+						</span>
+						<span class="text-p-sm text-ink-gray-5">
+							{{ times.length }} of {{ maximumTimes }}
+						</span>
+					</div>
 
-				<div v-else class="flex flex-col gap-3">
-					<div
-						v-for="(time, index) in times"
-						:key="index"
-						class="flex items-center gap-2"
-					>
-						<FormControl
-							class="w-full"
-							type="time"
-							v-model="times[index]"
-						/>
-						<Button
-							v-if="times.length > 1"
-							icon="x"
-							@click="times.splice(index, 1)"
-						/>
+					<div class="grid grid-cols-2 gap-x-3 gap-y-2">
+						<div
+							v-for="(time, index) in times"
+							:key="index"
+							class="flex items-center gap-1"
+						>
+							<FormControl
+								class="flex-1"
+								type="time"
+								v-model="times[index]"
+							/>
+							<Button
+								v-if="times.length > 1"
+								variant="ghost"
+								icon="x"
+								:label="`Remove ${time}`"
+								@click="times.splice(index, 1)"
+							/>
+						</div>
 					</div>
 
 					<Button
 						v-if="times.length < maximumTimes"
 						class="w-fit"
+						variant="subtle"
 						icon-left="plus"
 						@click="addTime"
 					>
 						Add time
 					</Button>
 
-					<p class="text-p-sm text-ink-gray-5">
+					<p class="text-p-sm leading-5 text-ink-gray-5">
 						Times are in your timezone ({{ timezone }}). A backup starts
-						within the hour you pick, and replaces the default 6 hourly
-						schedule.
+						within the hour you pick.
 					</p>
 				</div>
 

--- a/dashboard/src/components/site/SiteBackupScheduleDialog.vue
+++ b/dashboard/src/components/site/SiteBackupScheduleDialog.vue
@@ -1,0 +1,137 @@
+<template>
+	<Dialog
+		v-model="show"
+		:options="{
+			title: 'Backup Schedule',
+			actions: [
+				{
+					label: 'Save',
+					variant: 'solid',
+					loading: $site?.updateBackupSchedule?.loading,
+					onClick: save,
+				},
+			],
+		}"
+	>
+		<template #body-content>
+			<div class="flex flex-col gap-4">
+				<Switch
+					v-model="custom"
+					label="Pick backup times"
+					description="Move backups off your working hours instead of leaving them to the default schedule"
+				/>
+
+				<p v-if="!custom" class="text-base text-ink-gray-6">
+					Backups are taken automatically every 6 hours.
+				</p>
+
+				<div v-else class="flex flex-col gap-3">
+					<div
+						v-for="(time, index) in times"
+						:key="index"
+						class="flex items-center gap-2"
+					>
+						<FormControl
+							class="w-full"
+							type="time"
+							v-model="times[index]"
+						/>
+						<Button
+							v-if="times.length > 1"
+							icon="x"
+							@click="times.splice(index, 1)"
+						/>
+					</div>
+
+					<Button
+						v-if="times.length < maximumTimes"
+						class="w-fit"
+						icon-left="plus"
+						@click="addTime"
+					>
+						Add time
+					</Button>
+
+					<p class="text-p-sm text-ink-gray-5">
+						Times are in your timezone ({{ timezone }}). A backup starts
+						within the hour you pick, and replaces the default 6 hourly
+						schedule.
+					</p>
+				</div>
+
+				<ErrorMessage :message="errorMessage" />
+			</div>
+		</template>
+	</Dialog>
+</template>
+
+<script>
+import { Switch, getCachedDocumentResource } from 'frappe-ui';
+import { toast } from 'vue-sonner';
+import dayjs, { timeLocal, timeServer } from '../../utils/dayjs';
+import { getToastErrorMessage } from '../../utils/toast';
+
+export default {
+	props: ['site'],
+	components: { Switch },
+	data() {
+		return {
+			show: true,
+			custom: false,
+			times: ['02:00'],
+			maximumTimes: 4,
+			errorMessage: null,
+		};
+	},
+	mounted() {
+		this.$site.getBackupSchedule.submit().then((schedule) => {
+			this.custom = schedule.custom;
+			if (schedule.times.length) {
+				this.times = schedule.times.map(timeLocal);
+			}
+		});
+	},
+	computed: {
+		$site() {
+			return getCachedDocumentResource('Site', this.site);
+		},
+		timezone() {
+			return dayjs.tz.guess();
+		},
+	},
+	methods: {
+		addTime() {
+			// An hour after the last one, so a fresh row doesn't land in a taken hour
+			let last = this.times[this.times.length - 1] || '01:00';
+			this.times.push(dayjs(`2000-01-01 ${last}`).add(1, 'hour').format('HH:mm'));
+		},
+		save() {
+			this.errorMessage = this.validate();
+			if (this.errorMessage) return;
+
+			let promise = this.$site.updateBackupSchedule.submit({
+				times: this.custom ? this.times.map(timeServer) : [],
+			});
+			toast.promise(promise, {
+				loading: 'Saving backup schedule...',
+				success: () => {
+					this.show = false;
+					return 'Backup schedule saved.';
+				},
+				error: (e) => getToastErrorMessage(e),
+			});
+		},
+		validate() {
+			if (!this.custom) return null;
+			if (this.times.some((time) => !time))
+				return 'Pick a time for every backup.';
+			// The scheduler runs once an hour, so two backups in the same hour
+			// would silently collapse into one.
+			let hours = this.times.map((time) => timeServer(time).split(':')[0]);
+			if (new Set(hours).size !== hours.length)
+				return 'Backups have to be at least an hour apart.';
+			return null;
+		},
+	},
+};
+</script>

--- a/dashboard/src/objects/site.js
+++ b/dashboard/src/objects/site.js
@@ -1,4 +1,10 @@
-import { Badge, createListResource, createResource, LoadingIndicator } from 'frappe-ui'
+import {
+	Badge,
+	createListResource,
+	createResource,
+	LoadingIndicator,
+	Tooltip,
+} from 'frappe-ui'
 import { defineAsyncComponent, h } from 'vue'
 import { toast } from 'vue-sonner'
 import ArrowLeftRightIcon from '~icons/lucide/arrow-left-right'
@@ -869,9 +875,14 @@ export default {
 					secondaryAction({ documentResource: site }) {
 						if (site.doc?.status !== 'Active') return null
 						return {
-							label: 'Schedule',
+							label: 'Backup Schedule',
 							slots: {
-								prefix: icon('clock'),
+								icon: () =>
+									h(
+										Tooltip,
+										{ text: 'Backup Schedule' },
+										icon('settings'),
+									),
 							},
 							onClick() {
 								renderDialog(

--- a/dashboard/src/objects/site.js
+++ b/dashboard/src/objects/site.js
@@ -60,6 +60,8 @@ export default {
 		addTag: 'add_resource_tag',
 		removeTag: 'remove_resource_tag',
 		getBackupDownloadLink: 'get_backup_download_link',
+		getBackupSchedule: 'get_backup_schedule',
+		updateBackupSchedule: 'update_backup_schedule',
 		fetchDatabaseTableSchemas: 'fetch_database_table_schemas',
 		fetchSitesDataForExport: 'fetch_sites_data_for_export',
 	},
@@ -859,6 +861,26 @@ export default {
 											site: site.name,
 											onScheduleBackupSuccess: () => backups.reload(),
 										},
+									),
+								)
+							},
+						}
+					},
+					secondaryAction({ documentResource: site }) {
+						if (site.doc?.status !== 'Active') return null
+						return {
+							label: 'Schedule',
+							slots: {
+								prefix: icon('clock'),
+							},
+							onClick() {
+								renderDialog(
+									h(
+										defineAsyncComponent(
+											() =>
+												import('../components/site/SiteBackupScheduleDialog.vue'),
+										),
+										{ site: site.name },
 									),
 								)
 							},

--- a/dashboard/src/utils/dayjs.js
+++ b/dashboard/src/utils/dayjs.js
@@ -27,6 +27,21 @@ export function dayjsIST(dateTimeString) {
 	return dayjs(dateTimeString).tz('Asia/Calcutta');
 }
 
+// Times of day (HH:mm) with no date of their own. Anchoring them to today keeps
+// the offset right for timezones that observe DST.
+export function timeLocal(serverTime) {
+	return convertTimeOfDay(serverTime, 'Asia/Calcutta', dayjs.tz.guess());
+}
+
+export function timeServer(localTime) {
+	return convertTimeOfDay(localTime, dayjs.tz.guess(), 'Asia/Calcutta');
+}
+
+function convertTimeOfDay(time, from, to) {
+	const today = dayjs().format('YYYY-MM-DD');
+	return dayjs.tz(`${today} ${time}`, from).tz(to).format('HH:mm');
+}
+
 export function dayjsFloorToMinutes(d, interval) {
 	const minutes = d.minute();
 	const floored = Math.floor(minutes / interval) * interval;

--- a/press/press/doctype/site/backups.py
+++ b/press/press/doctype/site/backups.py
@@ -265,11 +265,7 @@ class ScheduledBackupJob:
 			self.sites_without_offsite = []
 
 	def take_offsite(self, site: frappe._dict, day: datetime.date) -> bool:
-		return (
-			self.offsite_setup
-			and site.name not in self.sites_without_offsite
-			and not SiteBackup.offsite_backup_exists(site.name, day)
-		)
+		return should_take_offsite_backup(site.name, day, self.offsite_setup, self.sites_without_offsite)
 
 	def get_site_time(self, site: dict[str, str]) -> datetime:
 		timezone = site.timezone or "Asia/Kolkata"
@@ -345,6 +341,17 @@ class ScheduledBackupJob:
 			frappe.db.rollback()
 
 
+def should_take_offsite_backup(
+	site: str, day: datetime.date, offsite_setup: bool, sites_without_offsite: list[str]
+) -> bool:
+	"""Offsite backups go out once a day, and only on plans that include them."""
+	return (
+		offsite_setup
+		and site not in sites_without_offsite
+		and not SiteBackup.offsite_backup_exists(site, day)
+	)
+
+
 def schedule_logical_backups_for_sites_with_backup_time():
 	"""
 	Schedule logical backups for sites with backup time.
@@ -352,9 +359,20 @@ def schedule_logical_backups_for_sites_with_backup_time():
 	Run this hourly only
 	"""
 	sites = Site.get_sites_with_backup_time("Logical")
+	if not sites:
+		return
+
+	day = frappe.utils.getdate()
+	offsite_setup = PressSettings.is_offsite_setup()
+	sites_without_offsite = Subscription.get_sites_without_offsite_backups()
 	for site in sites:
+		offsite = should_take_offsite_backup(site.name, day, offsite_setup, sites_without_offsite)
 		site_doc: Site = frappe.get_doc("Site", site.name)
-		site_doc.backup(with_files=True, offsite=True, physical=False)
+		site_doc.backup(
+			with_files=offsite or not SiteBackup.file_backup_exists(site.name, day),
+			offsite=offsite,
+			physical=False,
+		)
 		frappe.db.commit()
 
 

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -103,8 +103,6 @@ from press.utils import (
 from press.utils.dns import _change_dns_record, check_dns_cname_a, create_dns_record
 
 if TYPE_CHECKING:
-	from datetime import datetime
-
 	from frappe.types import DF
 	from frappe.types.DF import Table
 
@@ -135,6 +133,10 @@ SERVER_SCRIPT_DISABLED_VERSION = (
 	15  # version from which server scripts were disabled on public benches. No longer set in site
 )
 TRANSITORY_STATES = ["Updating", "Recovering", "Pending", "Installing"]
+
+# Matches the four backups a day a site gets on the default schedule, so moving
+# backups off working hours doesn't turn into asking for more of them.
+MAXIMUM_CUSTOM_BACKUP_TIMES = 4
 
 # Conditions a site must satisfy for the agent to stream offsite backup
 # artifacts straight to S3 instead of uploading them after the dump finishes.
@@ -727,6 +729,34 @@ class Site(Document, TagHelpers):
 				frappe.throw(
 					f"Multiple backups have been scheduled at following hour {h}:00:00. Please configure the newer custom backup hours to a different time of the day."
 				)
+
+	@dashboard_whitelist()
+	def get_backup_schedule(self) -> dict:
+		"""Times are on the server's clock, same as the scheduler reads them."""
+		return {
+			"custom": bool(self.schedule_logical_backup_at_custom_time),
+			"times": sorted(
+				frappe.utils.get_time(row.backup_time).strftime("%H:%M") for row in self.logical_backup_times
+			),
+		}
+
+	@dashboard_whitelist()
+	@site_action(["Active"])
+	def update_backup_schedule(self, times: list[str] | None = None):
+		"""Replace the site's custom backup times. No times means back to the default schedule.
+
+		Only logical backups. Physical backups deactivate the site while they run,
+		so they stay behind `allow_physical_backup_by_user`.
+		"""
+		times = [parse_backup_time(time) for time in times or []]
+		if len(times) > MAXIMUM_CUSTOM_BACKUP_TIMES:
+			frappe.throw(f"A site can have at most {MAXIMUM_CUSTOM_BACKUP_TIMES} backups a day.")
+
+		self.logical_backup_times = []
+		for backup_time in times:
+			self.append("logical_backup_times", {"backup_time": backup_time})
+		self.schedule_logical_backup_at_custom_time = bool(times)
+		self.save()
 
 	def capture_signup_event(self, event: str):
 		team = frappe.get_doc("Team", self.team)
@@ -4500,6 +4530,13 @@ class Site(Document, TagHelpers):
 		if not d:
 			return None
 		return str(timedelta(seconds=round(d.total_seconds() * 2)))
+
+
+def parse_backup_time(time: str) -> str:
+	try:
+		return datetime.strptime(time, "%H:%M").strftime("%H:%M:00")
+	except (TypeError, ValueError):
+		frappe.throw(f"{time} is not a valid backup time. Use HH:MM.")
 
 
 def get_inbound_ip(server: str) -> str | None:

--- a/press/press/doctype/site/test_backups.py
+++ b/press/press/doctype/site/test_backups.py
@@ -5,6 +5,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from press.press.doctype.agent_job.agent_job import AgentJob
+from press.press.doctype.press_settings.press_settings import PressSettings
 from press.press.doctype.site.backups import (
 	ScheduledBackupJob,
 	schedule_logical_backups_for_sites_with_backup_time,
@@ -13,6 +14,7 @@ from press.press.doctype.site.backups import (
 from press.press.doctype.site.site import Site
 from press.press.doctype.site.test_site import create_test_site
 from press.press.doctype.site_backup.test_site_backup import create_test_site_backup
+from press.press.doctype.subscription.subscription import Subscription
 
 
 @patch("press.press.doctype.site.backups.frappe.db.commit", new=MagicMock)
@@ -236,6 +238,40 @@ class TestScheduledBackupJob(FrappeTestCase):
 			schedule_logical_backups_for_sites_with_backup_time()
 		mock_backup.assert_called_once()
 		mock_backup.reset_mock()
+
+	def _create_site_with_backup_times(self, *times: str) -> Site:
+		site: Site = create_test_site()
+		site.update_backup_schedule(list(times))
+		return site
+
+	def test_custom_time_backup_is_not_offsite_on_a_plan_without_offsite_backups(self):
+		site = self._create_site_with_backup_times("00:00")
+
+		with (
+			patch.object(PressSettings, "is_offsite_setup", return_value=True),
+			patch.object(Subscription, "get_sites_without_offsite_backups", return_value=[site.name]),
+			self.freeze_time("2021-01-01 00:00"),
+		):
+			schedule_logical_backups_for_sites_with_backup_time()
+
+		self.assertEqual(self._offsite_count(site.name), 0)
+		self.assertEqual(frappe.db.count("Site Backup", {"site": site.name}), 1)
+
+	def test_custom_time_backups_go_offsite_only_once_a_day(self):
+		site = self._create_site_with_backup_times("00:00", "01:00")
+
+		with (
+			patch.object(PressSettings, "is_offsite_setup", return_value=True),
+			patch.object(Subscription, "get_sites_without_offsite_backups", return_value=[]),
+		):
+			with self.freeze_time("2021-01-01 00:00"):
+				schedule_logical_backups_for_sites_with_backup_time()
+			frappe.get_last_doc("Site Backup", {"site": site.name}).db_set("status", "Success")
+			with self.freeze_time("2021-01-01 01:00"):
+				schedule_logical_backups_for_sites_with_backup_time()
+
+		self.assertEqual(self._offsite_count(site.name), 1)
+		self.assertEqual(frappe.db.count("Site Backup", {"site": site.name}), 2)
 
 
 @patch.object(AgentJob, "after_insert", new=Mock())

--- a/press/press/doctype/site/test_backups.py
+++ b/press/press/doctype/site/test_backups.py
@@ -236,3 +236,60 @@ class TestScheduledBackupJob(FrappeTestCase):
 			schedule_logical_backups_for_sites_with_backup_time()
 		mock_backup.assert_called_once()
 		mock_backup.reset_mock()
+
+
+@patch.object(AgentJob, "after_insert", new=Mock())
+class TestBackupSchedule(FrappeTestCase):
+	"""The backup schedule as the dashboard reads and writes it."""
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_setting_backup_times_takes_the_site_off_the_default_schedule(self):
+		site: Site = create_test_site()
+
+		site.update_backup_schedule(["02:00", "14:00"])
+
+		site.reload()
+		self.assertEqual(site.get_backup_schedule(), {"custom": True, "times": ["02:00", "14:00"]})
+		self.assertNotIn(site.name, [s.name for s in Site.get_sites_for_backup(6)])
+
+	def test_clearing_backup_times_returns_the_site_to_the_default_schedule(self):
+		site: Site = create_test_site()
+		site.update_backup_schedule(["02:00"])
+		site.reload()
+
+		site.update_backup_schedule([])
+
+		site.reload()
+		self.assertEqual(site.get_backup_schedule(), {"custom": False, "times": []})
+
+	def test_backup_schedule_rejects_more_than_four_times_a_day(self):
+		site: Site = create_test_site()
+
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"at most 4 backups a day",
+			site.update_backup_schedule,
+			["01:00", "02:00", "03:00", "04:00", "05:00"],
+		)
+
+	def test_backup_schedule_rejects_a_time_that_is_not_hh_mm(self):
+		site: Site = create_test_site()
+
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"not a valid backup time",
+			site.update_backup_schedule,
+			["2 AM"],
+		)
+
+	def test_backup_schedule_rejects_two_backups_in_the_same_hour(self):
+		site: Site = create_test_site()
+
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"Multiple backups have been scheduled",
+			site.update_backup_schedule,
+			["02:00", "02:30"],
+		)


### PR DESCRIPTION
Closes #2408

Users open tickets asking us to move their site's backup time because the default 6-hourly schedule lands in their working hours and slows the site down. We change it from desk today. This lets them do it themselves.

`Site` already has `logical_backup_times` and `schedule_logical_backup_at_custom_time` driving `schedule_logical_backups_for_sites_with_backup_time`. Nothing new on the scheduling side — this exposes what's there.

## What it does

**Sites → Backups → Schedule** opens a dialog to switch from the default schedule to up to four times of day.

- Times are stored on the server's clock, the same way the scheduler reads them, and shown in the viewer's timezone — consistent with `dayjsLocal` and every other time in the dashboard.
- Capped at four a day to match the four the default schedule gives, so moving backups off working hours doesn't become a way to ask for more of them.
- Clearing the times puts the site back on the default schedule.
- Writes go through `update_backup_schedule` only; the child table isn't in `dashboard_fields`, so the cap and the enable flag can't be bypassed via `set_value`.

Logical backups only. Physical backups deactivate the site while they run, so they stay behind `allow_physical_backup_by_user`.

## Included fix

`schedule_logical_backups_for_sites_with_backup_time` passed `offsite=True, with_files=True` unconditionally, so a site on a plan without offsite backups got them anyway — once per configured time rather than once a day. That was survivable while backup times were desk-only. It isn't once any user can set them, so the second commit makes that path reuse the entitlement rules the default scheduler already applies.

## Testing

`bench --site <site> run-tests --app press --module press.press.doctype.site.test_backups` — 14 tests, all passing (7 new, 7 pre-existing).

Covered: custom times take the site off the default schedule, clearing returns it, the four-a-day cap, malformed times, two backups in the same hour, and both sides of the offsite entitlement fix.