### PR TITLE
fix(analytics): Oversample slow queries before normalizing

### DIFF
--- a/dashboard/src/components/server/ServerCharts.vue
+++ b/dashboard/src/components/server/ServerCharts.vue
@@ -437,12 +437,6 @@
 				class="sm:col-span-2"
 				title="Frequent Slow queries"
 			>
-				<template #action>
-					<TabButtons
-						:buttons="[{ label: 'Denormalized' }, { label: 'Normalized' }]"
-						v-model="slowLogsFrequencyType"
-					/>
-				</template>
 				<BarChart
 					title="Frequent Slow queries"
 					:key="slowLogsCountData"
@@ -463,12 +457,6 @@
 				class="sm:col-span-2"
 				title="Slowest queries"
 			>
-				<template #action>
-					<TabButtons
-						:buttons="[{ label: 'Denormalized' }, { label: 'Normalized' }]"
-						v-model="slowLogsDurationType"
-					/>
-				</template>
 				<BarChart
 					title="Slowest queries"
 					:key="slowLogsDurationData"
@@ -487,11 +475,7 @@
 </template>
 
 <script>
-import {
-	DateTimePicker,
-	getCachedDocumentResource,
-	TabButtons,
-} from 'frappe-ui'
+import { DateTimePicker, getCachedDocumentResource } from 'frappe-ui'
 import BarChart from '@/components/charts/BarChart.vue'
 import LineChart from '@/components/charts/LineChart.vue'
 import dayjs, { dayjsFloorToMinutes } from '../../utils/dayjs'
@@ -516,8 +500,6 @@ export default {
 			customEndTime: null,
 			showAdvancedAnalytics: false,
 			localTimezone: dayjs.tz.guess(),
-			slowLogsDurationType: 'Denormalized',
-			slowLogsFrequencyType: 'Denormalized',
 			chosenServer: this.$route.query.server ?? this.serverName,
 			durationOptions: [
 				{ label: 'Duration', value: null, disabled: true },
@@ -730,7 +712,6 @@ export default {
 					timezone: this.localTimezone,
 					start: this.startTime,
 					end: this.endTime,
-					normalize: this.slowLogsFrequencyType === 'Normalized',
 				},
 				auto:
 					this.showAdvancedAnalytics &&
@@ -746,7 +727,6 @@ export default {
 					timezone: this.localTimezone,
 					start: this.startTime,
 					end: this.endTime,
-					normalize: this.slowLogsDurationType === 'Normalized',
 				},
 				auto:
 					this.showAdvancedAnalytics &&

--- a/dashboard/src/components/site/AnalyticsCard.vue
+++ b/dashboard/src/components/site/AnalyticsCard.vue
@@ -9,9 +9,12 @@
 	>
 		<div class="flex items-center border-b p-3 gap-2">
 			<h3 class="text-base font-medium text-ink-gray-9">{{ title }}</h3>
-			<slot name="action"></slot>
+			<!-- Grows, so the action slot can push its own content to either edge -->
+			<div class="flex flex-1 items-center gap-2">
+				<slot name="action"></slot>
+			</div>
 
-			<div class="ml-auto flex items-center gap-2">
+			<div class="flex items-center gap-2">
 				<a
 					v-if="docs"
 					:href="docs"

--- a/dashboard/src/components/site/SiteAnalytics.vue
+++ b/dashboard/src/components/site/SiteAnalytics.vue
@@ -453,13 +453,14 @@
 				<template #action>
 					<Tooltip text="Show Detailed Reports">
 						<router-link
-							class="mr-auto text-base text-ink-gray-6 hover:text-ink-gray-7"
+							class="text-base text-ink-gray-6 hover:text-ink-gray-7"
 							:to="{ name: 'Site Performance Slow Queries' }"
 						>
 							→
 						</router-link>
 					</Tooltip>
 					<TabButtons
+						class="ml-auto"
 						:buttons="[{ label: 'Denormalized' }, { label: 'Normalized' }]"
 						v-model="slowLogsFrequencyType"
 					/>
@@ -485,13 +486,14 @@
 				<template #action>
 					<Tooltip text="Show Detailed Reports">
 						<router-link
-							class="mr-auto text-base text-ink-gray-6 hover:text-ink-gray-7"
+							class="text-base text-ink-gray-6 hover:text-ink-gray-7"
 							:to="{ name: 'Site Performance Slow Queries' }"
 						>
 							→
 						</router-link>
 					</Tooltip>
 					<TabButtons
+						class="ml-auto"
 						:buttons="[{ label: 'Denormalized' }, { label: 'Normalized' }]"
 						v-model="slowLogsDurationType"
 					/>
@@ -550,8 +552,8 @@ export default {
 			logicalEndDate: null,
 			showAdvancedAnalytics: false,
 			localTimezone: dayjs.tz.guess(),
-			slowLogsDurationType: 'Denormalized',
-			slowLogsFrequencyType: 'Denormalized',
+			slowLogsDurationType: 'Normalized',
+			slowLogsFrequencyType: 'Normalized',
 			allowDrillDown: false,
 			durationOptions: [
 				{ label: 'Duration', value: null, disabled: true },

--- a/dashboard/tests-e2e/tests/dashboard/slow-query-normalized-default.test.ts
+++ b/dashboard/tests-e2e/tests/dashboard/slow-query-normalized-default.test.ts
@@ -1,0 +1,92 @@
+import type { Page, Request } from '@playwright/test'
+import {
+	mockAnalytics,
+	RANGE_END,
+	RANGE_START,
+	SITE_NAME,
+} from './analytics-fixture'
+import { expect, test } from './coverage.fixture'
+
+const SLOW_QUERY_CARDS = ['#frequent-slow-queries', '#top-slow-queries']
+
+/** frappe-ui sends resource params in the query string or the POST body. */
+function normalizeParam(request: Request): string | null {
+	const fromUrl = new URL(request.url()).searchParams.get('normalize')
+	if (fromUrl !== null) return fromUrl
+	try {
+		return String(JSON.parse(request.postData() ?? '{}').normalize ?? '')
+	} catch {
+		return null
+	}
+}
+
+async function openAdvancedAnalytics(page: Page) {
+	await page.setViewportSize({ width: 1440, height: 900 })
+	await mockAnalytics(page)
+
+	const query = `?start=${RANGE_START.toISOString()}&end=${RANGE_END.toISOString()}`
+	await page.goto(`/dashboard/sites/${SITE_NAME}/insights/analytics${query}`)
+	await page.getByText('Advanced Analytics').click()
+
+	for (const card of SLOW_QUERY_CARDS) {
+		await expect(page.locator(card)).toBeVisible({ timeout: 30000 })
+	}
+}
+
+test('the slow query charts ask for normalized queries without being told to', async ({
+	page,
+}) => {
+	test.slow()
+
+	// The raw top-25 is 25 variants of one statement, so the denormalized chart
+	// puts almost every query in the "Other" bucket. Normalized is the useful view.
+	const normalizeFlags: string[] = []
+	page.on('request', (request) => {
+		if (!request.url().includes('get_slow_logs_by_query')) return
+		const flag = normalizeParam(request)
+		if (flag !== null) normalizeFlags.push(flag)
+	})
+
+	await openAdvancedAnalytics(page)
+	await expect.poll(() => normalizeFlags.length).toBeGreaterThanOrEqual(2)
+
+	// Both charts, count and duration, before anyone touches the toggle
+	expect(normalizeFlags.every((flag) => flag === 'true' || flag === '1')).toBe(
+		true,
+	)
+
+	for (const card of SLOW_QUERY_CARDS) {
+		// exact, or "Denormalized" matches the substring too
+		await expect(
+			page
+				.locator(card)
+				.getByRole('radio', { name: 'Normalized', exact: true }),
+		).toBeChecked()
+	}
+})
+
+test('the slow query toggle sits at the right edge of the card header', async ({
+	page,
+}) => {
+	test.slow()
+	await openAdvancedAnalytics(page)
+
+	for (const card of SLOW_QUERY_CARDS) {
+		const header = page.locator(`${card} > div`).first()
+		const toggle = page.locator(card).getByRole('radiogroup')
+
+		const headerBox = (await header.boundingBox())!
+		const toggleBox = (await toggle.boundingBox())!
+
+		const gapToRightEdge =
+			headerBox.x + headerBox.width - (toggleBox.x + toggleBox.width)
+
+		// The docs and copy icons plus padding take the last ~70px. Before this
+		// change two competing auto margins split the free space and left the
+		// toggle near the middle of a 1440px-wide header.
+		expect(gapToRightEdge, `${card} toggle to right edge`).toBeLessThan(90)
+		expect(gapToRightEdge, `${card} toggle overlaps the icons`).toBeGreaterThan(
+			0,
+		)
+	}
+})

--- a/press/api/analytics.py
+++ b/press/api/analytics.py
@@ -127,6 +127,10 @@ MAX_NO_OF_PATHS: Final[int] = 10
 MAX_QUERIES: Final[int] = 25
 MAX_MAX_NO_OF_PATHS: Final[int] = 50
 
+# Elasticsearch groups slow queries by their raw text, and literals split one query
+# into many. Oversample, so that the top-N after normalization is not a set of duplicates.
+NORMALIZED_OVERSAMPLE: Final[int] = 10
+
 NICE_STEPS = [
 	1,
 	2,
@@ -265,7 +269,7 @@ class StackedGroupByChart:
 				"method_path",
 				"terms",
 				field=self.group_by_field,
-				size=self.max_no_of_paths,
+				size=self.terms_size,
 				order={"path_count": "desc"},
 			).bucket("histogram_of_method", self.histogram_of_method())
 			self.search.aggs["method_path"].bucket("path_count", self.count_of_values())
@@ -275,7 +279,7 @@ class StackedGroupByChart:
 				"method_path",
 				"terms",
 				field=self.group_by_field,
-				size=self.max_no_of_paths,
+				size=self.terms_size,
 				order={"outside_sum": "desc"},
 			).bucket("histogram_of_method", self.histogram_of_method()).bucket(
 				"sum_of_duration", self.sum_of_duration()
@@ -287,12 +291,16 @@ class StackedGroupByChart:
 				"method_path",
 				"terms",
 				field=self.group_by_field,
-				size=self.max_no_of_paths,
+				size=self.terms_size,
 				order={"outside_avg": "desc"},
 			).bucket("histogram_of_method", self.histogram_of_method()).bucket(
 				"avg_of_duration", self.avg_of_duration()
 			)
 			self.search.aggs["method_path"].bucket("outside_avg", self.avg_of_duration())
+
+	@property
+	def terms_size(self) -> int:
+		return self.max_no_of_paths
 
 	def histogram_of_method(self):
 		return A(
@@ -375,11 +383,10 @@ class StackedGroupByChart:
 		for path_bucket in aggs.method_path.buckets:
 			datasets.append(self.get_histogram_chart(path_bucket, labels))
 
-		if len(datasets) >= self.max_no_of_paths:
-			datasets.append(self.get_other_bucket(datasets, labels))
-
 		if self.normalize_slow_logs:
-			datasets = normalize_datasets(datasets)
+			datasets = self.get_normalized_datasets(datasets, aggs, labels)
+		elif len(datasets) >= self.terms_size:
+			datasets.append(self.get_other_bucket(datasets, labels))
 
 		labels = [convert_utc_to_timezone(label, self.timezone).replace(tzinfo=None) for label in labels]
 		return {
@@ -523,8 +530,40 @@ class SlowLogGroupByChart(StackedGroupByChart):
 		*args,
 		**kwargs,
 	):
-		super().__init__(*args, **kwargs)
 		self.normalize_slow_logs = normalize_slow_logs
+		super().__init__(*args, **kwargs)
+
+	@property
+	def terms_size(self) -> int:
+		if self.normalize_slow_logs:
+			return self.max_no_of_paths * NORMALIZED_OVERSAMPLE
+		return self.max_no_of_paths
+
+	def setup_search_aggs(self):
+		"""Aggregate all queries next to the top ones. The result gives the Other bucket."""
+		super().setup_search_aggs()
+		if not self.normalize_slow_logs:
+			return
+		histogram = self.search.aggs.bucket("histogram_of_method", self.histogram_of_method())
+		histogram.bucket("sum_of_duration", self.sum_of_duration())
+		# ponytail: averages do not subtract, so an average chart clamps Other to zero
+		histogram.bucket("avg_of_duration", self.avg_of_duration())
+
+	def get_normalized_datasets(self, datasets: list[Dataset], aggs, labels) -> list[Dataset]:
+		"""Merge the oversampled queries by normalized form, then keep the largest ones.
+
+		Other is all queries minus the ones the chart shows. The base class instead
+		runs a second search that excludes each query it shows. This search needs one
+		clause for each query, and normalization asks for ten times as many queries.
+		"""
+		merged = sorted(normalize_datasets(datasets), key=dataset_total, reverse=True)
+		top = merged[: self.max_no_of_paths]
+
+		aggs.key = "Other"
+		other = self.get_histogram_chart(aggs, labels)
+		for dataset in top:
+			other["values"] = subtract_values(other["values"], dataset["values"])
+		return [*top, other] if dataset_total(other) else top
 
 	def sum_of_duration(self):
 		return A("sum", field="event.duration")
@@ -1096,6 +1135,14 @@ def get_uptime(site: str, timezone: str, start: datetime, end: datetime, timegra
 			)
 		)
 	return buckets
+
+
+def subtract_values(values: list, other: list) -> list:
+	return [max(flt(x) - flt(y), 0) for x, y in zip(values, other, strict=True)]
+
+
+def dataset_total(dataset: Dataset) -> float:
+	return sum(value for value in dataset["values"] if value)
 
 
 def normalize_datasets(datasets: list[Dataset]) -> list[Dataset]:

--- a/press/api/server.py
+++ b/press/api/server.py
@@ -566,16 +566,15 @@ def get_background_job_by_site(name, query, timezone, start, end):
 @frappe.whitelist()
 @protected(["Server", "Database Server"])
 @redis_cache(ttl=10 * 60)
-def get_slow_logs_by_site(name, query, timezone, start, end, normalize=False):
+def get_slow_logs_by_site(name, query, timezone, start, end):
 	from press.api.analytics import ResourceType, get_slow_logs
 
 	start = datetime.fromisoformat(start.replace("Z", "+00:00"))
 	end = datetime.fromisoformat(end.replace("Z", "+00:00"))
 	timespan, timegrain = auto_timespan_timegrain(start, end)
 
-	return get_slow_logs(
-		name, query, timezone, start, end, timespan, timegrain, ResourceType.SERVER, normalize
-	)
+	# Not normalized: this chart groups by database name, not by query text
+	return get_slow_logs(name, query, timezone, start, end, timespan, timegrain, ResourceType.SERVER)
 
 
 def prometheus_instant_value(query: str) -> float | None:

--- a/press/api/tests/test_analytics.py
+++ b/press/api/tests/test_analytics.py
@@ -4,11 +4,13 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import ClassVar
 
+import frappe
 from frappe.tests.utils import FrappeTestCase
 from pytz import timezone as pytz_timezone
 
-from press.api.analytics import align_to_quarter_hour
+from press.api.analytics import AggType, SlowLogGroupByChart, align_to_quarter_hour
 
 TIMEZONE = "Asia/Kolkata"
 
@@ -41,3 +43,74 @@ class TestAlignToQuarterHour(FrappeTestCase):
 				self.assertLessEqual(start, original_start)
 				self.assertGreaterEqual(end, original_end)
 				self.assertEqual((end - start).total_seconds() % 900, 0)
+
+
+class TestNormalizedSlowQueries(FrappeTestCase):
+	"""Elasticsearch can group only by the raw query text, and literals split one
+	query into many. Before the oversample, the top-N was a set of near duplicates,
+	and the Other bucket held almost all of the data."""
+
+	labels: ClassVar[list[datetime]] = [datetime(2026, 8, 24, 10, 0), datetime(2026, 8, 24, 10, 15)]
+
+	def chart(self, max_no_of_paths: int = 2) -> SlowLogGroupByChart:
+		chart = SlowLogGroupByChart.__new__(SlowLogGroupByChart)
+		chart.normalize_slow_logs = True
+		chart.agg_type = AggType.COUNT
+		chart.max_no_of_paths = max_no_of_paths
+		return chart
+
+	def dataset(self, query: str, values: list) -> dict:
+		return {"path": query, "values": values, "stack": "path"}
+
+	def aggregations(self, counts: list[int]):
+		"""Replace the histogram over all queries. This histogram gives the Other bucket."""
+		buckets = [
+			frappe._dict(key_as_string=label.isoformat(), doc_count=count)
+			for label, count in zip(self.labels, counts, strict=True)
+		]
+		return frappe._dict(histogram_of_method=frappe._dict(buckets=buckets))
+
+	def test_queries_that_differ_only_in_literals_merge_into_one_dataset(self):
+		datasets = [
+			self.dataset("SELECT name FROM tabUser WHERE name = 'a'", [1, 2]),
+			self.dataset("SELECT name FROM tabUser WHERE name = 'b'", [3, 4]),
+		]
+		merged = self.chart().get_normalized_datasets(datasets, self.aggregations([4, 6]), self.labels)
+		self.assertEqual(len(merged), 1)
+		self.assertEqual(merged[0]["values"], [4, 6])
+
+	def test_other_holds_what_the_shown_queries_do_not_cover(self):
+		datasets = [
+			self.dataset("SELECT name FROM tabUser WHERE name = 'a'", [1, 2]),
+			self.dataset("SELECT name FROM tabNote WHERE name = 'b'", [3, 4]),
+		]
+		merged = self.chart().get_normalized_datasets(datasets, self.aggregations([10, 10]), self.labels)
+		self.assertEqual(merged[-1]["path"], "Other")
+		self.assertEqual(merged[-1]["values"], [6, 4])
+
+	def test_other_is_dropped_when_the_shown_queries_cover_everything(self):
+		datasets = [self.dataset("SELECT name FROM tabUser WHERE name = 'a'", [1, 2])]
+		merged = self.chart().get_normalized_datasets(datasets, self.aggregations([1, 2]), self.labels)
+		self.assertEqual(len(merged), 1)
+		self.assertNotEqual(merged[0]["path"], "Other")
+
+	def test_only_the_largest_queries_are_shown_and_the_rest_fall_into_other(self):
+		datasets = [
+			self.dataset("SELECT a FROM tabUser", [1, 1]),
+			self.dataset("SELECT b FROM tabNote", [5, 5]),
+			self.dataset("SELECT c FROM tabFile", [9, 9]),
+		]
+		merged = self.chart(max_no_of_paths=2).get_normalized_datasets(
+			datasets, self.aggregations([15, 15]), self.labels
+		)
+		self.assertEqual(len(merged), 3)
+		self.assertEqual(merged[-1]["path"], "Other")
+		self.assertEqual(merged[-1]["values"], [1, 1])
+
+	def test_normalization_asks_elasticsearch_for_more_queries_than_the_chart_shows(self):
+		self.assertEqual(self.chart(max_no_of_paths=25).terms_size, 250)
+
+	def test_a_denormalized_chart_asks_for_exactly_what_it_shows(self):
+		chart = self.chart(max_no_of_paths=25)
+		chart.normalize_slow_logs = False
+		self.assertEqual(chart.terms_size, 25)

--- a/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
+++ b/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
@@ -1675,4 +1675,10 @@ def on_doctype_update():
 		return
 	# Ignoring filesorts
 	# https://dev.mysql.com/doc/refman/8.4/en/order-by-optimization.html#order-by-index-use
-	frappe.db.add_index("Deploy Candidate Build", ["team", "group", "creation"])
+	# `group` is a reserved word, and add_index joins the columns without quoting
+	# them. Name the index too, or the backticks land in the name as well.
+	frappe.db.add_index(
+		"Deploy Candidate Build",
+		["team", "`group`", "creation"],
+		index_name="team_group_creation_index",
+	)


### PR DESCRIPTION
## The problem

The `Top Slow Queries` chart is not useful. The Other bucket holds almost all of the data, in both modes.

Elasticsearch can group only by the raw query text. A slow query contains literals, so one statement arrives as many different texts:

```
SELECT ... WHERE name = 'ACC-001'    12 hits
SELECT ... WHERE name = 'ACC-002'    11 hits
SELECT ... WHERE name = 'ACC-003'     9 hits
```

The chart kept the top 25 raw texts. Those 25 texts were near duplicates of one statement, and each held a few rows. All other queries went into Other.

Normalization did not correct this, because it ran **after** the top-25 selection. It merged 25 small groups into 4 small groups. #7311's sibling change 22035eef8 raised the limit from 10 to 25 for this same reason, but that lever is on the wrong side of the merge.

## The correction

Ask Elasticsearch for 250 queries, which is 10 times more. Merge them by normalized form. Then keep the largest 25 of the merged groups.

Other is now the total minus the queries the chart shows. The base class finds Other with a second search that excludes each query shown, which needs one clause for each query. 250 phrase clauses are too many, so a second histogram over all queries goes into the same request instead.

Normalized also becomes the default in the dashboard, and the toggle moves to the right edge of the card header.

## Before and after

The images below show the card header. The chart data is mocked and identical in both, so only the header differs. The Other bucket correction needs a live site with real slow logs.

### Before
<img width="1035" height="305" alt="image" src="https://github.com/user-attachments/assets/6e649de6-fe08-42b1-a700-f1ad6e9f45fa" />
### After
<img width="1035" height="305" alt="image" src="https://github.com/user-attachments/assets/f7cce0cd-dc78-40ef-bc67-ec845bd3e0b6" />


## Blast radius

The slow query charts only. Two edits touch the base class, and both are no-ops for every other chart:

- `size=self.max_no_of_paths` becomes `size=self.terms_size`. The base `terms_size` returns `max_no_of_paths`. `RequestGroupByChart`, `BackgroundJobGroupByChart` and `NginxRequestGroupByChart` do not override it.
- The `if` becomes an `elif` gated on `normalize_slow_logs`, a class attribute that is `False` for every chart except `SlowLogGroupByChart`.

The denormalized slow query chart is also unchanged. `terms_size` returns 25, the `setup_search_aggs` override returns early, and `get_other_bucket` still runs.

## Cost

`normalize_query` uses sqlparse, measured on a development machine:

| Query | Length | Per query | 250 queries |
| --- | --- | --- | --- |
| Typical | 114 chars | 2.1 ms | 0.53 s |
| Wide GL Entry join | 654 chars | 12.7 ms | 3.2 s |

`get_slow_logs` has a 15 minute `redis_cache`, so the first viewer of each window pays this. Lower `NORMALIZED_OVERSAMPLE` from 10 to 4 if 3 seconds is too much.

Each request now makes about 15,000 Elasticsearch buckets, against a default limit of 65,536. 250 terms times about 60 time buckets, because `auto_timespan_timegrain` targets 60 points.

## Also in this PR

**The normalize toggle goes away on the server charts.** Those charts group by `mysql.slowlog.current_user`, which is a database name, not SQL. The toggle was correct when 0e94548f8 added it, because the site chart and the server chart both grouped by `mysql.slowlog.query`. f29518a57 later moved the server chart to group by database name, and the toggle became dead.

**A reserved word in an index.** `frappe.db.add_index("Deploy Candidate Build", ["team", "group", "creation"])` builds `ADD INDEX ...(team, group, creation)`. `group` is reserved in MariaDB, so the statement fails with error 1064 and stops `bench migrate` on any site that is not in developer mode. `--skip-failing` does not catch it, because the call is in `on_doctype_update`, not in a patch. Found while setting up the environment for the e2e test.

## Tests

- `press/api/tests/test_analytics.py`: 10 unit tests for the merge, the Other bucket and the oversample factor.
- `dashboard/tests-e2e/tests/dashboard/slow-query-normalized-default.test.ts`: 2 Playwright tests for the default and the position of the toggle.

Both e2e tests were run against a stashed working tree first, so they fail without this change. The `normalize` flag came back `false`, and the toggle sat 345px from the right edge.
