### PR TITLE
feat(server): Add OOM kills chart to server analytics

### DIFF
--- a/dashboard/src/components/server/ServerCharts.vue
+++ b/dashboard/src/components/server/ServerCharts.vue
@@ -124,6 +124,25 @@
 			</AnalyticsCard>
 
 			<AnalyticsCard
+				docs="https://docs.frappe.io/cloud/servers/guidelines-for-choosing-a-server-plan#bench-memory-usage"
+				title="OOM Kills"
+			>
+				<LineChart
+					type="time"
+					title="OOM Kills"
+					unit="kills"
+					:key="oomKillsData"
+					:data="oomKillsData"
+					:chartTheme="[$theme.colors.red[500]]"
+					:loading="$resources.oomKills.loading"
+					:error="$resources.oomKills.error"
+					:showCard="false"
+					class="h-[15.55rem] p-2 pb-3"
+					@datazoom="handleDataZoom"
+				/>
+			</AnalyticsCard>
+
+			<AnalyticsCard
 				docs="https://docs.frappe.io/cloud/servers/guidelines-for-choosing-a-server-plan#server-analytics"
 				title="Disk Space"
 			>
@@ -599,6 +618,22 @@ export default {
 				auto: true,
 			}
 		},
+		oomKills() {
+			return {
+				url: 'press.api.server.analytics',
+				params: {
+					name: this.chosenServer,
+					timezone: this.localTimezone,
+					query: 'oom_kills',
+					start: this.startTime,
+					end: this.endTime,
+					server_type: this.serverOptions.find(
+						(s) => s.value === this.chosenServer,
+					)?.label,
+				},
+				auto: true,
+			}
+		},
 		network() {
 			return {
 				url: 'press.api.server.analytics',
@@ -959,6 +994,12 @@ export default {
 			if (!memory) return
 
 			return this.transformSingleLineChartData(memory)
+		},
+		oomKillsData() {
+			let oomKills = this.$resources.oomKills.data
+			if (!oomKills) return
+
+			return this.transformSingleLineChartData(oomKills)
 		},
 		iopsData() {
 			let iops = this.$resources.iops.data

--- a/press/api/server.py
+++ b/press/api/server.py
@@ -484,6 +484,10 @@ def analytics(name, query, timezone, start, end, server_type=None):
 			f"""node_memory_MemTotal_bytes{{instance="{name}",job="node"}} - node_memory_MemFree_bytes{{instance="{name}",job="node"}} - (node_memory_Cached_bytes{{instance="{name}",job="node"}} + node_memory_Buffers_bytes{{instance="{name}",job="node"}})""",
 			lambda x: "Used",
 		),
+		"oom_kills": (
+			f"""round(increase(node_vmstat_oom_kill{{instance="{name}", job="node"}}[{rate_interval}s]))""",
+			lambda x: "OOM Kills",
+		),
 		"database_uptime": (
 			# avg over the bucket, else a short outage between steps is invisible on long timespans
 			f"""avg_over_time(mysql_up{{instance="{name}",job="mariadb"}}[{timegrain}s]) * 100""",


### PR DESCRIPTION
An OOM kill leaves no trace in Press. It is only visible in `dmesg` on the server, which needs SSH. A unified server, where MariaDB and the agent share the RAM of one box, is where this matters most.

Adds an OOM Kills chart next to Memory in server analytics, from `node_vmstat_oom_kill`. node_exporter 1.8.2 already scrapes this by default (vmstat field regex `^(oom_kill|pgpg|pswp|pg.*fault).*`), so no agent or playbook change is necessary.

Shown for all server types, not only Database Server, because it is a node metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)