### PR TITLE
feat(dashboard): Link chart cards to the docs

### DIFF
--- a/dashboard/src/components/server/ReleaseGroupCharts.vue
+++ b/dashboard/src/components/server/ReleaseGroupCharts.vue
@@ -19,7 +19,10 @@
 			/>
 		</div>
 		<div class="grid grid-cols-1 gap-5 sm:grid-cols-2">
-			<AnalyticsCard title="Memory">
+			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/bench-analytics"
+				title="Memory"
+			>
 				<LineChart
 					type="time"
 					title="Memory"
@@ -33,7 +36,10 @@
 					class="h-[15.55rem] p-2 pb-3"
 				/>
 			</AnalyticsCard>
-			<AnalyticsCard title="CPU">
+			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/bench-analytics"
+				title="CPU"
+			>
 				<LineChart
 					type="time"
 					title="CPU"
@@ -49,7 +55,10 @@
 			</AnalyticsCard>
 		</div>
 		<div class="grid grid-cols-1 gap-5 sm:grid-cols-2">
-			<AnalyticsCard title="Incoming Network">
+			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/bench-analytics"
+				title="Incoming Network"
+			>
 				<LineChart
 					type="time"
 					title="Memory"
@@ -63,7 +72,10 @@
 					class="h-[15.55rem] p-2 pb-3"
 				/>
 			</AnalyticsCard>
-			<AnalyticsCard title="Outgoing Network">
+			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/bench-analytics"
+				title="Outgoing Network"
+			>
 				<LineChart
 					type="time"
 					title="CPU"
@@ -79,7 +91,10 @@
 			</AnalyticsCard>
 		</div>
 		<div class="grid grid-cols-1 gap-5 sm:grid-cols-2">
-			<AnalyticsCard title="Read Bytes">
+			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/bench-analytics"
+				title="Read Bytes"
+			>
 				<LineChart
 					type="time"
 					title="Memory"
@@ -93,7 +108,10 @@
 					class="h-[15.55rem] p-2 pb-3"
 				/>
 			</AnalyticsCard>
-			<AnalyticsCard title="Write Bytes">
+			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/bench-analytics"
+				title="Write Bytes"
+			>
 				<LineChart
 					type="time"
 					title="CPU"

--- a/dashboard/src/components/server/ReleaseGroupCharts.vue
+++ b/dashboard/src/components/server/ReleaseGroupCharts.vue
@@ -112,10 +112,10 @@
 </template>
 
 <script>
-import LineChart from '@/components/charts/LineChart.vue';
-import BarChart from '@/components/charts/BarChart.vue';
-import AnalyticsCard from '../site/AnalyticsCard.vue';
-import dayjs from '../../utils/dayjs';
+import BarChart from '@/components/charts/BarChart.vue'
+import LineChart from '@/components/charts/LineChart.vue'
+import dayjs from '../../utils/dayjs'
+import AnalyticsCard from '../site/AnalyticsCard.vue'
 
 export default {
 	props: ['serverName'],
@@ -142,7 +142,7 @@ export default {
 				this.$theme.colors.gray[500],
 				this.$theme.colors.orange[500],
 			],
-		};
+		}
 	},
 	watch: {
 		chosenGroup() {
@@ -150,7 +150,7 @@ export default {
 				query: {
 					name: this.chosenGroup,
 				},
-			});
+			})
 		},
 	},
 	resources: {
@@ -163,7 +163,7 @@ export default {
 					duration: this.duration,
 				},
 				auto: true,
-			};
+			}
 		},
 		cpu() {
 			return {
@@ -174,7 +174,7 @@ export default {
 					duration: this.duration,
 				},
 				auto: true,
-			};
+			}
 		},
 		incomingNetwork() {
 			return {
@@ -185,7 +185,7 @@ export default {
 					duration: this.duration,
 				},
 				auto: true,
-			};
+			}
 		},
 		outgoingNetwork() {
 			return {
@@ -196,7 +196,7 @@ export default {
 					duration: this.duration,
 				},
 				auto: true,
-			};
+			}
 		},
 		readBytesFs() {
 			return {
@@ -207,7 +207,7 @@ export default {
 					duration: this.duration,
 				},
 				auto: true,
-			};
+			}
 		},
 		writeBytesFs() {
 			return {
@@ -218,7 +218,7 @@ export default {
 					duration: this.duration,
 				},
 				auto: true,
-			};
+			}
 		},
 		groups() {
 			return {
@@ -229,15 +229,15 @@ export default {
 					filters: { server: this.serverName, enabled: 1 },
 				},
 				auto: true,
-			};
+			}
 		},
 	},
 	computed: {
 		releaseGroupOptions() {
-			let groups = this.$resources.groups.data;
+			let groups = this.$resources.groups.data
 
 			if (!groups) {
-				return null;
+				return null
 			}
 
 			let filteredGroups = groups
@@ -245,81 +245,80 @@ export default {
 				.map((group) => ({
 					label: group.title,
 					value: group.name,
-				}));
+				}))
 
 			if (!this.chosenGroup) {
-				this.chosenGroup = filteredGroups[0].value;
+				this.chosenGroup = filteredGroups[0].value
 			}
 
-			return filteredGroups;
+			return filteredGroups
 		},
 		memoryData() {
-			let memory = this.$resources.memory.data?.memory;
-			if (!memory) return;
+			let memory = this.$resources.memory.data?.memory
+			if (!memory) return
 
-			return this.transformMultiLineChartData(memory);
+			return this.transformMultiLineChartData(memory)
 		},
 		cpuData() {
-			let cpu = this.$resources.cpu.data?.cpu;
-			if (!cpu) return;
+			let cpu = this.$resources.cpu.data?.cpu
+			if (!cpu) return
 
-			return this.transformMultiLineChartData(cpu);
+			return this.transformMultiLineChartData(cpu)
 		},
 		incomingNetwork() {
-			let traffic =
-				this.$resources.incomingNetwork.data?.network_traffic_inward;
-			if (!traffic) return;
+			let traffic = this.$resources.incomingNetwork.data?.network_traffic_inward
+			if (!traffic) return
 
-			return this.transformMultiLineChartData(traffic);
+			return this.transformMultiLineChartData(traffic)
 		},
 		outgoingNetwork() {
 			let network_traffic_outward =
-				this.$resources.outgoingNetwork.data?.network_traffic_outward;
-			if (!network_traffic_outward) return;
+				this.$resources.outgoingNetwork.data?.network_traffic_outward
+			if (!network_traffic_outward) return
 
-			return this.transformMultiLineChartData(network_traffic_outward);
+			return this.transformMultiLineChartData(network_traffic_outward)
 		},
 		readBytesFs() {
-			let read_bytes_fs = this.$resources.readBytesFs.data?.read_bytes_fs;
-			if (!read_bytes_fs) return;
+			let read_bytes_fs = this.$resources.readBytesFs.data?.read_bytes_fs
+			if (!read_bytes_fs) return
 
-			return this.transformMultiLineChartData(read_bytes_fs);
+			return this.transformMultiLineChartData(read_bytes_fs)
 		},
 		writeBytesFs() {
-			let write_bytes_fs = this.$resources.writeBytesFs.data?.write_bytes_fs;
-			if (!write_bytes_fs) return;
+			let write_bytes_fs = this.$resources.writeBytesFs.data?.write_bytes_fs
+			if (!write_bytes_fs) return
 
-			return this.transformMultiLineChartData(write_bytes_fs);
+			return this.transformMultiLineChartData(write_bytes_fs)
 		},
 	},
 	methods: {
 		transformMultiLineChartData(data, stack = null, percentage = false) {
-			if (!data.datasets?.length) return;
+			if (!data.datasets?.length) return
 
-			let total = [];
+			let total = []
 			if (percentage) {
 				// the sum of each cpu values tends to differ by few values
 				// so we need to calculate the total for each timestamp
 				for (let i = 0; i < data.datasets[0].values.length; i++) {
 					for (let j = 0; j < data.datasets.length; j++) {
-						if (!total[i]) total[i] = 0;
-						total[i] += data.datasets[j].values[i];
+						if (!total[i]) total[i] = 0
+						total[i] += data.datasets[j].values[i]
 					}
 				}
 			}
 			const datasets = data.datasets.map(({ name, values }) => {
-				let dataset = [];
+				let dataset = []
 				for (let i = 0; i < values.length; i++) {
 					dataset.push([
 						+new Date(data.labels[i]),
 						percentage ? (values[i] / total[i]) * 100 : values[i],
-					]);
+					])
 				}
-				return { name, dataset, stack };
-			});
+				return { name, dataset, stack }
+			})
 
-			return { datasets, yMax: percentage ? 100 : null };
+			return { datasets, yMax: percentage ? 100 : null }
 		},
 	},
-};
+}
 </script>

--- a/dashboard/src/components/server/ServerCharts.vue
+++ b/dashboard/src/components/server/ServerCharts.vue
@@ -458,12 +458,12 @@ import {
 	DateTimePicker,
 	getCachedDocumentResource,
 	TabButtons,
-} from 'frappe-ui';
-import LineChart from '@/components/charts/LineChart.vue';
-import BarChart from '@/components/charts/BarChart.vue';
-import AnalyticsCard from '../site/AnalyticsCard.vue';
-import dayjs, { dayjsFloorToMinutes } from '../../utils/dayjs';
-import { duration } from '../../utils/format';
+} from 'frappe-ui'
+import BarChart from '@/components/charts/BarChart.vue'
+import LineChart from '@/components/charts/LineChart.vue'
+import dayjs, { dayjsFloorToMinutes } from '../../utils/dayjs'
+import { duration } from '../../utils/format'
+import AnalyticsCard from '../site/AnalyticsCard.vue'
 
 export default {
 	props: ['serverName'],
@@ -474,7 +474,7 @@ export default {
 		DateTimePicker,
 	},
 	data() {
-		const defaultDuration = '1h';
+		const defaultDuration = '1h'
 
 		return {
 			defaultDuration,
@@ -508,7 +508,7 @@ export default {
 				this.$theme.colors.gray[500],
 				this.$theme.colors.orange[500],
 			],
-		};
+		}
 	},
 	watch: {
 		chosenServer() {
@@ -516,22 +516,22 @@ export default {
 				query: {
 					server: this.chosenServer,
 				},
-			});
+			})
 		},
 		duration: {
 			// sync, so that a zoom can overwrite the range this sets before any
 			// chart reads it. Otherwise the tab refetches the default range first.
 			flush: 'sync',
 			handler() {
-				const now = dayjs();
+				const now = dayjs()
 				// floor to 15 minutes to avoid issues with caching
-				const flooredEndDate = dayjsFloorToMinutes(now, 15);
-				this.customEndTime = flooredEndDate.toDate();
+				const flooredEndDate = dayjsFloorToMinutes(now, 15)
+				this.customEndTime = flooredEndDate.toDate()
 				const dur =
 					this.duration === 'custom'
 						? this.defaultDurationToArray
-						: this.inputDurationToArray;
-				this.customStartTime = flooredEndDate.subtract(...dur).toDate();
+						: this.inputDurationToArray
+				this.customStartTime = flooredEndDate.subtract(...dur).toDate()
 			},
 		},
 	},
@@ -550,7 +550,7 @@ export default {
 					)?.label,
 				},
 				auto: true,
-			};
+			}
 		},
 		cpu() {
 			return {
@@ -566,7 +566,7 @@ export default {
 					)?.label,
 				},
 				auto: true,
-			};
+			}
 		},
 		memory() {
 			return {
@@ -582,7 +582,7 @@ export default {
 					)?.label,
 				},
 				auto: true,
-			};
+			}
 		},
 		network() {
 			return {
@@ -598,7 +598,7 @@ export default {
 					)?.label,
 				},
 				auto: true,
-			};
+			}
 		},
 		iops() {
 			return {
@@ -614,7 +614,7 @@ export default {
 					)?.label,
 				},
 				auto: true,
-			};
+			}
 		},
 		space() {
 			return {
@@ -630,7 +630,7 @@ export default {
 					)?.label,
 				},
 				auto: true,
-			};
+			}
 		},
 		requestCountBySite() {
 			return {
@@ -644,7 +644,7 @@ export default {
 				},
 				auto:
 					this.showAdvancedAnalytics && this.isServerType('Application Server'),
-			};
+			}
 		},
 		requestDurationBySite() {
 			return {
@@ -658,7 +658,7 @@ export default {
 				},
 				auto:
 					this.showAdvancedAnalytics && this.isServerType('Application Server'),
-			};
+			}
 		},
 		backgroundJobCountBySite() {
 			return {
@@ -672,7 +672,7 @@ export default {
 				},
 				auto:
 					this.showAdvancedAnalytics && this.isServerType('Application Server'),
-			};
+			}
 		},
 		backgroundJobDurationBySite() {
 			return {
@@ -686,7 +686,7 @@ export default {
 				},
 				auto:
 					this.showAdvancedAnalytics && this.isServerType('Application Server'),
-			};
+			}
 		},
 		slowLogsCount() {
 			return {
@@ -702,7 +702,7 @@ export default {
 				auto:
 					this.showAdvancedAnalytics &&
 					!this.isServerType('Application Server'),
-			};
+			}
 		},
 		slowLogsDuration() {
 			return {
@@ -718,7 +718,7 @@ export default {
 				auto:
 					this.showAdvancedAnalytics &&
 					!this.isServerType('Application Server'),
-			};
+			}
 		},
 		databaseUptime() {
 			return {
@@ -736,7 +736,7 @@ export default {
 				auto:
 					this.isServerType('Database Server') ||
 					this.isServerType('Replication Server'),
-			};
+			}
 		},
 		databaseCommandsCount() {
 			return {
@@ -755,7 +755,7 @@ export default {
 					this.showAdvancedAnalytics &&
 					(this.isServerType('Database Server') ||
 						this.isServerType('Replication Server')),
-			};
+			}
 		},
 		databaseConnections() {
 			return {
@@ -774,7 +774,7 @@ export default {
 					this.showAdvancedAnalytics &&
 					(this.isServerType('Database Server') ||
 						this.isServerType('Replication Server')),
-			};
+			}
 		},
 		innodbBufferPoolSize() {
 			return {
@@ -793,7 +793,7 @@ export default {
 					this.showAdvancedAnalytics &&
 					(this.isServerType('Database Server') ||
 						this.isServerType('Replication Server')),
-			};
+			}
 		},
 		innodbBufferPoolSizeOfTotalRam() {
 			return {
@@ -812,7 +812,7 @@ export default {
 					this.showAdvancedAnalytics &&
 					(this.isServerType('Database Server') ||
 						this.isServerType('Replication Server')),
-			};
+			}
 		},
 		innodbBufferPoolMissPercentage() {
 			return {
@@ -831,7 +831,7 @@ export default {
 					this.showAdvancedAnalytics &&
 					(this.isServerType('Database Server') ||
 						this.isServerType('Replication Server')),
-			};
+			}
 		},
 		innodbAvgRowLockTime() {
 			return {
@@ -850,12 +850,12 @@ export default {
 					this.showAdvancedAnalytics &&
 					(this.isServerType('Database Server') ||
 						this.isServerType('Replication Server')),
-			};
+			}
 		},
 	},
 	computed: {
 		$server() {
-			return getCachedDocumentResource('Server', this.serverName);
+			return getCachedDocumentResource('Server', this.serverName)
 		},
 		serverOptions() {
 			const options = [
@@ -875,55 +875,55 @@ export default {
 					label: 'Replication Server',
 					value: this.$server.doc.replication_server,
 				},
-			].filter((v) => v.value);
+			].filter((v) => v.value)
 			if (options.length === 1 && !this.chosenServer) {
-				this.chosenServer = options[0].value;
+				this.chosenServer = options[0].value
 			}
-			return options;
+			return options
 		},
 		inputDurationToArray() {
 			if (this.duration === 'custom') {
-				return null;
+				return null
 			}
-			const durationValue = Number(this.duration.slice(0, -1));
-			const durationUnit = this.duration.slice(-1);
-			return [durationValue, durationUnit];
+			const durationValue = Number(this.duration.slice(0, -1))
+			const durationUnit = this.duration.slice(-1)
+			return [durationValue, durationUnit]
 		},
 		defaultDurationToArray() {
-			const durationValue = Number(this.defaultDuration.slice(0, -1));
-			const durationUnit = this.defaultDuration.slice(-1);
-			return [durationValue, durationUnit];
+			const durationValue = Number(this.defaultDuration.slice(0, -1))
+			const durationUnit = this.defaultDuration.slice(-1)
+			return [durationValue, durationUnit]
 		},
 		startTime() {
 			if (this.duration === 'custom') {
-				return this.customStartTime;
+				return this.customStartTime
 			}
 			return dayjs(this.endTime)
 				.subtract(...this.inputDurationToArray)
-				.toDate();
+				.toDate()
 		},
 		endTime() {
 			if (this.duration === 'custom') {
-				return this.customEndTime;
+				return this.customEndTime
 			}
-			const now = dayjs();
+			const now = dayjs()
 			// floor to 15 minutes to avoid issues with caching
-			const flooredNow = dayjsFloorToMinutes(now, 15);
-			return flooredNow.toDate();
+			const flooredNow = dayjsFloorToMinutes(now, 15)
+			return flooredNow.toDate()
 		},
 		loadAverageData() {
-			let loadavg = this.$resources.loadavg.data;
-			if (!loadavg) return;
+			let loadavg = this.$resources.loadavg.data
+			if (!loadavg) return
 
 			loadavg.datasets.sort(
 				(a, b) => Number(a.name.split(' ')[2]) - Number(b.name.split(' ')[2]),
-			);
+			)
 
-			return this.transformMultiLineChartData(loadavg);
+			return this.transformMultiLineChartData(loadavg)
 		},
 		cpuData() {
-			let cpu = this.$resources.cpu.data;
-			if (!cpu) return;
+			let cpu = this.$resources.cpu.data
+			if (!cpu) return
 			const order = [
 				'system',
 				'user',
@@ -933,104 +933,104 @@ export default {
 				'nice',
 				'steal',
 				'idle',
-			];
+			]
 
 			cpu.datasets = cpu.datasets.sort((a, b) => {
-				return order.indexOf(a.name) - order.indexOf(b.name);
-			});
+				return order.indexOf(a.name) - order.indexOf(b.name)
+			})
 
-			return this.transformMultiLineChartData(cpu, 'cpu', true);
+			return this.transformMultiLineChartData(cpu, 'cpu', true)
 		},
 		memoryData() {
-			let memory = this.$resources.memory.data;
-			if (!memory) return;
+			let memory = this.$resources.memory.data
+			if (!memory) return
 
-			return this.transformSingleLineChartData(memory);
+			return this.transformSingleLineChartData(memory)
 		},
 		iopsData() {
-			let iops = this.$resources.iops.data;
-			if (!iops) return;
+			let iops = this.$resources.iops.data
+			if (!iops) return
 
-			return this.transformMultiLineChartData(iops);
+			return this.transformMultiLineChartData(iops)
 		},
 		spaceData() {
-			let space = this.$resources.space.data;
-			if (!space) return;
+			let space = this.$resources.space.data
+			if (!space) return
 
-			return this.transformMultiLineChartData(space);
+			return this.transformMultiLineChartData(space)
 		},
 		networkData() {
-			let network = this.$resources.network.data;
-			if (!network) return;
+			let network = this.$resources.network.data
+			if (!network) return
 
-			return this.transformSingleLineChartData(network);
+			return this.transformSingleLineChartData(network)
 		},
 		requestCountBySiteData() {
-			const requests = this.$resources.requestCountBySite.data;
-			if (!requests) return;
+			const requests = this.$resources.requestCountBySite.data
+			if (!requests) return
 
-			return requests;
+			return requests
 		},
 		requestDurationBySiteData() {
-			const requests = this.$resources.requestDurationBySite.data;
-			if (!requests) return;
+			const requests = this.$resources.requestDurationBySite.data
+			if (!requests) return
 
-			return requests;
+			return requests
 		},
 		backgroundJobCountBySiteData() {
-			const jobs = this.$resources.backgroundJobCountBySite.data;
-			if (!jobs) return;
+			const jobs = this.$resources.backgroundJobCountBySite.data
+			if (!jobs) return
 
-			return jobs;
+			return jobs
 		},
 		backgroundJobDurationBySiteData() {
-			const jobs = this.$resources.backgroundJobDurationBySite.data;
-			if (!jobs) return;
+			const jobs = this.$resources.backgroundJobDurationBySite.data
+			if (!jobs) return
 
-			return jobs;
+			return jobs
 		},
 		slowLogsDurationData() {
-			const slowLogs = this.$resources.slowLogsDuration.data;
-			if (!slowLogs) return;
+			const slowLogs = this.$resources.slowLogsDuration.data
+			if (!slowLogs) return
 
-			return slowLogs;
+			return slowLogs
 		},
 		slowLogsCountData() {
-			const slowLogs = this.$resources.slowLogsCount.data;
-			if (!slowLogs) return;
+			const slowLogs = this.$resources.slowLogsCount.data
+			if (!slowLogs) return
 
-			return slowLogs;
+			return slowLogs
 		},
 		databaseUptimeData() {
-			const uptime = this.$resources.databaseUptime.data;
-			if (!uptime) return;
+			const uptime = this.$resources.databaseUptime.data
+			if (!uptime) return
 
-			const data = this.transformSingleLineChartData(uptime);
+			const data = this.transformSingleLineChartData(uptime)
 			// uptime sits at 100%, so a zero-based axis flattens every dip
-			return data && { ...data, yScale: true };
+			return data && { ...data, yScale: true }
 		},
 		databaseCommandsCountData() {
-			const commandsCount = this.$resources.databaseCommandsCount.data;
-			if (!commandsCount) return;
+			const commandsCount = this.$resources.databaseCommandsCount.data
+			if (!commandsCount) return
 
-			return this.transformMultiLineChartData(commandsCount, null, false);
+			return this.transformMultiLineChartData(commandsCount, null, false)
 		},
 		databaseConnectionsData() {
-			const connections = this.$resources.databaseConnections.data;
-			if (!connections) return;
+			const connections = this.$resources.databaseConnections.data
+			if (!connections) return
 
-			return this.transformMultiLineChartData(connections, null, false);
+			return this.transformMultiLineChartData(connections, null, false)
 		},
 		innodbBufferPoolSizeData() {
-			let innodbBufferPoolSize = this.$resources.innodbBufferPoolSize.data;
-			if (!innodbBufferPoolSize) return;
+			let innodbBufferPoolSize = this.$resources.innodbBufferPoolSize.data
+			if (!innodbBufferPoolSize) return
 
-			return this.transformSingleLineChartData(innodbBufferPoolSize, false);
+			return this.transformSingleLineChartData(innodbBufferPoolSize, false)
 		},
 		innodbBufferPoolSizeOfTotalRamData() {
-			let data = this.$resources.innodbBufferPoolSizeOfTotalRam.data;
-			if (!data || (data.datasets && data.datasets.length === 0)) return;
-			let payload = this.transformSingleLineChartData(data, true);
+			let data = this.$resources.innodbBufferPoolSizeOfTotalRam.data
+			if (!data || (data.datasets && data.datasets.length === 0)) return
+			let payload = this.transformSingleLineChartData(data, true)
 			payload['markLine'] = {
 				data: [
 					{
@@ -1057,14 +1057,14 @@ export default {
 					},
 				],
 				symbol: ['none', 'none'],
-			};
-			return payload;
+			}
+			return payload
 		},
 		innodbBufferPoolMissPercentageData() {
-			let data = this.$resources.innodbBufferPoolMissPercentage.data;
-			if (!data || (data.datasets && data.datasets.length === 0)) return;
+			let data = this.$resources.innodbBufferPoolMissPercentage.data
+			if (!data || (data.datasets && data.datasets.length === 0)) return
 
-			let payload = this.transformSingleLineChartData(data, false);
+			let payload = this.transformSingleLineChartData(data, false)
 			payload['markLine'] = {
 				data: [
 					{
@@ -1080,83 +1080,83 @@ export default {
 					},
 				],
 				symbol: ['none', 'none'],
-			};
-			return payload;
+			}
+			return payload
 		},
 		innodbAvgRowLockTimeData() {
-			let data = this.$resources.innodbAvgRowLockTime.data;
-			if (!data) return;
-			return this.transformSingleLineChartData(data, false);
+			let data = this.$resources.innodbAvgRowLockTime.data
+			if (!data) return
+			return this.transformSingleLineChartData(data, false)
 		},
 	},
 	methods: {
 		transformSingleLineChartData(data, percentage = false) {
-			if (!data.datasets?.length) return;
+			if (!data.datasets?.length) return
 
-			let dataset = [];
-			const name = data.datasets ? data.datasets[0]?.name : null;
+			let dataset = []
+			const name = data.datasets ? data.datasets[0]?.name : null
 			for (let index = 0; index < data.datasets[0].values.length; index++) {
 				dataset.push([
 					+new Date(data.labels[index]),
 					data.datasets[0].values[index],
-				]);
+				])
 			}
 
 			return {
 				datasets: [{ dataset: dataset, name }],
 				yMax: percentage ? 100 : null,
-			};
+			}
 		},
 		transformMultiLineChartData(data, stack = null, percentage = false) {
-			if (!data.datasets?.length) return;
+			if (!data.datasets?.length) return
 
-			let total = [];
+			let total = []
 			if (percentage) {
 				// the sum of each cpu values tends to differ by few values
 				// so we need to calculate the total for each timestamp
 				for (let i = 0; i < data.datasets[0].values.length; i++) {
 					for (let j = 0; j < data.datasets.length; j++) {
-						if (!total[i]) total[i] = 0;
-						total[i] += data.datasets[j].values[i];
+						if (!total[i]) total[i] = 0
+						total[i] += data.datasets[j].values[i]
 					}
 				}
 			}
 			const datasets = data.datasets.map(({ name, values }) => {
-				let dataset = [];
+				let dataset = []
 				for (let i = 0; i < values.length; i++) {
 					dataset.push([
 						+new Date(data.labels[i]),
 						percentage ? (values[i] / total[i]) * 100 : values[i],
-					]);
+					])
 				}
-				return { name, dataset, stack };
-			});
+				return { name, dataset, stack }
+			})
 
-			return { datasets, yMax: percentage ? 100 : null };
+			return { datasets, yMax: percentage ? 100 : null }
 		},
 		isServerType(type) {
 			// Show all analytics for Unified Server
 			if (this.$server.doc.is_unified_server) {
-				type = 'Unified Server';
+				type = 'Unified Server'
 			}
 			return (
 				this.chosenServer ===
 				this.serverOptions.find((s) => s.label === type)?.value
-			);
+			)
 		},
 		toggleAdvancedAnalytics() {
-			this.showAdvancedAnalytics = !this.showAdvancedAnalytics;
+			this.showAdvancedAnalytics = !this.showAdvancedAnalytics
 		},
 		handleDataZoom({ startDate, endDate }) {
-			clearTimeout(this.zoomTimeout);
+			clearTimeout(this.zoomTimeout)
 			// debounce: one drag can end in more than one zoom event, and every
 			// chart on the tab refetches when the range changes
 			this.zoomTimeout = setTimeout(() => {
-				this.duration = 'custom';
-				this.customStartTime = startDate;
-				this.customEndTime = endDate;
-			}, 500);
+				this.duration = 'custom'
+				this.customStartTime = startDate
+				this.customEndTime = endDate
+			}, 500)
 		},
 	},
-};
+}
 </script>

--- a/dashboard/src/components/server/ServerCharts.vue
+++ b/dashboard/src/components/server/ServerCharts.vue
@@ -54,7 +54,10 @@
 				/>
 			</AnalyticsCard>
 
-			<AnalyticsCard title="CPU">
+			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/servers/guidelines-for-choosing-a-server-plan#cpu"
+				title="CPU"
+			>
 				<LineChart
 					type="time"
 					title="CPU"
@@ -79,7 +82,10 @@
 				/>
 			</AnalyticsCard>
 
-			<AnalyticsCard title="Load Average">
+			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/servers/guidelines-for-choosing-a-server-plan#load-average"
+				title="Load Average"
+			>
 				<LineChart
 					type="time"
 					title="Load Average"
@@ -98,7 +104,10 @@
 				/>
 			</AnalyticsCard>
 
-			<AnalyticsCard title="Memory">
+			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/servers/guidelines-for-choosing-a-server-plan#bench-memory-usage"
+				title="Memory"
+			>
 				<LineChart
 					type="time"
 					title="Memory"
@@ -114,7 +123,10 @@
 				/>
 			</AnalyticsCard>
 
-			<AnalyticsCard title="Disk Space">
+			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/servers/guidelines-for-choosing-a-server-plan#server-analytics"
+				title="Disk Space"
+			>
 				<LineChart
 					type="time"
 					title="Disk Space"
@@ -130,7 +142,10 @@
 				/>
 			</AnalyticsCard>
 
-			<AnalyticsCard title="Network">
+			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/servers/guidelines-for-choosing-a-server-plan#server-analytics"
+				title="Network"
+			>
 				<LineChart
 					type="time"
 					title="Network"
@@ -146,7 +161,10 @@
 				/>
 			</AnalyticsCard>
 
-			<AnalyticsCard title="Disk I/O">
+			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/servers/guidelines-for-choosing-a-server-plan#server-analytics"
+				title="Disk I/O"
+			>
 				<LineChart
 					type="time"
 					title="Disk I/O"
@@ -180,6 +198,7 @@
 		>
 			<!-- Advanced Charts -->
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/sites/monitoring#investigating-high-usage"
 				v-if="isServerType('Application Server')"
 				class="sm:col-span-2"
 				title="Request frequency by site"
@@ -199,6 +218,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/site/common-issues/site-slow-504-gateway-timeout"
 				v-if="isServerType('Application Server')"
 				class="sm:col-span-2"
 				title="Slowest request by site"
@@ -218,6 +238,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/sites/monitoring#investigating-high-usage"
 				v-if="isServerType('Application Server')"
 				class="sm:col-span-2"
 				title="Background job frequency by site"
@@ -237,6 +258,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/sites/monitoring#investigating-high-usage"
 				v-if="isServerType('Application Server')"
 				class="sm:col-span-2"
 				title="Slowest background jobs by site"
@@ -255,7 +277,11 @@
 				/>
 			</AnalyticsCard>
 
-			<AnalyticsCard title="Queries" v-if="isServerType('Database Server')">
+			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/faq/mariadb-slow-queries-in-your-site"
+				title="Queries"
+				v-if="isServerType('Database Server')"
+			>
 				<LineChart
 					type="time"
 					title="Queries"
@@ -281,6 +307,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/faq/mariadb-slow-queries-in-your-site"
 				title="DB Connections"
 				v-if="isServerType('Database Server')"
 			>
@@ -303,6 +330,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/faq/mariadb-slow-queries-in-your-site"
 				title="Average Row Lock Time"
 				v-if="isServerType('Database Server')"
 			>
@@ -322,6 +350,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/servers/guidelines-for-choosing-a-server-plan#very-high-database-server-memory-usage"
 				title="Buffer Pool Size"
 				v-if="isServerType('Database Server')"
 			>
@@ -341,6 +370,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/servers/guidelines-for-choosing-a-server-plan#very-high-database-server-memory-usage"
 				title="Buffer Pool Size of Total Ram"
 				v-if="isServerType('Database Server')"
 			>
@@ -371,6 +401,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/servers/guidelines-for-choosing-a-server-plan#very-high-database-server-memory-usage"
 				title="Buffer Pool Miss Percent"
 				v-if="isServerType('Database Server')"
 			>
@@ -401,6 +432,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/faq/mariadb-slow-queries-in-your-site"
 				v-if="isServerType('Database Server')"
 				class="sm:col-span-2"
 				title="Frequent Slow queries"
@@ -426,6 +458,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/faq/mariadb-slow-queries-in-your-site"
 				v-if="isServerType('Database Server')"
 				class="sm:col-span-2"
 				title="Slowest queries"

--- a/dashboard/src/components/site/AnalyticsCard.vue
+++ b/dashboard/src/components/site/AnalyticsCard.vue
@@ -11,7 +11,11 @@
 			<h3 class="text-base font-medium text-ink-gray-9">{{ title }}</h3>
 			<slot name="action"></slot>
 
-			<button @click="shareCard" class="flex items-center gap-1.5 ml-auto" aria-label="Copy">
+			<button
+				@click="shareCard"
+				class="flex items-center gap-1.5 ml-auto"
+				aria-label="Copy"
+			>
 				<LucideLink
 					class="size-3 outline-none duration-200 hover:text-current cursor-pointer"
 				/>
@@ -23,7 +27,7 @@
 </template>
 
 <script>
-import { Tooltip } from 'frappe-ui';
+import { Tooltip } from 'frappe-ui'
 
 export default {
 	name: 'AnalyticsCard',
@@ -37,7 +41,7 @@ export default {
 		return {
 			shouldHighlight: false,
 			_highlightTimeout: null,
-		};
+		}
 	},
 
 	computed: {
@@ -46,14 +50,14 @@ export default {
 				.toLowerCase()
 				.trim()
 				.replace(/[^a-z0-9]+/g, '-')
-				.replace(/^-+|-+$/g, '');
+				.replace(/^-+|-+$/g, '')
 		},
 	},
 
 	methods: {
 		shareCard() {
 			// emit an event to parent to handle sharing
-			this.$emit('share-card', this.slugifiedTitle);
+			this.$emit('share-card', this.slugifiedTitle)
 		},
 	},
 
@@ -61,17 +65,17 @@ export default {
 		'$route.hash': {
 			immediate: true,
 			handler(newHash) {
-				const slug = newHash?.replace('#', '');
+				const slug = newHash?.replace('#', '')
 				if (slug === this.slugifiedTitle) {
-					this.shouldHighlight = true;
+					this.shouldHighlight = true
 
-					clearTimeout(this._highlightTimeout);
+					clearTimeout(this._highlightTimeout)
 					this._highlightTimeout = setTimeout(() => {
-						this.shouldHighlight = false;
-					}, 1500);
+						this.shouldHighlight = false
+					}, 1500)
 				}
 			},
 		},
 	},
-};
+}
 </script>

--- a/dashboard/src/components/site/AnalyticsCard.vue
+++ b/dashboard/src/components/site/AnalyticsCard.vue
@@ -11,15 +11,29 @@
 			<h3 class="text-base font-medium text-ink-gray-9">{{ title }}</h3>
 			<slot name="action"></slot>
 
-			<button
-				@click="shareCard"
-				class="flex items-center gap-1.5 ml-auto"
-				aria-label="Copy"
-			>
-				<LucideLink
-					class="size-3 outline-none duration-200 hover:text-current cursor-pointer"
-				/>
-			</button>
+			<div class="ml-auto flex items-center gap-2">
+				<a
+					v-if="docs"
+					:href="docs"
+					target="_blank"
+					rel="noopener"
+					title="Read the docs"
+					aria-label="Read the docs"
+					class="flex items-center text-ink-gray-5 hover:text-ink-gray-8"
+				>
+					<LucideHelpCircle class="size-3.5" />
+				</a>
+
+				<button
+					@click="shareCard"
+					class="flex items-center gap-1.5"
+					aria-label="Copy"
+				>
+					<LucideLink
+						class="size-3 outline-none duration-200 hover:text-current cursor-pointer"
+					/>
+				</button>
+			</div>
 		</div>
 
 		<slot></slot>
@@ -31,7 +45,7 @@ import { Tooltip } from 'frappe-ui'
 
 export default {
 	name: 'AnalyticsCard',
-	props: ['title'],
+	props: ['title', 'docs'],
 	emits: ['share-card'],
 	components: {
 		Tooltip,

--- a/dashboard/src/components/site/SiteAnalytics.vue
+++ b/dashboard/src/components/site/SiteAnalytics.vue
@@ -70,7 +70,11 @@
 		/>
 
 		<div class="grid grid-cols-1 gap-5 sm:grid-cols-2">
-			<AnalyticsCard title="Daily Usage" @share-card="shareDashboard">
+			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/daily-usage-limit-reached"
+				title="Daily Usage"
+				@share-card="shareDashboard"
+			>
 				<LineChart
 					type="time"
 					title="Usage Counter"
@@ -96,7 +100,11 @@
 				/>
 			</AnalyticsCard>
 
-			<AnalyticsCard title="Requests" @share-card="shareDashboard">
+			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/sites/monitoring#site-analytics"
+				title="Requests"
+				@share-card="shareDashboard"
+			>
 				<LineChart
 					type="time"
 					title="Requests"
@@ -120,7 +128,11 @@
 				</template>
 			</AnalyticsCard>
 
-			<AnalyticsCard title="Requests CPU Usage" @share-card="shareDashboard">
+			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/sites/monitoring#site-analytics"
+				title="Requests CPU Usage"
+				@share-card="shareDashboard"
+			>
 				<LineChart
 					type="time"
 					title="Requests CPU Usage"
@@ -152,7 +164,11 @@
 			v-if="showAdvancedAnalytics"
 			class="grid grid-cols-1 gap-5 sm:grid-cols-2"
 		>
-			<AnalyticsCard title="Background Jobs" @share-card="shareDashboard">
+			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/sites/monitoring#site-analytics"
+				title="Background Jobs"
+				@share-card="shareDashboard"
+			>
 				<LineChart
 					type="time"
 					title="Background Jobs"
@@ -168,6 +184,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/sites/monitoring#site-analytics"
 				title="Background Jobs CPU Usage"
 				@share-card="shareDashboard"
 			>
@@ -186,6 +203,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/sites/monitoring#investigating-high-usage"
 				class="sm:col-span-2"
 				title="Frequent Requests"
 				@share-card="shareDashboard"
@@ -204,6 +222,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/site/common-issues/site-slow-504-gateway-timeout#what-does-other-mean-in-chart"
 				class="sm:col-span-2"
 				title="Slowest Requests"
 				@share-card="shareDashboard"
@@ -221,6 +240,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/site/common-issues/site-slow-504-gateway-timeout#slow-reports"
 				class="sm:col-span-2"
 				title="Query Report Durations"
 				v-if="queryReportRunReportsData"
@@ -244,6 +264,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/site/common-issues/site-slow-504-gateway-timeout"
 				class="sm:col-span-2"
 				title="Run Doc Method Durations"
 				v-if="runDocMethodMethodnamesData"
@@ -267,6 +288,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/site/common-issues/site-slow-504-gateway-timeout"
 				class="sm:col-span-2"
 				title="Save Docs Doctype Durations"
 				v-if="saveDocsDoctypesData"
@@ -288,6 +310,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/site/common-issues/site-slow-504-gateway-timeout"
 				class="sm:col-span-2"
 				title="Save Docs Action Durations"
 				v-if="saveDocsActionData"
@@ -309,6 +332,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/site/common-issues/site-slow-504-gateway-timeout"
 				class="sm:col-span-2"
 				title="Individual Request Time (Average)"
 				@share-card="shareDashboard"
@@ -325,6 +349,7 @@
 				/>
 			</AnalyticsCard>
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/sites/monitoring#investigating-high-usage"
 				class="sm:col-span-2"
 				title="Requests by IP"
 				@share-card="shareDashboard"
@@ -342,6 +367,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/sites/monitoring#investigating-high-usage"
 				class="sm:col-span-2"
 				title="Frequent Background Jobs"
 				@share-card="shareDashboard"
@@ -359,6 +385,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/sites/monitoring#investigating-high-usage"
 				class="sm:col-span-2"
 				title="Slowest Background Jobs"
 				@share-card="shareDashboard"
@@ -376,6 +403,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/site/common-issues/site-slow-504-gateway-timeout#slow-reports"
 				class="sm:col-span-2"
 				title="Background Report Durations"
 				v-if="generateReportReportsData"
@@ -399,6 +427,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/sites/monitoring#investigating-high-usage"
 				class="sm:col-span-2"
 				title="Individual Background Job Time (Average)"
 				@share-card="shareDashboard"
@@ -416,6 +445,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/faq/mariadb-slow-queries-in-your-site"
 				class="sm:col-span-2 [&_[aria-label='Copy']]:m-0"
 				title="Frequent Slow Queries"
 				@share-card="shareDashboard"
@@ -447,6 +477,7 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/faq/mariadb-slow-queries-in-your-site"
 				class="sm:col-span-2 [&_[aria-label='Copy']]:m-0"
 				title="Top Slow Queries"
 				@share-card="shareDashboard"


### PR DESCRIPTION
Users look at an analytics chart, cannot tell what it measures or what to do about a spike, and raise a ticket. Each chart card now has a `?` icon in its header that opens the doc page for that metric. Where the page has a matching heading, the link jumps to that section.

`AnalyticsCard` takes one new optional prop, `docs`. If it is not set, the card shows no icon. The two Uptime cards have no relevant doc page and stay as they are, because a `?` that leads to a 404 is worse than no `?`.

All routes come from the wiki search API, and all anchors come from the heading IDs of the rendered pages. None are guessed.

### Site analytics

| Chart | Link |
| --- | --- |
| Daily Usage | [daily-usage-limit-reached](https://docs.frappe.io/cloud/daily-usage-limit-reached) |
| Requests, Requests CPU Usage, Background Jobs, Background Jobs CPU Usage | [monitoring#site-analytics](https://docs.frappe.io/cloud/sites/monitoring#site-analytics) |
| Frequent Requests, Requests by IP, Frequent Background Jobs, Slowest Background Jobs, Individual Background Job Time | [monitoring#investigating-high-usage](https://docs.frappe.io/cloud/sites/monitoring#investigating-high-usage) |
| Slowest Requests | [site-slow-504#what-does-other-mean-in-chart](https://docs.frappe.io/cloud/site/common-issues/site-slow-504-gateway-timeout#what-does-other-mean-in-chart) |
| Query Report Durations, Background Report Durations | [site-slow-504#slow-reports](https://docs.frappe.io/cloud/site/common-issues/site-slow-504-gateway-timeout#slow-reports) |
| Run Doc Method Durations, Save Docs Doctype Durations, Save Docs Action Durations, Individual Request Time | [site-slow-504-gateway-timeout](https://docs.frappe.io/cloud/site/common-issues/site-slow-504-gateway-timeout) |
| Frequent Slow Queries, Top Slow Queries | [mariadb-slow-queries-in-your-site](https://docs.frappe.io/cloud/faq/mariadb-slow-queries-in-your-site) |

### Server

| Chart | Link |
| --- | --- |
| CPU | [server plan#cpu](https://docs.frappe.io/cloud/servers/guidelines-for-choosing-a-server-plan#cpu) |
| Load Average | [server plan#load-average](https://docs.frappe.io/cloud/servers/guidelines-for-choosing-a-server-plan#load-average) |
| Memory | [server plan#bench-memory-usage](https://docs.frappe.io/cloud/servers/guidelines-for-choosing-a-server-plan#bench-memory-usage) |
| Disk Space, Network, Disk I/O | [server plan#server-analytics](https://docs.frappe.io/cloud/servers/guidelines-for-choosing-a-server-plan#server-analytics) |
| Buffer Pool Size, Buffer Pool Size of Total Ram, Buffer Pool Miss Percent | [server plan#very-high-database-server-memory-usage](https://docs.frappe.io/cloud/servers/guidelines-for-choosing-a-server-plan#very-high-database-server-memory-usage) |
| Queries, DB Connections, Average Row Lock Time, Frequent Slow queries, Slowest queries | [mariadb-slow-queries-in-your-site](https://docs.frappe.io/cloud/faq/mariadb-slow-queries-in-your-site) |
| Slowest request by site | [site-slow-504-gateway-timeout](https://docs.frappe.io/cloud/site/common-issues/site-slow-504-gateway-timeout) |
| Request frequency by site, Background job frequency by site, Slowest background jobs by site | [monitoring#investigating-high-usage](https://docs.frappe.io/cloud/sites/monitoring#investigating-high-usage) |

### Bench group

| Chart | Link |
| --- | --- |
| Memory, CPU, Incoming Network, Outgoing Network, Read Bytes, Write Bytes | [bench-analytics](https://docs.frappe.io/cloud/bench-analytics) |

The first commit is a Biome reformat of the three files it rewrites on touch. It has no functional change. Review the second commit for the change itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
