### PR TITLE
fix(site): Hide non public and archived clusters from region list

### DIFF
--- a/press/api/site.py
+++ b/press/api/site.py
@@ -1281,6 +1281,8 @@ def set_bench_and_clusters(version, for_bench):
 			allowed_cluster_names = list(set(public_servers_clusters))
 
 		filters = {"name": ("in", allowed_cluster_names)}
+		if not for_bench:
+			filters["public"] = 1
 
 		version.group.clusters = frappe.db.get_all(
 			"Cluster",
@@ -1334,7 +1336,7 @@ def get_additional_clusters_for_private_benches(existing_clusters, cloud_provide
 
 		cluster_info = frappe.db.get_value(
 			"Cluster",
-			cluster_name,
+			{"name": cluster_name, "public": 1},
 			["name", "title", "image", "beta", "cloud_provider"],
 			as_dict=True,
 		)


### PR DESCRIPTION
shows only active clusters from region list in site page 


fixes this issue: 
<img width="1545" height="1189" alt="image" src="https://github.com/user-attachments/assets/4b559fbf-844e-451d-8e53-2c1005bf0639" />
