### PR TITLE
fix(database-server): Fix the audit transition jobs racing the row

### DIFF
--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -1402,6 +1402,8 @@ class DatabaseServer(BaseServer):
 		alone because a combined save can order a server_audit_* line above plugin-load-add,
 		which also stops it booting. Restarts MariaDB unless the line is already there.
 		"""
+		# The log directory play took minutes, so this row has moved on
+		self.reload()
 		self.add_or_update_mariadb_variable(
 			"plugin_load_add",
 			"value_str",
@@ -1413,6 +1415,8 @@ class DatabaseServer(BaseServer):
 		)
 
 	def configure_server_audit_plugin(self):
+		# Loading the plugin restarted MariaDB, so this row has moved on
+		self.reload()
 		for variable, value_type, value in self.server_audit_variables:
 			self.add_or_update_mariadb_variable(variable, value_type, value, persist=True, save=False)
 		self.flags.update_mariadb_system_variables_synchronously = True

--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -1349,6 +1349,8 @@ class DatabaseServer(BaseServer):
 	def _enable_database_audit_log(self):
 		"""Reconciling inside the try keeps a failure from leaving billing on."""
 		try:
+			# Don't let two transitions drive MariaDB at once
+			frappe.get_value(self.doctype, self.name, "status", for_update=True)
 			self.setup_mysql_log_directory()
 			self.load_server_audit_plugin()
 			self.configure_server_audit_plugin()
@@ -1374,6 +1376,8 @@ class DatabaseServer(BaseServer):
 
 	def _update_database_audit_log(self):
 		"""server_audit_events is dynamic, so the new mode applies without a restart."""
+		# Don't let two transitions drive MariaDB at once
+		frappe.get_value(self.doctype, self.name, "status", for_update=True)
 		self.configure_server_audit_plugin()
 		if not self.reconcile_audit_log_state():
 			frappe.throw(f"MariaDB on {self.name} stopped logging while its capture mode was changed.")
@@ -1459,6 +1463,8 @@ class DatabaseServer(BaseServer):
 		# plugin_load_add is left alone: add_or_update_mariadb_variable has no removal path,
 		# and a loaded plugin with logging off writes nothing.
 		try:
+			# Don't let two transitions drive MariaDB at once
+			frappe.get_value(self.doctype, self.name, "status", for_update=True)
 			self.add_or_update_mariadb_variable(
 				"server_audit_logging",
 				"value_str",


### PR DESCRIPTION
Enabling the audit trail fails with a timestamp mismatch (`Document has been modified after you have opened it`) on the way to MariaDB.

`_enable_database_audit_log` runs as one background job holding a single in-memory copy of the Database Server, and two of its steps are slow: `setup_mysql_log_directory()` runs an Ansible play, and `load_server_audit_plugin()` saves a variable that restarts MariaDB synchronously. Anything that writes the row during those minutes — an agent job callback, the hourly `upload_audit_logs_to_s3`, a variable sync — bumps `modified`, and the next `self.save()` throws.

### Reload before each save

Fixes the mismatch. This is what the rest of `database_server.py` does after an Ansible run (`play = ansible.run()` then `self.reload()`, at lines 918, 1002, 1081, 1110 and others). Neither method holds unsaved state at that point, so the reload cannot discard anything: `configure_server_audit_plugin` reloads, then appends its variables, then saves.

### Lock the row for the transition

`frappe.get_value(self.doctype, self.name, "status", for_update=True)`, taken by `_enable_database_audit_log`, `_update_database_audit_log` and `_disable_database_audit_log`. Two of these driving MariaDB at once would race — an enable configuring the plugin while a disable turns logging off leaves the flag and the subscription describing a server that isn't doing what they say. All three take it, since a lock only one path takes excludes nothing.

Worth knowing about its scope:

- It is released at the first `COMMIT`, and these jobs commit more than once (`reconcile_audit_log_state()` commits, and so does the synchronous variable-update job). So it covers the plays, not the whole job — the reload above is what actually keeps a concurrent writer from failing a save.
- It serialises rather than rejects: a second transition waits and then runs.
- In `_enable_database_audit_log` and `_disable_database_audit_log` it sits inside the existing `try`, so a lock wait that exceeds `innodb_lock_wait_timeout` surfaces as `QueryTimeoutError`, drops the subscription and settles the status instead of stranding the dialog in `Enabling`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtY8hShXthLb2HNYThbv8K