### PR TITLE
fix(docker): Ship headless Chromium in the bench image

### DIFF
--- a/press/docker/Dockerfile
+++ b/press/docker/Dockerfile
@@ -265,15 +265,34 @@ COPY --chown=frappe:frappe redis /home/frappe/frappe-bench/redis
 COPY --chown=frappe:frappe .vimrc /home/frappe/.vimrc
 COPY --chown=frappe:frappe common_site_config.json /home/frappe/frappe-bench/sites/common_site_config.json
 
-# Prebundle headless Chromium for the Chrome-based PDF generator (frappe.utils.chromium)
+# Prebundle headless Chromium for the Chrome-based PDF generator
+# Frappe and print_designer both look for chromium/chrome-linux/headless_shell and
+# neither downloads it at print time, so fetch the archive here. Going through
+# `bench setup-chrome` would tie the image to a Frappe version that ships the
+# command, and a download at runtime lands in the container's writable layer,
+# which the next deploy throws away.
+# Bump CHROMIUM_URL together with the version Frappe pins in
+# frappe/utils/chromium/download.py.
+{% if is_arm_build %}
+# Chrome for Testing publishes no linux-arm64 build, so use Playwright's, as Frappe does.
+ARG CHROMIUM_URL=https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1157/chromium-headless-shell-linux-arm64.zip
+{% else %}
+ARG CHROMIUM_URL=https://storage.googleapis.com/chrome-for-testing-public/133.0.6943.35/linux64/chrome-headless-shell-linux64.zip
+{% endif %}
 RUN --mount=type=cache,sharing=locked,id=chromium-{% if is_arm_build %}arm64{% else %}x86_64{% endif %},target=/home/frappe/chromium-cache,uid=1000,gid=1000 \
-  if [ -n "$(ls -A /home/frappe/chromium-cache 2>/dev/null)" ]; then \
-  mkdir -p /home/frappe/frappe-bench/chromium \
-  && cp -a /home/frappe/chromium-cache/. /home/frappe/frappe-bench/chromium/; \
-  elif bench setup-chrome --help > /dev/null 2>&1; then \
-  bench setup-chrome \
-  && cp -a /home/frappe/frappe-bench/chromium/. /home/frappe/chromium-cache/; \
-  else echo "bench setup-chrome unavailable on this Frappe version; skipping Chromium prebundle"; fi; \
+  if [ ! -f /home/frappe/chromium-cache/chrome-linux/headless_shell ]; then \
+  rm -rf /home/frappe/chromium-cache/chrome-linux /tmp/chromium-extract \
+  && wget -q -O /tmp/chromium.zip "$CHROMIUM_URL" \
+  && python${PYTHON_VERSION} -m zipfile -e /tmp/chromium.zip /tmp/chromium-extract \
+  && if [ -d /tmp/chromium-extract/chrome-linux ]; then \
+  mv /tmp/chromium-extract/chrome-linux /home/frappe/chromium-cache/chrome-linux; \
+  else mv /tmp/chromium-extract/chrome-headless-shell-* /home/frappe/chromium-cache/chrome-linux \
+  && mv /home/frappe/chromium-cache/chrome-linux/chrome-headless-shell /home/frappe/chromium-cache/chrome-linux/headless_shell; fi \
+  && rm -rf /tmp/chromium.zip /tmp/chromium-extract; fi \
+  && mkdir -p /home/frappe/frappe-bench/chromium \
+  && cp -a /home/frappe/chromium-cache/chrome-linux /home/frappe/frappe-bench/chromium/chrome-linux \
+  && chmod 0755 /home/frappe/frappe-bench/chromium/chrome-linux/headless_shell \
+  && /home/frappe/frappe-bench/chromium/chrome-linux/headless_shell --version \
   `#stage-setup-chromium`
 
 # Install other apps

--- a/press/press/doctype/deploy_candidate_build/test_deploy_candidate_build.py
+++ b/press/press/doctype/deploy_candidate_build/test_deploy_candidate_build.py
@@ -182,3 +182,29 @@ class TestDeployCandidateBuild(FrappeTestCase):
 				self.assertEqual(newly_created_build.name, build)
 			else:
 				self.assertEqual(deploy_candidate_build.name, build)
+
+	def test_dockerfile_installs_chromium_for_the_platform_being_built(self, _mock_commit):
+		build = self.deploy_candidate_build
+
+		build.platform = "x86_64"
+		intel_dockerfile = build._generate_dockerfile()
+		self.assertIn("chrome-headless-shell-linux64.zip", intel_dockerfile)
+		self.assertIn("id=chromium-x86_64", intel_dockerfile)
+
+		# Chrome for Testing publishes no linux-arm64 build, so ARM uses Playwright's.
+		build.platform = "arm64"
+		arm_dockerfile = build._generate_dockerfile()
+		self.assertIn("chromium-headless-shell-linux-arm64.zip", arm_dockerfile)
+		self.assertIn("id=chromium-arm64", arm_dockerfile)
+		self.assertNotIn("chrome-headless-shell-linux64.zip", arm_dockerfile)
+
+	def test_dockerfile_makes_the_bundled_chromium_executable(self, _mock_commit):
+		self.assertIn(
+			"chmod 0755 /home/frappe/frappe-bench/chromium/chrome-linux/headless_shell",
+			self.deploy_candidate_build._generate_dockerfile(),
+		)
+
+	def test_chromium_setup_shows_up_as_a_build_step(self, _mock_commit):
+		build = self.deploy_candidate_build
+		checkpoints = build._get_dockerfile_checkpoints(build._generate_dockerfile())
+		self.assertIn("setup-chromium", checkpoints)


### PR DESCRIPTION
## Problem

A customer hit `frappe.exceptions.ValidationError: Chromium not executable at chromium/chrome-linux/headless_shell`, fixed it, then hit the byte-for-byte identical traceback after deploying one of their own apps — print_designer untouched.

Chromium was reaching benches by accident:

- `bench setup-chrome` exists only on Frappe v16, or through print_designer. On v15 the prebundle step's guard failed and the step skipped, so **nothing chromium ended up in the image**.
- `/home/frappe/frappe-bench` is not a volume — only `sites/` and `logs/` are. So the runtime download landed in one container's writable layer: invisible to the bench's other containers, and discarded when containers are replaced. Every deploy started over. That is why it recurs regardless of which app was deployed, and why print_designer#553 cannot cover it.
- print_designer runs `setup_chromium` from `scheduler_events["all"]`, and `download_chromium()` does `rmtree` → `extractall()` (mode 0644) → chmod only at the very end. A print request landing in that window sees the binary at its expected path at 0644 and throws. `_find_chromium_executable()` never downloads or chmods — it looks and throws.

## Fix

Fetch the archive in the Dockerfile and unpack it to the path both Frappe and print_designer read, at mode 0755:

- Chrome for Testing on x86_64; Playwright's build on arm64, which is what Frappe uses since Chrome for Testing publishes no linux-arm64 build. Pinned to the versions Frappe pins in `frappe/utils/chromium/download.py`.
- Neither app downloads at print time, so with the binary present nothing happens at runtime any more — no window, nothing to lose on redeploy.
- Kept the per-platform cache mount, so only the first build on a build server pays for the download.
- A `--version` smoke test runs the binary during the build, which would have caught this class of bug immediately.

I first tried moving the step below the app installs so print_designer could supply `setup-chrome` on v15. Dropped that: it makes the image's contents depend on which app versions happen to be installed, which is what hid the problem in the first place.

The download is no longer tolerated failing — Chromium is a dependency of the image now.

## Testing

The rendered `RUN` was exercised in a sandbox against stubbed archives of both shapes:

| Scenario | Result |
| --- | --- |
| x86 archive (`chrome-headless-shell-linux64/chrome-headless-shell`), cache empty | renamed, binary 0755, smoke test passes |
| arm64 archive (`chrome-linux/headless_shell`), cache empty | binary 0755, smoke test passes |
| Cache hit, cached tree at 0644 | binary 0755 in the image, no download |
| Download fails | build fails |

## Related

- frappe/frappe#41661 — moves the chmod out of the rename branch on `develop` so a fresh download is executable. v16 still carries the bug (backport closed as frappe/frappe#42337); this PR does not depend on either, since with the binary baked in nothing downloads at runtime.
- frappe/print_designer#553 — repairs the exec bit during print_designer's own install, which does not survive a deploy.
- Needs a backport to `master` to reach production builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
