### PR TITLE
fix(dashboard): Say drop bench, not archive bench

### DIFF
--- a/dashboard/src/utils/benchOptions.ts
+++ b/dashboard/src/utils/benchOptions.ts
@@ -172,19 +172,19 @@ export const getBenchOptions = ({
 				}),
 		},
 		{
-			label: 'Archive Bench',
+			label: 'Drop Bench',
 			condition: () => true,
 			onClick: () =>
 				confirmBenchMethod({
 					bench,
-					title: 'Archive Bench',
-					message: `Are you sure you want to archive the bench <b>${bench}</b>?`,
-					label: 'Archive',
+					title: 'Drop Bench',
+					message: `Are you sure you want to drop the bench <b>${bench}</b>?`,
+					label: 'Drop',
 					theme: 'red',
 					method: 'archive',
-					loading: 'Scheduling bench for archival...',
-					success: 'Bench is scheduled for archival',
-					error: 'Failed to archive bench',
+					loading: 'Scheduling bench to be dropped...',
+					success: 'Bench is scheduled to be dropped',
+					error: 'Failed to drop bench',
 				}),
 		},
 		{


### PR DESCRIPTION
Every other destructive action in the dashboard uses the word "drop": drop site, drop server, drop bench group. The bench action menu was the only place that said "archive", so the same operation had two names in the UI.

This changes only the labels in the bench options menu — the button, the dialog title, the confirmation message, and the toast messages. The backend method is still `archive`, and the `Archived` status stays as it is.
