### PR TITLE
fix: Allow updates if other app versions changed

### DIFF
--- a/press/press/doctype/deploy_candidate/deploy_notifications.py
+++ b/press/press/doctype/deploy_candidate/deploy_notifications.py
@@ -793,6 +793,10 @@ def check_incompatible_node(old_dcb: "DeployCandidateBuild", new_dc: "DeployCand
 	if old_node != new_node:
 		return
 
+	# An app update can make the build compatible with the same Node version.
+	if apps_changed(old_dcb.candidate, new_dc):
+		return
+
 	frappe.throw(
 		f"The previous build failed because of an incompatible Node version. The Node version is still"
 		f" <b>{escape_html(new_node)}</b>. <b>Set a compatible Node version</b> in Bench Group &gt; Config &gt;"
@@ -829,6 +833,10 @@ def check_incompatible_python(old_dcb: "DeployCandidateBuild", new_dc: "DeployCa
 	new_python = new_dc.get_dependency_version("python")
 
 	if old_python != new_python:
+		return
+
+	# An app update can make the build compatible with the same Python version.
+	if apps_changed(old_dcb.candidate, new_dc):
 		return
 
 	frappe.throw(
@@ -1175,9 +1183,9 @@ def check_if_app_updated(old_dcb: "DeployCandidateBuild", new_dc: "DeployCandida
 	if old_hash != new_hash:
 		return
 
-	# The app itself wasn't updated, but the build may still succeed if the
-	# user changed the bench dependencies. Don't block the retry in that case.
-	if dependencies_changed(old_dcb.candidate, new_dc):
+	# The app itself wasn't updated, but the build may still succeed if the user
+	# changed a dependency or any other app. Don't block the retry in that case.
+	if build_inputs_changed(old_dcb.candidate, new_dc):
 		return
 
 	title = new_app.title or old_app.title
@@ -1190,9 +1198,20 @@ def check_if_app_updated(old_dcb: "DeployCandidateBuild", new_dc: "DeployCandida
 	)
 
 
+def build_inputs_changed(old_dc: "DeployCandidate", new_dc: "DeployCandidate") -> bool:
+	"""Whether any dependency version or app commit hash differs between the two candidates."""
+	return dependencies_changed(old_dc, new_dc) or apps_changed(old_dc, new_dc)
+
+
 def dependencies_changed(old_dc: "DeployCandidate", new_dc: "DeployCandidate") -> bool:
 	old = {d.dependency: d.version for d in old_dc.dependencies}
 	new = {d.dependency: d.version for d in new_dc.dependencies}
+	return old != new
+
+
+def apps_changed(old_dc: "DeployCandidate", new_dc: "DeployCandidate") -> bool:
+	old = {app.app: app.hash or app.pullable_hash for app in old_dc.apps}
+	new = {app.app: app.hash or app.pullable_hash for app in new_dc.apps}
 	return old != new
 
 

--- a/press/press/doctype/deploy_candidate/test_deploy_notifications.py
+++ b/press/press/doctype/deploy_candidate/test_deploy_notifications.py
@@ -11,9 +11,12 @@ from press.press.doctype.deploy_candidate.deploy_notifications import (
 )
 
 
-def make_dc(app_hash: str, dependencies: dict, environment_variables: dict):
+def make_dc(app_hash: str, dependencies: dict, environment_variables: dict, other_app_hash: str = "xyz789"):
 	return frappe._dict(
-		apps=[frappe._dict(app="frappe", hash=app_hash, pullable_hash=None, title="Frappe")],
+		apps=[
+			frappe._dict(app="frappe", hash=app_hash, pullable_hash=None, title="Frappe"),
+			frappe._dict(app="helpdesk", hash=other_app_hash, pullable_hash=None, title="Helpdesk"),
+		],
 		dependencies=[frappe._dict(dependency=k, version=v) for k, v in dependencies.items()],
 		environment_variables=[frappe._dict(key=k, value=v) for k, v in environment_variables.items()],
 	)
@@ -51,6 +54,14 @@ class TestCheckIfAppUpdated(FrappeTestCase):
 		env = {"FOO": "bar"}
 		old_build = make_old_build(make_dc("abc123", {"python": "3.11"}, env))
 		new_dc = make_dc("abc123", {"python": "3.12"}, env)
+
+		check_if_app_updated(old_build, new_dc)  # no raise
+
+	def test_allows_retry_when_another_apps_hash_changed(self):
+		deps = {"python": "3.11"}
+		env = {"FOO": "bar"}
+		old_build = make_old_build(make_dc("abc123", deps, env, other_app_hash="old111"))
+		new_dc = make_dc("abc123", deps, env, other_app_hash="new222")
 
 		check_if_app_updated(old_build, new_dc)  # no raise
 


### PR DESCRIPTION
Assume helpdesk failed due to framework version, now when I updated the framework verison helpdesk deploy shoudn't be blocked since the last deploy failed