### PR TITLE
feat(debugging): Add a script that scans for replica reads

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -249,6 +249,7 @@
 		"grequests",
 		"gshadow",
 		"GSSAPI",
+		"gsub",
 		"gstin",
 		"gstinhide",
 		"gstinshow",

--- a/debugging/README.md
+++ b/debugging/README.md
@@ -10,3 +10,12 @@ coredump from the server into the container and get a readable stacktrace.
 - [mariadb.build.md](mariadb.build.md) — build MariaDB from source with symbols
 - `mariadb.Dockerfile` — MariaDB 10.6 with debug symbols
 - `mariadb.build.Dockerfile` — the build environment for a source build
+
+## Replica reads
+
+A site with `read_from_replica` on sends some requests to the replica. If the
+replica is behind, the user sees data that is not there yet.
+
+- `scan-replica-reads.sh` — list the endpoints that read from the replica, and
+  the custom app code that changes the read path. Read only. Run it from the
+  bench directory of the server.

--- a/debugging/scan-replica-reads.sh
+++ b/debugging/scan-replica-reads.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Scan the apps of a bench for code that can serve a stale read on a site that
+# has read_from_replica on.
+#
+# READ ONLY: find, grep, awk, sort. It writes no file and touches no database.
+#
+# Run it from the bench directory:
+#   curl -sL https://raw.githubusercontent.com/frappe/press/fc-scripts/debugging/scan-replica-reads.sh | sh
+
+[ -d apps ] || { echo "run this from the bench directory" >&2; exit 1; }
+STANDARD='apps/(frappe|erpnext)/'   # filtered out of the override sections
+
+echo "== 1. reads the replica (@frappe.read_only) =="
+find apps -name '*.py' -not -path '*/node_modules/*' -not -path '*/tests/*' -print0 |
+xargs -0 -r awk '
+  FNR==1 { pending=0; whitelisted=0 }
+  /@frappe\.whitelist/ { whitelisted=1 }
+  /@(frappe\.)?read_only\(\)/ { pending=1 }
+  /^[[:space:]]*def[[:space:]]/ {
+    if (pending) {
+      name=$0; sub(/^[[:space:]]*def[[:space:]]+/, "", name); sub(/\(.*/, "", name)
+      module=FILENAME; sub(/^apps\/[^\/]+\//, "", module); sub(/\.py$/, "", module); gsub(/\//, ".", module)
+      printf "%s\t%s.%s\t%s:%d\n", (whitelisted ? "api     " : "internal"), module, name, FILENAME, FNR
+    }
+    pending=0; whitelisted=0
+  }' | sort -t"$(printf '\t')" -k2
+
+echo
+echo "== 2. custom app overrides of the read path (hooks.py) =="
+grep -rHn -A20 "^override_whitelisted_methods\|^override_doctype_class\|^permission_query_conditions\|^has_permission" apps/*/*/hooks.py |
+  grep '":' | grep -Ev "$STANDARD" | grep -v '#' | sort -u
+
+echo
+echo "== 3. custom controller get_list / get_count (virtual doctypes) =="
+grep -rHn --include='*.py' "def get_list(\|def get_count(" apps/ | grep -Ev "$STANDARD"
+
+echo
+echo "== 4. custom whitelisted methods named like the read API =="
+grep -rHn --include='*.py' "^def \(get\|get_list\|get_count\|get_detail\|get_doc\)(" apps/ | grep -Ev "$STANDARD"
+
+echo
+echo "== 5. redis doc cache in custom apps (a replica read poisons it) =="
+grep -rHn --include='*.py' "get_cached_doc\|get_cached_value" apps/ | grep -Ev "$STANDARD"


### PR DESCRIPTION
A site with `read_from_replica` on sends some requests to the replica. When the replica is behind, a user creates a document and the next screen reports that it does not exist. We had this today on a v15 site: the payment entry was created, but the list said it was not found, while `Seconds_Behind_Master` was 0.

`debugging/scan-replica-reads.sh` finds the code that can serve such a read. It runs on the server over ssh, from the bench directory:

```sh
curl -sL https://raw.githubusercontent.com/frappe/press/fc-scripts/debugging/scan-replica-reads.sh | sh
```

It prints five sections:

1. The methods with `@frappe.read_only()`. On v15 these are the desk list view (`reportview.get`, `get_list`, `get_count`, `export_query`, `get_stats`, `get_sidebar_stats`), the notifications, the query report and one data import method. `getdoc` is not one of them, so the form itself reads the primary.
2. Custom app hooks that change the read path: `override_whitelisted_methods`, `override_doctype_class`, `permission_query_conditions`, `has_permission`. A permission query condition gives the same "not found" message as replica lag, so this section separates the two causes.
3. Custom `get_list` / `get_count` controller methods (virtual doctypes).
4. Custom whitelisted methods with the names of the standard read API.
5. Custom calls to `get_cached_doc` / `get_cached_value`. These write to redis with no guard against the replica connection, so a stale read stays in the cache after the replica catches up.

The script is read only: `find`, `grep`, `awk` and `sort`. It writes no file, and it does not open the site or the database.

Kept it a shell script and not a bench command, because it must run over ssh where the site can be down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)