### PR TITLE
fix(dashboard): Name the currency in the audit log price

### DIFF
--- a/dashboard/src/components/server/ConfigureDatabaseAuditTrailDialog.vue
+++ b/dashboard/src/components/server/ConfigureDatabaseAuditTrailDialog.vue
@@ -188,8 +188,8 @@ export default {
 			const plan = this.$resources.s3StoragePlan.data?.[0]
 			if (!plan) return null
 			return this.$team.doc.currency === 'INR'
-				? `₹${plan.price_inr}`
-				: `$${plan.price_usd}`
+				? `${plan.price_inr} INR`
+				: `${plan.price_usd} USD`
 		},
 	},
 	methods: {


### PR DESCRIPTION
The audit trail dialog prints the storage price inside a sentence — "Stored logs are billed at **₹2** per GB per month, charged daily, and deleted once they pass the retention period." A bare symbol in running prose is easy to skim past, so it now reads `2 INR` / `0.025 USD`.

Note that the rest of the dashboard prints the symbol (`$team.doc.currency === 'INR' ? '₹' : '$'` in `BuyPrepaidCreditsForm.vue`, `billing/PrepaidCreditsForm.vue`, `PlansCards.vue`), where the price stands alone in a field or a plan card rather than mid-sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtY8hShXthLb2HNYThbv8K