### PR TITLE
feat(dashboard): Add drag to zoom on the server and site line charts

### DIFF
--- a/dashboard/src/components/charts/BarChart.vue
+++ b/dashboard/src/components/charts/BarChart.vue
@@ -47,13 +47,14 @@ import {
 import { graphic, use } from 'echarts/core'
 import { SVGRenderer } from 'echarts/renderers'
 import { DateTime } from 'luxon'
-import { onMounted, ref, toRefs } from 'vue'
+import { ref, toRefs } from 'vue'
 import VChart from 'vue-echarts'
 import NoDataMsg from '@/components/common/NoDataMsg.vue'
 import dayjs from '../../utils/dayjs'
 import { bytes, escapeHtml, getUnit } from '../../utils/format'
 import { theme } from '../../utils/theme'
 import Card from '../global/Card.vue'
+import { useDataZoom } from './useDataZoom'
 
 const props = defineProps({
 	showCard: {
@@ -257,37 +258,12 @@ const options = ref({
 const chartRef = ref(null)
 const emits = defineEmits(['datazoom'])
 
-onMounted(() => {
-	const chart = chartRef.value?.chart
-	// Detach before dispatching: takeGlobalCursor triggers a re-render, which
-	// fires `finished` again. Left attached, that is an endless render loop that
-	// pegs the main thread for as long as the page is open.
-	const activateDataZoomCursor = () => {
-		chart?.off('finished', activateDataZoomCursor)
-		chart?.dispatchAction({
-			type: 'takeGlobalCursor',
-			key: 'dataZoomSelect',
-			dataZoomSelectActive: true,
-		})
-	}
-	chart?.on('finished', activateDataZoomCursor)
+const labelToDate = (index) =>
+	dayjs(
+		data.value.labels[index],
+		'YYYY-MM-DD HH:mm:ss',
+		dayjs.tz.guess(),
+	).toDate()
 
-	chart?.on('datazoom', (evt) => {
-		const timezone = dayjs.tz.guess()
-		const { startValue: startIndex, endValue: endIndex } = evt.batch[0]
-		const responseLabelTimestampFormat = 'YYYY-MM-DD HH:mm:ss'
-		const startDate = dayjs(
-			data.value.labels[startIndex],
-			responseLabelTimestampFormat,
-			timezone,
-		)
-		const endDate = dayjs(
-			data.value.labels[endIndex],
-			responseLabelTimestampFormat,
-			timezone,
-		)
-		evt = { startDate: startDate.toDate(), endDate: endDate.toDate() }
-		emits('datazoom', evt)
-	})
-})
+useDataZoom(chartRef, labelToDate, emits)
 </script>

--- a/dashboard/src/components/charts/LineChart.vue
+++ b/dashboard/src/components/charts/LineChart.vue
@@ -27,6 +27,7 @@
 			<NoDataMsg v-else />
 		</div>
 		<VChart
+			ref="chartRef"
 			v-else
 			autoresize
 			class="chart"
@@ -39,9 +40,11 @@
 <script setup>
 import { LineChart } from 'echarts/charts'
 import {
+	DataZoomComponent,
 	GridComponent,
 	LegendComponent,
 	MarkLineComponent,
+	ToolboxComponent,
 	TooltipComponent,
 } from 'echarts/components'
 import { graphic, use } from 'echarts/core'
@@ -50,9 +53,11 @@ import { DateTime } from 'luxon'
 import { ref, toRefs } from 'vue'
 import VChart from 'vue-echarts'
 import NoDataMsg from '@/components/common/NoDataMsg.vue'
+import dayjs from '../../utils/dayjs'
 import { bytes, escapeHtml, getUnit } from '../../utils/format'
 import { theme } from '../../utils/theme'
 import Card from '../global/Card.vue'
+import { useDataZoom } from './useDataZoom'
 
 const props = defineProps({
 	showCard: {
@@ -113,6 +118,8 @@ use([
 	LineChart,
 	TooltipComponent,
 	MarkLineComponent,
+	DataZoomComponent,
+	ToolboxComponent,
 ])
 
 const initOptions = {
@@ -125,6 +132,13 @@ const options = ref({
 		left: 50,
 		right: 20,
 		bottom: data.value.datasets.length > 1 ? 60 : 30, // if there's legend show more space for it
+	},
+	toolbox: {
+		feature: {
+			dataZoom: {
+				yAxisIndex: false,
+			},
+		},
 	},
 	tooltip: {
 		trigger: 'axis',
@@ -232,4 +246,20 @@ const options = ref({
 		}
 	}),
 })
+
+const chartRef = ref(null)
+const emits = defineEmits(['datazoom'])
+
+// A time axis reports the zoomed range as timestamps, a category axis as
+// indexes into the labels.
+const axisValueToDate = (value) =>
+	type.value === 'time'
+		? new Date(value)
+		: dayjs(
+				data.value.labels[value],
+				'YYYY-MM-DD HH:mm:ss',
+				dayjs.tz.guess(),
+			).toDate()
+
+useDataZoom(chartRef, axisValueToDate, emits)
 </script>

--- a/dashboard/src/components/charts/useDataZoom.js
+++ b/dashboard/src/components/charts/useDataZoom.js
@@ -1,0 +1,35 @@
+import { onMounted } from 'vue'
+
+/**
+ * Turns on drag-to-zoom and reports the picked range as dates.
+ * `toDate` maps an axis value to a Date: a timestamp on a time axis, an index
+ * into the labels on a category axis.
+ */
+export function useDataZoom(chartRef, toDate, emit) {
+	onMounted(() => {
+		const chart = chartRef.value?.chart
+		// Wait for the first render: the toolbox drops the action before that.
+		// Detach before dispatching: takeGlobalCursor triggers a re-render, which
+		// fires `finished` again. Left attached, that is an endless render loop that
+		// pegs the main thread for as long as the page is open.
+		const activateDataZoomCursor = () => {
+			chart?.off('finished', activateDataZoomCursor)
+			chart?.dispatchAction({
+				type: 'takeGlobalCursor',
+				key: 'dataZoomSelect',
+				dataZoomSelectActive: true,
+			})
+		}
+		chart?.on('finished', activateDataZoomCursor)
+
+		chart?.on('datazoom', (event) => {
+			// A category axis reports the range in a batch, a time axis reports it
+			// on the event itself.
+			const { startValue, endValue } = event.batch?.[0] ?? event
+			emit('datazoom', {
+				startDate: toDate(startValue),
+				endDate: toDate(endValue),
+			})
+		})
+	})
+}

--- a/dashboard/src/components/server/ServerCharts.vue
+++ b/dashboard/src/components/server/ServerCharts.vue
@@ -518,16 +518,21 @@ export default {
 				},
 			});
 		},
-		duration() {
-			const now = dayjs();
-			// floor to 15 minutes to avoid issues with caching
-			const flooredEndDate = dayjsFloorToMinutes(now, 15);
-			this.customEndTime = flooredEndDate.toDate();
-			const dur =
-				this.duration === 'custom'
-					? this.defaultDurationToArray
-					: this.inputDurationToArray;
-			this.customStartTime = flooredEndDate.subtract(...dur).toDate();
+		duration: {
+			// sync, so that a zoom can overwrite the range this sets before any
+			// chart reads it. Otherwise the tab refetches the default range first.
+			flush: 'sync',
+			handler() {
+				const now = dayjs();
+				// floor to 15 minutes to avoid issues with caching
+				const flooredEndDate = dayjsFloorToMinutes(now, 15);
+				this.customEndTime = flooredEndDate.toDate();
+				const dur =
+					this.duration === 'custom'
+						? this.defaultDurationToArray
+						: this.inputDurationToArray;
+				this.customStartTime = flooredEndDate.subtract(...dur).toDate();
+			},
 		},
 	},
 	resources: {
@@ -1146,10 +1151,8 @@ export default {
 			clearTimeout(this.zoomTimeout);
 			// debounce: one drag can end in more than one zoom event, and every
 			// chart on the tab refetches when the range changes
-			this.zoomTimeout = setTimeout(async () => {
+			this.zoomTimeout = setTimeout(() => {
 				this.duration = 'custom';
-				// the duration watcher rewrites the custom range, so wait it out
-				await this.$nextTick();
 				this.customStartTime = startDate;
 				this.customEndTime = endDate;
 			}, 500);

--- a/dashboard/src/components/server/ServerCharts.vue
+++ b/dashboard/src/components/server/ServerCharts.vue
@@ -50,6 +50,7 @@
 					:error="$resources.databaseUptime.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 
@@ -74,6 +75,7 @@
 					:error="$resources.cpu.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 
@@ -92,6 +94,7 @@
 					:error="$resources.loadavg.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 
@@ -107,6 +110,7 @@
 					:error="$resources.memory.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 
@@ -122,6 +126,7 @@
 					:error="$resources.space.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 
@@ -137,6 +142,7 @@
 					:error="$resources.network.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 
@@ -152,6 +158,7 @@
 					:error="$resources.iops.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 		</div>
@@ -187,6 +194,7 @@
 					:error="$resources.requestCountBySite.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 
@@ -205,6 +213,7 @@
 					:error="$resources.requestDurationBySite.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 
@@ -223,6 +232,7 @@
 					:error="$resources.backgroundJobCountBySite.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 
@@ -241,6 +251,7 @@
 					:error="$resources.backgroundJobDurationBySite.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 
@@ -265,6 +276,7 @@
 					:error="$resources.databaseCommandsCount.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 
@@ -286,6 +298,7 @@
 					:error="$resources.databaseConnections.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 
@@ -304,6 +317,7 @@
 					:error="$resources.innodbAvgRowLockTime.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 
@@ -322,6 +336,7 @@
 					:error="$resources.innodbBufferPoolSize.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 
@@ -340,6 +355,7 @@
 					:error="$resources.innodbBufferPoolSizeOfTotalRam.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 				<template #action>
 					<router-link
@@ -369,6 +385,7 @@
 					:error="$resources.innodbBufferPoolMissPercentage.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 				<template #action>
 					<router-link
@@ -404,6 +421,7 @@
 					:error="$resources.slowLogsCount.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 
@@ -428,6 +446,7 @@
 					:error="$resources.slowLogsDuration.error"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 		</div>
@@ -1122,6 +1141,18 @@ export default {
 		},
 		toggleAdvancedAnalytics() {
 			this.showAdvancedAnalytics = !this.showAdvancedAnalytics;
+		},
+		handleDataZoom({ startDate, endDate }) {
+			clearTimeout(this.zoomTimeout);
+			// debounce: one drag can end in more than one zoom event, and every
+			// chart on the tab refetches when the range changes
+			this.zoomTimeout = setTimeout(async () => {
+				this.duration = 'custom';
+				// the duration watcher rewrites the custom range, so wait it out
+				await this.$nextTick();
+				this.customStartTime = startDate;
+				this.customEndTime = endDate;
+			}, 500);
 		},
 	},
 };

--- a/dashboard/src/components/site/SiteAnalytics.vue
+++ b/dashboard/src/components/site/SiteAnalytics.vue
@@ -81,6 +81,7 @@
 					:loading="$resources.analytics.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 
@@ -106,6 +107,7 @@
 					:loading="$resources.analytics.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 				<template #action>
 					<router-link
@@ -129,6 +131,7 @@
 					:loading="$resources.analytics.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 		</div>
@@ -160,6 +163,7 @@
 					:loading="$resources.backgroundJobUsage.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 
@@ -177,6 +181,7 @@
 					:loading="$resources.backgroundJobUsage.loading"
 					:showCard="false"
 					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
 				/>
 			</AnalyticsCard>
 

--- a/dashboard/tests-e2e/tests/dashboard/server-chart-datazoom.test.ts
+++ b/dashboard/tests-e2e/tests/dashboard/server-chart-datazoom.test.ts
@@ -129,8 +129,13 @@ test('dragging over a server line chart narrows the range to the selection', asy
 		})
 		.toBe(true)
 
+	// One refetch, not two: the range must never pass through a default window
+	// on its way to the dragged one, or every chart on the tab reloads twice.
+	const cpuRequests = requests.filter((request) => request.query === 'cpu')
+	expect(cpuRequests).toHaveLength(1)
+
 	// The refetch asks for the dragged window, not the 1 hour default.
-	const zoomed = requests.filter((request) => request.query === 'cpu').pop()!
+	const zoomed = cpuRequests.pop()!
 	const dataStart = RANGE_START.getTime()
 	const span = (BUCKETS - 1) * BUCKET_MS
 	const tolerance = 2 * BUCKET_MS

--- a/dashboard/tests-e2e/tests/dashboard/server-chart-datazoom.test.ts
+++ b/dashboard/tests-e2e/tests/dashboard/server-chart-datazoom.test.ts
@@ -1,0 +1,144 @@
+import type { Locator, Page } from '@playwright/test'
+import { expect, test } from './coverage.fixture'
+
+const APP_SERVER = 'f-test-app.frappe.cloud'
+const DATABASE_SERVER = 'm-test-db.frappe.cloud'
+
+const serverDoc = {
+	name: APP_SERVER,
+	title: 'Test Server',
+	status: 'Active',
+	is_unified_server: 0,
+	database_server: DATABASE_SERVER,
+	replication_server: null,
+}
+
+const RANGE_START = new Date('2026-08-19T00:00:00')
+const BUCKETS = 24
+const BUCKET_MS = 3600_000
+
+/** prometheus_query() labels are local wall clock time, not UTC. */
+function label(milliseconds: number) {
+	const date = new Date(milliseconds)
+	const pad = (value: number) => String(value).padStart(2, '0')
+	return (
+		`${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+		` ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
+	)
+}
+
+const LABELS = Array.from({ length: BUCKETS }, (_, i) =>
+	label(RANGE_START.getTime() + i * BUCKET_MS),
+)
+
+/** Same shape prometheus_query() returns: one dataset, one label per bucket. */
+const cpuPayload = {
+	labels: LABELS,
+	datasets: [
+		{ name: 'user', values: LABELS.map((_, i) => 10 + ((i * 7) % 60)) },
+	],
+}
+
+type Request = { query: string; start: Date; end: Date }
+
+/** Loads the analytics tab with CPU as the only chart that has data. */
+async function openCpuChart(page: Page, requests: Request[]) {
+	await page.setViewportSize({ width: 1440, height: 900 })
+
+	await page.route(
+		/\/api\/method\/press\.api\.client\.get\b/,
+		async (route) => {
+			const url = new URL(route.request().url())
+			if (url.searchParams.get('doctype') !== 'Server') return route.continue()
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ message: serverDoc }),
+			})
+		},
+	)
+
+	await page.route(
+		/\/api\/method\/press\.api\.server\.analytics/,
+		async (route) => {
+			const url = new URL(route.request().url())
+			const body = route.request().postDataJSON?.() ?? {}
+			const param = (key: string) => url.searchParams.get(key) ?? body[key]
+			const query = param('query')
+			requests.push({
+				query,
+				start: new Date(param('start')),
+				end: new Date(param('end')),
+			})
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({
+					message: query === 'cpu' ? cpuPayload : { datasets: [], labels: [] },
+				}),
+			})
+		},
+	)
+
+	await page.goto(`/dashboard/servers/${APP_SERVER}/analytics`)
+
+	const chart = page.locator('.chart').first()
+	await expect(chart.locator('svg text').first()).toBeVisible({
+		timeout: 30000,
+	})
+	return chart
+}
+
+/** Drags across the plot area, from one fraction of its width to another. */
+async function dragAcrossPlot(
+	page: Page,
+	chart: Locator,
+	from: number,
+	to: number,
+) {
+	const box = (await chart.boundingBox())!
+	// Plot area sits inside the LineChart grid: 50px left, 20px right.
+	const plotStart = box.x + 50
+	const plotWidth = box.width - 70
+	const y = box.y + box.height / 2
+
+	// The chart arms drag-to-zoom on its first finished render.
+	await page.waitForTimeout(2000)
+	await page.mouse.move(plotStart + plotWidth * from, y)
+	await page.mouse.down()
+	await page.mouse.move(plotStart + plotWidth * to, y, { steps: 10 })
+	await page.mouse.up()
+}
+
+test('dragging over a server line chart narrows the range to the selection', async ({
+	page,
+}) => {
+	const requests: Request[] = []
+	const chart = await openCpuChart(page, requests)
+	requests.length = 0
+
+	await dragAcrossPlot(page, chart, 0.25, 0.75)
+
+	// The zoom switches the duration to custom, which shows the two pickers.
+	await expect(page.getByText('Start')).toBeVisible({ timeout: 10000 })
+	await expect(page.getByText('End')).toBeVisible()
+
+	await expect
+		.poll(() => requests.some((request) => request.query === 'cpu'), {
+			timeout: 10000,
+		})
+		.toBe(true)
+
+	// The refetch asks for the dragged window, not the 1 hour default.
+	const zoomed = requests.filter((request) => request.query === 'cpu').pop()!
+	const dataStart = RANGE_START.getTime()
+	const span = (BUCKETS - 1) * BUCKET_MS
+	const tolerance = 2 * BUCKET_MS
+
+	expect(
+		Math.abs(zoomed.start.getTime() - (dataStart + span * 0.25)),
+	).toBeLessThan(tolerance)
+	expect(
+		Math.abs(zoomed.end.getTime() - (dataStart + span * 0.75)),
+	).toBeLessThan(tolerance)
+})

--- a/dashboard/tests-e2e/tests/dashboard/site-chart-datazoom.test.ts
+++ b/dashboard/tests-e2e/tests/dashboard/site-chart-datazoom.test.ts
@@ -1,0 +1,61 @@
+import {
+	mockAnalytics,
+	RANGE_END,
+	RANGE_START,
+	SITE_NAME,
+} from './analytics-fixture'
+import { expect, test } from './coverage.fixture'
+
+/** Start of the range the page holds, read back from its query string. */
+function rangeFromUrl(url: string) {
+	const query = new URL(url).searchParams
+	return {
+		start: new Date(query.get('start')!).getTime(),
+		end: new Date(query.get('end')!).getTime(),
+	}
+}
+
+test('dragging over a site line chart narrows the range to the selection', async ({
+	page,
+}) => {
+	await page.setViewportSize({ width: 1440, height: 900 })
+	await mockAnalytics(page)
+
+	const query = `?start=${RANGE_START.toISOString()}&end=${RANGE_END.toISOString()}`
+	await page.goto(`/dashboard/sites/${SITE_NAME}/insights/analytics${query}`)
+
+	// The first chart on the tab is the Usage Counter line chart.
+	const chart = page.locator('.chart').first()
+	await expect(chart.locator('svg text').first()).toBeVisible({
+		timeout: 30000,
+	})
+
+	const box = (await chart.boundingBox())!
+	// Plot area sits inside the LineChart grid: 50px left, 20px right.
+	const plotStart = box.x + 50
+	const plotWidth = box.width - 70
+	const y = box.y + box.height / 2
+
+	// The chart arms drag-to-zoom on its first finished render.
+	await page.waitForTimeout(2000)
+	await page.mouse.move(plotStart + plotWidth * 0.25, y)
+	await page.mouse.down()
+	await page.mouse.move(plotStart + plotWidth * 0.75, y, { steps: 10 })
+	await page.mouse.up()
+
+	// The page keeps its range in the query string, so read it back from there.
+	await expect
+		.poll(() => rangeFromUrl(page.url()).start, { timeout: 10000 })
+		.toBeGreaterThan(RANGE_START.getTime())
+
+	const span = RANGE_END.getTime() - RANGE_START.getTime()
+	const tolerance = span / 20
+	const zoomed = rangeFromUrl(page.url())
+
+	expect(
+		Math.abs(zoomed.start - (RANGE_START.getTime() + span * 0.25)),
+	).toBeLessThan(tolerance)
+	expect(
+		Math.abs(zoomed.end - (RANGE_START.getTime() + span * 0.75)),
+	).toBeLessThan(tolerance)
+})


### PR DESCRIPTION
## What

Drag over a chart to narrow the time range to your selection.

The site bar charts and the uptime chart had this. This PR adds it to:

- all 19 charts on the Server Analytics tab, line and bar
- the 5 site line charts: usage counter, requests, requests CPU usage, background jobs, background jobs CPU usage

Before this change, you found a spike and then set the range by hand with the duration select and the two pickers.

## How

`useDataZoom` is a new composable. It holds the drag-to-zoom code that `BarChart` had inline. `LineChart` uses it too, which is what makes the line charts work.

`ServerCharts` listens on every chart. The handler sets the duration to custom and sets both pickers to the dragged window. It waits 500ms, because one drag can send more than one zoom event. `SiteAnalytics` already had a handler, so its line charts needed only the listener.

The watcher on `duration` is sync now. The zoom writes its range before any chart reads it. Without this, the tab fetched a default range first and the dragged range after it.

The API does not change. `press.api.server.analytics` accepts any start and end. The fixed durations are in the dropdown only. A shorter range also gives a finer timegrain, because `auto_timespan_timegrain` divides the span into about 60 points. A zoom shows detail that the wide view averaged away.

This work found two things:

- The zoom event has two shapes. A category axis reports the range in `event.batch[0]`. A time axis reports it on the event. The old code read `event.batch[0]` only, and it fails on a line chart.
- The chart turns on the zoom cursor after its first `finished` render. Before that, the toolbox drops the action.

## Test

Two Playwright tests drag across a chart and check the range that the page requests:

```
✓ dragging over a server line chart narrows the range to the selection
✓ dragging over a site line chart narrows the range to the selection
```

The server test also checks that each chart makes one request, not two.

The `server-uptime-chart` and `site-analytics-scroll-perf` tests still pass.

I also tested by hand on a local Frappe Cloud with real Prometheus data. The drag sets the custom range, and the charts redraw at the finer timegrain. Advanced Analytics opens as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)