### PR TITLE
feat(invoice): Show the billed period on each invoice item

### DIFF
--- a/dashboard/src/components/InvoiceTable.vue
+++ b/dashboard/src/components/InvoiceTable.vue
@@ -16,6 +16,7 @@
 				<thead class="bg-surface-gray-2">
 					<tr class="text-ink-gray-6">
 						<th class="rounded-l p-2 text-left font-normal">Description</th>
+						<th class="whitespace-nowrap p-2 text-left font-normal">Period</th>
 						<th class="whitespace-nowrap p-2 text-right font-normal">Rate</th>
 						<th class="whitespace-nowrap p-2 text-right font-normal">
 							Quantity
@@ -46,6 +47,9 @@
 									({{ formatPlan(row.plan) }})
 								</span>
 							</td>
+							<td class="whitespace-nowrap py-1 pl-2 pr-2 text-ink-gray-7">
+								{{ formatPeriod(row) }}
+							</td>
 							<td class="py-1 pl-2 pr-2 text-right">
 								{{ formatCurrency(row.rate) }}
 							</td>
@@ -72,6 +76,7 @@
 					<tr v-if="doc.total_discount_amount > 0">
 						<td></td>
 						<td></td>
+						<td></td>
 						<td class="pb-2 pr-2 pt-4 text-right font-medium">
 							Total Without Discount
 						</td>
@@ -80,6 +85,7 @@
 						</td>
 					</tr>
 					<tr v-if="doc.total_discount_amount > 0">
+						<td></td>
 						<td></td>
 						<td></td>
 						<td class="pb-2 pr-2 pt-4 text-right font-medium">
@@ -94,6 +100,7 @@
 					<tr v-if="doc.gst > 0">
 						<td></td>
 						<td></td>
+						<td></td>
 						<td class="pb-2 pr-2 pt-4 text-right font-medium">
 							Total (Without Tax)
 						</td>
@@ -104,6 +111,7 @@
 					<tr v-if="doc.gst > 0">
 						<td></td>
 						<td></td>
+						<td></td>
 						<td class="pb-2 pr-2 pt-4 text-right font-medium">
 							IGST @ {{ Number(gstPercentage * 100) }}%
 						</td>
@@ -112,6 +120,7 @@
 						</td>
 					</tr>
 					<tr>
+						<td></td>
 						<td></td>
 						<td></td>
 						<td class="pb-2 pr-2 pt-4 text-right font-medium">Grand Total</td>
@@ -128,12 +137,14 @@
 						<tr>
 							<td></td>
 							<td></td>
+							<td></td>
 							<td class="pr-2 text-right font-medium">Applied Balance</td>
 							<td class="whitespace-nowrap py-3 pr-2 text-right font-medium">
 								- {{ formatCurrency(doc.applied_credits) }}
 							</td>
 						</tr>
 						<tr>
+							<td></td>
 							<td></td>
 							<td></td>
 							<td class="pr-2 text-right font-medium">Amount Due</td>
@@ -152,6 +163,7 @@
 </template>
 <script>
 import { getPlans } from '../data/plans'
+import dayjs from '../utils/dayjs'
 
 export default {
 	name: 'InvoiceTable',
@@ -231,6 +243,13 @@ export default {
 				)
 			}
 			return plan
+		},
+		formatPeriod(row) {
+			// plain dates, so format them as-is instead of shifting them to the local timezone
+			if (!row.period_start || !row.period_end) return '-'
+			const start = dayjs(row.period_start).format('D MMM')
+			const end = dayjs(row.period_end).format('D MMM')
+			return start === end ? start : `${start} - ${end}`
 		},
 		formatCurrency(value) {
 			if (!this.doc) return

--- a/press/api/billing.py
+++ b/press/api/billing.py
@@ -301,6 +301,8 @@ def fetch_invoice_items(invoice):
 			"amount",
 			"plan",
 			"description",
+			"period_start",
+			"period_end",
 			"discount",
 			"site",
 		],

--- a/press/patches.txt
+++ b/press/patches.txt
@@ -168,3 +168,4 @@ press.patches.v0_8_0.team_member_default_role
 press.patches.v0_8_0.add_app_source_to_app_audit
 press.patches.v0_8_0.bump_v16_bench_version_to_5_31_0
 press.patches.v0_8_0.bump_v15_bench_version_to_5_31_0
+press.press.doctype.invoice.patches.set_item_periods_on_draft_invoices

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -8,7 +8,7 @@ import typing
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import cint, flt, getdate
+from frappe.utils import cint, flt, formatdate, getdate
 from frappe.utils.data import fmt_money
 
 from press.api.billing import get_stripe
@@ -833,24 +833,7 @@ class Invoice(Document):
 	def update_item_descriptions(self):
 		for item in self.items:
 			if not item.description:
-				how_many_days = f"{cint(item.quantity)} day{'s' if item.quantity > 1 else ''}"
-				if item.document_type == "Site" and item.plan:
-					site_name = item.document_name.split(".archived")[0]
-					plan = frappe.get_cached_value("Site Plan", item.plan, "plan_title")
-					item.description = f"{site_name} active for {how_many_days} on {plan} plan"
-				elif item.document_type in ["Server", "Database Server"]:
-					server_title = frappe.get_cached_value(item.document_type, item.document_name, "title")
-					if item.plan == "Add-on Storage plan":
-						item.description = f"{server_title} Storage Add-on for {how_many_days}"
-					else:
-						item.description = f"{server_title} active for {how_many_days}"
-				elif item.document_type == "Server Snapshot":
-					item.description = f"{item.document_name} stored for {how_many_days}"
-				elif item.document_type == "Marketplace App":
-					app_title = frappe.get_cached_value("Marketplace App", item.document_name, "title")
-					item.description = f"Marketplace app {app_title} active for {how_many_days}"
-				else:
-					item.description = "Prepaid Credits"
+				item.description = get_item_description(item) + get_item_period_text(item)
 
 	def is_auto_scale_invoice_item(self, usage_record: UsageRecord) -> bool:
 		"""Check if this a secondary server usage record"""
@@ -928,11 +911,36 @@ class Invoice(Document):
 		else:
 			invoice_item.quantity = (invoice_item.quantity or 0) + 1
 
+		self.widen_item_period(invoice_item, usage_record_date)
+
 		if usage_record.payout:
 			self.payout += usage_record.payout
 
 		self.save()
 		usage_record.db_set("invoice", self.name)
+
+	def widen_item_period(self, invoice_item, usage_record_date):
+		"""Grow the item's billed period to include this usage record's date"""
+		if not invoice_item.period_start or getdate(invoice_item.period_start) > usage_record_date:
+			invoice_item.period_start = usage_record_date
+		if not invoice_item.period_end or getdate(invoice_item.period_end) < usage_record_date:
+			invoice_item.period_end = usage_record_date
+
+	def set_item_periods(self):
+		"""Read the billed period of every item back from the usage records it bills for"""
+		for invoice_item in self.items:
+			invoice_item.period_start = None
+			invoice_item.period_end = None
+
+		usage_records = frappe.get_all(
+			"Usage Record",
+			filters={"invoice": self.name, "docstatus": 1},
+			fields=["document_type", "document_name", "plan", "amount", "site", "date"],
+		)
+		for usage_record in usage_records:
+			invoice_item = self.get_invoice_item_for_usage_record(usage_record)
+			if invoice_item:
+				self.widen_item_period(invoice_item, getdate(usage_record.date))
 
 	def remove_usage_record(self, usage_record):
 		if self.type != "Subscription":
@@ -953,8 +961,10 @@ class Invoice(Document):
 			return
 
 		invoice_item.quantity -= 1
-		self.save()
+		# unlink first, so that the periods are read back from the remaining usage records
 		usage_record.db_set("invoice", None)
+		self.set_item_periods()
+		self.save()
 
 	def get_invoice_item_for_usage_record(self, usage_record):
 		invoice_item = None
@@ -1377,6 +1387,34 @@ class Invoice(Document):
 			return None
 		stripe = get_stripe()
 		return stripe.Invoice.retrieve(self.stripe_invoice_id)
+
+
+def get_item_description(item):
+	how_many_days = f"{cint(item.quantity)} day{'s' if item.quantity > 1 else ''}"
+	if item.document_type == "Site" and item.plan:
+		site_name = item.document_name.split(".archived")[0]
+		plan = frappe.get_cached_value("Site Plan", item.plan, "plan_title")
+		return f"{site_name} active for {how_many_days} on {plan} plan"
+	if item.document_type in ["Server", "Database Server"]:
+		server_title = frappe.get_cached_value(item.document_type, item.document_name, "title")
+		if item.plan == "Add-on Storage plan":
+			return f"{server_title} Storage Add-on for {how_many_days}"
+		return f"{server_title} active for {how_many_days}"
+	if item.document_type == "Server Snapshot":
+		return f"{item.document_name} stored for {how_many_days}"
+	if item.document_type == "Marketplace App":
+		app_title = frappe.get_cached_value("Marketplace App", item.document_name, "title")
+		return f"Marketplace app {app_title} active for {how_many_days}"
+	return "Prepaid Credits"
+
+
+def get_item_period_text(item):
+	"""Tell the customer which days of the invoice period the item bills for"""
+	if not item.period_start or not item.period_end:
+		return ""
+	if getdate(item.period_start) == getdate(item.period_end):
+		return f" on {formatdate(item.period_start)}"
+	return f" from {formatdate(item.period_start)} to {formatdate(item.period_end)}"
 
 
 def finalize_draft_invoices():

--- a/press/press/doctype/invoice/patches/set_item_periods_on_draft_invoices.py
+++ b/press/press/doctype/invoice/patches/set_item_periods_on_draft_invoices.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# For license information, please see license.txt
+
+import frappe
+
+
+def execute():
+	"""Set the billed period on the items of every draft invoice.
+
+	New items get their period from the usage records that come in after this patch.
+	Items that already exist would otherwise start from the day of the deploy.
+	Submitted invoices keep an empty period, because their descriptions are final.
+	"""
+	frappe.reload_doc("press", "doctype", "invoice_item")
+	invoices = frappe.get_all("Invoice", {"docstatus": 0, "type": "Subscription"}, pluck="name")
+	for name in invoices:
+		invoice = frappe.get_doc("Invoice", name)
+		invoice.set_item_periods()
+		for item in invoice.items:
+			item.db_update()
+		frappe.db.commit()

--- a/press/press/doctype/invoice/test_invoice.py
+++ b/press/press/doctype/invoice/test_invoice.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
-from frappe.utils.data import add_days, today
+from frappe.utils.data import add_days, formatdate, getdate, today
 
 from press.press.doctype.team.test_team import create_test_team
 
@@ -22,6 +22,12 @@ class TestInvoice(FrappeTestCase):
 
 	def tearDown(self):
 		frappe.db.rollback()
+
+	def create_usage_record(self, date, amount=10):
+		usage_record = frappe.get_doc(doctype="Usage Record", team=self.team.name, amount=amount, date=date)
+		usage_record.insert()
+		usage_record.submit()
+		return usage_record
 
 	def test_invoice_add_usage_record(self):
 		invoice = frappe.get_doc(
@@ -73,6 +79,60 @@ class TestInvoice(FrappeTestCase):
 		self.assertEqual(len(invoice.items), 3)
 		self.assertEqual(invoice.total, 90)
 		self.assertEqual(usage_records[0].invoice, None)
+
+	def test_invoice_item_period_covers_first_and_last_usage_record(self):
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=today(),
+			period_end=add_days(today(), 10),
+		).insert()
+
+		for day in [0, 1, 2]:
+			self.create_usage_record(date=add_days(today(), day))
+
+		invoice.reload()
+
+		self.assertEqual(len(invoice.items), 1)
+		self.assertEqual(invoice.items[0].period_start, getdate(today()))
+		self.assertEqual(invoice.items[0].period_end, getdate(add_days(today(), 2)))
+
+	def test_invoice_item_period_moves_when_the_first_usage_record_is_cancelled(self):
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=today(),
+			period_end=add_days(today(), 10),
+		).insert()
+
+		usage_records = [self.create_usage_record(date=add_days(today(), day)) for day in [0, 1, 2]]
+
+		usage_records[0].cancel()
+		invoice.reload()
+
+		self.assertEqual(invoice.items[0].period_start, getdate(add_days(today(), 1)))
+		self.assertEqual(invoice.items[0].period_end, getdate(add_days(today(), 2)))
+
+	def test_invoice_item_description_names_the_billed_period(self):
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=today(),
+			period_end=add_days(today(), 10),
+		).insert()
+
+		for day in [0, 1]:
+			self.create_usage_record(date=add_days(today(), day))
+
+		invoice.reload()
+		with patch.object(invoice, "create_stripe_invoice", return_value=None):
+			invoice.finalize_invoice()
+
+		period = f"from {formatdate(today())} to {formatdate(add_days(today(), 1))}"
+		self.assertTrue(
+			invoice.items[0].description.endswith(period),
+			f"{invoice.items[0].description} does not end with {period}",
+		)
 
 	def test_invoice_with_credits_less_than_total(self):
 		invoice = frappe.get_doc(

--- a/press/press/doctype/invoice_item/invoice_item.json
+++ b/press/press/doctype/invoice_item/invoice_item.json
@@ -9,6 +9,8 @@
 		"document_name",
 		"plan",
 		"description",
+		"period_start",
+		"period_end",
 		"quantity",
 		"rate",
 		"amount",
@@ -18,7 +20,26 @@
 		"has_marketplace_payout_completed"
 	],
 	"fields": [
-		{ "fieldname": "description", "fieldtype": "Data", "label": "Description" },
+		{
+			"fieldname": "description",
+			"fieldtype": "Data",
+			"label": "Description",
+			"length": 240
+		},
+		{
+			"description": "First day of usage that this item bills for",
+			"fieldname": "period_start",
+			"fieldtype": "Date",
+			"label": "Period Start",
+			"read_only": 1
+		},
+		{
+			"description": "Last day of usage that this item bills for",
+			"fieldname": "period_end",
+			"fieldtype": "Date",
+			"label": "Period End",
+			"read_only": 1
+		},
 		{
 			"columns": 1,
 			"default": "1",
@@ -93,7 +114,7 @@
 	"index_web_pages_for_search": 1,
 	"istable": 1,
 	"links": [],
-	"modified": "2024-11-06 20:44:24.686991",
+	"modified": "2026-08-14 12:00:00.000000",
 	"modified_by": "Administrator",
 	"module": "Press",
 	"name": "Invoice Item",

--- a/press/press/doctype/invoice_item/invoice_item.py
+++ b/press/press/doctype/invoice_item/invoice_item.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2020, Frappe and contributors
 # For license information, please see license.txt
 
@@ -26,6 +25,8 @@ class InvoiceItem(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
+		period_end: DF.Date | None
+		period_start: DF.Date | None
 		plan: DF.Data | None
 		quantity: DF.Float
 		rate: DF.Currency


### PR DESCRIPTION
Fixes #4942

## Problem

An invoice line tells the customer what was charged and how much. It does not tell the customer **when**. A partner sees `server-1 Storage Add-on for 12 days` and cannot tell which 12 days. The same is true after a server resize: the invoice shows two lines for the same server on two plans, but not the day the change happened.

## Solution

Each Invoice Item now keeps the first and the last date of the usage records it bills for.

- `period_start` and `period_end` are new read-only Date fields on Invoice Item.
- `add_usage_record` widens the period of an item when it adds a usage record to it.
- `remove_usage_record` reads the periods back from the usage records that stay, so a cancelled usage record cannot leave a wrong date.
- The item description names the period. Example: `server-1 Storage Add-on for 12 days from 03-08-2026 to 14-08-2026`. The description also goes into the invoice PDF.
- The dashboard invoice table shows a **Period** column, and the CSV download includes the two dates.

The period comes from the usage records, and not from a new log doctype, because the usage records already hold the date of each charge.

## Notes

- A patch fills the period on the items of draft invoices. Without it, the items that already exist on this month's draft invoice would look like they start on the day of the deploy. Submitted invoices keep an empty period, because their descriptions are final.
- The `description` field is now 240 characters, up from 140. The period text adds about 30 characters, and a long site name plus a plan name could pass the old limit.

## Tests

Three new tests in `test_invoice.py`:

- `test_invoice_item_period_covers_first_and_last_usage_record`
- `test_invoice_item_period_moves_when_the_first_usage_record_is_cancelled`
- `test_invoice_item_description_names_the_billed_period`

All 32 tests in `press.press.doctype.invoice.test_invoice` pass, together with the subscription tests. `ruff check`, Biome, and semgrep are clean, and the dashboard builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)