### PR TITLE
fix(site-update): Clear the fatal flag when an update recovers

### DIFF
--- a/press/press/doctype/site_update/site_update.py
+++ b/press/press/doctype/site_update/site_update.py
@@ -882,6 +882,10 @@ def update_status(name: str, status: str):
 				),
 			)
 	if status in ["Success", "Recovered"]:
+		site = frappe.db.get_value("Site Update", name, "site")
+		if frappe.db.get_value("Site", site, "fatal_site_update") == name:
+			# The update recovered after it was marked Fatal. Stop blocking the site.
+			frappe.db.set_value("Site", site, "fatal_site_update", None)
 		backup_type = frappe.db.get_value("Site Update", name, "backup_type")
 		if backup_type == "Physical":
 			# Remove the snapshot

--- a/press/press/doctype/site_update/test_site_update.py
+++ b/press/press/doctype/site_update/test_site_update.py
@@ -37,6 +37,7 @@ from press.press.doctype.site_update.site_update import (
 	is_site_in_deploy_hours,
 	run_scheduled_updates,
 	sites_with_available_update,
+	update_status,
 )
 from press.press.doctype.subscription.test_subscription import create_test_subscription
 
@@ -218,6 +219,18 @@ class TestSiteUpdate(FrappeTestCase):
 			frappe.get_value("Site", site.name, "fatal_site_update"),
 			site_update,
 			"Site's fatal_site_update should be set to the last fatal Site Update",
+		)
+
+	def test_recovery_after_fatal_status_clears_fatal_flag_on_site(self):
+		site = create_test_site()
+		site_update = create_test_site_update(site.name, site.group, "Fatal", ignore_validate=True)
+		frappe.db.set_value("Site", site.name, "fatal_site_update", site_update.name)
+
+		update_status(site_update.name, "Recovered")
+
+		self.assertIsNone(
+			frappe.db.get_value("Site", site.name, "fatal_site_update"),
+			"A retried physical restore that recovers the update should unblock the site",
 		)
 
 	@patch("press.press.doctype.server.server.frappe.db.commit", new=MagicMock)


### PR DESCRIPTION
A customer reported a site that could not update or migrate. The site had `fatal_site_update` set. But every Site Update on the site was `Success` or `Recovered`, and all steps of the recovery job were green.

## What happened

1. The update used a physical backup. The `Physical Backup Restoration` failed. So `trigger_recovery_job` marked the update `Fatal`, set the site to `Broken`, and set `fatal_site_update` ([site_update.py:674](https://github.com/frappe/press/blob/develop/press/press/doctype/site_update/site_update.py#L674)). It returned before it made a recovery job.
2. The restoration was retried and was successful. Then `process_physical_backup_restoration_status_update` called `trigger_recovery_job` again. This was possible because `recover_job` was still empty.
3. The recovery job was successful. The update became `Recovered`, and the site became `Active` again. Nothing cleared `fatal_site_update`.

The site is then blocked forever. `should_try_update` skips the site. `sites_with_available_update` removes the site from the list. `check_fatal_site_update` stops a manual update or a migration. Support has no failed job to examine, because there is none.

Before this change, three places cleared the flag: the manual "cause of failure is resolved" button, the callback of the restore-tables fallback, and a successful site restore. No status change cleared it.

## The fix

All status changes of a Site Update go through `update_status`. When the status becomes `Success` or `Recovered`, and the site still points to this update, the code clears the pointer.

The change does not touch `cause_of_failure_is_resolved`. The migration can still be broken. That flag is what keeps the scheduled updates away.

## Test

`test_recovery_after_fatal_status_clears_fatal_flag_on_site` fails without the fix. It passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AkCm7a7e4hSD1oEv5kLi2m