### PR TITLE
feat(ui): Route the bench logs dialog so the 500 page can link to it (backport #7257)

### DIFF
--- a/dashboard/src/components/group/BenchLogsDialog.vue
+++ b/dashboard/src/components/group/BenchLogsDialog.vue
@@ -15,7 +15,9 @@
 							<lucide-arrow-left class="inline-block h-4 w-4" />
 						</template>
 					</Button>
-					<h2 class="ml-4 text-lg font-medium text-ink-gray-9">{{ logName }}</h2>
+					<h2 class="ml-4 text-lg font-medium text-ink-gray-9">
+						{{ logName }}
+					</h2>
 					<div class="!ml-auto flex gap-2">
 						<Button @click="log.reload()" :loading="log.loading">
 							<template #icon>
@@ -45,20 +47,23 @@
 </template>
 
 <script setup>
-import { createResource } from 'frappe-ui';
-import { defineProps, h, ref } from 'vue';
-import LucideSparkleIcon from '~icons/lucide/sparkle';
-import ObjectList from '../ObjectList.vue';
-import { date } from '../../utils/format';
-import router from '../../router';
+import { createResource } from 'frappe-ui'
+import { defineProps, h, ref } from 'vue'
+import LucideSparkleIcon from '~icons/lucide/sparkle'
+import router from '../../router'
+import { date } from '../../utils/format'
+import ObjectList from '../ObjectList.vue'
 
 const props = defineProps({
 	bench: String,
-});
+	// a deep link (the 500 page's error log link) names one log, so open it
+	// straight away instead of showing the list first
+	initialLog: String,
+})
 
-const show = ref(true);
-const logName = ref('');
-const showLog = ref(false);
+const show = ref(true)
+const logName = ref(props.initialLog ?? '')
+const showLog = ref(Boolean(props.initialLog))
 
 const log = createResource({
 	url: 'press.api.bench.log',
@@ -67,12 +72,14 @@ const log = createResource({
 			name: `bench-${props.bench?.split('-')[1]}`,
 			bench: props.bench,
 			log: logName.value,
-		};
+		}
 	},
-});
+})
+
+if (showLog.value) log.fetch()
 
 const navigateToLogBrowser = () => {
-	show.value = false;
+	show.value = false
 	router.push({
 		name: 'Log Browser',
 		params: {
@@ -80,8 +87,8 @@ const navigateToLogBrowser = () => {
 			docName: props.bench,
 			logId: logName.value,
 		},
-	});
-};
+	})
+}
 
 const listOptions = ref({
 	resource() {
@@ -91,16 +98,16 @@ const listOptions = ref({
 				return {
 					name: `bench-${props.bench?.split('-')[1]}`,
 					bench: props.bench,
-				};
+				}
 			},
 			cache: ['BenchLogs', props.bench],
 			auto: true,
-		};
+		}
 	},
 	onRowClick(row) {
-		logName.value = row.name;
-		showLog.value = true;
-		log.fetch();
+		logName.value = row.name
+		showLog.value = true
+		log.fetch()
 	},
 	columns: [
 		{
@@ -112,14 +119,14 @@ const listOptions = ref({
 			fieldname: 'size',
 			class: 'text-ink-gray-6',
 			format(value) {
-				return `${value} kB`;
+				return `${value} kB`
 			},
 		},
 		{
 			label: 'Created On',
 			fieldname: 'created',
 			format(value) {
-				return value ? date(value, 'lll') : '';
+				return value ? date(value, 'lll') : ''
 			},
 		},
 	],
@@ -130,13 +137,13 @@ const listOptions = ref({
 			},
 			label: 'View in Log Browser',
 			onClick: () => {
-				show.value = false;
+				show.value = false
 				router.push({
 					name: 'Log Browser',
 					params: { mode: 'bench', docName: props.bench },
-				});
+				})
 			},
 		},
 	],
-});
+})
 </script>

--- a/dashboard/src/components/group/BenchLogsDialog.vue
+++ b/dashboard/src/components/group/BenchLogsDialog.vue
@@ -34,6 +34,7 @@
 				</div>
 				<div class="mt-4">
 					<div
+						ref="logBody"
 						class="h-[34rem] overflow-scroll rounded border border-outline-gray-1 bg-gray-900 px-2.5 py-2 text-sm text-ink-gray-2"
 					>
 						<pre>{{
@@ -48,7 +49,7 @@
 
 <script setup>
 import { createResource } from 'frappe-ui'
-import { defineProps, h, ref } from 'vue'
+import { defineProps, h, nextTick, ref } from 'vue'
 import LucideSparkleIcon from '~icons/lucide/sparkle'
 import router from '../../router'
 import { date } from '../../utils/format'
@@ -64,6 +65,7 @@ const props = defineProps({
 const show = ref(true)
 const logName = ref(props.initialLog ?? '')
 const showLog = ref(Boolean(props.initialLog))
+const logBody = ref(null)
 
 const log = createResource({
 	url: 'press.api.bench.log',
@@ -73,6 +75,12 @@ const log = createResource({
 			bench: props.bench,
 			log: logName.value,
 		}
+	},
+	onSuccess() {
+		// newest entries are at the end, and these files run to megabytes
+		nextTick(() => {
+			if (logBody.value) logBody.value.scrollTop = logBody.value.scrollHeight
+		})
 	},
 })
 

--- a/dashboard/src/objects/bench.ts
+++ b/dashboard/src/objects/bench.ts
@@ -1,17 +1,18 @@
-import { Tooltip } from 'frappe-ui';
-import LucideAppWindow from '~icons/lucide/app-window';
-import type { VNode } from 'vue';
-import { defineAsyncComponent, h } from 'vue';
-import { getTeam, switchToTeam } from '../data/team';
-import { icon } from '../utils/components';
+import { Tooltip } from 'frappe-ui'
+import type { VNode } from 'vue'
+import { defineAsyncComponent, h } from 'vue'
+import LucideAppWindow from '~icons/lucide/app-window'
+import { getTeam, switchToTeam } from '../data/team'
+import { icon } from '../utils/components'
 import {
 	clusterOptions,
 	getSitesTabColumns,
 	sitesTabRoute,
-	siteTabFilterControls
-} from './common';
-import { getAppsTab } from './common/apps';
-import { getJobsTab } from './common/jobs';
+	siteTabFilterControls,
+} from './common'
+import { getAppsTab } from './common/apps'
+import { getJobsTab } from './common/jobs'
+import { getPatchesTab } from './common/patches'
 import type {
 	Breadcrumb,
 	BreadcrumbArgs,
@@ -22,18 +23,17 @@ import type {
 	List,
 	RouteDetail,
 	Row,
-	Tab
-} from './common/types';
-import { getLogsTab } from './tabs/site/logs';
-import { getPatchesTab } from './common/patches';
+	Tab,
+} from './common/types'
+import { getLogsTab } from './tabs/site/logs'
 
 export default {
 	doctype: 'Bench',
 	whitelistedMethods: {},
 	detail: getDetail(),
 	list: getList(),
-	routes: getRoutes()
-} satisfies DashboardObject as DashboardObject;
+	routes: getRoutes(),
+} satisfies DashboardObject as DashboardObject
 
 function getDetail() {
 	return {
@@ -42,7 +42,7 @@ function getDetail() {
 		route: '/benches/:name',
 		tabs: getTabs(),
 		actions: ({ documentResource: res }) => {
-			const team = getTeam();
+			const team = getTeam()
 			return [
 				{
 					label: 'Options',
@@ -55,26 +55,26 @@ function getDetail() {
 							onClick() {
 								window.open(
 									`${window.location.protocol}//${window.location.host}/app/bench/${res.name}`,
-									'_blank'
-								);
-							}
+									'_blank',
+								)
+							},
 						},
 						{
 							label: 'Impersonate Team',
 							icon: defineAsyncComponent(
-								() => import('~icons/lucide/venetian-mask')
+								() => import('~icons/lucide/venetian-mask'),
 							),
 							condition: () => window.is_system_user ?? false,
 							onClick() {
-								switchToTeam(res.doc.team);
-							}
-						}
-					]
-				}
-			];
-		}
+								switchToTeam(res.doc.team)
+							},
+						},
+					],
+				},
+			]
+		},
 		// breadcrumbs // use default breadcrumbs
-	} satisfies Detail as Detail;
+	} satisfies Detail as Detail
 }
 
 function getTabs() {
@@ -84,8 +84,8 @@ function getTabs() {
 		getJobsTab('Bench'),
 		getProcessesTab(),
 		getLogsTab(false),
-		getPatchesTab(true)
-	] satisfies Tab[] as Tab[];
+		getPatchesTab(true),
+	] satisfies Tab[] as Tab[]
 }
 
 function getRoutes() {
@@ -93,14 +93,22 @@ function getRoutes() {
 		{
 			name: 'Bench Job',
 			path: 'jobs/:id',
-			component: () => import('../pages/JobPage.vue')
+			component: () => import('../pages/JobPage.vue'),
 		},
 		{
 			name: 'Bench Log',
 			path: 'logs/:logName',
-			component: () => import('../pages/LogPage.vue')
-		}
-	] satisfies RouteDetail[] as RouteDetail[];
+			// LogPage is unreachable from the sidebar now that benches live under
+			// their group. Old links (the 500 page points here) go to the dialog
+			// on the group's Sites tab instead. A bench is named
+			// <group>-<serial>-<server>, which is where the group comes from.
+			redirect: (to) => ({
+				name: 'Release Group Detail Sites',
+				params: { name: `bench-${String(to.params.name).split('-')[1]}` },
+				query: { bench: to.params.name, log: to.params.logName },
+			}),
+		},
+	] satisfies RouteDetail[] as RouteDetail[]
 }
 
 function getList() {
@@ -111,7 +119,7 @@ function getList() {
 			'group.title as group_title',
 			'cluster.name as cluster_name',
 			'cluster.image as cluster_image',
-			'cluster.title as cluster_title'
+			'cluster.title as cluster_title',
 		],
 		orderBy: 'creation desc',
 		searchField: 'name',
@@ -120,67 +128,67 @@ function getList() {
 				label: 'Bench',
 				fieldname: 'name',
 				class: 'font-medium',
-				suffix: getBenchTitleSuffix
+				suffix: getBenchTitleSuffix,
 			},
 			{
 				label: 'Status',
 				fieldname: 'status',
 				type: 'Badge',
-				width: '100px'
+				width: '100px',
 			},
 			{
 				label: 'Sites',
 				fieldname: 'site_count',
 				type: 'Number',
 				width: '100px',
-				align: 'right'
+				align: 'right',
 			},
 			{
 				label: 'Region',
 				fieldname: 'cluster',
 				width: 0.75,
 				format: (value, row) => String(row.cluster_title || value || ''),
-				prefix: getClusterImagePrefix
+				prefix: getClusterImagePrefix,
 			},
-			{ label: 'Bench', fieldname: 'group_title', width: '350px' }
+			{ label: 'Bench', fieldname: 'group_title', width: '350px' },
 		],
-		filterControls
-	} satisfies List as List;
+		filterControls,
+	} satisfies List as List
 }
 
 export function getBenchTitleSuffix(row: Row) {
-	const ch: VNode[] = [];
-	if (row.inplace_update_docker_image) ch.push(getInPlaceUpdatesSuffix(row));
-	if (row.has_app_patch_applied) ch.push(getAppPatchSuffix(row));
-	if (!ch.length) return;
+	const ch: VNode[] = []
+	if (row.inplace_update_docker_image) ch.push(getInPlaceUpdatesSuffix(row))
+	if (row.has_app_patch_applied) ch.push(getAppPatchSuffix(row))
+	if (!ch.length) return
 
 	return h(
 		'div',
 		{
-			class: 'flex flex-row gap-2'
+			class: 'flex flex-row gap-2',
 		},
-		ch
-	);
+		ch,
+	)
 }
 
 function getInPlaceUpdatesSuffix(row: Row) {
 	const count = Number(
-		String(row.inplace_update_docker_image).split('-').at(-1)
-	);
+		String(row.inplace_update_docker_image).split('-').at(-1),
+	)
 
-	let title = 'Bench has been updated in place';
+	let title = 'Bench has been updated in place'
 	if (!Number.isNaN(count) && count > 1) {
-		title += ` ${count} times`;
+		title += ` ${count} times`
 	}
 
 	return h(
 		'div',
 		{
 			title,
-			class: 'rounded-full bg-surface-gray-2 p-1'
+			class: 'rounded-full bg-surface-gray-2 p-1',
 		},
-		h(icon('star', 'w-3 h-3'))
-	);
+		h(icon('star', 'w-3 h-3')),
+	)
 }
 
 function getAppPatchSuffix(row: Row) {
@@ -188,20 +196,20 @@ function getAppPatchSuffix(row: Row) {
 		'div',
 		{
 			title: 'Apps in this bench may have been patched',
-			class: 'rounded-full bg-surface-gray-2 p-1'
+			class: 'rounded-full bg-surface-gray-2 p-1',
 		},
-		h(icon('hash', 'w-3 h-3'))
-	);
+		h(icon('hash', 'w-3 h-3')),
+	)
 }
 
 export function getClusterImagePrefix(row: Row) {
-	if (!row.cluster_image) return;
+	if (!row.cluster_image) return
 
 	return h('img', {
 		src: row.cluster_image,
 		class: 'w-4 h-4',
-		alt: row.cluster_title
-	});
+		alt: row.cluster_title,
+	})
 }
 
 export function filterControls() {
@@ -217,24 +225,24 @@ export function filterControls() {
 				'Installing',
 				'Updating',
 				'Broken',
-				'Archived'
-			]
+				'Archived',
+			],
 		},
 		{
 			type: 'link',
 			label: 'Bench',
 			fieldname: 'group',
 			options: {
-				doctype: 'Release Group'
-			}
+				doctype: 'Release Group',
+			},
 		},
 		{
 			type: 'select',
 			label: 'Region',
 			fieldname: 'cluster',
-			options: clusterOptions
-		}
-	] satisfies FilterField[] as FilterField[];
+			options: clusterOptions,
+		},
+	] satisfies FilterField[] as FilterField[]
 }
 
 export function getSitesTab() {
@@ -245,10 +253,10 @@ export function getSitesTab() {
 		type: 'list',
 		list: {
 			doctype: 'Site',
-			filters: r => ({
+			filters: (r) => ({
 				group: r.doc.group,
 				bench: r.name,
-				skip_team_filter_for_system_user_and_support_agent: true
+				skip_team_filter_for_system_user_and_support_agent: true,
 			}),
 			fields: [
 				'name',
@@ -258,24 +266,24 @@ export function getSitesTab() {
 				'plan.price_usd as price_usd',
 				'plan.price_inr as price_inr',
 				'cluster.image as cluster_image',
-				'cluster.title as cluster_title'
+				'cluster.title as cluster_title',
 			],
 			orderBy: 'creation desc, bench desc',
 			pageLength: 99999,
 			columns: getSitesTabColumns(true),
 			filterControls: siteTabFilterControls,
 			route: sitesTabRoute,
-			primaryAction: r => {
+			primaryAction: (r) => {
 				return {
 					label: 'New Site',
 					slots: {
-						prefix: icon('plus', 'w-4 h-4')
+						prefix: icon('plus', 'w-4 h-4'),
 					},
 					route: {
 						name: 'Release Group New Site',
-						params: { bench: r.documentResource.doc.group }
-					}
-				};
+						params: { bench: r.documentResource.doc.group },
+					},
+				}
 			},
 			rowActions: ({ row }) => [
 				{
@@ -284,17 +292,17 @@ export function getSitesTab() {
 					onClick() {
 						window.open(
 							`${window.location.protocol}//${window.location.host}/app/site/${row.name}`,
-							'_blank'
-						);
-					}
-				}
-			]
-		}
-	} satisfies Tab;
+							'_blank',
+						)
+					},
+				},
+			],
+		},
+	} satisfies Tab
 }
 
 export function getProcessesTab() {
-	const url = 'press.api.bench.get_processes';
+	const url = 'press.api.bench.get_processes'
 	return {
 		label: 'Processes',
 		icon: icon('cpu'),
@@ -304,17 +312,17 @@ export function getProcessesTab() {
 			resource({ documentResource: res }) {
 				return {
 					params: {
-						name: res.name
+						name: res.name,
 					},
 					url,
 					auto: true,
-					cache: ['ObjectList', url, res.name]
-				};
+					cache: ['ObjectList', url, res.name],
+				}
 			},
 			columns: getProcessesColumns(),
-			rowActions: () => [] // TODO: allow issuing supectl commands
-		}
-	} satisfies Tab as Tab;
+			rowActions: () => [], // TODO: allow issuing supectl commands
+		},
+	} satisfies Tab as Tab
 }
 
 export function getProcessesColumns() {
@@ -326,66 +334,66 @@ export function getProcessesColumns() {
 		Stopped: 'gray',
 		Exited: 'gray',
 		Unknown: 'gray',
-		Fatal: 'red'
-	};
+		Fatal: 'red',
+	}
 
-	type Status = keyof typeof processStatusColorMap;
+	type Status = keyof typeof processStatusColorMap
 	return [
 		{
 			label: 'Name',
 			width: 2,
-			fieldname: 'name'
+			fieldname: 'name',
 		},
 		{
 			label: 'Group',
 			width: 1.5,
 			fieldname: 'group',
-			format: v => String(v ?? '')
+			format: (v) => String(v ?? ''),
 		},
 		{
 			label: 'Status',
 			type: 'Badge',
 			width: 0.7,
 			fieldname: 'status',
-			theme: value => processStatusColorMap[value as Status] ?? 'gray',
+			theme: (value) => processStatusColorMap[value as Status] ?? 'gray',
 			suffix: ({ message }) => {
 				if (!message) {
-					return;
+					return
 				}
 
 				return h(
 					Tooltip,
 					{
 						text: message,
-						placement: 'top'
+						placement: 'top',
 					},
-					() => h(icon('alert-circle', 'w-3 h-3'))
-				);
-			}
+					() => h(icon('alert-circle', 'w-3 h-3')),
+				)
+			},
 		},
 		{
 			label: 'Uptime',
-			fieldname: 'uptime_string'
-		}
-	] satisfies ColumnField[] as ColumnField[];
+			fieldname: 'uptime_string',
+		},
+	] satisfies ColumnField[] as ColumnField[]
 }
 
 function breadcrumbs({ items, documentResource: bench }: BreadcrumbArgs) {
-	const $team = getTeam();
+	const $team = getTeam()
 	const benchCrumb = {
 		label: bench.doc?.name,
-		route: `/benches/${bench.doc?.name}`
-	};
+		route: `/benches/${bench.doc?.name}`,
+	}
 
 	if (bench.doc.group_team == $team.doc?.name || $team.doc?.is_desk_user) {
 		return [
 			{
 				label: bench.doc?.group_title,
-				route: `/groups/${bench.doc?.group}`
+				route: `/groups/${bench.doc?.group}`,
 			},
-			benchCrumb
-		] satisfies Breadcrumb[];
+			benchCrumb,
+		] satisfies Breadcrumb[]
 	}
 
-	return [...items.slice(0, -1), benchCrumb] satisfies Breadcrumb[];
+	return [...items.slice(0, -1), benchCrumb] satisfies Breadcrumb[]
 }

--- a/dashboard/src/objects/common/types.ts
+++ b/dashboard/src/objects/common/types.ts
@@ -1,215 +1,217 @@
-import type { defineAsyncComponent, h, Component } from 'vue';
-import type { icon } from '../../utils/components';
+import type { Component, defineAsyncComponent, h } from 'vue'
+import type { RouteRecordRaw } from 'vue-router'
+import type { icon } from '../../utils/components'
 
 type ListResource = {
-	data: Record<string, unknown>[];
-	reload: () => void;
+	data: Record<string, unknown>[]
+	reload: () => void
 	runDocMethod: {
-		submit: (r: { method: string; [key: string]: any }) => Promise<unknown>;
-	};
+		submit: (r: { method: string; [key: string]: any }) => Promise<unknown>
+	}
 	delete: {
-		submit: (name: string, cb: { onSuccess: () => void }) => Promise<unknown>;
-	};
-};
+		submit: (name: string, cb: { onSuccess: () => void }) => Promise<unknown>
+	}
+}
 export interface ResourceBase {
-	url: string;
-	auto: boolean;
-	cache: string[];
+	url: string
+	auto: boolean
+	cache: string[]
 }
 
 export interface ResourceWithParams extends ResourceBase {
-	params: Record<string, unknown>;
+	params: Record<string, unknown>
 }
 
 export interface ResourceWithMakeParams extends ResourceBase {
-	makeParams: () => Record<string, unknown>;
+	makeParams: () => Record<string, unknown>
 }
 
-export type Resource = ResourceWithParams | ResourceWithMakeParams;
+export type Resource = ResourceWithParams | ResourceWithMakeParams
 
 export interface DocumentResource {
-	name: string;
-	doc: Record<string, any>;
-	[key: string]: any;
+	name: string
+	doc: Record<string, any>
+	[key: string]: any
 }
 
-type Icon = ReturnType<typeof icon>;
-type AsyncComponent = ReturnType<typeof defineAsyncComponent>;
+type Icon = ReturnType<typeof icon>
+type AsyncComponent = ReturnType<typeof defineAsyncComponent>
 
 export interface DashboardObject {
-	doctype: string;
-	whitelistedMethods: Record<string, string>;
-	list: List;
-	detail: Detail;
-	routes: RouteDetail[];
+	doctype: string
+	whitelistedMethods: Record<string, string>
+	list: List
+	detail: Detail
+	routes: RouteDetail[]
 }
 
 export interface Detail {
-	titleField: string;
-	statusBadge: StatusBadge;
-	breadcrumbs?: Breadcrumbs;
-	route: string;
-	tabs: Tab[];
-	actions: (r: { documentResource: DocumentResource }) => Action[];
+	titleField: string
+	statusBadge: StatusBadge
+	breadcrumbs?: Breadcrumbs
+	route: string
+	tabs: Tab[]
+	actions: (r: { documentResource: DocumentResource }) => Action[]
 }
 
 export interface List {
-	route: string;
-	title: string;
-	fields: string[]; // TODO: Incomplete
-	searchField: string;
-	columns: ColumnField[];
-	orderBy: string;
-	filterControls: FilterControls;
-	primaryAction?: PrimaryAction;
+	route: string
+	title: string
+	fields: string[] // TODO: Incomplete
+	searchField: string
+	columns: ColumnField[]
+	orderBy: string
+	filterControls: FilterControls
+	primaryAction?: PrimaryAction
 }
 type R = {
-	listResource: ListResource;
-	documentResource: DocumentResource;
-};
-type FilterControls = (r: R) => FilterField[];
+	listResource: ListResource
+	documentResource: DocumentResource
+}
+type FilterControls = (r: R) => FilterField[]
 type PrimaryAction = (r: R) => {
-	label: string;
-	variant?: string;
+	label: string
+	variant?: string
 	slots: {
-		prefix: Icon;
-	};
-	onClick?: () => void;
-};
+		prefix: Icon
+	}
+	onClick?: () => void
+}
 type StatusBadge = (r: { documentResource: DocumentResource }) => {
-	label: string;
-};
-export type Breadcrumb = { label: string; route: string };
+	label: string
+}
+export type Breadcrumb = { label: string; route: string }
 export type BreadcrumbArgs = {
-	documentResource: DocumentResource;
-	items: Breadcrumb[];
-};
-export type Breadcrumbs = (r: BreadcrumbArgs) => Breadcrumb[];
+	documentResource: DocumentResource
+	items: Breadcrumb[]
+}
+export type Breadcrumbs = (r: BreadcrumbArgs) => Breadcrumb[]
 
 export interface FilterField {
-	label: string;
-	fieldname: string;
-	type: string;
-	class?: string;
+	label: string
+	fieldname: string
+	type: string
+	class?: string
 	options?:
 		| {
-				doctype: string;
+				doctype: string
 				filters?: {
-					doctype_name?: string;
-				};
+					doctype_name?: string
+				}
 		  }
-		| string[];
+		| string[]
 }
 
 export interface ColumnField {
-	label: string;
-	fieldname?: string;
-	class?: string;
-	width?: string | number;
-	type?: string;
-	format?: (value: any, row: Row) => string | undefined;
-	link?: (value: unknown, row: Row) => string;
-	prefix?: (row: Row) => Component | undefined;
-	suffix?: (row: Row) => Component | undefined;
-	theme?: (value: unknown) => string;
-	align?: 'left' | 'right';
+	label: string
+	fieldname?: string
+	class?: string
+	width?: string | number
+	type?: string
+	format?: (value: any, row: Row) => string | undefined
+	link?: (value: unknown, row: Row) => string
+	prefix?: (row: Row) => Component | undefined
+	suffix?: (row: Row) => Component | undefined
+	theme?: (value: unknown) => string
+	align?: 'left' | 'right'
 }
 
-export type Row = Record<string, any>;
+export type Row = Record<string, any>
 
 export interface Tab {
-	label: string;
-	icon: Icon;
-	route: string;
-	type: string;
-	condition?: (r: DocumentResource) => boolean;
-	childrenRoutes?: string[];
-	component?: AsyncComponent;
-	props?: (r: DocumentResource) => Record<string, unknown>;
-	list?: TabList;
+	label: string
+	icon: Icon
+	route: string
+	type: string
+	condition?: (r: DocumentResource) => boolean
+	childrenRoutes?: string[]
+	component?: AsyncComponent
+	props?: (r: DocumentResource) => Record<string, unknown>
+	list?: TabList
 }
 
 export interface TabList {
-	doctype?: string;
-	orderBy?: string;
-	filters?: (r: DocumentResource) => Record<string, unknown>;
-	route?: (row: Row) => Route;
-	pageLength?: number;
-	columns: ColumnField[];
-	fields?: Record<string, string[]>[] | string[];
+	doctype?: string
+	orderBy?: string
+	filters?: (r: DocumentResource) => Record<string, unknown>
+	route?: (row: Row) => Route
+	pageLength?: number
+	columns: ColumnField[]
+	fields?: Record<string, string[]>[] | string[]
 	rowActions?: (r: {
-		row: Row;
-		listResource: ListResource;
-		documentResource: DocumentResource;
-	}) => Action[];
-	primaryAction?: PrimaryAction;
-	filterControls?: FilterControls;
+		row: Row
+		listResource: ListResource
+		documentResource: DocumentResource
+	}) => Action[]
+	primaryAction?: PrimaryAction
+	filterControls?: FilterControls
 	banner?: (r: {
-		documentResource: DocumentResource;
-	}) => BannerConfig | undefined;
-	searchField?: string;
-	experimental?: boolean;
-	documentation?: string;
-	resource?: (r: { documentResource: DocumentResource }) => Resource;
+		documentResource: DocumentResource
+	}) => BannerConfig | undefined
+	searchField?: string
+	experimental?: boolean
+	documentation?: string
+	resource?: (r: { documentResource: DocumentResource }) => Resource
 }
 
 interface Action {
-	label: string;
+	label: string
 	slots?: {
-		prefix?: Icon;
-	};
-	theme?: string;
-	variant?: string;
-	onClick?: () => void;
-	condition?: () => boolean;
-	route?: Route;
-	options?: Option[];
+		prefix?: Icon
+	}
+	theme?: string
+	variant?: string
+	onClick?: () => void
+	condition?: () => boolean
+	route?: Route
+	options?: Option[]
 }
 
 export interface Route {
-	name: string;
-	params: Record<string, unknown>;
+	name: string
+	params: Record<string, unknown>
 }
 
 export interface RouteDetail {
-	name: string;
-	path: string;
-	component: Component;
+	name: string
+	path: string
+	component?: Component
+	redirect?: RouteRecordRaw['redirect']
 }
 
 interface Option {
-	label: string;
-	icon: Icon | AsyncComponent;
-	condition: () => boolean;
-	onClick: () => void;
+	label: string
+	icon: Icon | AsyncComponent
+	condition: () => boolean
+	onClick: () => void
 }
 
 export interface BannerConfig {
-	title: string;
-	dismissable: boolean;
-	id: string;
-	type?: string;
+	title: string
+	dismissable: boolean
+	id: string
+	type?: string
 	button?: {
-		label: string;
-		variant: string;
-		onClick?: () => void;
-	};
+		label: string
+		variant: string
+		onClick?: () => void
+	}
 }
 
 export interface DialogConfig {
-	title: string;
-	message: string;
-	primaryAction?: { onClick: () => void };
-	onSuccess?: (o: { hide: () => void }) => void;
+	title: string
+	message: string
+	primaryAction?: { onClick: () => void }
+	onSuccess?: (o: { hide: () => void }) => void
 }
 
 export interface Process {
-	program: string;
-	name: string;
-	status: string;
-	uptime?: number;
-	uptime_string?: string;
-	message?: string;
-	group?: string;
-	pid?: number;
+	program: string
+	name: string
+	status: string
+	uptime?: number
+	uptime_string?: string
+	message?: string
+	group?: string
+	pid?: number
 }

--- a/dashboard/src/pages/ReleaseGroupBenchSites.vue
+++ b/dashboard/src/pages/ReleaseGroupBenchSites.vue
@@ -44,27 +44,27 @@
 	</div>
 </template>
 <script lang="jsx">
-import Badge from '@/components/global/Badge.vue';
-import { createResource, getCachedDocumentResource, Tooltip } from 'frappe-ui';
-import { defineAsyncComponent, h } from 'vue';
-import { toast } from 'vue-sonner';
-import ActionButton from '../components/ActionButton.vue';
-import SSHCertificateDialog from '../components/group/SSHCertificateDialog.vue';
-import ObjectList from '../components/ObjectList.vue';
+import { createResource, getCachedDocumentResource, Tooltip } from 'frappe-ui'
+import { defineAsyncComponent, h } from 'vue'
+import { toast } from 'vue-sonner'
+import Badge from '@/components/global/Badge.vue'
+import ActionButton from '../components/ActionButton.vue'
+import CustomAlerts from '../components/CustomAlerts.vue'
+import DismissableBanner from '../components/DismissableBanner.vue'
+import SSHCertificateDialog from '../components/group/SSHCertificateDialog.vue'
+import ObjectList from '../components/ObjectList.vue'
 import {
 	filterControls as benchFilterControls,
 	getBenchTitleSuffix,
 	getClusterImagePrefix,
-} from '../objects/bench';
+} from '../objects/bench'
 import {
 	getSitesTabColumns,
 	sitesTabRoute,
 	siteTabFilterControls,
-} from '../objects/common';
-import { confirmDialog, icon, renderDialog } from '../utils/components';
-import { getToastErrorMessage } from '../utils/toast';
-import DismissableBanner from '../components/DismissableBanner.vue';
-import CustomAlerts from '../components/CustomAlerts.vue';
+} from '../objects/common'
+import { confirmDialog, icon, renderDialog } from '../utils/components'
+import { getToastErrorMessage } from '../utils/toast'
 
 export default {
 	name: 'ReleaseGroupBenchSites',
@@ -74,7 +74,7 @@ export default {
 		return {
 			showAppVersionDialog: false,
 			sitesGroupedByBench: [],
-		};
+		}
 	},
 	resources: {
 		benches() {
@@ -95,10 +95,10 @@ export default {
 				pageLength: this.isPublicBench ? 20 : 99999,
 				auto: true,
 				onSuccess() {
-					if (this.isPublicBench) return;
-					this.$resources.sites.fetch();
+					if (this.isPublicBench) return
+					this.$resources.sites.fetch()
 				},
-			};
+			}
 		},
 		inQueueBenches() {
 			return {
@@ -113,7 +113,7 @@ export default {
 				orderBy: 'creation desc',
 				pageLength: 99999,
 				auto: true,
-			};
+			}
 		},
 		sites() {
 			return {
@@ -137,20 +137,20 @@ export default {
 				orderBy: 'creation desc, bench desc',
 				pageLength: 99999,
 				transform(data) {
-					return this.groupSitesByBench(data);
+					return this.groupSitesByBench(data)
 				},
 				auto: false,
-			};
+			}
 		},
 	},
 	computed: {
 		// Public benches has a lot of site so dont show sites list
 		isPublicBench() {
-			return Boolean(this.$releaseGroup.doc?.public);
+			return Boolean(this.$releaseGroup.doc?.public)
 		},
 		listOptions() {
-			if (this.isPublicBench) return this.benchListOptions;
-			return this.groupedSiteListOptions;
+			if (this.isPublicBench) return this.benchListOptions
+			return this.groupedSiteListOptions
 		},
 
 		benchListOptions() {
@@ -185,17 +185,17 @@ export default {
 				route: (row) => ({ name: 'Bench Detail', params: { name: row.name } }),
 				rowActions: ({ row }) => this.benchOptions(row),
 				primaryAction: this.newSiteAction,
-			};
+			}
 		},
 		groupedSiteListOptions() {
 			return {
 				list: this.$resources.sites,
 				groupHeader: ({ group: bench }) => {
-					if (!bench?.status) return;
+					if (!bench?.status) return
 
-					const options = this.benchOptions(bench);
-					const IconHash = icon('hash', 'w-3 h-3');
-					const IconStar = icon('star', 'w-3 h-3');
+					const options = this.benchOptions(bench)
+					const IconHash = icon('hash', 'w-3 h-3')
+					const IconStar = icon('star', 'w-3 h-3')
 					return (
 						<div class="flex items-center">
 							<Tooltip text="View bench details">
@@ -233,7 +233,7 @@ export default {
 							)}
 							<ActionButton class="ml-auto" options={options} />
 						</div>
-					);
+					)
 				},
 				emptyStateMessage: this.$releaseGroup.doc.deploy_information.last_deploy
 					? 'No sites found'
@@ -242,7 +242,7 @@ export default {
 				filterControls: siteTabFilterControls,
 				route: sitesTabRoute,
 				primaryAction: this.newSiteAction,
-			};
+			}
 		},
 		appVersionOptions() {
 			return {
@@ -255,10 +255,10 @@ export default {
 						label: 'Repo',
 						fieldname: 'repository',
 						format(value, row) {
-							return `${row.repository_owner}/${row.repository}`;
+							return `${row.repository_owner}/${row.repository}`
 						},
 						link: (value, row) => {
-							return row.repository_url;
+							return row.repository_url
 						},
 					},
 					{
@@ -271,10 +271,10 @@ export default {
 						fieldname: 'hash',
 						type: 'Badge',
 						format(value, row) {
-							return value.slice(0, 7);
+							return value.slice(0, 7)
 						},
 						link: (value, row) => {
-							return `https://github.com/${row.repository_owner}/${row.repository}/commit/${value}`;
+							return `https://github.com/${row.repository_owner}/${row.repository}/commit/${value}`
 						},
 					},
 					{
@@ -284,13 +284,27 @@ export default {
 					},
 				],
 				data: () => this.$releaseGroup.getAppVersions.data,
-			};
+			}
 		},
 		$releaseGroup() {
-			return getCachedDocumentResource('Release Group', this.releaseGroup);
+			return getCachedDocumentResource('Release Group', this.releaseGroup)
 		},
 	},
+	mounted() {
+		const { bench, log } = this.$route.query
+		if (bench) this.showBenchLogs(bench, log)
+	},
 	methods: {
+		// the bench detail page is off the sidebar, so this dialog is the only
+		// way in. Deep links land here too, e.g. the 500 page's error log link:
+		// /groups/<group>/sites?bench=<bench>&log=web.error.log
+		showBenchLogs(bench, initialLog) {
+			const BenchLogsDialog = defineAsyncComponent(
+				() => import('../components/group/BenchLogsDialog.vue'),
+			)
+
+			renderDialog(h(BenchLogsDialog, { bench, initialLog }))
+		},
 		newSiteAction() {
 			return {
 				label: 'New Site',
@@ -307,24 +321,24 @@ export default {
 					name: 'Release Group New Site',
 					params: { bench: this.releaseGroup },
 				},
-			};
+			}
 		},
 		groupSitesByBench(data) {
-			if (!this.$resources.benches.data) return [];
+			if (!this.$resources.benches.data) return []
 			return this.$resources.benches.data.map((bench) => {
-				let sites = (data || []).filter((site) => site.bench === bench.name);
-				const isLargeDataset = this.$resources.benches.data?.length >= 1000;
+				let sites = (data || []).filter((site) => site.bench === bench.name)
+				const isLargeDataset = this.$resources.benches.data?.length >= 1000
 				return {
 					...bench,
 					// To prevent rendering delays for large servers with many benches and sites
 					collapsed: isLargeDataset,
 					group: bench.name,
 					rows: sites,
-				};
-			});
+				}
+			})
 		},
 		benchOptions(bench) {
-			if (!bench) return [];
+			if (!bench) return []
 
 			return [
 				{
@@ -344,7 +358,7 @@ export default {
 							this.$releaseGroup.getAppVersions
 								.submit({ bench: bench.name })
 								.then(() => {
-									this.showAppVersionDialog = true;
+									this.showAppVersionDialog = true
 								}),
 							{
 								loading: 'Fetching apps...',
@@ -352,7 +366,7 @@ export default {
 								error: 'Failed to fetch apps',
 								duration: 1000,
 							},
-						);
+						)
 					},
 				},
 				{
@@ -364,23 +378,13 @@ export default {
 								bench: bench.name,
 								releaseGroup: this.$releaseGroup.name,
 							}),
-						);
+						)
 					},
 				},
 				{
 					label: 'View Logs',
 					condition: () => bench.status === 'Active',
-					onClick: () => {
-						let BenchLogsDialog = defineAsyncComponent(
-							() => import('../components/group/BenchLogsDialog.vue'),
-						);
-
-						renderDialog(
-							h(BenchLogsDialog, {
-								bench: bench.name,
-							}),
-						);
-					},
+					onClick: () => this.showBenchLogs(bench.name),
 				},
 				{
 					label: 'Update All Sites',
@@ -400,22 +404,19 @@ export default {
 										{
 											loading: 'Scheduling updates for the sites...',
 											success: () => {
-												hide();
-												return 'Sites have been scheduled for update';
+												hide()
+												return 'Sites have been scheduled for update'
 											},
 											error: (e) => {
-												hide();
-												return getToastErrorMessage(
-													e,
-													'Failed to update sites',
-												);
+												hide()
+												return getToastErrorMessage(e, 'Failed to update sites')
 											},
 											duration: 1000,
 										},
-									);
+									)
 								},
 							},
-						});
+						})
 					},
 				},
 				{
@@ -433,18 +434,18 @@ export default {
 									toast.promise(this.runBenchMethod(bench.name, 'restart'), {
 										loading: 'Restarting bench...',
 										success: () => {
-											hide();
-											return 'Bench will restart shortly';
+											hide()
+											return 'Bench will restart shortly'
 										},
 										error: (e) => {
-											hide();
-											return getToastErrorMessage(e, 'Failed to restart bench');
+											hide()
+											return getToastErrorMessage(e, 'Failed to restart bench')
 										},
 										duration: 1000,
-									});
+									})
 								},
 							},
-						});
+						})
 					},
 				},
 				{
@@ -467,21 +468,18 @@ export default {
 									toast.promise(this.runBenchMethod(bench.name, 'rebuild'), {
 										loading: 'Rebuilding assets...',
 										success: () => {
-											hide();
-											return 'Assets will be rebuilt in the background. This may take a few minutes.';
+											hide()
+											return 'Assets will be rebuilt in the background. This may take a few minutes.'
 										},
 										error: (e) => {
-											hide();
-											return getToastErrorMessage(
-												e,
-												'Failed to rebuild assets',
-											);
+											hide()
+											return getToastErrorMessage(e, 'Failed to rebuild assets')
 										},
 										duration: 1000,
-									});
+									})
 								},
 							},
-						});
+						})
 					},
 				},
 				{
@@ -499,15 +497,15 @@ export default {
 									toast.promise(this.runBenchMethod(bench.name, 'archive'), {
 										loading: 'Scheduling bench for archival...',
 										success: () => {
-											hide();
-											return 'Bench is scheduled for archival';
+											hide()
+											return 'Bench is scheduled for archival'
 										},
 										error: (e) =>
 											getToastErrorMessage(e, 'Failed to archive bench'),
-									});
+									})
 								},
 							},
-						});
+						})
 					},
 				},
 				{
@@ -516,32 +514,32 @@ export default {
 					onClick: () => {
 						let SupervisorProcessesDialog = defineAsyncComponent(
 							() => import('../components/group/SupervisorProcessesDialog.vue'),
-						);
+						)
 
 						renderDialog(
 							h(SupervisorProcessesDialog, {
 								bench: bench.name,
 							}),
-						);
+						)
 					},
 				},
 			].filter((option) => {
-				const hasAccess = this.actionsAccess[option.label] ?? true;
-				if (!hasAccess) return false;
-				if (!option.condition?.()) return false;
-				return true;
-			});
+				const hasAccess = this.actionsAccess[option.label] ?? true
+				if (!hasAccess) return false
+				if (!option.condition?.()) return false
+				return true
+			})
 		},
 		runBenchMethod(name, methodName) {
 			const method = createResource({
 				url: 'press.api.client.run_doc_method',
-			});
+			})
 			return method.submit({
 				dt: 'Bench',
 				dn: name,
 				method: methodName,
-			});
+			})
 		},
 	},
-};
+}
 </script>


### PR DESCRIPTION
Manual backport of #7257. Mergify never made one: the pull request had no `backport-master` label.

Cherry-picks `e219d8e32` and `f080d1208` on to master. Both apply clean.

Merge this before #7259's backport. The follow-up fix uses the `logBody` ref and the `initialLog` prop that this pull request adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)