### PR TITLE
fix(analytics): Align the uptime range correctly below one hour

### DIFF
--- a/press/api/analytics.py
+++ b/press/api/analytics.py
@@ -1013,6 +1013,17 @@ def get_rounded_boundary(dt: datetime, timegrain: int = 60):
 	return datetime.fromtimestamp(floored_ts, tz=dt.tzinfo)
 
 
+def align_to_quarter_hour(start: datetime, end: datetime, timezone: str) -> tuple[datetime, datetime]:
+	"""Widen the range to the quarter-hour marks around it."""
+	local_start = start.astimezone(pytz_timezone(timezone))
+	local_end = end.astimezone(pytz_timezone(timezone))
+	return (
+		local_start.replace(minute=local_start.minute // 15 * 15, second=0, microsecond=0),
+		local_end.replace(minute=0, second=0, microsecond=0)
+		+ timedelta(minutes=(local_end.minute // 15 + 1) * 15),
+	)
+
+
 def get_uptime(site: str, timezone: str, start: datetime, end: datetime, timegrain: int):
 	monitor_server = frappe.db.get_single_value("Press Settings", "monitor_server")
 	if not monitor_server:
@@ -1034,13 +1045,7 @@ def get_uptime(site: str, timezone: str, start: datetime, end: datetime, timegra
 	# if the difference is less than an hour, set timegrain to 1 min
 	elif int((end - start).total_seconds()) < 60 * 60:
 		timegrain = 60
-		# align end to the next 15-minute interval, start to the previous one
-		local_end = end.astimezone(pytz_timezone(timezone))
-		end = local_end.replace(minute=0, second=0, microsecond=0) + timedelta(
-			minutes=(local_end.minute // 15 + 1) * 15
-		)
-		local_start = start.astimezone(pytz_timezone(timezone))
-		start = local_start.replace(minute=local_start.minute // 15 * 15, second=0, microsecond=0)
+		start, end = align_to_quarter_hour(start, end, timezone)
 
 	query: dict[str, str | float] = {
 		"query": (

--- a/press/api/analytics.py
+++ b/press/api/analytics.py
@@ -1034,19 +1034,13 @@ def get_uptime(site: str, timezone: str, start: datetime, end: datetime, timegra
 	# if the difference is less than an hour, set timegrain to 1 min
 	elif int((end - start).total_seconds()) < 60 * 60:
 		timegrain = 60
+		# align end to the next 15-minute interval, start to the previous one
 		local_end = end.astimezone(pytz_timezone(timezone))
-		# align end to next 15-minute interval if not already aligned
-		minutes = (local_end.minute // 15 + 1) * 15
-		if minutes == 60:
-			local_end = local_end.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
-		else:
-			local_end = local_end.replace(minute=minutes, second=0, microsecond=0)
-		end = local_end
-		# align start to previous 15-minute interval if not already aligned
+		end = local_end.replace(minute=0, second=0, microsecond=0) + timedelta(
+			minutes=(local_end.minute // 15 + 1) * 15
+		)
 		local_start = start.astimezone(pytz_timezone(timezone))
-		minutes = (local_start.minute // 15 - (1 if local_end.minute % 15 != 0 else 0)) * 15
-		local_start = local_end.replace(minute=minutes, second=0, microsecond=0)
-		start = local_start
+		start = local_start.replace(minute=local_start.minute // 15 * 15, second=0, microsecond=0)
 
 	query: dict[str, str | float] = {
 		"query": (

--- a/press/api/tests/test_analytics.py
+++ b/press/api/tests/test_analytics.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026, Frappe and Contributors
+# See license.txt
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from frappe.tests.utils import FrappeTestCase
+from pytz import timezone as pytz_timezone
+
+from press.api.analytics import align_to_quarter_hour
+
+TIMEZONE = "Asia/Kolkata"
+
+
+class TestAlignToQuarterHour(FrappeTestCase):
+	def local(self, hour: int, minute: int) -> datetime:
+		return pytz_timezone(TIMEZONE).localize(datetime(2026, 8, 24, hour, minute))
+
+	def test_range_that_crosses_the_hour_keeps_start_before_end(self):
+		"""A range like 10:50-10:55 used to align start after end, and prometheus answered with an error"""
+		start, end = align_to_quarter_hour(self.local(10, 50), self.local(10, 55), TIMEZONE)
+		self.assertEqual(start, self.local(10, 45))
+		self.assertEqual(end, self.local(11, 0))
+
+	def test_range_widens_to_the_marks_around_it(self):
+		start, end = align_to_quarter_hour(self.local(10, 5), self.local(10, 20), TIMEZONE)
+		self.assertEqual(start, self.local(10, 0))
+		self.assertEqual(end, self.local(10, 30))
+
+	def test_aligned_end_moves_to_the_next_mark(self):
+		_, end = align_to_quarter_hour(self.local(10, 0), self.local(10, 15), TIMEZONE)
+		self.assertEqual(end, self.local(10, 30))
+
+	def test_every_minute_of_the_hour_gives_a_range_of_whole_quarters(self):
+		for minute in range(60):
+			for length in (1, 5, 15, 30, 59):
+				original_start = self.local(10, 0) + timedelta(minutes=minute)
+				original_end = original_start + timedelta(minutes=length)
+				start, end = align_to_quarter_hour(original_start, original_end, TIMEZONE)
+				self.assertLessEqual(start, original_start)
+				self.assertGreaterEqual(end, original_end)
+				self.assertEqual((end - start).total_seconds() % 900, 0)


### PR DESCRIPTION
## Problem

The uptime chart fails when you zoom into a range shorter than one hour:

```
File "apps/press/press/api/analytics.py", line 1063, in get_uptime
  if not response["data"]["result"]:
KeyError: 'data'
```

The sub-hour branch of `get_uptime` aligns the range to 15-minute marks. The start alignment read the already-rewritten `local_end` instead of `local_start`, and subtracted a quarter based on that new end. For a range of 10:50-10:55 it moved `end` to 11:00 and then set `start` to 11:45. Start came after end, Prometheus answered with a 400 error body that has no `data` key, and the lookup raised `KeyError`.

## Fix

Start floors to its own previous 15-minute mark. End ceils to the next one with a `timedelta`, so the `minutes == 60` special case is no longer necessary.

I kept the `response["data"]` lookup unguarded. A guard there would hide Prometheus errors instead of showing them.

## Test

Checked `start <= original start < original end <= end`, and that the range is a multiple of 15 minutes, for every minute offset in an hour and for range lengths of 1, 5, 15, 30 and 59 minutes. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)