### PR TITLE
fix(dashboard): Show resource titles in the role resource picker

### DIFF
--- a/dashboard/src/components/settings/RoleCreateDialog.vue
+++ b/dashboard/src/components/settings/RoleCreateDialog.vue
@@ -73,7 +73,7 @@
 							v-for="resource in resources"
 							class="text-base border rounded-xl px-2 py-2"
 						>
-							{{ resource.document_name }}
+							{{ resource.label }}
 						</div>
 					</div>
 				</div>

--- a/dashboard/src/components/settings/RoleResources.vue
+++ b/dashboard/src/components/settings/RoleResources.vue
@@ -90,6 +90,11 @@
 							:name="icons[item.document_type]"
 						/>
 						{{ item.label }}
+						<span
+							v-if="item.label !== item.document_name"
+							class="ml-2 text-ink-gray-5"
+							>{{ item.document_name }}</span
+						>
 					</template>
 				</MultiSelect>
 			</template>

--- a/dashboard/src/components/settings/RoleResources.vue
+++ b/dashboard/src/components/settings/RoleResources.vue
@@ -90,11 +90,6 @@
 							:name="icons[item.document_type]"
 						/>
 						{{ item.label }}
-						<span
-							v-if="item.label !== item.document_name"
-							class="ml-2 text-ink-gray-5"
-							>{{ item.document_name }}</span
-						>
 					</template>
 				</MultiSelect>
 			</template>

--- a/dashboard/src/components/settings/data.ts
+++ b/dashboard/src/components/settings/data.ts
@@ -16,6 +16,7 @@ const sites = createListResource({
 const servers = createListResource({
 	doctype: 'Server',
 	auto: true,
+	fields: ['name', 'title'],
 	pageLength: 99999,
 	filters: {
 		team: team.doc?.name,
@@ -25,6 +26,7 @@ const servers = createListResource({
 const releaseGroups = createListResource({
 	doctype: 'Release Group',
 	auto: true,
+	fields: ['name', 'title'],
 	pageLength: 99999,
 	filters: {
 		team: team.doc?.name,
@@ -62,7 +64,7 @@ export const teamResources = computed(() => {
 			...servers.data.map((server: any) => ({
 				document_type: 'Server',
 				document_name: server.name,
-				label: server.name,
+				label: server.title || server.name,
 				value: server.name,
 			})),
 		);
@@ -72,7 +74,7 @@ export const teamResources = computed(() => {
 			...releaseGroups.data.map((rg: any) => ({
 				document_type: 'Release Group',
 				document_name: rg.name,
-				label: rg.name,
+				label: rg.title || rg.name,
 				value: rg.name,
 			})),
 		);

--- a/dashboard/src/components/settings/data.ts
+++ b/dashboard/src/components/settings/data.ts
@@ -7,6 +7,7 @@ const team = getTeam();
 const sites = createListResource({
 	doctype: 'Site',
 	auto: true,
+	fields: ['name', 'host_name'],
 	pageLength: 99999,
 	filters: {
 		team: team.doc?.name,
@@ -54,7 +55,7 @@ export const teamResources = computed(() => {
 			...sites.data.map((site: any) => ({
 				document_type: 'Site',
 				document_name: site.name,
-				label: site.name,
+				label: site.host_name || site.name,
 				value: site.name,
 			})),
 		);

--- a/dashboard/src/components/settings/data.ts
+++ b/dashboard/src/components/settings/data.ts
@@ -43,6 +43,11 @@ export const teamMembers = (ignore: string[] = []) => {
 		}));
 };
 
+// Titles are not unique. Two benches can share one, and the native select of
+// the create dialog has no room for a second line, so the name goes inline.
+const resourceLabel = (title: string, name: string) =>
+	title && title !== name ? `${title} (${name})` : name;
+
 export const teamResources = computed(() => {
 	const r: {
 		document_type: string;
@@ -55,7 +60,7 @@ export const teamResources = computed(() => {
 			...sites.data.map((site: any) => ({
 				document_type: 'Site',
 				document_name: site.name,
-				label: site.host_name || site.name,
+				label: resourceLabel(site.host_name, site.name),
 				value: site.name,
 			})),
 		);
@@ -65,7 +70,7 @@ export const teamResources = computed(() => {
 			...servers.data.map((server: any) => ({
 				document_type: 'Server',
 				document_name: server.name,
-				label: server.title || server.name,
+				label: resourceLabel(server.title, server.name),
 				value: server.name,
 			})),
 		);
@@ -75,7 +80,7 @@ export const teamResources = computed(() => {
 			...releaseGroups.data.map((rg: any) => ({
 				document_type: 'Release Group',
 				document_name: rg.name,
-				label: rg.title || rg.name,
+				label: resourceLabel(rg.title, rg.name),
 				value: rg.name,
 			})),
 		);


### PR DESCRIPTION
Fixes #7306

The "Include a resource in this role." dropdown, and the Resources select of the role create dialog, listed every resource by its `name`. Benches and servers carry an autogenerated name, so the list was a wall of `bench-12345` entries that nobody can tell apart.

`teamResources` fetched the list resources without a `fields` option, so it only ever had the name. Server and Release Group both have a `title` field, so fetching it in the same list call is enough. No second lookup is needed, unlike the role detail cards, which resolve the title server side in `PressRole.get_flat_resources`.

Sites have no title. Their equivalent is the primary domain, and the rest of the dashboard already labels them `host_name || name` ([sites/list/Page.vue](https://github.com/frappe/press/blob/develop/dashboard/src/pages/sites/list/Page.vue#L315), [objects/site.js](https://github.com/frappe/press/blob/develop/dashboard/src/objects/site.js#L80)). The picker now follows.

The name stays in the label, in brackets, because titles are not unique and because the name is what the role stores. It is dropped when it is the same as the label. The name is part of the label string rather than a second span, since the create dialog uses a native select, which renders a plain string.

## The label

| | Before | After |
| --- | --- | --- |
| Bench | `bench-12345` | `ERPNext Production (bench-12345)` |
| Server | `f2-mumbai-1.frappe.cloud` | `Mumbai Production (f2-mumbai-1.frappe.cloud)` |
| Site with a custom domain | `erpnext-shop.frappe.cloud` | `shop.example.com (erpnext-shop.frappe.cloud)` |
| Site without one | `mysite.frappe.cloud` | `mysite.frappe.cloud` |

The same label is used for the options of both dialogs and for the chips of the selected resources.