### PR TITLE
feat(server): Consider free disk for new site servers on Hetzner

### DIFF
--- a/press/press/doctype/server/server_monitoring.py
+++ b/press/press/doctype/server/server_monitoring.py
@@ -15,6 +15,7 @@ from press.utils import log_error
 from press.utils.raven import send_raven_message
 
 RAVEN_SERVER_ALERTS_CHANNEL = "frappe-cloud-server-alerts"
+HEALTH_ALERT_SENT_CACHE_KEY = "public_server_pool_health_alert_sent"
 PROMETHEUS_REGEX_META_CHAR_PATTERN = re.compile(r"([\\.^$*+?()[\]{}|])")
 # Hetzner volumes do not grow on demand, so disk decides where new sites go
 DISK_AWARE_PROVIDERS = ["Hetzner"]
@@ -406,8 +407,13 @@ def _query_prometheus_vector(query: str, url: str, auth: tuple[str, str]) -> lis
 
 
 def _send_public_server_pool_health_alert(server_issues: dict[str, list[str]]) -> None:
+	"""Alert once a day. The pool refresh runs every hour, but a busy server stays busy."""
 	if not server_issues:
 		return
+
+	if frappe.cache().get_value(HEALTH_ALERT_SENT_CACHE_KEY):
+		return
+	frappe.cache().set_value(HEALTH_ALERT_SENT_CACHE_KEY, 1, expires_in_sec=24 * 60 * 60)
 
 	affected_servers = sorted(server_issues)
 	header_lines = [

--- a/press/press/doctype/server/server_monitoring.py
+++ b/press/press/doctype/server/server_monitoring.py
@@ -46,11 +46,15 @@ def monitor_server_and_refresh_new_bench_and_site_server_pool() -> None:
 	3. Prefer healthy servers, and fall back to the least-bad server when a cluster has no healthy candidates
 	4. Keep new sites away from Hetzner servers that are low on disk, and alert about them
 	"""
-	server_names, servers_by_cluster, disk_aware_servers = _get_public_primary_servers_by_cluster()
+	(
+		server_names,
+		servers_by_cluster,
+		disk_aware_servers_by_mount_point,
+	) = _get_public_primary_servers_by_cluster()
 	if not server_names:
 		return
 
-	metrics = _get_public_server_health_metrics(server_names, disk_aware_servers)
+	metrics = _get_public_server_health_metrics(server_names, disk_aware_servers_by_mount_point)
 	if not metrics:
 		return
 
@@ -61,18 +65,30 @@ def monitor_server_and_refresh_new_bench_and_site_server_pool() -> None:
 	_create_no_suitable_servers_incident(pool_decision["fallback_servers_by_cluster"], metrics)
 
 
-def _get_public_primary_servers_by_cluster() -> tuple[list[str], dict[str, list[str]], list[str]]:
+def _get_public_primary_servers_by_cluster() -> tuple[list[str], dict[str, list[str]], dict[str, list[str]]]:
 	servers = frappe.get_all(
 		"Server",
 		filters={"status": "Active", "is_primary": True, "public": True, "exclude_for_scheduling": False},
-		fields=["name", "cluster", "provider"],
+		fields=["name", "cluster", "provider", "has_data_volume"],
 	)
 	server_names = [server.name for server in servers]
 	servers_by_cluster: dict[str, list[str]] = {}
 	for server in servers:
 		servers_by_cluster.setdefault(server.cluster, []).append(server.name)
-	disk_aware_servers = [server.name for server in servers if server.provider in DISK_AWARE_PROVIDERS]
-	return server_names, servers_by_cluster, disk_aware_servers
+	return server_names, servers_by_cluster, _get_disk_aware_servers_by_mount_point(servers)
+
+
+def _get_disk_aware_servers_by_mount_point(servers: list[frappe._dict]) -> dict[str, list[str]]:
+	"""Group the servers whose disk decides site placement by the mount point of their benches."""
+	from press.press.doctype.server.server import BENCH_DATA_MNT_POINT  # circular import
+
+	servers_by_mount_point: dict[str, list[str]] = {}
+	for server in servers:
+		if server.provider not in DISK_AWARE_PROVIDERS:
+			continue
+		mount_point = BENCH_DATA_MNT_POINT if server.has_data_volume else "/"
+		servers_by_mount_point.setdefault(mount_point, []).append(server.name)
+	return servers_by_mount_point
 
 
 def _get_public_server_pool_decision(
@@ -241,7 +257,7 @@ def _apply_public_server_pool_decision(
 
 def _get_public_server_health_metrics(
 	server_names: list[str],
-	disk_aware_servers: list[str] | None = None,
+	disk_aware_servers_by_mount_point: dict[str, list[str]] | None = None,
 ) -> PublicServerHealthMetrics | None:
 	"""Fetch memory, CPU, kernel OOM-kill and disk metrics for public servers from Prometheus."""
 	if not server_names:
@@ -280,7 +296,9 @@ def _get_public_server_health_metrics(
 	):
 		return None
 
-	available_disk_bytes, available_disk_ratio = _get_available_disk(disk_aware_servers or [], url, auth)
+	available_disk_bytes, available_disk_ratio = _get_available_disk(
+		disk_aware_servers_by_mount_point or {}, url, auth
+	)
 
 	return {
 		"available_memory_bytes": _build_public_server_metric_map(
@@ -297,32 +315,34 @@ def _get_public_server_health_metrics(
 
 
 def _get_available_disk(
-	server_names: list[str],
+	servers_by_mount_point: dict[str, list[str]],
 	url: str,
 	auth: tuple[str, str],
 ) -> tuple[dict[str, float], dict[str, float]]:
-	"""Fetch free bytes and free ratio of the fullest volume that holds benches."""
-	from press.press.doctype.server.server import BENCH_DATA_MNT_POINT  # circular import
+	"""Fetch free bytes and free ratio of the volume that holds the benches."""
+	available_disk_bytes: dict[str, float] = {}
+	available_disk_ratio: dict[str, float] = {}
 
-	if not server_names:
-		return {}, {}
+	for mount_point, server_names in servers_by_mount_point.items():
+		instance_matcher = "|".join(_escape_prometheus_regex_literal(name) for name in server_names)
+		labels = f'instance=~"^({instance_matcher})$", job="node", mountpoint="{mount_point}"'
+		available_disk_bytes_query = f"node_filesystem_avail_bytes{{{labels}}}"
+		available_disk_ratio_query = (
+			f"node_filesystem_avail_bytes{{{labels}}} / node_filesystem_size_bytes{{{labels}}}"
+		)
 
-	instance_matcher = "|".join(_escape_prometheus_regex_literal(name) for name in server_names)
-	labels = f'instance=~"^({instance_matcher})$", job="node", mountpoint=~"/|{BENCH_DATA_MNT_POINT}"'
-	available_disk_bytes_query = f"min by (instance) (node_filesystem_avail_bytes{{{labels}}})"
-	available_disk_ratio_query = (
-		f"min by (instance) (node_filesystem_avail_bytes{{{labels}}}"
-		f" / node_filesystem_size_bytes{{{labels}}})"
-	)
+		available_disk_bytes.update(
+			_build_public_server_metric_map(
+				server_names, _query_prometheus_vector(available_disk_bytes_query, url, auth)
+			)
+		)
+		available_disk_ratio.update(
+			_build_public_server_metric_map(
+				server_names, _query_prometheus_vector(available_disk_ratio_query, url, auth)
+			)
+		)
 
-	return (
-		_build_public_server_metric_map(
-			server_names, _query_prometheus_vector(available_disk_bytes_query, url, auth)
-		),
-		_build_public_server_metric_map(
-			server_names, _query_prometheus_vector(available_disk_ratio_query, url, auth)
-		),
-	)
+	return available_disk_bytes, available_disk_ratio
 
 
 def _get_public_server_pool_prometheus_connection() -> tuple[str, tuple[str, str]] | None:

--- a/press/press/doctype/server/server_monitoring.py
+++ b/press/press/doctype/server/server_monitoring.py
@@ -16,6 +16,10 @@ from press.utils.raven import send_raven_message
 
 RAVEN_SERVER_ALERTS_CHANNEL = "frappe-cloud-server-alerts"
 PROMETHEUS_REGEX_META_CHAR_PATTERN = re.compile(r"([\\.^$*+?()[\]{}|])")
+# Hetzner volumes do not grow on demand, so disk decides where new sites go
+DISK_AWARE_PROVIDERS = ["Hetzner"]
+MINIMUM_SITE_DISK_BYTES = 50 * 1024 * 1024 * 1024
+MINIMUM_SITE_DISK_RATIO = 0.5
 
 
 class PublicServerHealthMetrics(TypedDict):
@@ -23,6 +27,8 @@ class PublicServerHealthMetrics(TypedDict):
 	available_memory_ratio: dict[str, float]
 	cpu_idle_ratio: dict[str, float]
 	oom_kills: dict[str, float]
+	available_disk_bytes: dict[str, float]
+	available_disk_ratio: dict[str, float]
 
 
 class PublicServerPoolDecision(TypedDict):
@@ -38,32 +44,35 @@ def monitor_server_and_refresh_new_bench_and_site_server_pool() -> None:
 	1. Consider active, public primary servers for each cluster
 	2. Fetch memory, CPU and OOM-kill health for all servers in bulk from Prometheus
 	3. Prefer healthy servers, and fall back to the least-bad server when a cluster has no healthy candidates
+	4. Keep new sites away from Hetzner servers that are low on disk, and alert about them
 	"""
-	server_names, servers_by_cluster = _get_public_primary_servers_by_cluster()
+	server_names, servers_by_cluster, disk_aware_servers = _get_public_primary_servers_by_cluster()
 	if not server_names:
 		return
 
-	metrics = _get_public_server_health_metrics(server_names)
+	metrics = _get_public_server_health_metrics(server_names, disk_aware_servers)
 	if not metrics:
 		return
 
 	pool_decision = _get_public_server_pool_decision(servers_by_cluster, metrics)
 	_apply_public_server_pool_decision(server_names, pool_decision)
 	_send_public_server_pool_health_alert(pool_decision["server_issues"])
+	_send_low_disk_alert(pool_decision["selected_site_servers"], metrics)
 	_create_no_suitable_servers_incident(pool_decision["fallback_servers_by_cluster"], metrics)
 
 
-def _get_public_primary_servers_by_cluster() -> tuple[list[str], dict[str, list[str]]]:
+def _get_public_primary_servers_by_cluster() -> tuple[list[str], dict[str, list[str]], list[str]]:
 	servers = frappe.get_all(
 		"Server",
 		filters={"status": "Active", "is_primary": True, "public": True, "exclude_for_scheduling": False},
-		fields=["name", "cluster"],
+		fields=["name", "cluster", "provider"],
 	)
 	server_names = [server.name for server in servers]
 	servers_by_cluster: dict[str, list[str]] = {}
 	for server in servers:
 		servers_by_cluster.setdefault(server.cluster, []).append(server.name)
-	return server_names, servers_by_cluster
+	disk_aware_servers = [server.name for server in servers if server.provider in DISK_AWARE_PROVIDERS]
+	return server_names, servers_by_cluster, disk_aware_servers
 
 
 def _get_public_server_pool_decision(
@@ -104,8 +113,9 @@ def _get_public_server_pool_decision(
 			decision["selected_bench_servers"].add(
 				max(sorted(healthy_servers), key=lambda server: _get_bench_pool_score(server, metrics))
 			)
+			site_servers = _servers_with_enough_disk(healthy_servers, metrics["available_disk_bytes"])
 			decision["selected_site_servers"].add(
-				max(sorted(healthy_servers), key=lambda server: _get_site_pool_score(server, metrics))
+				max(sorted(site_servers), key=lambda server: _get_site_pool_score(server, metrics))
 			)
 			continue
 
@@ -123,6 +133,16 @@ def _get_public_server_pool_decision(
 			)
 
 	return decision
+
+
+def _servers_with_enough_disk(server_names: list[str], available_disk_bytes: dict[str, float]) -> list[str]:
+	"""Drop servers that are low on disk. Only disk-aware providers are in the map."""
+	servers = [
+		server
+		for server in server_names
+		if available_disk_bytes.get(server, MINIMUM_SITE_DISK_BYTES) >= MINIMUM_SITE_DISK_BYTES
+	]
+	return servers or server_names
 
 
 def _get_public_server_health_issues(server: str, metrics: PublicServerHealthMetrics) -> list[str]:
@@ -219,8 +239,11 @@ def _apply_public_server_pool_decision(
 		)
 
 
-def _get_public_server_health_metrics(server_names: list[str]) -> PublicServerHealthMetrics | None:
-	"""Fetch memory, CPU and kernel OOM-kill metrics for public servers from Prometheus."""
+def _get_public_server_health_metrics(
+	server_names: list[str],
+	disk_aware_servers: list[str] | None = None,
+) -> PublicServerHealthMetrics | None:
+	"""Fetch memory, CPU, kernel OOM-kill and disk metrics for public servers from Prometheus."""
 	if not server_names:
 		return None
 
@@ -257,6 +280,8 @@ def _get_public_server_health_metrics(server_names: list[str]) -> PublicServerHe
 	):
 		return None
 
+	available_disk_bytes, available_disk_ratio = _get_available_disk(disk_aware_servers or [], url, auth)
+
 	return {
 		"available_memory_bytes": _build_public_server_metric_map(
 			server_names, available_memory_bytes_results
@@ -266,7 +291,38 @@ def _get_public_server_health_metrics(server_names: list[str]) -> PublicServerHe
 		),
 		"cpu_idle_ratio": _build_public_server_metric_map(server_names, cpu_idle_ratio_results),
 		"oom_kills": _build_public_server_metric_map(server_names, oom_kills_results, default=0.0),
+		"available_disk_bytes": available_disk_bytes,
+		"available_disk_ratio": available_disk_ratio,
 	}
+
+
+def _get_available_disk(
+	server_names: list[str],
+	url: str,
+	auth: tuple[str, str],
+) -> tuple[dict[str, float], dict[str, float]]:
+	"""Fetch free bytes and free ratio of the fullest volume that holds benches."""
+	from press.press.doctype.server.server import BENCH_DATA_MNT_POINT  # circular import
+
+	if not server_names:
+		return {}, {}
+
+	instance_matcher = "|".join(_escape_prometheus_regex_literal(name) for name in server_names)
+	labels = f'instance=~"^({instance_matcher})$", job="node", mountpoint=~"/|{BENCH_DATA_MNT_POINT}"'
+	available_disk_bytes_query = f"min by (instance) (node_filesystem_avail_bytes{{{labels}}})"
+	available_disk_ratio_query = (
+		f"min by (instance) (node_filesystem_avail_bytes{{{labels}}}"
+		f" / node_filesystem_size_bytes{{{labels}}})"
+	)
+
+	return (
+		_build_public_server_metric_map(
+			server_names, _query_prometheus_vector(available_disk_bytes_query, url, auth)
+		),
+		_build_public_server_metric_map(
+			server_names, _query_prometheus_vector(available_disk_ratio_query, url, auth)
+		),
+	)
 
 
 def _get_public_server_pool_prometheus_connection() -> tuple[str, tuple[str, str]] | None:
@@ -353,6 +409,51 @@ def _send_public_server_pool_health_alert(server_issues: dict[str, list[str]]) -
 	send_raven_message(
 		"\n".join(header_lines + table_header + table_rows).strip(), RAVEN_SERVER_ALERTS_CHANNEL
 	)
+
+
+def _send_low_disk_alert(
+	selected_site_servers: set[str],
+	metrics: PublicServerHealthMetrics,
+) -> None:
+	"""Alert when new sites go to a server that is low on disk.
+
+	The disk of these servers does not grow on demand. Add a server in the
+	cluster instead of a move to a larger plan.
+	"""
+	available_disk_bytes = metrics["available_disk_bytes"]
+	available_disk_ratio = metrics["available_disk_ratio"]
+	low_disk_servers = sorted(
+		server
+		for server in selected_site_servers
+		if server in available_disk_bytes
+		and (
+			available_disk_bytes[server] < MINIMUM_SITE_DISK_BYTES
+			or available_disk_ratio.get(server, 1.0) < MINIMUM_SITE_DISK_RATIO
+		)
+	)
+	if not low_disk_servers:
+		return
+
+	minimum_disk_gib = MINIMUM_SITE_DISK_BYTES / 1024**3
+	header_lines = [
+		f"**Public Server Pool Disk Alerts** - {len(low_disk_servers)}",
+		"",
+		"New sites go to these servers, but they are low on disk. Add a server in the cluster.",
+		f"Thresholds: free disk < {minimum_disk_gib:.0f} GiB, or free disk < "
+		f"{MINIMUM_SITE_DISK_RATIO * 100:.0f}% of the volume",
+		"",
+		"| Server | Free disk | Free |",
+		"| --- | --- | --- |",
+	]
+
+	table_rows = [
+		f"| {_escape_markdown_table_cell(server)} "
+		f"| {available_disk_bytes[server] / 1024**3:.2f} GiB "
+		f"| {available_disk_ratio.get(server, 0.0) * 100:.2f}% |"
+		for server in low_disk_servers
+	]
+
+	send_raven_message("\n".join(header_lines + table_rows).strip(), RAVEN_SERVER_ALERTS_CHANNEL)
 
 
 def _escape_markdown_table_cell(value: str) -> str:

--- a/press/press/doctype/server/server_monitoring.py
+++ b/press/press/doctype/server/server_monitoring.py
@@ -461,23 +461,28 @@ def _send_low_disk_alert(
 		return
 
 	minimum_disk_gib = MINIMUM_SITE_DISK_BYTES / 1024**3
+	minimum_disk_percent = MINIMUM_SITE_DISK_RATIO * 100
+	threshold_line = (
+		f"Thresholds: free disk < {minimum_disk_gib:.0f} GiB, "
+		f"or free disk < {minimum_disk_percent:.0f}% of the volume"
+	)
 	header_lines = [
 		f"**Public Server Pool Disk Alerts** - {len(low_disk_servers)}",
 		"",
 		"New sites go to these servers, but they are low on disk. Add a server in the cluster.",
-		f"Thresholds: free disk < {minimum_disk_gib:.0f} GiB, or free disk < "
-		f"{MINIMUM_SITE_DISK_RATIO * 100:.0f}% of the volume",
+		threshold_line,
 		"",
 		"| Server | Free disk | Free |",
 		"| --- | --- | --- |",
 	]
 
-	table_rows = [
-		f"| {_escape_markdown_table_cell(server)} "
-		f"| {available_disk_bytes[server] / 1024**3:.2f} GiB "
-		f"| {available_disk_ratio.get(server, 0.0) * 100:.2f}% |"
-		for server in low_disk_servers
-	]
+	table_rows = []
+	for server in low_disk_servers:
+		free_disk_gib = available_disk_bytes[server] / 1024**3
+		free_disk_percent = available_disk_ratio.get(server, 0.0) * 100
+		table_rows.append(
+			f"| {_escape_markdown_table_cell(server)} | {free_disk_gib:.2f} GiB | {free_disk_percent:.2f}% |"
+		)
 
 	send_raven_message("\n".join(header_lines + table_rows).strip(), RAVEN_SERVER_ALERTS_CHANNEL)
 

--- a/press/press/doctype/server/test_server_monitoring.py
+++ b/press/press/doctype/server/test_server_monitoring.py
@@ -10,10 +10,12 @@ from frappe.tests.utils import FrappeTestCase
 
 from press.press.doctype.server.server import BENCH_DATA_MNT_POINT
 from press.press.doctype.server.server_monitoring import (
+	HEALTH_ALERT_SENT_CACHE_KEY,
 	MINIMUM_SITE_DISK_BYTES,
 	PublicServerHealthMetrics,
 	_get_disk_aware_servers_by_mount_point,
 	_send_low_disk_alert,
+	_send_public_server_pool_health_alert,
 	_servers_with_enough_disk,
 )
 
@@ -30,6 +32,24 @@ def create_test_metrics(
 		"available_disk_bytes": available_disk_bytes,
 		"available_disk_ratio": available_disk_ratio,
 	}
+
+
+@patch("press.press.doctype.server.server_monitoring.send_raven_message")
+class TestPublicServerPoolHealthAlert(FrappeTestCase):
+	def setUp(self):
+		frappe.cache().delete_value(HEALTH_ALERT_SENT_CACHE_KEY)
+
+	def tearDown(self):
+		frappe.cache().delete_value(HEALTH_ALERT_SENT_CACHE_KEY)
+
+	def test_alert_sent_for_server_with_health_issues(self, send_raven_message):
+		_send_public_server_pool_health_alert({"busy.server": ["RAM utilization: 90.00%"]})
+		self.assertIn("busy.server", send_raven_message.call_args[0][0])
+
+	def test_alert_not_repeated_on_the_next_hourly_run(self, send_raven_message):
+		_send_public_server_pool_health_alert({"busy.server": ["RAM utilization: 90.00%"]})
+		_send_public_server_pool_health_alert({"busy.server": ["RAM utilization: 90.00%"]})
+		self.assertEqual(send_raven_message.call_count, 1)
 
 
 class TestDiskAwareServersByMountPoint(FrappeTestCase):

--- a/press/press/doctype/server/test_server_monitoring.py
+++ b/press/press/doctype/server/test_server_monitoring.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2019, Frappe and Contributors
+# See license.txt
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from press.press.doctype.server.server_monitoring import (
+	MINIMUM_SITE_DISK_BYTES,
+	PublicServerHealthMetrics,
+	_send_low_disk_alert,
+	_servers_with_enough_disk,
+)
+
+
+def create_test_metrics(
+	available_disk_bytes: dict[str, float],
+	available_disk_ratio: dict[str, float],
+) -> PublicServerHealthMetrics:
+	return {
+		"available_memory_bytes": {},
+		"available_memory_ratio": {},
+		"cpu_idle_ratio": {},
+		"oom_kills": {},
+		"available_disk_bytes": available_disk_bytes,
+		"available_disk_ratio": available_disk_ratio,
+	}
+
+
+class TestServersWithEnoughDisk(FrappeTestCase):
+	def test_server_below_disk_floor_is_not_a_candidate(self):
+		servers = _servers_with_enough_disk(
+			["low.hetzner", "high.hetzner"],
+			{"low.hetzner": MINIMUM_SITE_DISK_BYTES - 1, "high.hetzner": MINIMUM_SITE_DISK_BYTES},
+		)
+		self.assertEqual(servers, ["high.hetzner"])
+
+	def test_server_of_other_provider_is_a_candidate(self):
+		"""Only disk-aware providers are in the map. The others must not be dropped."""
+		self.assertEqual(_servers_with_enough_disk(["aws.server"], {}), ["aws.server"])
+
+	def test_all_servers_below_disk_floor_keeps_every_candidate(self):
+		servers = ["low.hetzner", "lower.hetzner"]
+		self.assertEqual(
+			_servers_with_enough_disk(servers, {"low.hetzner": 1.0, "lower.hetzner": 0.0}), servers
+		)
+
+
+@patch("press.press.doctype.server.server_monitoring.send_raven_message")
+class TestLowDiskAlert(FrappeTestCase):
+	def test_alert_sent_for_selected_server_below_disk_floor(self, send_raven_message):
+		metrics = create_test_metrics({"low.hetzner": 20 * 1024**3}, {"low.hetzner": 0.8})
+		_send_low_disk_alert({"low.hetzner"}, metrics)
+		self.assertIn("low.hetzner", send_raven_message.call_args[0][0])
+		self.assertIn("20.00 GiB", send_raven_message.call_args[0][0])
+
+	def test_alert_sent_for_selected_server_that_is_half_full(self, send_raven_message):
+		metrics = create_test_metrics({"full.hetzner": 900 * 1024**3}, {"full.hetzner": 0.45})
+		_send_low_disk_alert({"full.hetzner"}, metrics)
+		self.assertIn("45.00%", send_raven_message.call_args[0][0])
+
+	def test_no_alert_for_selected_server_with_enough_disk(self, send_raven_message):
+		metrics = create_test_metrics({"free.hetzner": 900 * 1024**3}, {"free.hetzner": 0.9})
+		_send_low_disk_alert({"free.hetzner"}, metrics)
+		send_raven_message.assert_not_called()
+
+	def test_no_alert_for_server_of_other_provider(self, send_raven_message):
+		_send_low_disk_alert({"aws.server"}, create_test_metrics({}, {}))
+		send_raven_message.assert_not_called()

--- a/press/press/doctype/server/test_server_monitoring.py
+++ b/press/press/doctype/server/test_server_monitoring.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
+from press.press.doctype.server.server import BENCH_DATA_MNT_POINT
 from press.press.doctype.server.server_monitoring import (
 	MINIMUM_SITE_DISK_BYTES,
 	PublicServerHealthMetrics,
+	_get_disk_aware_servers_by_mount_point,
 	_send_low_disk_alert,
 	_servers_with_enough_disk,
 )
@@ -27,6 +30,23 @@ def create_test_metrics(
 		"available_disk_bytes": available_disk_bytes,
 		"available_disk_ratio": available_disk_ratio,
 	}
+
+
+class TestDiskAwareServersByMountPoint(FrappeTestCase):
+	def test_server_with_data_volume_is_read_on_the_bench_mount_point(self):
+		servers = [frappe._dict(name="volume.hetzner", provider="Hetzner", has_data_volume=1)]
+		self.assertEqual(
+			_get_disk_aware_servers_by_mount_point(servers),
+			{BENCH_DATA_MNT_POINT: ["volume.hetzner"]},
+		)
+
+	def test_server_without_data_volume_is_read_on_the_root_mount_point(self):
+		servers = [frappe._dict(name="root.hetzner", provider="Hetzner", has_data_volume=0)]
+		self.assertEqual(_get_disk_aware_servers_by_mount_point(servers), {"/": ["root.hetzner"]})
+
+	def test_server_of_other_provider_is_left_out(self):
+		servers = [frappe._dict(name="aws.server", provider="AWS EC2", has_data_volume=1)]
+		self.assertEqual(_get_disk_aware_servers_by_mount_point(servers), {})
 
 
 class TestServersWithEnoughDisk(FrappeTestCase):


### PR DESCRIPTION
## Problem

The hourly public server pool refresh picks the site server of each cluster on CPU idle and free RAM only. Disk is not part of the decision. A Hetzner server can be almost full and still win, so new sites keep going to it. Hetzner volumes do not grow on demand, so the only answers today are a move to a larger plan, or a manual change of the pool flags.

## Change

`monitor_server_and_refresh_new_bench_and_site_server_pool` now also reads the free disk of the volume that holds the benches (`/opt/volumes/benches`, or `/` when there is no data volume). Servers with less than 50 GiB free are dropped before the site server of the cluster is chosen.

Only Hetzner servers get the disk query, because the volumes of the other providers grow on demand. Servers of other providers are not in the disk map, so nothing changes for them. If all servers in a cluster are below the floor, the old choice stands — each cluster must keep a server for new sites.

The bench pool is not changed.

## Alert

A message goes to the `frappe-cloud-server-alerts` Raven channel when the selected site server has less than 50 GiB free, or less than 50% of its volume free:

```
**Public Server Pool Disk Alerts** - 1

New sites go to these servers, but they are low on disk. Add a server in the cluster.
Thresholds: free disk < 50 GiB, or free disk < 50% of the volume

| Server | Free disk | Free |
| --- | --- | --- |
| f1.frappe.cloud | 320.10 GiB | 45.20% |
```

Half full is early enough to add a server in the cluster, instead of a move to the largest plan again. The alert repeats every hour while the condition holds, like the existing health alert.

## Tests

`press/press/doctype/server/test_server_monitoring.py` — 7 tests on the disk filter and on the alert. All pass.

```
bench --site test_frappe_cloud run-tests --app press --module press.press.doctype.server.test_server_monitoring
```

## Note

`press/press/doctype/server/server.py` still holds an older `refresh_new_bench_and_site_server_pool`. Nothing calls it — `press/hooks.py` schedules the `server_monitoring` one. It is not touched here.
