### PR TITLE
feat(agent-update): Handle play failures and let servers opt out

### DIFF
--- a/press/press/doctype/agent_update/agent_update.py
+++ b/press/press/doctype/agent_update/agent_update.py
@@ -614,17 +614,17 @@ class AgentUpdate(Document):
 		)
 
 	def _update_agent_on_server(self):
-		current_agent_update_to_process = self.current_agent_update_to_process
-		server_doc = frappe.get_doc(
-			current_agent_update_to_process.server_type, current_agent_update_to_process.server
-		)
+		agent_update_server = self.current_agent_update_to_process
+		is_rollback = agent_update_server.status == "Rolling Back"
+		try:
+			self._run_agent_update_play(agent_update_server, is_rollback)
+		except Exception:
+			frappe.db.rollback()
+			self._fail_agent_update_play(agent_update_server, is_rollback)
 
-		is_rollback = False
-		if current_agent_update_to_process.status == "Rolling Back":
-			is_rollback = True
-		commit = self.commit_hash
-		if is_rollback:
-			commit = current_agent_update_to_process.rollback_commit
+	def _run_agent_update_play(self, agent_update_server: AgentUpdateServer, is_rollback: bool):
+		server_doc = frappe.get_doc(agent_update_server.server_type, agent_update_server.server)
+		commit = agent_update_server.rollback_commit if is_rollback else self.commit_hash
 
 		play = Ansible(
 			playbook="update_agent.yml",
@@ -638,24 +638,40 @@ class AgentUpdate(Document):
 			port=server_doc._ssh_port(),
 		)
 
-		data_to_update = {
-			"start": frappe.utils.now_datetime(),
-		}
-
-		if is_rollback:
-			data_to_update["rollback_ansible_play"] = play.play
-		else:
-			data_to_update["update_ansible_play"] = play.play
-
+		play_field = "rollback_ansible_play" if is_rollback else "update_ansible_play"
 		frappe.db.set_value(
 			"Agent Update Server",
-			current_agent_update_to_process.name,
-			data_to_update,
+			agent_update_server.name,
+			{"start": frappe.utils.now_datetime(), play_field: play.play},
 			update_modified=False,
 		)
 		frappe.db.commit()
 
 		play.run()
+
+	def _fail_agent_update_play(self, agent_update_server: AgentUpdateServer, is_rollback: bool):
+		"""The play can blow up before it records a status, so mark the failure ourselves."""
+		frappe.log_error(
+			"Agent Update Play Failed",
+			reference_doctype=self.doctype,
+			reference_name=self.name,
+		)
+
+		# A failed update still gets rolled back, a failed rollback has nowhere left to go
+		data_to_update = {
+			"status": "Fatal" if is_rollback else "Failure",
+			"end": frappe.utils.now_datetime(),
+		}
+		if is_rollback:
+			data_to_update["reason_of_fatal_status"] = "Rollback play failed to run. Check the error log."
+
+		frappe.db.set_value(
+			"Agent Update Server",
+			agent_update_server.name,
+			data_to_update,
+			update_modified=False,
+		)
+		frappe.db.commit()
 
 	@property
 	def github_access_token_header(self):

--- a/press/press/doctype/agent_update/agent_update.py
+++ b/press/press/doctype/agent_update/agent_update.py
@@ -190,7 +190,7 @@ class AgentUpdate(Document):
 		self.add_server_entries()
 
 	def add_server_entries(self):
-		filters = {"status": "Active"}
+		filters = {"status": "Active", "disable_agent_update": 0}
 		if self.exclude_self_hosted_servers:
 			filters.update({"is_self_hosted": 0})
 
@@ -501,6 +501,12 @@ class AgentUpdate(Document):
 		"""
 
 		if current_agent_update_to_process.status == "Pending":
+			# The server can be opted out after the plan was made
+			if self._is_agent_update_disabled(current_agent_update_to_process):
+				current_agent_update_to_process.status = "Skipped"
+				self.save(ignore_version=True)
+				return False
+
 			if (
 				self.run_on_fewer_servers_and_pause
 				and not self.paused_due_to_test_mode
@@ -594,6 +600,13 @@ class AgentUpdate(Document):
 			self.save()
 
 		return False
+
+	def _is_agent_update_disabled(self, agent_update_server: AgentUpdateServer) -> bool:
+		return bool(
+			frappe.db.get_value(
+				agent_update_server.server_type, agent_update_server.server, "disable_agent_update"
+			)
+		)
 
 	def _halt_agent_jobs(self, agent_update_server: AgentUpdateServer):
 		frappe.db.set_value(

--- a/press/press/doctype/database_server/database_server.json
+++ b/press/press/doctype/database_server/database_server.json
@@ -22,6 +22,7 @@
 		"is_self_hosted",
 		"enable_physical_backup",
 		"halt_agent_jobs",
+		"disable_agent_update",
 		"enable_schema_size_parser",
 		"column_break_qsqm",
 		"is_server_setup",
@@ -243,6 +244,13 @@
 			"fieldname": "halt_agent_jobs",
 			"fieldtype": "Check",
 			"label": "Halt Agent Jobs"
+		},
+		{
+			"default": "0",
+			"description": "Don't update the agent on this server",
+			"fieldname": "disable_agent_update",
+			"fieldtype": "Check",
+			"label": "Disable Agent Update"
 		},
 		{
 			"fieldname": "column_break_qsqm",
@@ -944,7 +952,7 @@
 			"link_fieldname": "database_server"
 		}
 	],
-	"modified": "2026-05-19 03:59:16.146497",
+	"modified": "2026-08-13 12:00:00.000000",
 	"modified_by": "Administrator",
 	"module": "Press",
 	"name": "Database Server",

--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -76,6 +76,7 @@ class DatabaseServer(BaseServer):
 		database_audit_log_max_disk_gb: DF.Int
 		database_audit_log_status: DF.Literal["Disabled", "Enabling", "Enabled", "Disabling"]
 		db_port: DF.Int
+		disable_agent_update: DF.Check
 		domain: DF.Link | None
 		enable_binlog_indexing: DF.Check
 		enable_binlog_upload_to_s3: DF.Check

--- a/press/press/doctype/proxy_server/proxy_server.json
+++ b/press/press/doctype/proxy_server/proxy_server.json
@@ -24,6 +24,7 @@
 		"team",
 		"public",
 		"halt_agent_jobs",
+		"disable_agent_update",
 		"exclude_from_auto_selection",
 		"storage_section",
 		"auto_add_storage_min",
@@ -441,6 +442,13 @@
 		},
 		{
 			"default": "0",
+			"description": "Don't update the agent on this server",
+			"fieldname": "disable_agent_update",
+			"fieldtype": "Check",
+			"label": "Disable Agent Update"
+		},
+		{
+			"default": "0",
 			"fieldname": "tls_certificate_renewal_failed",
 			"fieldtype": "Check",
 			"label": "TLS Certificate Renewal Failed",
@@ -499,7 +507,7 @@
 		}
 	],
 	"links": [],
-	"modified": "2026-03-15 19:01:43.557830",
+	"modified": "2026-08-13 12:00:00.000000",
 	"modified_by": "Administrator",
 	"module": "Press",
 	"name": "Proxy Server",

--- a/press/press/doctype/proxy_server/proxy_server.py
+++ b/press/press/doctype/proxy_server/proxy_server.py
@@ -35,6 +35,7 @@ class ProxyServer(BaseServer):
 		bastion_server: DF.Link | None
 		cluster: DF.Link | None
 		disable_agent_job_auto_retry: DF.Check
+		disable_agent_update: DF.Check
 		domain: DF.Link | None
 		domains: DF.Table[ProxyServerDomain]
 		enabled_default_routing: DF.Check

--- a/press/press/doctype/server/server.json
+++ b/press/press/doctype/server/server.json
@@ -33,6 +33,7 @@
 		"use_agent_job_callbacks",
 		"is_pyspy_setup",
 		"halt_agent_jobs",
+		"disable_agent_update",
 		"stop_deployments",
 		"is_for_recovery",
 		"is_monitoring_disabled",
@@ -643,6 +644,13 @@
 			"label": "Halt Agent Jobs"
 		},
 		{
+			"default": "0",
+			"description": "Don't update the agent on this server",
+			"fieldname": "disable_agent_update",
+			"fieldtype": "Check",
+			"label": "Disable Agent Update"
+		},
+		{
 			"default": "x86_64",
 			"fieldname": "platform",
 			"fieldtype": "Select",
@@ -844,7 +852,7 @@
 			"link_fieldname": "app_server"
 		}
 	],
-	"modified": "2026-06-18 10:49:09.702133",
+	"modified": "2026-08-13 12:00:00.000000",
 	"modified_by": "Administrator",
 	"module": "Press",
 	"name": "Server",

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1012,10 +1012,16 @@ class BaseServer(Document, TagHelpers):
 
 	@frappe.whitelist()
 	def update_agent_ansible(self):
+		self.validate_agent_update_allowed()
 		# ponytail: 1h, not the long queue's 1500s — a busy rq worker's warm shutdown alone is 1500s
 		frappe.enqueue_doc(self.doctype, self.name, "_update_agent_ansible", queue="long", timeout=3600)
 
+	def validate_agent_update_allowed(self):
+		if self.disable_agent_update:
+			frappe.throw(f"Agent update is disabled on {self.name}")
+
 	def _update_agent_ansible(self, throw_on_failure: bool = False):
+		self.validate_agent_update_allowed()
 		try:
 			agent_branch = frappe.get_value("Press Settings", "Press Settings", "branch")
 			if not agent_branch:
@@ -3065,6 +3071,7 @@ class Server(BaseServer):
 		database_server: DF.Link | None
 		db_healthcheck_token: DF.Password | None
 		disable_agent_job_auto_retry: DF.Check
+		disable_agent_update: DF.Check
 		domain: DF.Link | None
 		enable_logical_replication_during_site_update: DF.Check
 		enable_on_prem_failover_support: DF.Check


### PR DESCRIPTION
### Problem

- The Ansible play can fail before it records a status. The constructor fails on an SSH lookup, a bad playbook, or a failed `Ansible Play` insert. The `play.run()` call can also fail.
- When this occurs, the server stays in the `Running` state. There is no play to poll. Thus the update does not stop, and `halt_agent_jobs` stays on for that server.
- There is also no way to keep a server out of an agent update.

### Changes

- Catch the failure of the play. Set the server to `Failure`, so that it rolls back. Set it to `Fatal` if the rollback play is the play that failed. Write the traceback to the Error Log.
- Add a `Disable Agent Update` checkbox to Server, Database Server, and Proxy Server.
- The Agent Update tool does not add these servers. It also makes the check again before it starts a play, because you usually set the flag after the plan exists. Then the server becomes `Skipped`.
- A manual update throws an error. Thus the operator sees why the update did not start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
