### PR TITLE
fix(server): Install rclone on servers created from an image

### DIFF
--- a/press/press/doctype/press_job/jobs/create_server.py
+++ b/press/press/doctype/press_job/jobs/create_server.py
@@ -50,6 +50,10 @@ class CreateServerJob(PressJob):
 		# wazuh, ...) - they'd still be running when the reboot lands
 		self.set_docker_mtu_hetzner()
 
+		# Before set_additional_config, so provisioning waits for rclone instead of
+		# racing the apt plays that step enqueues
+		self.enable_backup_streaming()
+
 		self.set_additional_config()
 
 		if self.is_fs_server:
@@ -293,6 +297,13 @@ class CreateServerJob(PressJob):
 			return
 
 		self.server_doc.start_replication()
+
+	@task(queue="long", timeout=1200)
+	def enable_backup_streaming(self):
+		if self.server_type != "Server":
+			return
+
+		self.server_doc.enable_backup_streaming()
 
 	@task
 	def set_additional_config(self):

--- a/press/press/doctype/server/server.json
+++ b/press/press/doctype/server/server.json
@@ -532,7 +532,7 @@
 		},
 		{
 			"default": "0",
-			"description": "Stream backups directly to offsite storage instead of staging them on the server",
+			"description": "Stream backups directly to offsite storage instead of staging them on the server. Set during provisioning once rclone is installed",
 			"fieldname": "stream_backups",
 			"fieldtype": "Check",
 			"label": "Stream Backups"

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -3453,7 +3453,7 @@ class Server(BaseServer):
 
 	@frappe.whitelist()
 	def setup_rclone(self):
-		frappe.enqueue_doc(self.doctype, self.name, "_setup_rclone")
+		frappe.enqueue_doc(self.doctype, self.name, "_setup_rclone", queue="long", timeout=1200)
 
 	@frappe.whitelist()
 	def install_nfs_common(self):

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -3484,7 +3484,7 @@ class Server(BaseServer):
 		except Exception:
 			log_error("Install and ncdu Setup Exception", server=self.as_dict())
 
-	def _setup_rclone(self):
+	def _setup_rclone(self) -> AnsiblePlay | None:
 		try:
 			ansible = Ansible(
 				playbook="install_rclone.yml",
@@ -3492,9 +3492,20 @@ class Server(BaseServer):
 				user=self._ssh_user(),
 				port=self._ssh_port(),
 			)
-			ansible.run()
+			return ansible.run()
 		except Exception:
 			log_error("Install Rclone Exception", server=self.as_dict())
+			return None
+
+	def enable_backup_streaming(self):
+		"""Install rclone, then let this server stream offsite backups.
+
+		The agent rejects a streamed backup when rclone is missing, so the flag
+		must not be set until the play has actually succeeded.
+		"""
+		play = self._setup_rclone()
+		if play and play.status == "Success":
+			self.db_set("stream_backups", True)
 
 	@frappe.whitelist()
 	def add_upstream_to_proxy(self):

--- a/press/press/doctype/server/test_server.py
+++ b/press/press/doctype/server/test_server.py
@@ -696,6 +696,38 @@ class TestServer(FrappeTestCase):
 				server.set_auditd_setup_from_base_playbook()
 				self.assertFalse(server.is_auditd_setup)
 
+	def test_backup_streaming_enabled_after_rclone_play_succeeds(self):
+		server = create_test_server()
+		self.assertFalse(server.stream_backups)
+
+		with patch("press.press.doctype.server.server.Ansible") as Ansible:
+			Ansible.return_value.run.return_value = Mock(status="Success")
+			server.enable_backup_streaming()
+
+		server.reload()
+		self.assertTrue(server.stream_backups)
+
+	def test_backup_streaming_stays_disabled_when_rclone_play_fails(self):
+		"""The agent rejects a streamed backup when rclone is missing."""
+		server = create_test_server()
+
+		with patch("press.press.doctype.server.server.Ansible") as Ansible:
+			Ansible.return_value.run.return_value = Mock(status="Failure")
+			server.enable_backup_streaming()
+
+		server.reload()
+		self.assertFalse(server.stream_backups)
+
+	def test_backup_streaming_stays_disabled_when_rclone_play_errors_out(self):
+		server = create_test_server()
+
+		with patch("press.press.doctype.server.server.Ansible") as Ansible:
+			Ansible.return_value.run.side_effect = Exception("Connection refused")
+			server.enable_backup_streaming()
+
+		server.reload()
+		self.assertFalse(server.stream_backups)
+
 	@patch.object(BaseServer, "_archive", new=Mock())
 	@patch.object(BaseServer, "disable_subscription", new=Mock())
 	def test_archival_uninstalls_wazuh_agent_when_installed(self):
@@ -779,7 +811,7 @@ class TestServer(FrappeTestCase):
 		settings = create_test_press_settings()
 		settings.wazuh_api_url = "https://wazuh.example.com:55000"
 		settings.wazuh_api_username = "user"
-		settings.wazuh_api_password = "pass"
+		settings.wazuh_api_password = "pass"  # pragma: allowlist secret
 		settings.wazuh_api_verify_tls = 0
 		settings.save()
 
@@ -801,7 +833,7 @@ class TestServer(FrappeTestCase):
 		settings = create_test_press_settings()
 		settings.wazuh_api_url = "https://wazuh.example.com:55000"
 		settings.wazuh_api_username = "user"
-		settings.wazuh_api_password = "pass"
+		settings.wazuh_api_password = "pass"  # pragma: allowlist secret
 		settings.wazuh_api_verify_tls = 0
 		settings.save()
 

--- a/press/press/doctype/server/test_server.py
+++ b/press/press/doctype/server/test_server.py
@@ -719,12 +719,17 @@ class TestServer(FrappeTestCase):
 		self.assertFalse(server.stream_backups)
 
 	def test_backup_streaming_stays_disabled_when_rclone_play_errors_out(self):
+		"""An unreachable server logs the failure instead of raising."""
 		server = create_test_server()
 
-		with patch("press.press.doctype.server.server.Ansible") as Ansible:
+		with (
+			patch("press.press.doctype.server.server.Ansible") as Ansible,
+			patch("press.press.doctype.server.server.log_error") as log_error,
+		):
 			Ansible.return_value.run.side_effect = Exception("Connection refused")
 			server.enable_backup_streaming()
 
+		log_error.assert_called_once()
 		server.reload()
 		self.assertFalse(server.stream_backups)
 


### PR DESCRIPTION
## Why

`Install Rclone` was never running on servers created from the dashboard.

The `install_rclone` role is only wired into the full setup playbooks (`press/playbooks/server.yml`, `unified_server.yml`), which are played by `Server._setup_server()` / `_setup_unified_server()`. Dashboard-created servers never take that path: `api/server.py:new()` → `Cluster.create_server()` → `VirtualMachine.create_server()`, and since those VMs boot from a prebaked `virtual_machine_image`, the server doc is inserted with `is_server_setup` already set to true, so `server.yml` is skipped entirely.

The post-boot work for those servers is done by the **Create Server** press job. `Server.setup_rclone()` has existed since cc10819f4 but had no automatic caller, so it only ever ran if someone invoked it by hand.

## What changed

**A dedicated, synchronous rclone step in the Create Server job.** Rather than adding `setup_rclone()` to `set_additional_config()`, which only *enqueues* its plays, the job gets its own `@task`:

```python
@task(queue="long", timeout=1200)
def enable_backup_streaming(self):
    if self.server_type != "Server":
        return

    self.server_doc.enable_backup_streaming()
```

It runs ahead of `set_additional_config()` for two reasons: provisioning has to actually wait for rclone before anything advertises streaming, and that step enqueues filebeat, wazuh, earlyoom, ncdu and cadvisor — several of which use apt, so running rclone inside that pool would have it contending for the dpkg lock. The `server_type != "Server"` guard also covers unified servers, since those are `Server` docs.

**`stream_backups` is set by that step, not by a field default.** The flag is a consequence of a successful install:

```python
def enable_backup_streaming(self):
    """Install rclone, then let this server stream offsite backups.

    The agent rejects a streamed backup when rclone is missing, so the flag
    must not be set until the play has actually succeeded.
    """
    play = self._setup_rclone()
    if play and play.status == "Success":
        self.db_set("stream_backups", True)
```

Defaulting the field to `1` would have been wrong: the doc is inserted with streaming on while rclone is still absent, so an offsite backup landing in that window — or on a server where the play failed — advertises streaming and gets rejected by the agent for a missing binary. `_setup_rclone()` now returns its `Ansible Play` instead of discarding it; `Ansible.run()` folds task failures into the play's `status` rather than raising (`runner.py:252-266`), so `status == "Success"` is the real signal, and the `play and` guard covers the exception path, which still logs as before.

**A failed play leaves streaming off rather than failing the job.** Raising would fail the press job and block `is_provisioning_press_job_completed`, marking a healthy server un-provisioned over an optional backup optimization. The failed `Ansible Play` record is the signal instead.

**`setup_rclone()` gets an explicit queue and timeout** (second commit). It inherited `enqueue_doc`'s defaults — `queue="default", timeout=300` (`background_jobs.py:218`) — so a play that has to SSH in, fetch a deb from GitHub and run apt got 300s on the queue that also carries agent job polling. Now `queue="long", timeout=1200`, matching the other playbook enqueues in the file (`_install_nginx`, `_setup_auditd`, `_set_docker_mtu`) and the ceiling on the new press job task.

## Tests

Three in `TestServer`, following the existing `test_install_marks_wazuh_agent_installed_on_successful_play` pattern: streaming enabled after a successful play, and staying disabled both when the play returns `Failure` and when `Ansible.run` raises.

The `Ansible.run` raises case also patches `log_error`. `press.utils.log_error` re-raises the active exception under `frappe.flags.in_test` (`utils/__init__.py:49-58`), so `_setup_rclone()`'s `except` branch — which swallows the failure in production — rethrew it out of `enable_backup_streaming()` on CI. Patching it at the importing module is what `press/api/tests/test_github.py` already does, and the test asserts the call so it still proves the failure is logged rather than silently dropped.

## Notes for review

- **Servers provisioned through `server.yml` still won't stream.** That path plays the `install_rclone` role but never sets the flag, so bootstrap and manual "Setup Server" servers stay opted out until someone sets it. Left alone deliberately — the reported bug is the dashboard/image path. Happy to have `_setup_server()`'s success branch set it too if that's wanted.
- **Existing servers are untouched.** They keep `stream_backups = 0` and have no rclone. Enabling streaming on any of them needs `_setup_rclone()` run first, and there's currently no desk button for it (`server.js` exposes no action for `setup_rclone` or `setup_ncdu`), so today it's a console call. A button and/or a backfill patch would be worth adding separately.
- **Two unrelated lines touched.** `settings.wazuh_api_password = "pass"` in `test_server.py` got a `# pragma: allowlist secret`. It's a pre-existing false positive that `detect-secrets` only surfaces once the file is staged, and it blocks committing any change to that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

