### PR TITLE
fix: Add press_otp and press_otp_sent cache to persistent cache keys

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -505,6 +505,8 @@ __persistent_cache_keys = [
 	"one_time_login_key*",
 	"press-auth-logs",
 	"rl:*",
+	"press_otp:*",
+	"press_otp_sent:*"
 ]
 
 # `frappe.rename_doc` erases all caches, this hook preserves some of them.


### PR DESCRIPTION
The cache keys seems to be evicted and then raising invalid otp issue.