### PR TITLE
feat(dashboard): Open advanced analytics by default

### DIFF
--- a/dashboard/src/components/server/ServerCharts.vue
+++ b/dashboard/src/components/server/ServerCharts.vue
@@ -498,7 +498,7 @@ export default {
 			duration: defaultDuration,
 			customStartTime: null,
 			customEndTime: null,
-			showAdvancedAnalytics: false,
+			showAdvancedAnalytics: true,
 			localTimezone: dayjs.tz.guess(),
 			chosenServer: this.$route.query.server ?? this.serverName,
 			durationOptions: [

--- a/dashboard/src/components/site/SiteAnalytics.vue
+++ b/dashboard/src/components/site/SiteAnalytics.vue
@@ -550,7 +550,7 @@ export default {
 			logicalStartDate: null,
 			inputEndDate: null,
 			logicalEndDate: null,
-			showAdvancedAnalytics: false,
+			showAdvancedAnalytics: true,
 			localTimezone: dayjs.tz.guess(),
 			slowLogsDurationType: 'Normalized',
 			slowLogsFrequencyType: 'Normalized',

--- a/dashboard/tests-e2e/tests/dashboard/site-analytics-scroll-perf.test.ts
+++ b/dashboard/tests-e2e/tests/dashboard/site-analytics-scroll-perf.test.ts
@@ -72,16 +72,15 @@ async function measureScroll(page: Page): Promise<ScrollStats> {
 	})
 }
 
-/** Open the tab with a 15-day range and wait for every chart to be painted. */
-async function openAdvancedAnalytics(page: Page) {
+/** Load the tab with a 15-day range and wait for every chart to be painted. */
+async function loadAnalyticsPage(page: Page) {
 	await page.setViewportSize({ width: 1440, height: 900 })
 	await mockAnalytics(page)
 
 	const query = `?start=${RANGE_START.toISOString()}&end=${RANGE_END.toISOString()}`
 	await page.goto(`/dashboard/sites/${SITE_NAME}/insights/analytics${query}`)
 
-	await page.getByText('Advanced Analytics').click()
-
+	// The advanced section is open by default, so no click is necessary.
 	// 14 advanced bar charts plus 5 base line charts must be painted before
 	// measuring, otherwise we time an empty page.
 	await expect
@@ -94,7 +93,7 @@ test('advanced analytics leaves the main thread idle once charts are painted', a
 	page,
 }) => {
 	test.slow()
-	await openAdvancedAnalytics(page)
+	await loadAnalyticsPage(page)
 
 	// Guards the echarts feedback loop: a `finished` handler that dispatches an
 	// action re-triggers `finished`, so the charts re-render forever and the tab
@@ -124,7 +123,7 @@ test('advanced analytics scrolls smoothly with a full 15-day dataset', async ({
 	page,
 }) => {
 	test.slow()
-	await openAdvancedAnalytics(page)
+	await loadAnalyticsPage(page)
 
 	const stats = await measureScroll(page)
 	console.log('scroll stats:', JSON.stringify(stats))

--- a/dashboard/tests-e2e/tests/dashboard/slow-query-normalized-default.test.ts
+++ b/dashboard/tests-e2e/tests/dashboard/slow-query-normalized-default.test.ts
@@ -20,14 +20,14 @@ function normalizeParam(request: Request): string | null {
 	}
 }
 
-async function openAdvancedAnalytics(page: Page) {
+async function loadAnalyticsPage(page: Page) {
 	await page.setViewportSize({ width: 1440, height: 900 })
 	await mockAnalytics(page)
 
 	const query = `?start=${RANGE_START.toISOString()}&end=${RANGE_END.toISOString()}`
 	await page.goto(`/dashboard/sites/${SITE_NAME}/insights/analytics${query}`)
-	await page.getByText('Advanced Analytics').click()
 
+	// The advanced section is open by default, so no click is necessary.
 	for (const card of SLOW_QUERY_CARDS) {
 		await expect(page.locator(card)).toBeVisible({ timeout: 30000 })
 	}
@@ -47,7 +47,7 @@ test('the slow query charts ask for normalized queries without being told to', a
 		if (flag !== null) normalizeFlags.push(flag)
 	})
 
-	await openAdvancedAnalytics(page)
+	await loadAnalyticsPage(page)
 	await expect.poll(() => normalizeFlags.length).toBeGreaterThanOrEqual(2)
 
 	// Both charts, count and duration, before anyone touches the toggle
@@ -69,7 +69,7 @@ test('the slow query toggle sits at the right edge of the card header', async ({
 	page,
 }) => {
 	test.slow()
-	await openAdvancedAnalytics(page)
+	await loadAnalyticsPage(page)
 
 	for (const card of SLOW_QUERY_CARDS) {
 		const header = page.locator(`${card} > div`).first()


### PR DESCRIPTION
## Problem

The advanced charts on the site analytics page and the server analytics page are inside a collapsed section. The user must click "Advanced Analytics" to see them. Most users do not click, so the charts do not get seen.

## Change

The section is now open when the page loads. The toggle stays, so the user can still collapse it.

The chart resources are gated on the same flag. They now load with the page instead of after the click.

## Files

- `dashboard/src/components/site/SiteAnalytics.vue`
- `dashboard/src/components/server/ServerCharts.vue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)