### PR TITLE
fix(database-server): Break glass before a dashboard binlog purge

### DIFF
--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -2312,6 +2312,8 @@ Latest binlog : {latest_binlog.get("name", "")} - {last_binlog_size_mb} MB {last
 		This will purge binlogs from disk.
 		to_binlog and older binlogs will be purged.
 		"""
+		# A full disk starves the agent, and the purge itself is what makes the room back
+		broke_glass = self.break_glass_if_agent_disk_full()
 		try:
 			binlogs_in_disk = [r["name"] for r in self.get_binlogs_raw_data().get("binlogs_in_disk", [])]
 			prefix = to_binlog.split(".")[0] + "."
@@ -2323,6 +2325,8 @@ Latest binlog : {latest_binlog.get("name", "")} - {last_binlog_size_mb} MB {last
 			frappe.msgprint(f"Purged to {to_binlog}", "Successfully purged binlogs")
 			if self.enable_binlog_indexing:
 				self.sync_binlogs_info(index_binlogs=False, upload_binlogs=False)
+			if broke_glass:
+				self.restore_glass_file()
 		except Exception as e:
 			frappe.throw(f"Failed to purge binlogs. Please try again later. {e!s}")
 			raise e

--- a/press/press/doctype/database_server/test_database_server.py
+++ b/press/press/doctype/database_server/test_database_server.py
@@ -267,3 +267,44 @@ class TestDatabaseServer(FrappeTestCase):
 		from press.api.server import prometheus_instant_value
 
 		self.assertIsNone(prometheus_instant_value('mysql_up{instance="m1",job="mariadb"}'))
+
+	@patch.object(Agent, "purge_binlog", new=Mock())
+	@patch.object(
+		DatabaseServer,
+		"get_binlogs_raw_data",
+		new=Mock(return_value={"binlogs_in_disk": [{"name": "mysql-bin.000002"}]}),
+	)
+	@patch.object(BaseServer, "restore_glass_file")
+	@patch.object(BaseServer, "break_glass")
+	@patch.object(BaseServer, "free_space")
+	def test_purge_binlogs_breaks_glass_on_a_full_disk_and_restores_it_after(
+		self, free_space: Mock, break_glass: Mock, restore_glass_file: Mock
+	):
+		# The agent can't answer on a full disk, and the purge is what makes the room back
+		free_space.return_value = 0
+		server = create_test_database_server()
+
+		server.purge_binlogs(to_binlog="mysql-bin.000001")
+
+		break_glass.assert_called_once()
+		restore_glass_file.assert_called_once()
+
+	@patch.object(Agent, "purge_binlog", new=Mock())
+	@patch.object(
+		DatabaseServer,
+		"get_binlogs_raw_data",
+		new=Mock(return_value={"binlogs_in_disk": [{"name": "mysql-bin.000002"}]}),
+	)
+	@patch.object(BaseServer, "restore_glass_file")
+	@patch.object(BaseServer, "break_glass")
+	@patch.object(BaseServer, "free_space")
+	def test_purge_binlogs_keeps_the_glass_file_when_the_disk_has_room(
+		self, free_space: Mock, break_glass: Mock, restore_glass_file: Mock
+	):
+		free_space.return_value = 50 * 1024 * 1024 * 1024
+		server = create_test_database_server()
+
+		server.purge_binlogs(to_binlog="mysql-bin.000001")
+
+		break_glass.assert_not_called()
+		restore_glass_file.assert_not_called()

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1110,13 +1110,20 @@ class BaseServer(Document, TagHelpers):
 		agent = Agent(self.name, self.doctype)
 		if not force and agent.should_skip_requests():
 			return
-		if force and self.agent_disk_full():
-			self.break_glass()
+		if force:
+			self.break_glass_if_agent_disk_full()
 		agent.cleanup_unused_files(force)
 
 	def agent_disk_full(self) -> bool:
 		# On unified servers the agent shares the data disk; a full data volume starves it.
 		return self.free_space("/") < GLASS_FILE_SIZE
+
+	def break_glass_if_agent_disk_full(self) -> bool:
+		"""Give the agent room to work on a full disk. Tells whether glass was broken."""
+		if not self.agent_disk_full():
+			return False
+		self.break_glass()
+		return True
 
 	def on_trash(self):
 		plays = frappe.get_all("Ansible Play", filters={"server": self.name})


### PR DESCRIPTION
## Problem

A user opens the binlog dialog and purges binlogs when the database disk is full. That same full disk starves the agent, so `fetch_binlog_list` and `/database/binlogs/purge` fail, and the dashboard shows "Failed to purge binlogs. Please try again later."

Every server keeps a 200 MB `/root/glass` file for exactly this — `extend_ec2_volume`, `extend_frappe_compute_volume` and forced agent cleanup already remove it to make room. The purge path did not.

## Change

`purge_binlogs` now removes the glass file first when the disk is full, and restores it after the purge, since the purge is what frees the space back.

The glass check and break moved into `BaseServer.break_glass_if_agent_disk_full()`, reused by the forced cleanup path that already did the same two lines.

Forceful purge (`purge_binlogs_forcefully`) is left alone. It runs over ssh with `rm` and restarts MariaDB itself, so it needs no free space and no agent.

## Tests

`test_purge_binlogs_breaks_glass_on_a_full_disk_and_restores_it_after` and `test_purge_binlogs_keeps_the_glass_file_when_the_disk_has_room` in `test_database_server.py`. Full `test_database_server` (14) and `test_server` (39) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)