### PR TITLE
fix(client): Strip unwanted fields from save

### DIFF
--- a/press/api/client.py
+++ b/press/api/client.py
@@ -17,7 +17,7 @@ from frappe.query_builder.terms import ValueWrapper
 from frappe.utils import cstr
 from pypika.queries import QueryBuilder
 
-from press.access import dashboard_access_rules, ownership
+from press.access import SECTIONS, dashboard_access_rules, ownership
 from press.access.support_access import has_support_access
 from press.exceptions import TeamHeaderNotInRequestError
 from press.guards import role_guard
@@ -114,6 +114,10 @@ ALLOWED_DOCTYPES = [
 	"Site Plan Change",
 	"Plan Change",
 ]
+
+# What a dashboard save carries along but never means to write: the standard
+# fields, and the access sections `dashboard_access_rules` adds in `get`.
+READ_ONLY_FIELDS = frozenset([*default_fields, *child_table_fields, *SECTIONS])
 
 whitelisted_methods = set()
 
@@ -334,15 +338,10 @@ def set_value(doctype: str, name: str, fieldname: dict | str, value: str | None 
 	if not has_support_access(doctype, name):
 		check_document_write_access(doctype, name)
 
-	check_editable_fields(doctype, fields_being_set(fieldname, value))
+	values = writable_values(values_being_set(fieldname, value))
+	check_editable_fields(doctype, list(values))
 
-	fields = fieldname if isinstance(fieldname, dict) else {fieldname: value}
-	for field in fields:
-		# fields mentioned in dashboard_fields are allowed to be set via set_value
-		if not is_allowed_field(doctype, field):
-			raise_not_permitted()
-
-	_set_value(doctype, name, fieldname, value)
+	_set_value(doctype, name, values, None)
 
 	# frappe set_value returns just the doc and not press's overriden `get_doc`
 	return get(doctype, name)
@@ -525,22 +524,35 @@ def is_allowed_field(doctype, field):
 	return False
 
 
-def fields_being_set(fieldname: dict | str, value: str | None) -> list[str]:
-	"""The fields `frappe.client.set_value` will write, however it was called.
+def values_being_set(fieldname: dict | str, value: str | None) -> dict:
+	"""What `set_value` was asked to write, however it was called.
 
 	It takes either a mapping or a single fieldname with its value, and a
 	fieldname that parses as JSON is treated as the mapping.
 	"""
 	if isinstance(fieldname, dict):
-		return list(fieldname)
+		return fieldname
 
 	if value:
-		return [fieldname]
+		return {fieldname: value}
 
 	try:
-		return list(json.loads(fieldname))
+		values = json.loads(fieldname)
 	except (TypeError, ValueError):
-		return [fieldname]
+		values = None
+
+	return values if isinstance(values, dict) else {fieldname: ""}
+
+
+def writable_values(values: dict) -> dict:
+	"""Leave out what the dashboard sends back without meaning to write it.
+
+	A dashboard editor saves by posting the whole document it read, so the
+	standard fields and the access sections `get` adds ride along with the
+	edited ones. Refusing the write over those would fail every such save, and
+	honouring them would let a request rewrite `owner` or `docstatus`.
+	"""
+	return {field: value for field, value in values.items() if field not in READ_ONLY_FIELDS}
 
 
 def check_editable_fields(doctype: str, fields: list[str]):

--- a/press/api/tests/test_client.py
+++ b/press/api/tests/test_client.py
@@ -14,10 +14,11 @@ from press.api.client import (
 	ALLOWED_DOCTYPES,
 	check_document_access,
 	check_document_write_access,
-	fields_being_set,
 	get,
 	get_list,
 	set_value,
+	values_being_set,
+	writable_values,
 )
 from press.overrides import before_request
 from press.press.doctype.agent_job.test_agent_job import create_test_agent_job
@@ -314,12 +315,27 @@ class TestEditableFields(FrappeTestCase):
 
 		self.assertEqual(getattr(get_controller("Subscription"), "dashboard_editable_fields", ()), ())
 
-	def test_fields_being_set_reads_every_calling_convention(self):
-		self.assertEqual(fields_being_set({"plan": "x", "team": "y"}, None), ["plan", "team"])
-		self.assertEqual(fields_being_set("plan", "x"), ["plan"])
-		self.assertEqual(fields_being_set('{"plan": "x"}', None), ["plan"])
+	def test_values_being_set_reads_every_calling_convention(self):
+		self.assertEqual(values_being_set({"plan": "x", "team": "y"}, None), {"plan": "x", "team": "y"})
+		self.assertEqual(values_being_set("plan", "x"), {"plan": "x"})
+		self.assertEqual(values_being_set('{"plan": "x"}', None), {"plan": "x"})
 		# A bare fieldname is not JSON, and frappe treats it as one field set to ""
-		self.assertEqual(fields_being_set("plan", None), ["plan"])
+		self.assertEqual(values_being_set("plan", None), {"plan": ""})
+
+	def test_writable_values_drops_the_fields_a_dashboard_save_carries_along(self):
+		values = {
+			"owner": "someone@example.com",
+			"creation": "2026-08-26 21:51:49.591602",
+			"modified": "2026-08-26 21:51:49.591602",
+			"modified_by": "someone@example.com",
+			"docstatus": 1,
+			"idx": 0,
+			"tabs_access": {},
+			"actions_access": {},
+			"enabled": 0,
+		}
+
+		self.assertEqual(writable_values(values), {"enabled": 0})
 
 
 @patch("frappe.sendmail", new=Mock())

--- a/press/press/doctype/server_firewall/test_server_firewall.py
+++ b/press/press/doctype/server_firewall/test_server_firewall.py
@@ -41,6 +41,31 @@ class TestServerFirewallDashboardEditing(FrappeTestCase):
 		saved = frappe.get_doc("Server Firewall", self.firewall.name)
 		self.assertEqual([rule.source for rule in saved.rules], [rule["source"] for rule in rules])
 
+	def test_owner_can_save_the_whole_document_the_dashboard_read(self):
+		"""frappe-ui posts back every field it read, standard ones included."""
+		owner = self.firewall.owner
+		document = {
+			"owner": "somebody@example.com",
+			"creation": "2026-08-26 21:51:49.591602",
+			"modified": "2026-08-26 21:51:49.591602",
+			"modified_by": "somebody@example.com",
+			"docstatus": 1,
+			"idx": 0,
+			"enabled": 1,
+			"rules": [{"source": "173.245.48.0/20", "port": 443, "protocol": "TCP", "action": "Allow"}],
+			"tabs_access": {},
+			"actions_access": {},
+		}
+
+		sign_in_as(self.team)
+		set_value("Server Firewall", self.firewall.name, document)
+
+		saved = frappe.get_doc("Server Firewall", self.firewall.name)
+		self.assertEqual(saved.enabled, 1)
+		self.assertEqual([rule.source for rule in saved.rules], ["173.245.48.0/20"])
+		self.assertEqual(saved.owner, owner)
+		self.assertEqual(saved.docstatus, 0)
+
 	def test_another_team_cannot_write_the_rules_table(self):
 		other_team = create_test_press_admin_team()
 


### PR DESCRIPTION
The frappe-ui document resource saves by posting back every field it read, so `set_value` receives the standard fields and the `tabs_access` and `actions_access` sections `get` adds, alongside the edited ones. `check_editable_fields` refused the write over the first of those, and the firewall page answered every save with "Server Firewall.owner cannot be edited from the dashboard".

Those fields are now dropped before the check rather than refused, and the narrowed mapping is what reaches `frappe.client.set_value`. That closes a hole too: frappe only refuses a standard field when `fieldname` is a string, so a dict payload could rewrite `owner` or `docstatus`.