### PR TITLE
feat(log-page): Scroll to the end of the log on load

### DIFF
--- a/dashboard/src/pages/LogPage.vue
+++ b/dashboard/src/pages/LogPage.vue
@@ -45,10 +45,11 @@
 			class="mt-5 flex rounded bg-surface-gray-7 dark:bg-surface-gray-1 p-4 text-sm text-ink-gray-2 dark:text-ink-gray-8"
 		>
 			<span v-if="$resources.log.loading" class="flex items-center gap-2">
-				<Spinner /> Loading...
+				<Spinner />
+				Loading...
 			</span>
 
-			<pre v-else class="flex-1 min-w-0 overflow-auto">{{
+			<pre ref="logBody" v-else class="flex-1 min-w-0 overflow-auto">{{
 				log || 'No output'
 			}}</pre>
 
@@ -58,10 +59,10 @@
 </template>
 
 <script>
-import { FeatherIcon, Spinner } from 'frappe-ui';
-import { getObject } from '../objects';
-import { unreachable } from '../objects/common';
-import CopyBtn from '@/components/utils/CopyBtn.vue';
+import { FeatherIcon, Spinner } from 'frappe-ui'
+import CopyBtn from '@/components/utils/CopyBtn.vue'
+import { getObject } from '../objects'
+import { unreachable } from '../objects/common'
 
 export default {
 	name: 'LogPage',
@@ -69,11 +70,11 @@ export default {
 	components: { FeatherIcon },
 	resources: {
 		log() {
-			const url = this.forSite ? 'press.api.site.log' : 'press.api.bench.log';
-			const params = { log: this.logName, name: this.name };
+			const url = this.forSite ? 'press.api.site.log' : 'press.api.bench.log'
+			const params = { log: this.logName, name: this.name }
 			if (!this.forSite) {
-				params.name = `bench-${this.name?.split('-')[1]}`;
-				params.bench = this.name;
+				params.name = `bench-${this.name?.split('-')[1]}`
+				params.bench = this.name
 			}
 
 			return {
@@ -81,26 +82,31 @@ export default {
 				params,
 				auto: true,
 				transform(log) {
-					return log[this.logName];
+					return log[this.logName]
 				},
 				onSuccess() {
-					this.lastLoaded = Date.now();
+					this.lastLoaded = Date.now()
+					// the newest entries are at the end, and these files run to megabytes.
+					// scrollIntoView walks up to whichever ancestor actually scrolls.
+					this.$nextTick(() =>
+						this.$refs.logBody?.scrollIntoView({ block: 'end' }),
+					)
 				},
-			};
+			}
 		},
 	},
 	computed: {
 		forSite() {
-			if (this.objectType === 'Site') return true;
-			if (this.objectType === 'Bench') return false;
-			throw unreachable;
+			if (this.objectType === 'Site') return true
+			if (this.objectType === 'Bench') return false
+			throw unreachable
 		},
 		object() {
-			return getObject(this.objectType);
+			return getObject(this.objectType)
 		},
 		log() {
-			return this.$resources.log.data;
+			return this.$resources.log.data
 		},
 	},
-};
+}
 </script>


### PR DESCRIPTION
## Why

A log is read from the end. `web.error.log` and friends run to megabytes, so landing at the top means scrolling past hours of history to reach the entry you came for.

[frappe/agent#581](https://github.com/frappe/agent/pull/581) makes this sharper: the 500 error page now deep links to `/dashboard/benches/<bench>/logs/web.error.log`, so people arrive here from a site that is currently broken, wanting the last traceback. Landing at the top of a 140 KB file is the wrong place.

## What

Adds a `ref` to the `<pre>` and scrolls it into view once the log resource resolves.

```js
this.$nextTick(() => this.$refs.logBody?.scrollIntoView({ block: 'end' }));
```

`scrollIntoView` walks up to whichever ancestor actually scrolls, so this works whether the `<pre>`, a dashboard container, or the window is the scrollport — the markup alone doesn't settle which, and this avoids hardcoding the wrong one.

Applied unconditionally rather than behind a query param from the error page: the end is the right landing spot for every route into this page, and it keeps the change in one repo.

## Note for reviewers

Most of the diff is biome. The committed file predates the current config (semicolons, import order), so the pre-commit hook rewrites it for anyone who touches this file. The actual change is the `ref="logBody"` attribute and the four lines in `onSuccess`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)