### PR TITLE
fix(firewall): Permission error on toggle

### DIFF
--- a/press/press/doctype/server_firewall/server_firewall.py
+++ b/press/press/doctype/server_firewall/server_firewall.py
@@ -36,6 +36,13 @@ class ServerFirewall(Document):
 		"rules",
 	)
 
+	# The firewall page is an editor: it flips the switch and rewrites the rules
+	# table, then saves both through `set_value`.
+	dashboard_editable_fields = (
+		"enabled",
+		"rules",
+	)
+
 	def before_validate(self):
 		self.deduplicate_rules()
 

--- a/press/press/doctype/server_firewall/test_server_firewall.py
+++ b/press/press/doctype/server_firewall/test_server_firewall.py
@@ -1,20 +1,62 @@
 # Copyright (c) 2026, Frappe and Contributors
 # See license.txt
 
-# import frappe
-from frappe.tests import IntegrationTestCase
+import frappe
+from frappe.tests.utils import FrappeTestCase
 
-# On IntegrationTestCase, the doctype test records and all
-# link-field test record dependencies are recursively loaded
-# Use these module variables to add/remove to/from that list
-EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
-IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+from press.api.client import set_value
+from press.api.tests.test_client import sign_in_as
+from press.press.doctype.server.test_server import create_test_server
+from press.press.doctype.team.test_team import create_test_press_admin_team
 
 
-class IntegrationTestServerFirewall(IntegrationTestCase):
-	"""
-	Integration tests for ServerFirewall.
-	Use this class for testing interactions between multiple components.
-	"""
+class TestServerFirewallDashboardEditing(FrappeTestCase):
+	"""The firewall page saves the switch and the rules table through `set_value`."""
 
-	pass
+	def setUp(self):
+		super().setUp()
+		self.team = create_test_press_admin_team()
+		self.server = create_test_server(team=self.team.name)
+		self.firewall = frappe.get_doc("Server Firewall", {"server_id": self.server.name})
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.rollback()
+
+	def test_owner_can_enable_the_firewall_from_the_dashboard(self):
+		sign_in_as(self.team)
+		set_value("Server Firewall", self.firewall.name, {"enabled": 1})
+
+		self.assertEqual(frappe.db.get_value("Server Firewall", self.firewall.name, "enabled"), 1)
+
+	def test_owner_can_write_the_rules_table_from_the_dashboard(self):
+		rules = [
+			{"source": "173.245.48.0/20", "port": 443, "protocol": "TCP", "action": "Allow"},
+			{"source": "103.21.244.0/22", "port": 443, "protocol": "TCP", "action": "Allow"},
+		]
+
+		sign_in_as(self.team)
+		set_value("Server Firewall", self.firewall.name, {"enabled": 1, "rules": rules})
+
+		saved = frappe.get_doc("Server Firewall", self.firewall.name)
+		self.assertEqual([rule.source for rule in saved.rules], [rule["source"] for rule in rules])
+
+	def test_another_team_cannot_write_the_rules_table(self):
+		other_team = create_test_press_admin_team()
+
+		sign_in_as(other_team)
+		with self.assertRaises(frappe.PermissionError):
+			set_value("Server Firewall", self.firewall.name, {"enabled": 1})
+
+		self.assertEqual(frappe.db.get_value("Server Firewall", self.firewall.name, "enabled"), 0)
+
+	def test_server_id_stays_out_of_reach_from_the_dashboard(self):
+		other_server = create_test_server(team=self.team.name)
+
+		sign_in_as(self.team)
+		with self.assertRaises(frappe.PermissionError):
+			set_value("Server Firewall", self.firewall.name, {"server_id": other_server.name})
+
+		self.assertEqual(
+			frappe.db.get_value("Server Firewall", self.firewall.name, "server_id"), self.server.name
+		)


### PR DESCRIPTION
This fixes an issue where the user is not able to enable/disable fiewalls. The root cause is a missing editable field declaration.