### PR TITLE
feat(site): Let allowed teams skip backups on public benches

### DIFF
--- a/dashboard/src/components/SiteUpdateDialog.vue
+++ b/dashboard/src/components/SiteUpdateDialog.vue
@@ -24,7 +24,7 @@
 							label="Skip taking backup for this update"
 							type="checkbox"
 							v-model="skipBackups"
-							v-if="!$site.doc.group_public"
+							v-if="$site.doc.can_skip_backups"
 						/>
 						<div
 							class="flex items-center rounded border border-outline-gray-1 bg-surface-gray-2 p-4 text-sm text-ink-gray-6"

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -392,6 +392,7 @@ class Site(Document, TagHelpers):
 		doc.version = group.version
 		doc.group_team = group.team
 		doc.group_public = group.public or group.central_bench
+		doc.can_skip_backups = self.can_skip_backups
 		doc.latest_frappe_version = frappe.db.get_value(
 			"Frappe Version", {"status": "Stable", "public": True}, order_by="name desc"
 		)
@@ -1510,6 +1511,7 @@ class Site(Document, TagHelpers):
 		scheduled_time: str | None = None,
 	):
 		log_site_activity(self.name, "Update")
+		self.validate_skipping_backups(skip_backups)
 
 		doc = frappe.get_doc(
 			{
@@ -1532,12 +1534,21 @@ class Site(Document, TagHelpers):
 		skip_backups: bool = False,
 		scheduled_time: str | None = None,
 	):
+		self.validate_skipping_backups(skip_backups)
+
 		doc = frappe.get_doc("Site Update", name)
 		doc.skipped_failing_patches = skip_failing_patches
 		doc.skipped_backups = skip_backups
 		doc.scheduled_time = scheduled_time
 		doc.save()
 		return doc.name
+
+	def validate_skipping_backups(self, skip_backups: bool):
+		if not skip_backups or self.can_skip_backups:
+			return
+		frappe.throw(
+			"Backups can't be skipped for sites on a public bench. Please contact support to allow your team to skip them."
+		)
 
 	@dashboard_whitelist()
 	def cancel_scheduled_update(self, site_update: str):
@@ -3728,6 +3739,16 @@ class Site(Document, TagHelpers):
 	@cached_property
 	def is_group_public(self):
 		return bool(frappe.get_cached_value("Release Group", self.group, "public"))
+
+	@property
+	def can_skip_backups(self) -> bool:
+		"""Sites on a public bench can skip backups only if their team is allowed to."""
+		group = frappe.get_cached_value(
+			"Release Group", self.group, ["public", "central_bench"], as_dict=True
+		)
+		if not (group.public or group.central_bench):
+			return True
+		return bool(frappe.db.get_value("Team", self.team, "skip_backups"))
 
 	@dashboard_whitelist()
 	@redis_cache(ttl=60)

--- a/press/press/doctype/site_update/test_site_update.py
+++ b/press/press/doctype/site_update/test_site_update.py
@@ -940,3 +940,58 @@ class TestSiteUpdate(FrappeTestCase):
 			"too large to update without a physical backup",
 			site_update.validate_backup_type_for_large_database,
 		)
+
+
+@patch.object(AgentJob, "enqueue_http_request", new=Mock())
+class TestSkipBackupsPermission(FrappeTestCase):
+	"""Only teams allowed to skip backups may do so for sites on a public bench."""
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def _create_updatable_site(self, public_group: bool) -> Site:
+		group = create_test_release_group([create_test_app()], public=public_group)
+		bench = create_test_bench(group=group)
+		destination_bench = create_test_bench(group=group, server=bench.server)
+		create_test_deploy_candidate_differences(destination_bench.candidate)
+		return create_test_site(bench=bench.name)
+
+	def test_site_on_private_bench_can_skip_backups(self):
+		site = self._create_updatable_site(public_group=False)
+
+		self.assertTrue(site.can_skip_backups)
+		self.assertTrue(site.schedule_update(skip_backups=True))
+
+	def test_site_on_public_bench_cannot_skip_backups_by_default(self):
+		site = self._create_updatable_site(public_group=True)
+
+		self.assertFalse(site.can_skip_backups)
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"Backups can't be skipped for sites on a public bench",
+			site.schedule_update,
+			skip_backups=True,
+		)
+		self.assertFalse(frappe.db.exists("Site Update", {"site": site.name}))
+
+	def test_site_on_public_bench_can_skip_backups_when_team_is_allowed(self):
+		site = self._create_updatable_site(public_group=True)
+		frappe.db.set_value("Team", site.team, "skip_backups", 1)
+
+		self.assertTrue(site.can_skip_backups)
+		site_update = site.schedule_update(skip_backups=True)
+
+		self.assertTrue(frappe.db.get_value("Site Update", site_update, "skipped_backups"))
+
+	def test_scheduled_update_on_public_bench_cannot_be_edited_to_skip_backups(self):
+		site = self._create_updatable_site(public_group=True)
+		site_update = site.schedule_update()
+
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"Backups can't be skipped for sites on a public bench",
+			site.edit_scheduled_update,
+			name=site_update,
+			skip_backups=True,
+		)
+		self.assertFalse(frappe.db.get_value("Site Update", site_update, "skipped_backups"))


### PR DESCRIPTION
Closes #2480

## Problem

Sites on a public (or central) bench never saw the "Skip taking backup for this update" checkbox — the site update dialog hid it with `v-if="!$site.doc.group_public"`. Users on shared benches had no way to skip the pre-update backup from the dashboard.

Meanwhile Team already has an `skip_backups` field labelled *"Allow to skip Backups"* with the description *"If checked, team can skip backups for site update"*, but the only place that honoured it was the bench group update dialog. Nothing enforced it on the server, so `Site.schedule_update(skip_backups=True)` accepted the flag from anyone calling the API directly, regardless of bench or team.

## Change

Make the team flag the single gate. A site can skip backups when its bench group is private, or when its team has been allowed to skip them:

- `Site.can_skip_backups` — the rule, in one place, exposed on the site document so the dashboard and the API can't drift.
- The site update dialog now shows the checkbox based on `can_skip_backups` instead of `group_public`. Nothing changes for private benches; public-bench users see it once their team is allowed.
- `schedule_update` and `edit_scheduled_update` validate the flag, so the permission holds for direct API callers too, not just the dialog.

Enabling it stays a support/admin action (the Team checkbox in desk) rather than something self-serve, since skipping a backup means a failed update can't be rolled back.

## Tests

Added `TestSkipBackupsPermission` in `test_site_update.py`, covering the private bench case, the public bench default, the public bench with the team flag set, and editing a scheduled update.

## Note

`SiteVersionUpgradeDialog.vue` still offers "Skip backups" with no gate at all, and `Site Migration` has no skip-backup option. Both are out of scope here — happy to follow up if we want the same rule applied across all update flows.
