### PR TITLE
feat(server): Add a button to copy the SSH command

### DIFF
--- a/dashboard/src/objects/server.js
+++ b/dashboard/src/objects/server.js
@@ -25,6 +25,7 @@ export default {
 		changePlan: 'change_plan',
 		toggleAutoIncreaseStorage: 'toggle_auto_increase_storage',
 		reboot: 'reboot',
+		getSSHCommand: 'get_ssh_command',
 		rename: 'rename',
 		cleanup: 'cleanup_unused_files',
 		dropServer: 'drop_server',
@@ -131,6 +132,16 @@ export default {
 									}/app/database-server/${server.doc.replication_server}`,
 									'_blank',
 								);
+							},
+						},
+						{
+							label: 'Copy SSH Command',
+							icon: icon('clipboard'),
+							condition: () => $team.doc?.is_desk_user,
+							async onClick() {
+								const command = await server.getSSHCommand.submit();
+								await navigator.clipboard.writeText(command);
+								toast.success('SSH command copied to clipboard');
 							},
 						},
 						{

--- a/press/press/doctype/managed_database_service/managed_database_service.js
+++ b/press/press/doctype/managed_database_service/managed_database_service.js
@@ -5,6 +5,7 @@ frappe.ui.form.on('Managed Database Service', {
 	refresh(frm) {
 		let command = `mysql -h ${frm.doc.name} -p -u ${frm.doc.database_root_user} -P ${frm.doc.port}`;
 		frm.add_custom_button('Console Access', () => {
+			frappe.utils.copy_to_clipboard(command);
 			frappe.msgprint(`<pre>${command}</pre>`);
 		});
 		frm.add_custom_button('Show Root Password', () => {

--- a/press/press/doctype/server/server.js
+++ b/press/press/doctype/server/server.js
@@ -75,6 +75,14 @@ frappe.ui.form.on('Server', {
 				true,
 				frm.doc.is_server_setup,
 			],
+			[
+				__('Copy SSH Command'),
+				() =>
+					frm
+						.call('get_ssh_command')
+						.then((r) => frappe.utils.copy_to_clipboard(r.message)),
+				false,
+			],
 			[__('Get Static IP'), 'get_static_ip', false],
 			[
 				__('Add public IP'),

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -2671,8 +2671,10 @@ node_filesystem_avail_bytes{{instance="{self.name}", mountpoint="{mountpoint}"}}
 		return f"ssh frappe@{frappe.db.get_single_value('Press Settings', 'domain')} -t '{command}'"
 
 	def _jump_through_proxy(self):
-		"""Servers are reachable only through the proxy server of their cluster."""
-		proxy = frappe.db.get_value("Proxy Server", {"status": "Active", "cluster": self.cluster}, "name")
+		"""Servers are reachable only through their proxy server."""
+		proxy = self.get("proxy_server") or frappe.db.get_value(
+			"Proxy Server", {"status": "Active", "cluster": self.cluster}, "name"
+		)
 		if not proxy or proxy == self.name:
 			return ""
 		return f" -J root@{proxy}"

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -52,6 +52,7 @@ from press.press.doctype.telegram_message.telegram_message import TelegramMessag
 from press.runner import Ansible
 from press.utils import docs, fmt_timedelta, log_error
 from press.utils.raven import send_raven_message
+from press.utils.user import is_desk_user
 from press.wazuh import WazuhManager
 
 if typing.TYPE_CHECKING:
@@ -2658,6 +2659,17 @@ node_filesystem_avail_bytes{{instance="{self.name}", mountpoint="{mountpoint}"}}
 		if not hasattr(self, "ssh_port"):
 			return 22
 		return self.ssh_port or 22
+
+	@frappe.whitelist()
+	def get_ssh_command(self):
+		"""SSH command that connects the same way Ansible does."""
+		if not is_desk_user():
+			frappe.throw("Only system users can get the SSH command", frappe.PermissionError)
+
+		command = f"ssh {self._ssh_user()}@{self.ip or self.private_ip} -p {self._ssh_port()}"
+		if hasattr(self, "bastion_host") and (bastion := self.bastion_host):
+			command += f" -J {bastion.ssh_user or 'root'}@{bastion.ip}:{bastion.ssh_port or 22}"
+		return command
 
 	def get_primary_frappe_public_key(self):
 		if primary_public_key := frappe.db.get_value(self.doctype, self.primary, "frappe_public_key"):

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -2660,7 +2660,7 @@ node_filesystem_avail_bytes{{instance="{self.name}", mountpoint="{mountpoint}"}}
 			return 22
 		return self.ssh_port or 22
 
-	@frappe.whitelist()
+	@dashboard_whitelist()
 	def get_ssh_command(self):
 		"""SSH command that hops through the press server and the cluster's proxy."""
 		if not is_desk_user():

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -2662,14 +2662,20 @@ node_filesystem_avail_bytes{{instance="{self.name}", mountpoint="{mountpoint}"}}
 
 	@frappe.whitelist()
 	def get_ssh_command(self):
-		"""SSH command that connects the same way Ansible does."""
+		"""SSH command that hops through the press server and the cluster's proxy."""
 		if not is_desk_user():
 			frappe.throw("Only system users can get the SSH command", frappe.PermissionError)
 
-		command = f"ssh {self._ssh_user()}@{self.ip or self.private_ip} -p {self._ssh_port()}"
-		if hasattr(self, "bastion_host") and (bastion := self.bastion_host):
-			command += f" -J {bastion.ssh_user or 'root'}@{bastion.ip}:{bastion.ssh_port or 22}"
-		return command
+		port = "" if self._ssh_port() == 22 else f" -p {self._ssh_port()}"
+		command = f"ssh{self._jump_through_proxy()} {self._ssh_user()}@{self.name}{port}"
+		return f"ssh frappe@{frappe.db.get_single_value('Press Settings', 'domain')} -t '{command}'"
+
+	def _jump_through_proxy(self):
+		"""Servers are reachable only through the proxy server of their cluster."""
+		proxy = frappe.db.get_value("Proxy Server", {"status": "Active", "cluster": self.cluster}, "name")
+		if not proxy or proxy == self.name:
+			return ""
+		return f" -J root@{proxy}"
 
 	def get_primary_frappe_public_key(self):
 		if primary_public_key := frappe.db.get_value(self.doctype, self.primary, "frappe_public_key"):

--- a/press/press/doctype/server/test_server.py
+++ b/press/press/doctype/server/test_server.py
@@ -831,6 +831,7 @@ class TestSSHCommand(FrappeTestCase):
 	def test_ssh_command_hops_through_press_server_and_proxy_server(self):
 		proxy_server = create_test_proxy_server(cluster=self.cluster)
 		server = create_test_server(proxy_server=proxy_server.name, cluster=self.cluster)
+		create_test_proxy_server(hostname="other", cluster=self.cluster)  # must not be picked
 
 		self.assertEqual(
 			server.get_ssh_command(),

--- a/press/press/doctype/server/test_server.py
+++ b/press/press/doctype/server/test_server.py
@@ -819,23 +819,31 @@ class TestServer(FrappeTestCase):
 
 @patch.object(BaseServer, "after_insert", new=Mock())
 class TestSSHCommand(FrappeTestCase):
+	def setUp(self):
+		from press.press.doctype.cluster.test_cluster import create_test_cluster
+
+		create_test_press_settings().db_set("domain", "fc.dev")
+		self.cluster = create_test_cluster(name="Mumbai").name
+
 	def tearDown(self):
 		frappe.db.rollback()
 
+	def test_ssh_command_hops_through_press_server_and_proxy_server(self):
+		proxy_server = create_test_proxy_server(cluster=self.cluster)
+		server = create_test_server(proxy_server=proxy_server.name, cluster=self.cluster)
+
+		self.assertEqual(
+			server.get_ssh_command(),
+			f"ssh frappe@fc.dev -t 'ssh -J root@{proxy_server.name} root@{server.name}'",
+		)
+
 	def test_ssh_command_uses_ssh_user_and_port_of_server(self):
-		server = create_test_server()
-		server.db_set({"ip": "1.2.3.4", "ssh_user": "ubuntu", "ssh_port": 2222})
-		server.reload()
-
-		self.assertEqual(server.get_ssh_command(), "ssh ubuntu@1.2.3.4 -p 2222")
-
-	def test_ssh_command_jumps_through_proxy_server_when_server_has_no_public_ip(self):
-		proxy_server = create_test_proxy_server()
-		server = create_test_server(proxy_server=proxy_server.name)
-		server.db_set("ip", None)
+		proxy_server = create_test_proxy_server(cluster=self.cluster)
+		server = create_test_server(proxy_server=proxy_server.name, cluster=self.cluster)
+		server.db_set({"ssh_user": "ubuntu", "ssh_port": 2222})
 		server.reload()
 
 		self.assertEqual(
 			server.get_ssh_command(),
-			f"ssh root@{server.private_ip} -p 22 -J root@{proxy_server.name}:22",
+			f"ssh frappe@fc.dev -t 'ssh -J root@{proxy_server.name} ubuntu@{server.name} -p 2222'",
 		)

--- a/press/press/doctype/server/test_server.py
+++ b/press/press/doctype/server/test_server.py
@@ -815,3 +815,27 @@ class TestServer(FrappeTestCase):
 
 		methods = [call.args[0] for call in requests.request.call_args_list]
 		self.assertNotIn("DELETE", methods)
+
+
+@patch.object(BaseServer, "after_insert", new=Mock())
+class TestSSHCommand(FrappeTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_ssh_command_uses_ssh_user_and_port_of_server(self):
+		server = create_test_server()
+		server.db_set({"ip": "1.2.3.4", "ssh_user": "ubuntu", "ssh_port": 2222})
+		server.reload()
+
+		self.assertEqual(server.get_ssh_command(), "ssh ubuntu@1.2.3.4 -p 2222")
+
+	def test_ssh_command_jumps_through_proxy_server_when_server_has_no_public_ip(self):
+		proxy_server = create_test_proxy_server()
+		server = create_test_server(proxy_server=proxy_server.name)
+		server.db_set("ip", None)
+		server.reload()
+
+		self.assertEqual(
+			server.get_ssh_command(),
+			f"ssh root@{server.private_ip} -p 22 -J root@{proxy_server.name}:22",
+		)


### PR DESCRIPTION
Getting into a server means reading the hostname off the form and remembering the two hops you need to make. This adds a `get_ssh_command` method on `BaseServer` and a button that copies the command to the clipboard:

```
ssh frappe@frappe.cloud -t 'ssh -J root@n2-mumbai.frappe.cloud root@f74-mumbai.frappe.cloud'
```

The outer hop is the press server (Press Settings > Domain), because servers are reachable only from there. The inner jump is the active proxy server of the server's cluster — the same shape as `break_glass`. The `-p` flag is added only when the server does not use port 22.

The button is in two places: the Actions group on the Server desk form, and the Options dropdown on the server dashboard, next to "View in Desk".

Only system users can call the method. Team members have write access to their own servers, so the `is_desk_user` condition on the dashboard button is not enough on its own.

The Console Access button on Managed Database Service now copies its command too, instead of only showing it in a dialog.

## Tests

`TestSSHCommand` in `test_server.py` — the full two-hop command, and the same with a custom SSH user and port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)