### PR TITLE
fix(billing): Price audit log storage per GB per month

### DIFF
--- a/dashboard/src/components/server/ConfigureDatabaseAuditTrailDialog.vue
+++ b/dashboard/src/components/server/ConfigureDatabaseAuditTrailDialog.vue
@@ -67,7 +67,7 @@
 					<p v-if="price" class="text-ink-gray-6 text-p-sm">
 						Stored logs are billed at
 						<span class="font-medium text-ink-gray-8">{{ price }}</span>
-						per GB stored, charged daily, and deleted once they pass the
+						per GB per month, charged daily, and deleted once they pass the
 						retention period.
 					</p>
 				</template>

--- a/press/fixtures/s3_storage_plan.json
+++ b/press/fixtures/s3_storage_plan.json
@@ -5,8 +5,8 @@
 		"enabled": 1,
 		"modified": "2026-08-11 00:00:00.000000",
 		"name": "Audit Log Storage plan",
-		"price_inr": 1.886,
-		"price_usd": 0.023,
+		"price_inr": 2.0,
+		"price_usd": 0.025,
 		"title": "Audit Log Storage plan"
 	}
 ]


### PR DESCRIPTION
Follow-up to #7190, which shipped the `S3 Storage Plan` fixture and the audit trail dialog.

### Pricing

`0.023` USD per GB per month is exactly AWS S3 Standard list price, so Press earned nothing over its own storage bill while still paying for PUT requests and absorbing the `0.001 MB` floor that `to_mb()` applies to tiny gzipped logs. Raised to `0.025`.

The rupee price moves from `1.886` to `2.0`. The other storage plans price at roughly 80x the dollar figure — `Add-on Storage plan` is `0.2` / `16.4` and `EBS Snapshot Plan` is `0.08` / `6.5` — and `2.0` / `0.025` keeps that.

### Dialog copy

The configure dialog said stored logs are billed at `₹1.886` "per GB stored, charged daily", which reads as a daily rate. `Subscription.create_usage_record` computes `price / plan.period`, and `Plan.period` is the number of days in the current month, so the stored number is a monthly price. It now says "per GB per month, charged daily".

The invoice label stays `Audit Log Storage ₹2/GB` to match its sibling `Storage Add-on ₹16.4/GB`, which is a monthly per-GB price too.

### Note, not addressed here

`flt(price_per_day * gb, 2)` rounds each day's amount to two decimals. At `0.025`/GB-month the daily rate is `$0.0008`/GB, so a dollar-billed team storing under ~6 GB rounds to `$0.00` every day. `Server Snapshot Plan` and `additional_storage` share this, so it is a platform-wide rounding floor rather than anything introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtY8hShXthLb2HNYThbv8K