### PR TITLE
feat: Give user an option to reactivate suspended account  postlogin

### DIFF
--- a/dashboard/src/pages/LoginSignup.vue
+++ b/dashboard/src/pages/LoginSignup.vue
@@ -435,7 +435,7 @@
 		>
 			<template v-slot:body-content>
 				<p class="text-p-base text-ink-gray-7">
-					This account is disabled. Reactivating restores your sites and
+					This account is disabled. Reactivating restores your account and
 					resumes billing.
 				</p>
 				<ErrorMessage

--- a/dashboard/src/pages/LoginSignup.vue
+++ b/dashboard/src/pages/LoginSignup.vue
@@ -427,6 +427,36 @@
 
 			</LoginBox>
 		</div>
+
+		<Dialog
+			v-model="showReactivateAccountDialog"
+			:options="{ title: 'Reactivate Account', size :'sm' }"
+			@close="cancelReactivation"
+		>
+			<template v-slot:body-content>
+				<p class="text-p-base text-ink-gray-7">
+					This account is disabled. Reactivating restores your sites and
+					resumes billing.
+				</p>
+				<ErrorMessage
+					class="mt-2"
+					:message="$resources.reactivateAccount.error"
+				/>
+			</template>
+
+			<template v-slot:actions>
+				<div class="flex justify-end gap-2">
+					<Button @click="cancelReactivation">Cancel</Button>
+					<Button
+						variant="solid"
+						:loading="$resources.reactivateAccount.loading"
+						@click="$resources.reactivateAccount.submit()"
+					>
+						Reactivate
+					</Button>
+				</div>
+			</template>
+		</Dialog>
 	</div>
 </template>
 
@@ -461,6 +491,7 @@ export default {
 			otpResendCountdown: 0,
 			resetPasswordEmailSent: false,
 			on2FARecovery: false,
+			showReactivateAccountDialog: Boolean(window.account_disabled),
 		};
 	},
 	mounted() {
@@ -657,6 +688,15 @@ export default {
 				url: 'press.api.account.is_2fa_enabled',
 			};
 		},
+		reactivateAccount() {
+			return {
+				url: 'press.api.account.reactivate_account',
+				onSuccess(team) {
+					localStorage.setItem('current_team', team);
+					window.location.href = '/dashboard';
+				},
+			};
+		},
 		verify2FA() {
 			return {
 				url: 'press.api.account.verify_2fa',
@@ -818,6 +858,10 @@ export default {
 					},
 				},
 			);
+		},
+		cancelReactivation() {
+			this.showReactivateAccountDialog = false;
+			this.$session.logoutWithoutReload.submit();
 		},
 		async afterLogin() {
 			localStorage.setItem('login_email', this.email);

--- a/dashboard/src/router.js
+++ b/dashboard/src/router.js
@@ -563,6 +563,11 @@ router.beforeEach(async (to, from, next) => {
 	let hasTeamPrivileges = !!window.default_team
 	let goingToLoginPage = to.matched.some((record) => record.meta.isLoginPage)
 
+	if (isLoggedIn && window.account_disabled) {
+		next(goingToLoginPage ? undefined : { name: 'Login' })
+		return
+	}
+
 	if (isLoggedIn && hasTeamPrivileges) {
 		await waitUntilTeamLoaded()
 		let $team = getTeam()

--- a/mypy.ini
+++ b/mypy.ini
@@ -71,5 +71,7 @@ ignore_missing_imports = true
 ignore_missing_imports = true
 [mypy-google_auth_oauthlib.*]
 ignore_missing_imports = true
+[mypy-googleapiclient.*]
+ignore_missing_imports = true
 [mypy-moto.*]
 ignore_missing_imports = true

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -438,7 +438,9 @@ def reactivate_account():
 	"""Enable the account of the logged in user, on their way in from the login page"""
 	team_name = get_disabled_team_of_user(frappe.session.user)
 	if not team_name:
-		frappe.throw("You don't have a disabled account to reactivate.")
+		frappe.throw(
+			"You don't have a disabled account to reactivate. Please log in with the account you disabled."
+		)
 
 	# The team is disabled, so get_current_team throws for this session and every
 	# permission check on the team and its sites fails. Run as Administrator,

--- a/press/api/account.py
+++ b/press/api/account.py
@@ -27,7 +27,14 @@ from press.press.doctype.team.team import (
 	get_child_team_members,
 	get_team_members,
 )
-from press.utils import docs, get_country_info, get_current_team, is_user_part_of_team, log_error
+from press.utils import (
+	docs,
+	get_country_info,
+	get_current_team,
+	get_disabled_team_of_user,
+	is_user_part_of_team,
+	log_error,
+)
 from press.utils import otp as otp_purpose
 from press.utils import user as user_utils
 from press.utils.otp import OneTimePassword
@@ -424,6 +431,26 @@ def enable_account():
 			f"Only the team owner can enable this account. Please ask the team owner to do this. {docs.doc_link(docs.DISABLE_ACCOUNT)}."
 		)
 	team.enable_account()
+
+
+@frappe.whitelist()
+def reactivate_account():
+	"""Enable the account of the logged in user, on their way in from the login page"""
+	team_name = get_disabled_team_of_user(frappe.session.user)
+	if not team_name:
+		frappe.throw("You don't have a disabled account to reactivate.")
+
+	# The team is disabled, so get_current_team throws for this session and every
+	# permission check on the team and its sites fails. Run as Administrator,
+	# mirroring setup_account.
+	current_user = frappe.session.user
+	try:
+		frappe.set_user("Administrator")
+		Team("Team", team_name).enable_account()
+	finally:
+		frappe.set_user(current_user)
+
+	return team_name
 
 
 @frappe.whitelist()

--- a/press/api/google.py
+++ b/press/api/google.py
@@ -74,7 +74,7 @@ def callback(code: str | None = None, state: str | None = None):  # noqa: C901
 
 	team_name, team_enabled = frappe.db.get_value("Team", {"user": email}, ["name", "enabled"]) or [0, 0]
 
-	if team_name and not team_enabled:
+	if team_name and not team_enabled and product_trial:
 		frappe.throw(_("Account {0} has been deactivated").format(email))
 		return None
 
@@ -95,9 +95,13 @@ def callback(code: str | None = None, state: str | None = None):  # noqa: C901
 
 		# login to existing account
 		frappe.local.login_manager.login_as(email)
-		team = frappe.get_doc("Team", team_name)
 		frappe.local.response.type = "redirect"
-		frappe.local.response.location = f"/dashboard{team.get_route_on_login()}"
+		if not team_enabled:
+			# route lookup fails for a disabled team, the dashboard asks them to reactivate
+			frappe.local.response.location = "/dashboard"
+		else:
+			team = frappe.get_doc("Team", team_name)
+			frappe.local.response.location = f"/dashboard{team.get_route_on_login()}"
 		return None
 
 	# create account request

--- a/press/api/oauth.py
+++ b/press/api/oauth.py
@@ -117,7 +117,8 @@ def callback(code=None, state=None):
 		# login
 		else:
 			frappe.local.login_manager.login_as(email)
-			team_name = frappe.db.get_value("Team", {"user": email}, "name")
+			# route lookup fails for a disabled team, the dashboard asks them to reactivate
+			team_name = frappe.db.get_value("Team", {"user": email, "enabled": 1}, "name")
 			route = frappe.get_doc("Team", team_name).get_route_on_login() if team_name else ""
 			frappe.local.response.type = "redirect"
 			frappe.response.location = f"/dashboard{route}"

--- a/press/api/tests/test_account.py
+++ b/press/api/tests/test_account.py
@@ -8,10 +8,12 @@ from frappe.tests.ui_test_helpers import create_test_user
 from press.api.account import (
 	accept_team_invite,
 	leave_team,
+	reactivate_account,
 	set_2fa_recovery_code_reminders,
 	signup,
 	validate_pincode,
 )
+from press.overrides import on_login
 from press.press.doctype.account_request.account_request import AccountRequest
 from press.press.doctype.team.team import Team
 from press.press.doctype.team.team_members import get_invitations
@@ -20,6 +22,7 @@ from press.press.doctype.team.test_team import (
 	create_test_team,
 )
 from press.press.doctype.user_2fa.test_user_2fa import create_test_user_2fa
+from press.utils import get_disabled_team_of_user
 
 
 @contextmanager
@@ -473,4 +476,41 @@ class TestSet2FARecoveryCodeReminders(TestCase):
 				f"2FA is not enabled for {other_team.user}",
 				set_2fa_recovery_code_reminders,
 				True,
+			)
+
+
+class TestReactivateAccount(TestCase):
+	def setUp(self):
+		self.team = create_test_team()
+		self.team.db_set("enabled", 0)
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def is_enabled(self) -> int:
+		return frappe.db.get_value("Team", self.team.name, "enabled")
+
+	def test_logging_in_does_not_enable_a_disabled_account(self):
+		with user_context(self.team.user):
+			on_login(Mock(user=self.team.user))
+		self.assertEqual(self.is_enabled(), 0)
+
+	def test_reactivating_enables_the_account_the_user_disabled(self):
+		with user_context(self.team.user):
+			reactivate_account()
+		self.assertEqual(self.is_enabled(), 1)
+
+	def test_belonging_to_another_team_does_not_hide_the_disabled_account(self):
+		other_team = create_test_team()
+		other_team.append("team_members", {"user": self.team.user})
+		other_team.save()
+		self.assertEqual(get_disabled_team_of_user(self.team.user), self.team.name)
+
+	def test_reactivating_an_enabled_account_throws(self):
+		self.team.db_set("enabled", 1)
+		with user_context(self.team.user):
+			self.assertRaisesRegex(
+				frappe.ValidationError,
+				"You don't have a disabled account to reactivate.",
+				reactivate_account,
 			)

--- a/press/api/tests/test_account.py
+++ b/press/api/tests/test_account.py
@@ -506,6 +506,18 @@ class TestReactivateAccount(TestCase):
 		other_team.save()
 		self.assertEqual(get_disabled_team_of_user(self.team.user), self.team.name)
 
+	def test_a_child_team_is_never_mistaken_for_the_account(self):
+		frappe.get_doc(
+			{
+				"doctype": "Team",
+				"user": self.team.user,
+				"parent_team": self.team.name,
+				"country": self.team.country,
+				"enabled": 1,
+			}
+		).insert(ignore_permissions=True)
+		self.assertEqual(get_disabled_team_of_user(self.team.user), self.team.name)
+
 	def test_reactivating_an_enabled_account_throws(self):
 		self.team.db_set("enabled", 1)
 		with user_context(self.team.user):

--- a/press/overrides.py
+++ b/press/overrides.py
@@ -70,12 +70,6 @@ def on_login(login_manager):
 	):
 		frappe.throw("Please re-login to verify your identity.")
 
-	if not frappe.db.exists("Team", {"user": frappe.session.user, "enabled": 1}) and frappe.db.exists(
-		"Team", {"user": frappe.session.user, "enabled": 0}
-	):
-		frappe.db.set_value("Team", {"user": frappe.session.user, "enabled": 0}, "enabled", 1)
-		frappe.db.commit()
-
 
 def before_job():
 	frappe.local._current_team = None

--- a/press/utils/__init__.py
+++ b/press/utils/__init__.py
@@ -235,6 +235,13 @@ def get_default_team_for_user(user):
 	return None
 
 
+def get_disabled_team_of_user(user):
+	"""Returns the Team the user owns and disabled, whichever other teams they belong to"""
+	if frappe.db.exists("Team", {"user": user, "enabled": 1}):
+		return None
+	return frappe.db.get_value("Team", {"user": user, "enabled": 0}, "name")
+
+
 def chat_enabled():
 	if frappe.session.user == "Guest":
 		return False

--- a/press/utils/__init__.py
+++ b/press/utils/__init__.py
@@ -236,10 +236,14 @@ def get_default_team_for_user(user):
 
 
 def get_disabled_team_of_user(user):
-	"""Returns the Team the user owns and disabled, whichever other teams they belong to"""
-	if frappe.db.exists("Team", {"user": user, "enabled": 1}):
+	"""Returns the account the user owns and disabled, whichever other teams they belong to
+
+	Child teams are not accounts, a partner owns one per customer.
+	"""
+	own_account = {"user": user, "parent_team": ("is", "not set")}
+	if frappe.db.exists("Team", own_account | {"enabled": 1}):
 		return None
-	return frappe.db.get_value("Team", {"user": user, "enabled": 0}, "name")
+	return frappe.db.get_value("Team", own_account | {"enabled": 0}, "name")
 
 
 def chat_enabled():

--- a/press/www/dashboard.py
+++ b/press/www/dashboard.py
@@ -8,6 +8,7 @@ from frappe.utils.caching import redis_cache
 from press.utils import (
 	chat_enabled,
 	get_default_team_for_user,
+	get_disabled_team_of_user,
 	get_valid_teams_for_user,
 )
 from press.utils.telemetry import pulse_boot_config
@@ -48,6 +49,7 @@ def get_boot():
 		press_site_name=frappe.conf.site,
 		site_name=frappe.local.site,
 		default_team=default_team,
+		account_disabled=bool(get_disabled_team_of_user(frappe.session.user)),
 		valid_teams=get_valid_teams_for_user(frappe.session.user),
 		chat_enabled=chat_enabled(),
 		is_system_user=frappe.session.data.user_type == "System User",


### PR DESCRIPTION
## Description

### Before :

- When suspended user logs in, backend automatically reactivates it , user wont even know if his account was suspended or not

### Now :

- we show if user account is suspended and ask them if they wanna reactivate


<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/53515fb4-5bb2-4af0-81a5-8a75c899c6e4" />
