### PR TITLE
fix(dashboard): Zoom the charts with a pinch on touch devices

### DIFF
--- a/dashboard/src/components/charts/useDataZoom.js
+++ b/dashboard/src/components/charts/useDataZoom.js
@@ -1,7 +1,17 @@
 import { onMounted } from 'vue'
 
+// A one finger drag must scroll the page, not draw a zoom box.
+const isTouchDevice = window.matchMedia('(pointer: coarse)').matches
+
+/** The zoomed range of the x axis: timestamps on a time axis, else indexes. */
+function xAxisWindow(chart) {
+	const axis = chart.getModel().getComponent('xAxis', 0).axis
+	return axis.scale.getExtent().map(Math.round)
+}
+
 /**
  * Turns on drag-to-zoom and reports the picked range as dates.
+ * On a touch device the gesture is a pinch instead of a drag.
  * `toDate` maps an axis value to a Date: a timestamp on a time axis, an index
  * into the labels on a category axis.
  */
@@ -20,15 +30,34 @@ export function useDataZoom(chartRef, toDate, emit) {
 				dataZoomSelectActive: true,
 			})
 		}
-		chart?.on('finished', activateDataZoomCursor)
+
+		if (isTouchDevice) {
+			// `inside` keeps the pinch. All the drag and wheel behaviour stays off,
+			// so a scroll of the page keeps its usual effect.
+			chart?.setOption({
+				dataZoom: [
+					{
+						type: 'inside',
+						zoomOnMouseWheel: false,
+						moveOnMouseMove: false,
+						moveOnMouseWheel: false,
+					},
+				],
+			})
+		} else {
+			chart?.on('finished', activateDataZoomCursor)
+		}
 
 		chart?.on('datazoom', (event) => {
 			// A category axis reports the range in a batch, a time axis reports it
-			// on the event itself.
+			// on the event itself. A pinch reports percentages only, so read the
+			// range off the axis.
 			const { startValue, endValue } = event.batch?.[0] ?? event
+			const [start, end] =
+				startValue == null ? xAxisWindow(chart) : [startValue, endValue]
 			emit('datazoom', {
-				startDate: toDate(startValue),
-				endDate: toDate(endValue),
+				startDate: toDate(start),
+				endDate: toDate(end),
 			})
 		})
 	})

--- a/dashboard/tests-e2e/tests/dashboard/site-chart-touch-zoom.test.ts
+++ b/dashboard/tests-e2e/tests/dashboard/site-chart-touch-zoom.test.ts
@@ -1,0 +1,117 @@
+import { devices } from '@playwright/test'
+import {
+	mockAnalytics,
+	RANGE_END,
+	RANGE_START,
+	SITE_NAME,
+} from './analytics-fixture'
+import { expect, test } from './coverage.fixture'
+
+// A phone: `(pointer: coarse)` matches, which is what turns the drag off.
+test.use({ ...devices['Pixel 5'] })
+
+const QUERY = `?start=${RANGE_START.toISOString()}&end=${RANGE_END.toISOString()}`
+
+function rangeFromUrl(url: string) {
+	const query = new URL(url).searchParams
+	return {
+		start: new Date(query.get('start')!).getTime(),
+		end: new Date(query.get('end')!).getTime(),
+	}
+}
+
+/** The plot area of the LineChart: 50px of axis on the left, 20px on the right. */
+async function plotBox(page) {
+	const chart = page.locator('.chart').first()
+	await expect(chart.locator('svg text').first()).toBeVisible({
+		timeout: 30000,
+	})
+	const box = (await chart.boundingBox())!
+	return {
+		left: box.x + 50,
+		width: box.width - 70,
+		middle: box.y + box.height / 2,
+	}
+}
+
+/** Touches the screen at each point, then moves each one to its target. */
+async function touchDrag(
+	page,
+	points: { from: [number, number]; to: [number, number] }[],
+) {
+	const session = await page.context().newCDPSession(page)
+	const at = (index: number, key: 'from' | 'to') => ({
+		x: points[index][key][0],
+		y: points[index][key][1],
+	})
+	const all = (key: 'from' | 'to') => points.map((_, index) => at(index, key))
+
+	await session.send('Input.dispatchTouchEvent', {
+		type: 'touchStart',
+		touchPoints: all('from'),
+	})
+	for (let step = 1; step <= 10; step++) {
+		const fraction = step / 10
+		await session.send('Input.dispatchTouchEvent', {
+			type: 'touchMove',
+			touchPoints: points.map((point) => ({
+				x: point.from[0] + (point.to[0] - point.from[0]) * fraction,
+				y: point.from[1] + (point.to[1] - point.from[1]) * fraction,
+			})),
+		})
+	}
+	await session.send('Input.dispatchTouchEvent', {
+		type: 'touchEnd',
+		touchPoints: [],
+	})
+	await session.detach()
+}
+
+test('a one finger drag over a site line chart keeps the range', async ({
+	page,
+}) => {
+	await mockAnalytics(page)
+	await page.goto(`/dashboard/sites/${SITE_NAME}/insights/analytics${QUERY}`)
+
+	const plot = await plotBox(page)
+	// The desktop chart arms drag-to-zoom on its first finished render.
+	await page.waitForTimeout(2000)
+
+	await touchDrag(page, [
+		{
+			from: [plot.left + plot.width * 0.25, plot.middle],
+			to: [plot.left + plot.width * 0.75, plot.middle],
+		},
+	])
+	await page.waitForTimeout(1000)
+
+	expect(rangeFromUrl(page.url())).toEqual({
+		start: RANGE_START.getTime(),
+		end: RANGE_END.getTime(),
+	})
+})
+
+test('a pinch over a site line chart narrows the range', async ({ page }) => {
+	await mockAnalytics(page)
+	await page.goto(`/dashboard/sites/${SITE_NAME}/insights/analytics${QUERY}`)
+
+	const plot = await plotBox(page)
+	await page.waitForTimeout(2000)
+
+	// Two fingers that move apart around the middle of the plot.
+	await touchDrag(page, [
+		{
+			from: [plot.left + plot.width * 0.45, plot.middle],
+			to: [plot.left + plot.width * 0.1, plot.middle],
+		},
+		{
+			from: [plot.left + plot.width * 0.55, plot.middle],
+			to: [plot.left + plot.width * 0.9, plot.middle],
+		},
+	])
+
+	await expect
+		.poll(() => rangeFromUrl(page.url()).start, { timeout: 10000 })
+		.toBeGreaterThan(RANGE_START.getTime())
+	expect(rangeFromUrl(page.url()).end).toBeLessThan(RANGE_END.getTime())
+})


### PR DESCRIPTION
## Problem

The charts on the analytics tab arm the drag-to-zoom cursor on every device ([useDataZoom.js](https://github.com/frappe/press/blob/develop/dashboard/src/components/charts/useDataZoom.js), added in #7275). On a phone a one finger drag is a scroll of the page, but the cursor makes that drag draw a zoom box. The tab thus zooms in when you try to scroll it.

## Change

A touch device (`(pointer: coarse)`) does not get the cursor. It gets an `inside` dataZoom with `zoomOnMouseWheel`, `moveOnMouseMove` and `moveOnMouseWheel` off, so only the pinch zooms and the drag scrolls the page as usual. The desktop behaviour does not change.

The pinch gives percentages in its `datazoom` event and not values, unlike the drag box. The handler therefore reads the range from the window of the x axis: timestamps on a time axis, indexes into the labels on a category axis, which is what the two charts already map to dates.

## Tests

`site-chart-touch-zoom.test.ts` runs the analytics tab as a Pixel 5. Playwright has no pinch, so the touch points go through CDP `Input.dispatchTouchEvent`: one point for the drag, two points that move apart for the pinch. The drag must keep the range, the pinch must narrow it.

Both tests fail on the code before this change, and both pass after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
