### PR TITLE
fix(ui): Add error states for notif panel & server name in incidents card

### DIFF
--- a/dashboard/src/components/navigation/sidebar/Notifications.vue
+++ b/dashboard/src/components/navigation/sidebar/Notifications.vue
@@ -171,6 +171,25 @@ const iconCss = {
   },
 };
 
+const classCss = {
+  Error: {
+    txt: "text-ink-red-4",
+    bg: "bg-surface-red-1",
+  },
+  Warning: {
+    txt: "text-ink-amber-3",
+    bg: "bg-surface-amber-1",
+  },
+};
+
+const tileCss = (notification) => ({
+  icon: LucideCircleAlert,
+  txt: "text-ink-gray-6",
+  bg: "bg-surface-gray-1",
+  ...iconCss[notification.type],
+  ...classCss[notification.class],
+});
+
 // Reload resource on tab switch
 const activeTab = ref(0);
 
@@ -259,11 +278,10 @@ useRealtimeNotifs((data) => {
             @click="markAsRead(x, togglePopover)" title="Click to mark as read">
             <!-- type icon -->
             <div class="size-8 flex-shrink-0 flex items-center p-2 rounded mb-auto mt-1 relative
-              dark:bg-surface-gray-1" :class="[iconCss[x.type].bg || 'bg-surface-gray-1']">
+              dark:bg-surface-gray-1" :class="tileCss(x).bg">
               <span v-if="x.read == 0"
                 class="p-0.5 ring-outline-gray-2 ring-2 bg-surface-gray-7 absolute rounded top-0 left-0" />
-              <component :is="iconCss[x.type].icon || LucideCircleAlert" class="size-4"
-                :class="iconCss[x.type].txt || 'text-ink-gray-6'" />
+              <component :is="tileCss(x).icon" class="size-4" :class="tileCss(x).txt" />
             </div>
 
 

--- a/dashboard/src/components/status/IncidentCard.vue
+++ b/dashboard/src/components/status/IncidentCard.vue
@@ -106,16 +106,10 @@ const props = defineProps<Props>();
 					<span class="text-sm font-semibold uppercase tracking-widest">
 						Investigation
 					</span>
+					<Badge :label="data.investigation.status" class="ml-auto" />
 				</div>
 
 				<div class="rounded-lg bg-surface-gray-1 px-4 py-3">
-					<div class="mb-2.5 flex items-center justify-between">
-						<span class="text-sm">
-							{{ data.investigation.name }}
-						</span>
-						<Badge :label="data.investigation.status" variant="solid" />
-					</div>
-
 					<details
 						v-for="group in data.investigation.groups"
 						:key="group.label"

--- a/dashboard/src/components/status/PrivateIncident.vue
+++ b/dashboard/src/components/status/PrivateIncident.vue
@@ -168,7 +168,6 @@ const incidentTrees = computed(() =>
 				return acc;
 			}, {});
 			investigation = {
-				name: incident.investigation_name,
 				status: incident.investigation_status,
 				groups: Object.entries(grouped).map(([label, steps]) => ({
 					label,

--- a/dashboard/src/pages/servers/list/BenchRow.vue
+++ b/dashboard/src/pages/servers/list/BenchRow.vue
@@ -223,7 +223,7 @@ onBeforeUnmount(() => {
 		<template #header="{ opened, toggle }">
 			<div
 				:class="[
-					'row-grid px-4 py-2 cursor-pointer items-center',
+					'row-grid mx-4 py-2 cursor-pointer items-center',
 					(totalLength - 1 == bench_i && opened) || bench_i != totalLength - 1
 						? 'bordered'
 						: '',
@@ -317,7 +317,7 @@ onBeforeUnmount(() => {
 
 		<div
 			v-if="sites?.data?.length > 0"
-			class="row-grid px-4 py-2 items-center text-sm text-ink-gray-5"
+			class="row-grid mx-4 py-2 items-center text-sm text-ink-gray-5"
 		>
 			<span />
 			<span class="ml-6">Site</span>
@@ -328,7 +328,7 @@ onBeforeUnmount(() => {
 
 		<div
 			v-else-if="!sites?.list?.loading"
-			class="row-grid px-4 py-2"
+			class="row-grid mx-4 py-2"
 			:class="[bench_i != totalLength - 1 ? 'bordered' : '']"
 		>
 			<span />
@@ -348,7 +348,7 @@ onBeforeUnmount(() => {
 			v-for="(site, site_i) in sites?.data"
 			:key="site.name"
 			:class="[
-				'row-grid px-4 py-2 items-center',
+				'row-grid mx-4 py-2 items-center',
 				site_i != sites?.data?.length - 1 || bench_i != totalLength - 1
 					? 'bordered'
 					: '',
@@ -398,7 +398,7 @@ onBeforeUnmount(() => {
 
 		<div
 			v-if="sites.hasNextPage"
-			class="px-4 py-2 border-t dark:border-outline-gray-2"
+			class="mx-4 py-2 border-t dark:border-outline-gray-2"
 		>
 			<Button
 				variant="ghost"

--- a/dashboard/src/pages/servers/list/ServerCard.vue
+++ b/dashboard/src/pages/servers/list/ServerCard.vue
@@ -152,7 +152,7 @@ const serverActions = (server) => [
 
 		<div
 			v-if="benches.hasNextPage"
-			class="flex px-4 py-2 border-t dark:border-outline-gray-2"
+			class="flex mx-4 py-2 border-t dark:border-outline-gray-2"
 		>
 			<Button
 				@click="benches.next()"

--- a/dashboard/src/pages/servers/list/ServerCard.vue
+++ b/dashboard/src/pages/servers/list/ServerCard.vue
@@ -70,7 +70,7 @@ const serverActions = (server) => [
 </script>
 
 <template>
-	<section class="shadow dark:bg-surface-cards rounded" :key="data.name">
+	<section class="shadow dark:bg-surface-cards rounded pb-2" :key="data.name">
 		<div class="bordered p-4 flex gap-3 items-center">
 			<Tooltip :text="data.provider">
 				<ServerIcon :provider="data.provider" class="size-6 mb-auto" />
@@ -108,7 +108,7 @@ const serverActions = (server) => [
 				</div>
 			</div>
 
-			<div class="flex items-center gap-1 text-ink-gray-6 ml-auto">
+			<div class="flex items-center gap-1 text-ink-gray-6 ml-auto text-sm">
 				<LucideMapPin class="size-4" />
 				<span
 					>{{ data?.cluster_title }}

--- a/press/api/incident.py
+++ b/press/api/incident.py
@@ -1,5 +1,5 @@
 import frappe
-from frappe.query_builder.functions import Count, DistinctOptionFunction
+from frappe.query_builder.functions import Coalesce, Count, DistinctOptionFunction
 from pypika.enums import Order
 from pypika.terms import Field
 
@@ -78,15 +78,18 @@ def get_incidents(resolved: bool = False, limit: int = 20, offset: int = 0) -> l
 	Incident = frappe.qb.DocType("Incident")
 	Investigation = frappe.qb.DocType("Incident Investigator")
 	InvestigationAction = frappe.qb.DocType("Action Step")
+	Server = frappe.qb.DocType("Server")
 	query = (
 		frappe.qb.from_(Incident)
 		.left_join(Investigation)
 		.on(Incident.investigation == Investigation.name)
 		.left_join(InvestigationAction)
 		.on(Investigation.name == InvestigationAction.parent)
+		.left_join(Server)
+		.on(Incident.server == Server.name)
 		.select(
 			Incident.name,
-			Incident.server,
+			Coalesce(Server.title, Incident.server).as_("server"),
 			Incident.status,
 			Incident.creation,
 			Incident.confirmed_at,

--- a/press/api/notifications.py
+++ b/press/api/notifications.py
@@ -26,6 +26,7 @@ def get_notifications(
 			PressNotification.is_actionable,
 			PressNotification.document_type,
 			PressNotification.document_name,
+			PressNotification["class"],
 		)
 		.where(PressNotification.team == get_current_team())
 		.orderby(PressNotification.creation, order=frappe.qb.desc)

--- a/press/incident_management/doctype/incident_investigator/incident_investigator.py
+++ b/press/incident_management/doctype/incident_investigator/incident_investigator.py
@@ -25,13 +25,13 @@ from press.runner import Ansible, StepHandler
 from press.runner import Status as StepStatus
 
 if typing.TYPE_CHECKING:
+	from press.incident_management.doctype.action_step.action_step import ActionStep
+	from press.incident_management.doctype.investigation_step.investigation_step import (
+		InvestigationStep,
+	)
 	from press.press.doctype.database_server.database_server import DatabaseServer
 	from press.press.doctype.server.server import Server
 	from press.press.doctype.virtual_machine.virtual_machine import VirtualMachine
-	from press.press.incident_management.doctype.action_step.action_step import ActionStep
-	from press.press.incident_management.doctype.investigation_step.investigation_step import (
-		InvestigationStep,
-	)
 
 
 INVESTIGATION_WINDOW = 5  # Use 5m timeframe

--- a/press/incident_management/doctype/incident_investigator/incident_investigator.py
+++ b/press/incident_management/doctype/incident_investigator/incident_investigator.py
@@ -168,7 +168,7 @@ class PrometheusInvestigationHelper:
 		step.save()
 
 	def has_high_cpu_load(self, instance: str, step: "InvestigationStep"):
-		"""Check high cpu rate during window"""
+		"""Check high CPU rate during window"""
 		query = f'node_cpu_seconds_total{{instance="{instance}",mode="idle"}}'
 		assert self.investigation_window_start_time and self.investigation_window_end_time, (
 			"Investigation window not set"
@@ -192,7 +192,7 @@ class PrometheusInvestigationHelper:
 		step.save()
 
 	def has_high_memory_usage(self, instance: str, step: "InvestigationStep"):
-		"Determine high memory usage over a period of investigation window"
+		"Determined high memory usage over a period of investigation window"
 		query = f"""
 				(
 					1 - (


### PR DESCRIPTION
## Error icons for notification tile 

By default deploy icon would show regardless of error/warning. This pr fixes it and colors the icon red based on notification's class ( warning/error, had to include this in the api response )


### Before

<img width="864" height="730" alt="image" src="https://github.com/user-attachments/assets/4a6c98f1-1269-4a3a-9a53-9140d6b75bbf" />
 
 
### After
<img width="646" height="334" alt="image" src="https://github.com/user-attachments/assets/74f644f5-d675-41b9-83c4-ce3eab367b50" />


##  Incident status card

Instead of showing this random id show the actual server name 

<img width="346" height="156" alt="image" src="https://github.com/user-attachments/assets/87252e66-bae1-4fe1-a789-a818434c9398" />
 