### PR TITLE
feat(dashboard): Highlight "disk full" in the purge binlogs action

### DIFF
--- a/dashboard/src/components/server/ServerActionCell.vue
+++ b/dashboard/src/components/server/ServerActionCell.vue
@@ -2,7 +2,10 @@
 	<div class="flex items-center justify-between gap-1">
 		<div>
 			<h3 class="text-base font-medium">{{ props.actionLabel }}</h3>
-			<p class="mt-1 text-p-base text-ink-gray-6">{{ props.description }}</p>
+			<p
+				class="mt-1 text-p-base text-ink-gray-6"
+				v-html="props.description"
+			></p>
 		</div>
 		<Button
 			v-if="server?.doc"

--- a/dashboard/tests-e2e/tests/dashboard/server-actions-disk-full.test.ts
+++ b/dashboard/tests-e2e/tests/dashboard/server-actions-disk-full.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from './coverage.fixture'
+
+const APP_SERVER = 'f-test-app.frappe.cloud'
+const DATABASE_SERVER = 'm-test-db.frappe.cloud'
+
+const appServerDoc = {
+	name: APP_SERVER,
+	title: 'Test Server',
+	status: 'Active',
+	is_unified_server: 0,
+	database_server: DATABASE_SERVER,
+	replication_server: null,
+	actions: [
+		{
+			action: 'Reboot server',
+			description: 'Reboot the server',
+			button_label: 'Reboot',
+			doc_method: 'reboot',
+			group: 'Server Actions',
+			server_doctype: 'Server',
+			server_name: APP_SERVER,
+		},
+	],
+}
+
+const databaseServerDoc = {
+	name: DATABASE_SERVER,
+	title: 'Test Database Server',
+	status: 'Active',
+	actions: [
+		{
+			action: 'Forcefully Purge Binlogs',
+			description:
+				'Use this in case of <span class="text-red-600">disk full</span> issues',
+			button_label: 'Purge',
+			doc_method: 'purge_binlogs_forcefully',
+			group: 'Database Actions',
+			server_doctype: 'Database Server',
+			server_name: DATABASE_SERVER,
+		},
+	],
+}
+
+test('disk full in the purge binlogs description is red', async ({ page }) => {
+	await page.route(
+		/\/api\/method\/press\.api\.client\.get\b/,
+		async (route) => {
+			const doctype = new URL(route.request().url()).searchParams.get('doctype')
+			const doc =
+				doctype === 'Server'
+					? appServerDoc
+					: doctype === 'Database Server'
+						? databaseServerDoc
+						: null
+			if (!doc) return route.continue()
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ message: doc }),
+			})
+		},
+	)
+
+	await page.goto(`/dashboard/servers/${APP_SERVER}/actions`)
+
+	const description = page.getByText('Use this in case of disk full issues')
+	await expect(description).toBeVisible({ timeout: 30000 })
+
+	const diskFull = description.locator('span', { hasText: 'disk full' })
+	await expect(diskFull).toHaveText('disk full')
+
+	const color = await diskFull.evaluate((el) => getComputedStyle(el).color)
+	const rest = await description.evaluate((el) => getComputedStyle(el).color)
+	expect(color, 'disk full is not the same grey as the rest').not.toBe(rest)
+
+	const [red, green, blue] = color.match(/\d+/g)!.map(Number)
+	expect(red, 'disk full is red').toBeGreaterThan(150)
+	expect(green).toBeLessThan(100)
+	expect(blue).toBeLessThan(100)
+})

--- a/dashboard/tests-e2e/tests/dashboard/server-actions-disk-full.test.ts
+++ b/dashboard/tests-e2e/tests/dashboard/server-actions-disk-full.test.ts
@@ -1,3 +1,4 @@
+import type { Page } from '@playwright/test'
 import { expect, test } from './coverage.fixture'
 
 const APP_SERVER = 'f-test-app.frappe.cloud'
@@ -16,6 +17,15 @@ const appServerDoc = {
 			description: 'Reboot the server',
 			button_label: 'Reboot',
 			doc_method: 'reboot',
+			group: 'Server Actions',
+			server_doctype: 'Server',
+			server_name: APP_SERVER,
+		},
+		{
+			action: 'Manage On-Prem Replication',
+			description: 'Manage On-Prem Replication &amp; Failover',
+			button_label: 'Manage',
+			doc_method: 'dummy',
 			group: 'Server Actions',
 			server_doctype: 'Server',
 			server_name: APP_SERVER,
@@ -41,7 +51,7 @@ const databaseServerDoc = {
 	],
 }
 
-test('disk full in the purge binlogs description is red', async ({ page }) => {
+async function mockServerDocs(page: Page) {
 	await page.route(
 		/\/api\/method\/press\.api\.client\.get\b/,
 		async (route) => {
@@ -60,6 +70,10 @@ test('disk full in the purge binlogs description is red', async ({ page }) => {
 			})
 		},
 	)
+}
+
+test('disk full in the purge binlogs description is red', async ({ page }) => {
+	await mockServerDocs(page)
 
 	await page.goto(`/dashboard/servers/${APP_SERVER}/actions`)
 
@@ -77,4 +91,17 @@ test('disk full in the purge binlogs description is red', async ({ page }) => {
 	expect(red, 'disk full is red').toBeGreaterThan(150)
 	expect(green).toBeLessThan(100)
 	expect(blue).toBeLessThan(100)
+})
+
+test('a description without markup renders as written', async ({ page }) => {
+	await mockServerDocs(page)
+	await page.goto(`/dashboard/servers/${APP_SERVER}/actions`)
+
+	// The rest of the tab still reads as plain text, entities included.
+	await expect(page.getByText('Reboot the server')).toBeVisible({
+		timeout: 30000,
+	})
+	await expect(
+		page.getByText('Manage On-Prem Replication & Failover'),
+	).toBeVisible()
 })

--- a/press/press/doctype/database_server/database_server.py
+++ b/press/press/doctype/database_server/database_server.py
@@ -409,7 +409,7 @@ class DatabaseServer(BaseServer):
 			},
 			{
 				"action": "Forcefully Purge Binlogs",
-				"description": "Use this in case of disk full issues",
+				"description": 'Use this in case of <span class="text-red-600">disk full</span> issues',
 				"button_label": "Purge",
 				"condition": self.status == "Active",
 				"doc_method": "purge_binlogs_forcefully",

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -427,7 +427,7 @@ class BaseServer(Document, TagHelpers):
 		actions = [
 			{
 				"action": "Manage On-Prem Replication",
-				"description": "Manage On-Prem Replication & Failover",
+				"description": "Manage On-Prem Replication &amp; Failover",
 				"button_label": "Manage",
 				"condition": self.status == "Active"
 				and self.doctype == "Server"


### PR DESCRIPTION
The **Forcefully Purge Binlogs** action on the server Actions tab is the remedy for a full database disk, but its description (`Use this in case of disk full issues`) looks the same as every other line on the tab. An operator that scans the tab for the disk full fix does not see it.

This marks the words **disk full** in red.

`ServerActionCell` now renders the action description with `v-html`. Every description in the `server_actions` lists is a static string in the code (`server.py`, `database_server.py`), so no user input reaches the markup.

### Test

`dashboard/tests-e2e/tests/dashboard/server-actions-disk-full.test.ts` mocks the server documents, opens the Actions tab and reads the computed colour of the `disk full` span. It asserts the colour, not the class name, because a class assertion still passes when the description is rendered as plain text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)