### PR TITLE
perf(site-backup): Stop polling and stop holding a worker to wait

### DIFF
--- a/dashboard/src/components/site/SiteBackupAuditTrail.vue
+++ b/dashboard/src/components/site/SiteBackupAuditTrail.vue
@@ -26,8 +26,8 @@ import { getDocResource } from '../../utils/resource'
 import ObjectList from '../ObjectList.vue'
 
 const DEFAULT_RANGE_DAYS = 30
-const POLL_MS = 5000
-const MAX_POLLS = 24
+// The build tells the page when it is done, so nothing is asked for on a timer
+const REALTIME_EVENT = 'backup_audit_trail_update'
 
 export default {
 	name: 'SiteBackupAuditTrail',
@@ -37,12 +37,13 @@ export default {
 		return {
 			startDate: null,
 			endDate: dayjs().format('YYYY-MM-DD'),
-			pollTimer: null,
-			polls: 0,
 		}
 	},
+	mounted() {
+		this.$socket?.on(REALTIME_EVENT, this.onTrailBuilt)
+	},
 	beforeUnmount() {
-		clearTimeout(this.pollTimer)
+		this.$socket?.off(REALTIME_EVENT, this.onTrailBuilt)
 	},
 	created() {
 		this.startDate = this.clampToSiteAge(
@@ -53,22 +54,17 @@ export default {
 	resources: {
 		history() {
 			return {
-				url: 'press.api.client.run_doc_method',
+				// Its own endpoint rather than a doc method, which would return the whole
+				// Site document alongside every answer
+				url: 'press.api.site.backup_history',
 				initialData: {},
 				makeParams: (params) => ({
-					dt: 'Site',
-					dn: this.name,
-					method: 'get_backup_history',
-					args: {
-						start_date: this.startDate,
-						end_date: this.endDate,
-						refresh: params?.refresh ? 1 : 0,
-					},
+					name: this.name,
+					start_date: this.startDate,
+					end_date: this.endDate,
+					refresh: params?.refresh ? 1 : 0,
 				}),
 				auto: true,
-				// Re-armed on every answer: watching the flag would stop after one look,
-				// because a second Preparing in a row is not a change
-				onSuccess: () => this.pollWhilePreparing(),
 			}
 		},
 	},
@@ -80,7 +76,7 @@ export default {
 			return dayjs(this.site.doc?.creation).format('YYYY-MM-DD')
 		},
 		history() {
-			return this.$resources.history.data?.message || {}
+			return this.$resources.history.data || {}
 		},
 		preparing() {
 			return this.history.status === 'Preparing'
@@ -98,9 +94,7 @@ export default {
 			if (this.preparing) {
 				return {
 					title:
-						this.polls < MAX_POLLS
-							? 'Putting the trail together. This page will fill in on its own.'
-							: 'This is taking longer than usual. Hit Refresh to look again.',
+						'Putting the trail together. This page will fill in on its own.',
 					type: 'info',
 					id: `${this.name}-preparing`,
 				}
@@ -201,7 +195,6 @@ export default {
 				updateFilters: ({ startDate, endDate }) => {
 					if (startDate) this.startDate = this.clampToSiteAge(startDate)
 					if (endDate) this.endDate = this.clampToSiteAge(endDate)
-					this.polls = 0
 					this.$resources.history.fetch()
 				},
 				actions: () => [
@@ -221,17 +214,17 @@ export default {
 		},
 	},
 	methods: {
-		pollWhilePreparing() {
-			clearTimeout(this.pollTimer)
-			if (!this.preparing || this.polls >= MAX_POLLS) return
-			this.polls += 1
-			this.pollTimer = setTimeout(
-				() => this.$resources.history.fetch(),
-				POLL_MS,
-			)
+		onTrailBuilt(data) {
+			// Every site shares the event, so only the range on screen reacts to it
+			if (
+				data?.site === this.name &&
+				data?.start_date === this.startDate &&
+				data?.end_date === this.endDate
+			) {
+				this.$resources.history.fetch()
+			}
 		},
 		rebuild() {
-			this.polls = 0
 			this.$resources.history.fetch({ refresh: true })
 		},
 		clampToSiteAge(day, { quiet = false } = {}) {

--- a/dashboard/src/components/site/SiteBackupAuditTrail.vue
+++ b/dashboard/src/components/site/SiteBackupAuditTrail.vue
@@ -35,7 +35,11 @@ export default {
 	components: { ObjectList },
 	data() {
 		return {
-			startDate: null,
+			// Set here, not in created: the resource fetches before the component's own
+			// hooks run, and would send nothing. The server trims what it is given.
+			startDate: dayjs()
+				.subtract(DEFAULT_RANGE_DAYS, 'day')
+				.format('YYYY-MM-DD'),
 			endDate: dayjs().format('YYYY-MM-DD'),
 		}
 	},
@@ -44,12 +48,6 @@ export default {
 	},
 	beforeUnmount() {
 		this.$socket?.off(REALTIME_EVENT, this.onTrailBuilt)
-	},
-	created() {
-		this.startDate = this.clampToSiteAge(
-			dayjs().subtract(DEFAULT_RANGE_DAYS, 'day').format('YYYY-MM-DD'),
-			{ quiet: true },
-		)
 	},
 	resources: {
 		history() {
@@ -65,6 +63,12 @@ export default {
 					refresh: params?.refresh ? 1 : 0,
 				}),
 				auto: true,
+				// The dates the pickers show follow the range the trail was built for,
+				// which is trimmed to the days this site could have been backed up on
+				onSuccess: (data) => {
+					if (data?.start_date) this.startDate = data.start_date
+					if (data?.end_date) this.endDate = data.end_date
+				},
 			}
 		},
 	},
@@ -227,13 +231,11 @@ export default {
 		rebuild() {
 			this.$resources.history.fetch({ refresh: true })
 		},
-		clampToSiteAge(day, { quiet = false } = {}) {
+		clampToSiteAge(day) {
 			if (!this.site.doc?.creation || day >= this.siteCreatedOn) return day
-			if (!quiet) {
-				toast.info(
-					`This site was created on ${date(this.siteCreatedOn, 'll')}, so that is the earliest date available.`,
-				)
-			}
+			toast.info(
+				`This site was created on ${date(this.siteCreatedOn, 'll')}, so that is the earliest date available.`,
+			)
 			return this.siteCreatedOn
 		},
 		exportCSV() {

--- a/dashboard/src/components/site/SiteBackupAuditTrail.vue
+++ b/dashboard/src/components/site/SiteBackupAuditTrail.vue
@@ -215,12 +215,12 @@ export default {
 	},
 	methods: {
 		onTrailBuilt(data) {
-			// Every site shares the event, so only the range on screen reacts to it
-			if (
-				data?.site === this.name &&
-				data?.start_date === this.startDate &&
-				data?.end_date === this.endDate
-			) {
+			if (data?.site !== this.name) return
+
+			// Match on the range the server says it used, not the one we asked with: it
+			// trims a start before the site existed and an end past today
+			const { start_date: start, end_date: end } = this.history
+			if (!start || (data.start_date === start && data.end_date === end)) {
 				this.$resources.history.fetch()
 			}
 		},

--- a/press/api/site.py
+++ b/press/api/site.py
@@ -725,7 +725,7 @@ def backup_history(name: str, start_date: str, end_date: str, refresh: bool = Fa
 	from press.press.doctype.site_backup.backup_history import get_backup_history
 
 	if not isinstance(name, str):
-		frappe.throw("Site name must be text.")
+		frappe.throw("Could not read the site name. Give it as text, for example demo.frappe.cloud.")
 
 	return get_backup_history(name, start_date, end_date, refresh=cint(refresh))
 

--- a/press/api/site.py
+++ b/press/api/site.py
@@ -716,13 +716,16 @@ def running_jobs(name):
 
 @frappe.whitelist()
 @protected("Site")
-def backup_history(name, start_date, end_date, refresh=False):
+def backup_history(name: str, start_date: str, end_date: str, refresh: bool = False):
 	"""Whether a backup was taken on each day of the range, answered even for days the list hides.
 
 	Deliberately not a doc method: the page asks repeatedly while a trail is being built,
 	and run_doc_method returns the whole Site document with every answer.
 	"""
 	from press.press.doctype.site_backup.backup_history import get_backup_history
+
+	if not isinstance(name, str):
+		frappe.throw("Site name must be text.")
 
 	return get_backup_history(name, start_date, end_date, refresh=cint(refresh))
 

--- a/press/api/site.py
+++ b/press/api/site.py
@@ -716,6 +716,19 @@ def running_jobs(name):
 
 @frappe.whitelist()
 @protected("Site")
+def backup_history(name, start_date, end_date, refresh=False):
+	"""Whether a backup was taken on each day of the range, answered even for days the list hides.
+
+	Deliberately not a doc method: the page asks repeatedly while a trail is being built,
+	and run_doc_method returns the whole Site document with every answer.
+	"""
+	from press.press.doctype.site_backup.backup_history import get_backup_history
+
+	return get_backup_history(name, start_date, end_date, refresh=cint(refresh))
+
+
+@frappe.whitelist()
+@protected("Site")
 def backups(name):
 	available_offsite_backups = frappe.db.get_single_value("Press Settings", "offsite_backups_count") or 30
 	fields = [

--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -1448,13 +1448,6 @@ class Site(Document, TagHelpers):
 		).insert()
 
 	@dashboard_whitelist()
-	def get_backup_history(self, start_date, end_date, refresh=False):
-		"""Whether a backup was taken on each day of the range, answered even for days the list hides."""
-		from press.press.doctype.site_backup.backup_history import get_backup_history
-
-		return get_backup_history(self.name, start_date, end_date, refresh=cint(refresh))
-
-	@dashboard_whitelist()
 	def get_backup_download_link(self, backup, file):
 		from botocore.exceptions import ClientError
 

--- a/press/press/doctype/site_backup/backup_history.py
+++ b/press/press/doctype/site_backup/backup_history.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import time
 from datetime import date, timedelta
 from urllib.parse import parse_qs, urlparse
 
@@ -30,17 +29,8 @@ PARTIAL_CACHE_TTL = 60
 # Long enough to outlast a build, short enough that a lost worker does not wedge a range
 BUILD_TTL = 5 * 60
 
-# The server reads its job database as a job of its own, and Press delivers that job from
-# a queue, so the wait is a queue wait and not a request
-AGENT_WAIT_SECONDS = 60
-AGENT_POLL_SECONDS = 3
-
-# Most servers run an agent without the route. The first ask finds out, and waits only
-# long enough for a healthy one to answer rather than the full wait.
-AGENT_PROBE_SECONDS = 10
-
-# Learned once and kept, so a server that can answer is waited for properly
-AGENT_SUPPORTED_TTL = 30 * 24 * 60 * 60
+# What the page listens on, so a finished build reaches it without asking
+REALTIME_EVENT = "backup_audit_trail_update"
 
 # Keeps the IN clause sane on a year of daily backups
 REMOTE_FILE_BATCH = 500
@@ -129,6 +119,17 @@ def build_and_cache(site: str, start_date: str, end_date: str):
 		)
 	finally:
 		frappe.cache().delete_value(build_key(site, start, end))
+	publish_update(site, start_date, end_date)
+
+
+def publish_update(site: str, start: str, end: str):
+	"""Tell whoever is looking at this range that there is something new to read."""
+	frappe.publish_realtime(
+		event=REALTIME_EVENT,
+		doctype="Site",
+		docname=site,
+		message={"site": site, "start_date": str(start), "end_date": str(end)},
+	)
 
 
 def resolve_range(site: str, start_date: str, end_date: str) -> tuple[date, date]:
@@ -189,12 +190,12 @@ def merge_stored(backups: dict[str, dict], stored: dict[str, dict]) -> dict[str,
 
 
 def await_agent_backup_jobs(site: str, start: date, end: date) -> tuple[dict[str, dict], bool]:
-	"""What the site's server remembers running, waited for rather than polled from a page.
+	"""What the site's server remembers running, if it has already said.
 
-	The server reads its job database as a job, and Press delivers that job from a queue,
-	so the answer is a minute away at worst. This runs in a background worker, which is
-	the right place to wait. Only the current server is asked: jobs a site ran before
-	moving stay on the server it left, and its objects come from the buckets it used.
+	The server reads its job database as a job of its own, so the answer is never ready
+	the first time. Nothing waits for it: the job's callback drops the built trail when
+	it lands, and the next build picks the answer up. Only the current server is asked,
+	since jobs a site ran before moving stay on the server it left.
 	"""
 	server = frappe.db.get_value("Site", site, "server")
 	if not server or is_agent_silenced(server):
@@ -202,14 +203,9 @@ def await_agent_backup_jobs(site: str, start: date, end: date) -> tuple[dict[str
 
 	answer = read_agent_answer(site, start, end)
 	if answer is None:
-		if not request_agent_backup_jobs(server, site, start, end):
-			return {}, False
-		# A server not yet known to answer is given a short look, not the full wait
-		seconds = AGENT_WAIT_SECONDS if is_agent_supported(server) else AGENT_PROBE_SECONDS
-		answer = wait_for_agent_answer(site, start, end, seconds)
-
-	if answer is None:
+		request_agent_backup_jobs(server, site, start, end)
 		return {}, False
+
 	# A truncated answer dropped the oldest days in the range, so it is not the whole story
 	return days_from_agent_jobs(answer["jobs"]), not answer.get("truncated")
 
@@ -218,21 +214,8 @@ def read_agent_answer(site: str, start: date, end: date) -> dict | None:
 	return frappe.cache().get_value(agent_answer_key(site, start, end))
 
 
-def wait_for_agent_answer(site: str, start: date, end: date, seconds: int) -> dict | None:
-	# Another worker delivers the job, so the job has to be visible to it before we wait
-	frappe.db.commit()
-
-	deadline = time.monotonic() + seconds
-	while time.monotonic() < deadline:
-		time.sleep(AGENT_POLL_SECONDS)
-		answer = read_agent_answer(site, start, end)
-		if answer is not None:
-			return answer
-	return None
-
-
 def request_agent_backup_jobs(server: str, site: str, start: date, end: date) -> bool:
-	"""Queue the read and commit, since another worker delivers the job to the agent."""
+	"""Queue the read. Nothing waits on it, so this returns as soon as the job exists."""
 	try:
 		# Deduplicated by Agent, so asking again while one is running adds nothing
 		Agent(server).fetch_site_backup_jobs(site, str(start), str(end))
@@ -266,9 +249,6 @@ def process_fetch_backup_jobs_update(job):
 	if job.status != "Success" or not job.data:
 		return
 
-	# It answered once, so the next ask is worth waiting out
-	frappe.cache().set_value(agent_supported_key(job.server), 1, expires_in_sec=AGENT_SUPPORTED_TTL)
-
 	query = parse_qs(urlparse(job.request_path).query)
 	site, start, end = query.get("site"), query.get("start"), query.get("end")
 	if not (site and start and end):
@@ -279,14 +259,9 @@ def process_fetch_backup_jobs_update(job):
 		frappe.parse_json(job.data),
 		expires_in_sec=CACHE_TTL,
 	)
-
-
-def agent_supported_key(server: str) -> str:
-	return f"backup_audit_trail_agent_supported:{server}"
-
-
-def is_agent_supported(server: str) -> bool:
-	return bool(frappe.cache().get_value(agent_supported_key(server)))
+	# The trail was built without this, so drop it and tell the page to look again
+	frappe.cache().delete_value(cache_key(site[0], start[0], end[0]))
+	publish_update(site[0], start[0], end[0])
 
 
 def agent_silence_key(server: str) -> str:

--- a/press/press/doctype/site_backup/backup_history.py
+++ b/press/press/doctype/site_backup/backup_history.py
@@ -32,6 +32,12 @@ BUILD_TTL = 5 * 60
 # What the page listens on, so a finished build reaches it without asking
 REALTIME_EVENT = "backup_audit_trail_update"
 
+AGENT_JOB_TYPE = "Fetch Backup Jobs"
+
+# A job the agent never acknowledged after this is not being delivered, and the trail
+# goes on without it rather than expecting it on every look
+UNDELIVERED_GRACE_SECONDS = 60
+
 # Keeps the IN clause sane on a year of daily backups
 REMOTE_FILE_BATCH = 500
 
@@ -215,14 +221,38 @@ def read_agent_answer(site: str, start: date, end: date) -> dict | None:
 
 
 def request_agent_backup_jobs(server: str, site: str, start: date, end: date) -> bool:
-	"""Queue the read. Nothing waits on it, so this returns as soon as the job exists."""
+	"""Queue the read, unless nothing is reaching this server or one is already stuck."""
+	agent = Agent(server)
+	# An Agent Request Failure row means the server is unreachable, and a job created
+	# now would only sit undelivered
+	if agent.should_skip_requests() or has_stuck_request(server):
+		return False
+
 	try:
 		# Deduplicated by Agent, so asking again while one is running adds nothing
-		Agent(server).fetch_site_backup_jobs(site, str(start), str(end))
+		agent.fetch_site_backup_jobs(site, str(start), str(end))
 	except Exception:
 		silence_agent(server)
 		return False
 	return True
+
+
+def has_stuck_request(server: str) -> bool:
+	"""A job the agent never gave an id to never reached it, delivery failure included."""
+	return bool(
+		frappe.db.exists(
+			"Agent Job",
+			{
+				"job_type": AGENT_JOB_TYPE,
+				"server": server,
+				"job_id": 0,
+				"creation": (
+					"<",
+					frappe.utils.add_to_date(None, seconds=-UNDELIVERED_GRACE_SECONDS),
+				),
+			},
+		)
+	)
 
 
 def days_from_agent_jobs(jobs: list[dict]) -> dict[str, dict]:

--- a/press/press/doctype/site_backup/backup_history.py
+++ b/press/press/doctype/site_backup/backup_history.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
 from datetime import date, timedelta
 from urllib.parse import parse_qs, urlparse
 
@@ -77,17 +78,26 @@ def get_backup_history(site: str, start_date: str, end_date: str, refresh: bool 
 	"""
 	start, end = resolve_range(site, start_date, end_date)
 	if start > end:
-		return ready([])
+		return with_range(ready([]), start, end)
 
 	if refresh:
 		frappe.cache().delete_value(cache_key(site, start, end))
 
 	cached = frappe.cache().get_value(cache_key(site, start, end))
 	if cached is not None:
-		return cached
+		return with_range(cached, start, end)
 
 	queue_build(site, start, end)
-	return {"status": "Preparing", "days": [], "unconfirmed": False}
+	return with_range({"status": "Preparing", "days": [], "unconfirmed": False}, start, end)
+
+
+def with_range(history: dict, start: date, end: date) -> dict:
+	"""The range actually used, which is trimmed to the days the site could have.
+
+	The page keys its completion event off this, so it has to hear the trimmed dates
+	rather than the ones it asked with.
+	"""
+	return history | {"start_date": str(start), "end_date": str(end)}
 
 
 def ready(days: list[dict], unconfirmed: bool = False) -> dict:
@@ -138,9 +148,23 @@ def publish_update(site: str, start: str, end: str):
 	)
 
 
+def parse_day(value, which: str) -> date:
+	"""A date, or a plain error saying so. Callers include whitelisted API parameters."""
+	if isinstance(value, date):
+		return value
+
+	if isinstance(value, str):
+		with suppress(Exception):
+			if day := getdate(value):
+				return day
+
+	frappe.throw(f"Could not read the {which} date. Give it as YYYY-MM-DD, for example 2023-10-02.")
+	raise ValueError(which)  # frappe.throw already raised; this keeps the return type honest
+
+
 def resolve_range(site: str, start_date: str, end_date: str) -> tuple[date, date]:
 	"""Trim the asked-for range to days the site could have been backed up on."""
-	start, end = getdate(start_date), getdate(end_date)
+	start, end = parse_day(start_date, "start"), parse_day(end_date, "end")
 	if start > end:
 		frappe.throw(
 			f"The start date {start} comes after the end date {end}, so the range covers no days. "

--- a/press/press/doctype/site_backup/test_backup_history.py
+++ b/press/press/doctype/site_backup/test_backup_history.py
@@ -645,6 +645,50 @@ class TestBackupHistory(FrappeTestCase):
 
 		self.queue_backup_jobs.assert_called_once()
 
+	def test_a_trimmed_range_comes_back_with_the_trail(self):
+		"""The page keys its completion event off this, so it has to be the used range."""
+		history = get_backup_history(self.site.name, "2022-06-01", "2023-01-05")
+
+		self.assertEqual(history["start_date"], "2023-01-01")
+		self.assertEqual(history["end_date"], "2023-01-05")
+
+	def test_a_future_end_comes_back_trimmed_to_today(self):
+		today = frappe.utils.getdate()
+
+		history = get_backup_history(self.site.name, str(today), str(frappe.utils.add_days(today, 30)))
+
+		self.assertEqual(history["end_date"], str(today))
+
+	def test_the_event_carries_the_same_range_the_trail_reports(self):
+		history = self.audit_trail("2022-06-01", "2023-01-05")
+
+		published = [
+			call.kwargs["message"]
+			for call in self.publish_realtime.call_args_list
+			if call.kwargs.get("event") == REALTIME_EVENT
+		]
+		self.assertIn(
+			{
+				"site": self.site.name,
+				"start_date": history["start_date"],
+				"end_date": history["end_date"],
+			},
+			published,
+		)
+
+	def test_a_date_that_is_not_a_date_is_rejected_plainly(self):
+		"""Whitelisted parameters arrive as whatever the caller sent."""
+		for value in [{"a": 1}, ["2023-10-02"], None, "banana", 20231002]:
+			with self.subTest(value=value):
+				self.assertRaisesRegex(
+					frappe.ValidationError,
+					"Could not read the start date",
+					get_backup_history,
+					self.site.name,
+					value,
+					"2023-10-02",
+				)
+
 	def test_reversed_range_is_rejected(self):
 		self.assertRaisesRegex(
 			frappe.ValidationError,

--- a/press/press/doctype/site_backup/test_backup_history.py
+++ b/press/press/doctype/site_backup/test_backup_history.py
@@ -11,6 +11,7 @@ from moto import mock_aws
 
 from press.press.doctype.site.test_site import create_test_site
 from press.press.doctype.site_backup.backup_history import (
+	AGENT_JOB_TYPE,
 	CACHE_TTL,
 	MAX_RANGE_DAYS,
 	PARTIAL_CACHE_TTL,
@@ -42,6 +43,10 @@ class TestBackupHistory(FrappeTestCase):
 		frappe.db.set_value("Site", self.site.name, "creation", "2023-01-01 00:00:00", update_modified=False)
 		self.setup_press_settings()
 		boto3.client("s3", region_name=REGION).create_bucket(Bucket=BUCKET)
+		# Building a test bench leaves failures against its server, which would make
+		# every test look like it is talking to an unreachable agent
+		frappe.db.delete("Agent Request Failure", {"server": self.server})
+
 		# The server answers as a job of its own, so tests leave its answer in the
 		# cache the way the job callback would, and stub the queueing
 		agent = patch("press.press.doctype.site_backup.backup_history.Agent.fetch_site_backup_jobs")
@@ -69,6 +74,40 @@ class TestBackupHistory(FrappeTestCase):
 		get_backup_history(self.site.name, start, end)
 		return get_backup_history(self.site.name, start, end)
 
+	def given_undelivered_job(self, minutes_ago: int):
+		"""A job the agent never acknowledged, which leaves job_id at 0."""
+		if not frappe.db.exists("Agent Job Type", AGENT_JOB_TYPE):
+			frappe.get_doc(
+				{
+					"doctype": "Agent Job Type",
+					"name": AGENT_JOB_TYPE,
+					"request_method": "POST",
+					"request_path": "server/backup-jobs",
+					"steps": [{"step_name": AGENT_JOB_TYPE}],
+				}
+			).insert(ignore_permissions=True)
+
+		job = frappe.get_doc(
+			{
+				"doctype": "Agent Job",
+				"server_type": "Server",
+				"server": self.server,
+				"site": self.site.name,
+				"status": "Undelivered",
+				"job_type": AGENT_JOB_TYPE,
+				"request_method": "POST",
+				"request_path": "server/backup-jobs",
+				"request_data": "{}",
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.set_value(
+			"Agent Job",
+			job.name,
+			"creation",
+			frappe.utils.add_to_date(None, minutes=-minutes_ago),
+			update_modified=False,
+		)
+
 	def build_calls(self) -> int:
 		return sum(1 for call in self.enqueue_build.call_args_list if call.args[0] == BUILD_METHOD)
 
@@ -82,10 +121,12 @@ class TestBackupHistory(FrappeTestCase):
 
 	def tearDown(self):
 		# The silence flag lives in redis, which no rollback undoes
-		frappe.cache().delete_value(
-			f"backup_audit_trail_agent_unavailable:{frappe.db.get_value('Site', self.site.name, 'server')}"
-		)
+		frappe.cache().delete_value(f"backup_audit_trail_agent_unavailable:{self.server}")
 		frappe.db.rollback()
+
+	@property
+	def server(self) -> str:
+		return frappe.db.get_value("Site", self.site.name, "server")
 
 	def setup_press_settings(self):
 		settings = frappe.get_single("Press Settings")
@@ -569,6 +610,40 @@ class TestBackupHistory(FrappeTestCase):
 		)
 
 		self.assertIsNone(frappe.cache().get_value(cache_key(self.site.name, day, day)))
+
+	def test_an_unreachable_server_is_not_asked(self):
+		"""An Agent Request Failure row means nothing is getting through to it."""
+		frappe.get_doc(
+			{
+				"doctype": "Agent Request Failure",
+				"server_type": "Server",
+				"server": self.server,
+				"failure_count": 1,
+				"error": "Connection refused",
+				"traceback": "Connection refused",
+			}
+		).insert(ignore_permissions=True)
+		self.upload_backup("2023-10-02", "20231002_000502-database.sql.gz", body=b"x" * 8)
+
+		history = self.audit_trail("2023-10-02", "2023-10-02")
+
+		self.queue_backup_jobs.assert_not_called()
+		# The buckets still answer, so the trail is not held up by the server
+		self.assertEqual(history["days"][0]["database"], 8)
+
+	def test_a_job_left_undelivered_is_not_waited_on(self):
+		self.given_undelivered_job(minutes_ago=5)
+
+		self.audit_trail("2023-10-02", "2023-10-02")
+
+		self.queue_backup_jobs.assert_not_called()
+
+	def test_a_job_only_just_queued_still_counts(self):
+		self.given_undelivered_job(minutes_ago=0)
+
+		self.audit_trail("2023-10-02", "2023-10-02")
+
+		self.queue_backup_jobs.assert_called_once()
 
 	def test_reversed_range_is_rejected(self):
 		self.assertRaisesRegex(

--- a/press/press/doctype/site_backup/test_backup_history.py
+++ b/press/press/doctype/site_backup/test_backup_history.py
@@ -14,11 +14,14 @@ from press.press.doctype.site_backup.backup_history import (
 	CACHE_TTL,
 	MAX_RANGE_DAYS,
 	PARTIAL_CACHE_TTL,
+	REALTIME_EVENT,
 	agent_answer_key,
 	build_and_cache,
+	cache_key,
 	cache_seconds,
 	get_backup_history,
 	process_fetch_backup_jobs_update,
+	read_agent_answer,
 	ready,
 )
 
@@ -57,12 +60,9 @@ class TestBackupHistory(FrappeTestCase):
 		enqueue = patch.object(frappe, "enqueue", side_effect=run_build_inline)
 		self.enqueue_build = enqueue.start()
 		self.addCleanup(enqueue.stop)
-		wait = patch(
-			"press.press.doctype.site_backup.backup_history.wait_for_agent_answer",
-			return_value=None,
-		)
-		self.wait_for_agent = wait.start()
-		self.addCleanup(wait.stop)
+		realtime = patch("press.press.doctype.site_backup.backup_history.frappe.publish_realtime")
+		self.publish_realtime = realtime.start()
+		self.addCleanup(realtime.stop)
 
 	def audit_trail(self, start: str, end: str) -> dict:
 		"""The first look starts the build. It finishes inline here, so look again."""
@@ -544,6 +544,31 @@ class TestBackupHistory(FrappeTestCase):
 		day = self.audit_trail("2023-10-02", "2023-10-02")["days"][0]
 
 		self.assertEqual(day["status"], "Not Available")
+
+	def test_a_build_never_waits_on_the_server(self):
+		"""Sleeping here would hold a long queue worker while the agent job is delivered."""
+		self.audit_trail("2023-10-02", "2023-10-02")
+
+		self.queue_backup_jobs.assert_called_once()
+		self.assertIsNone(read_agent_answer(self.site.name, "2023-10-02", "2023-10-02"))
+
+	def test_a_finished_build_tells_the_page_to_look_again(self):
+		self.audit_trail("2023-10-02", "2023-10-02")
+
+		events = [call.kwargs.get("event") for call in self.publish_realtime.call_args_list]
+		self.assertIn(REALTIME_EVENT, events)
+
+	def test_the_servers_answer_drops_the_trail_built_without_it(self):
+		"""Otherwise the answer sits behind an hour-old trail that was built ignoring it."""
+		day = frappe.utils.getdate("2023-10-02")
+		self.audit_trail("2023-10-02", "2023-10-02")
+		self.assertIsNotNone(frappe.cache().get_value(cache_key(self.site.name, day, day)))
+
+		process_fetch_backup_jobs_update(
+			self.fake_job(data={"jobs": [self.agent_job("2023-10-02 04:00:00")], "truncated": False})
+		)
+
+		self.assertIsNone(frappe.cache().get_value(cache_key(self.site.name, day, day)))
 
 	def test_reversed_range_is_rejected(self):
 		self.assertRaisesRegex(

--- a/press/press/doctype/site_backup/test_backup_history.py
+++ b/press/press/doctype/site_backup/test_backup_history.py
@@ -676,6 +676,20 @@ class TestBackupHistory(FrappeTestCase):
 			published,
 		)
 
+	def test_a_site_name_that_is_not_text_is_rejected_plainly(self):
+		from press.api.site import backup_history
+
+		for value in [{"a": 1}, ["x"], 5]:
+			with self.subTest(value=value):
+				self.assertRaisesRegex(
+					frappe.ValidationError,
+					"Could not read the site name",
+					backup_history,
+					value,
+					"2023-10-01",
+					"2023-10-02",
+				)
+
 	def test_a_date_that_is_not_a_date_is_rejected_plainly(self):
 		"""Whitelisted parameters arrive as whatever the caller sent."""
 		for value in [{"a": 1}, ["2023-10-02"], None, "banana", 20231002]:


### PR DESCRIPTION
Three costs, each fine alone and not together once a few hundred people open a trail at once.

The build slept up to a minute waiting on the server's job. That holds a long queue worker, and a thousand of those would starve the queue that also carries backups and site work. It builds from what it has now, and the job's callback drops the built trail when the answer lands so the next build picks it up.

The page asked again every five seconds until the trail appeared. It subscribes instead, and the build says when there is something to read. Nothing is asked for on a timer.

Those asks went through run_doc_method, which returns the whole Site document with every answer, so checking whether a trail was ready cost about what loading the site page costs. It has its own endpoint now.