### PR TITLE
fix(server): Archive leftover benches instead of blocking the drop

### DIFF
--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1510,16 +1510,8 @@ class BaseServer(Document, TagHelpers):
 					"Cannot archive a server with sites on it. Please archive all the sites before performing the drop action."
 				)
 			)
-		if frappe.get_all(
-			"Bench",
-			filters={"server": self.name, "status": ("!=", "Archived")},
-			ignore_ifnull=True,
-		):
-			frappe.throw(
-				_(
-					"The server has a few benches on it. Please archive them from their respective dashboards before attempting a drop."
-				)
-			)
+
+		self.archive_benches()
 
 		if self.is_wazuh_agent_installed:
 			self.uninstall_wazuh_agent()
@@ -1547,6 +1539,29 @@ class BaseServer(Document, TagHelpers):
 			)
 		self.disable_subscription()
 		self.remove_from_release_groups()
+
+	def archive_benches(self):
+		"""Archive the bench records left on the server.
+
+		The server has no sites left and its machine is about to be terminated,
+		so nothing has to be removed from it. Asking the user to archive the
+		benches first only blocks the drop: a bench that never came up cannot be
+		archived through the agent, and the dashboard offers no archive action.
+		"""
+		from press.press.doctype.bench.bench import Bench
+
+		benches = frappe.get_all(
+			"Bench",
+			filters={"server": self.name, "status": ("!=", "Archived")},
+			fields=["name", "is_ssh_proxy_setup"],
+			ignore_ifnull=True,
+		)
+		for bench in benches:
+			doc = Bench("Bench", bench.name)
+			doc.check_unarchived_sites()
+			if bench.is_ssh_proxy_setup:
+				doc.remove_ssh_user()
+			frappe.db.set_value("Bench", bench.name, "status", "Archived")
 
 	def _archive(self, reason=None):
 		self.run_press_job("Archive Server", arguments={"reason": reason})

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -1550,17 +1550,25 @@ class BaseServer(Document, TagHelpers):
 		"""
 		from press.press.doctype.bench.bench import Bench
 
-		benches = frappe.get_all(
-			"Bench",
-			filters={"server": self.name, "status": ("!=", "Archived")},
-			fields=["name", "is_ssh_proxy_setup"],
-			ignore_ifnull=True,
-		)
+		benches = [
+			Bench("Bench", name)
+			for name in frappe.get_all(
+				"Bench",
+				filters={"server": self.name, "status": ("!=", "Archived")},
+				pluck="name",
+				ignore_ifnull=True,
+			)
+		]
+
+		# Check every bench before archiving any. check_unarchived_sites commits,
+		# so a bench that fails the check halfway would leave the earlier ones
+		# archived while the server archive aborts.
 		for bench in benches:
-			doc = Bench("Bench", bench.name)
-			doc.check_unarchived_sites()
+			bench.check_unarchived_sites()
+
+		for bench in benches:
 			if bench.is_ssh_proxy_setup:
-				doc.remove_ssh_user()
+				bench.remove_ssh_user()
 			frappe.db.set_value("Bench", bench.name, "status", "Archived")
 
 	def _archive(self, reason=None):

--- a/press/press/doctype/server/test_server.py
+++ b/press/press/doctype/server/test_server.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 import typing
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import frappe
 from frappe.core.utils import find
@@ -14,6 +14,7 @@ from frappe.tests.utils import FrappeTestCase
 from moto import mock_aws
 
 from press.agent import Agent
+from press.exceptions import ArchiveBenchError
 from press.press.doctype.app.test_app import create_test_app
 from press.press.doctype.database_server.test_database_server import (
 	create_test_database_server,
@@ -25,16 +26,16 @@ from press.press.doctype.proxy_server.test_proxy_server import create_test_proxy
 from press.press.doctype.release_group.test_release_group import create_test_release_group
 from press.press.doctype.server.server import (
 	BaseServer,
+	Server,
 	process_cleanup_unused_files_job_update,
 	sync_wazuh_agent_status,
 )
 from press.press.doctype.server_plan.test_server_plan import create_test_server_plan
-from press.press.doctype.site.test_site import create_test_bench
+from press.press.doctype.site.test_site import create_test_bench, create_test_site
 from press.press.doctype.team.test_team import create_test_team
 from press.press.doctype.virtual_machine.test_virtual_machine import create_test_virtual_machine
 
 if typing.TYPE_CHECKING:
-	from press.press.doctype.server.server import Server
 	from press.press.doctype.server_plan.server_plan import ServerPlan
 	from press.press.doctype.virtual_machine.virtual_machine import VirtualMachine
 
@@ -779,7 +780,7 @@ class TestServer(FrappeTestCase):
 		settings = create_test_press_settings()
 		settings.wazuh_api_url = "https://wazuh.example.com:55000"
 		settings.wazuh_api_username = "user"
-		settings.wazuh_api_password = "pass"
+		settings.wazuh_api_password = "pass"  # pragma: allowlist secret
 		settings.wazuh_api_verify_tls = 0
 		settings.save()
 
@@ -801,7 +802,7 @@ class TestServer(FrappeTestCase):
 		settings = create_test_press_settings()
 		settings.wazuh_api_url = "https://wazuh.example.com:55000"
 		settings.wazuh_api_username = "user"
-		settings.wazuh_api_password = "pass"
+		settings.wazuh_api_password = "pass"  # pragma: allowlist secret
 		settings.wazuh_api_verify_tls = 0
 		settings.save()
 
@@ -848,3 +849,37 @@ class TestSSHCommand(FrappeTestCase):
 			server.get_ssh_command(),
 			f"ssh frappe@fc.dev -t 'ssh -J root@{proxy_server.name} ubuntu@{server.name} -p 2222'",
 		)
+
+
+@patch("press.press.doctype.bench.bench.frappe.db.commit", new=MagicMock)
+@patch.object(BaseServer, "after_insert", new=Mock())
+class TestArchiveBenches(FrappeTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_broken_bench_left_on_server_is_archived_instead_of_blocking_the_drop(self):
+		bench = create_test_bench()
+		bench.db_set("status", "Broken")
+		server = Server("Server", bench.server)
+
+		server.archive_benches()
+
+		self.assertEqual(frappe.db.get_value("Bench", bench.name, "status"), "Archived")
+
+	def test_ssh_user_of_archived_bench_is_removed_from_the_proxy(self):
+		bench = create_test_bench()
+		bench.db_set("is_ssh_proxy_setup", True)
+		server = Server("Server", bench.server)
+
+		with patch.object(Agent, "remove_ssh_user") as remove_ssh_user:
+			server.archive_benches()
+
+		self.assertEqual(remove_ssh_user.call_args.args[0].name, bench.name)
+
+	def test_bench_that_still_has_a_site_is_not_archived(self):
+		bench = create_test_bench()
+		create_test_site(bench=bench.name)
+		server = Server("Server", bench.server)
+
+		self.assertRaisesRegex(ArchiveBenchError, "unarchived sites", server.archive_benches)
+		self.assertEqual(frappe.db.get_value("Bench", bench.name, "status"), "Active")

--- a/press/press/doctype/server/test_server.py
+++ b/press/press/doctype/server/test_server.py
@@ -883,3 +883,19 @@ class TestArchiveBenches(FrappeTestCase):
 
 		self.assertRaisesRegex(ArchiveBenchError, "unarchived sites", server.archive_benches)
 		self.assertEqual(frappe.db.get_value("Bench", bench.name, "status"), "Active")
+
+	def test_no_bench_is_archived_when_a_later_bench_still_has_a_site(self):
+		server = create_test_server()
+		empty_bench = create_test_bench(server=server.name)
+		bench_with_site = create_test_bench(server=server.name)
+		create_test_site(bench=bench_with_site.name)
+		# Benches are read in `modified desc` order, so pin the empty one first.
+		frappe.db.set_value("Bench", empty_bench.name, "modified", "2026-01-02", update_modified=False)
+		frappe.db.set_value("Bench", bench_with_site.name, "modified", "2026-01-01", update_modified=False)
+
+		self.assertRaisesRegex(
+			ArchiveBenchError, "unarchived sites", Server("Server", server.name).archive_benches
+		)
+
+		statuses = frappe.get_all("Bench", {"server": server.name}, pluck="status")
+		self.assertNotIn("Archived", statuses)


### PR DESCRIPTION
## Problem

Dropping a server failed with an error the operator cannot act on:

> The server has a few benches on it. Please archive them from their respective dashboards before attempting a drop.

The guard blocks on any bench whose status is not `Archived`, so `Pending`, `Installing`, `Updating` and `Broken` benches block the drop too — and those are exactly the ones nobody can clear:

- `archive_obsolete_benches` selects `WHERE bench.status = "Active"`, so a bench left in `Pending` or `Broken` is invisible to every sweeper.
- The Bench dashboard object declares `whitelistedMethods: {}`, so there is no archive action in the UI at all. The instruction in the error is impossible to follow.
- The agent's `archive_bench` cannot help a bench whose directory it never created.

Encountered on a real drop: the bench had been sitting in `Pending` for days. `Bench.archive()` sets `status = "Pending"` and commits it (via `check_unarchived_sites` and `_mark_applied_patch_as_archived`) *before* the Archive Bench agent job exists, so any failure after that point leaves the bench in `Pending` permanently — `try_archive`'s rollback cannot undo a committed status. The only exit is the Archive Bench job callback, and that job never reached a final state. Clearing it took moving the bench directory to `archived/` by hand and editing the status field.

## Fix

`Server.archive()` now archives the leftover bench records itself instead of throwing. The site check immediately above already proves the server has no live sites, and the machine is about to be terminated, so nothing is left to remove from it.

- `check_unarchived_sites()` is kept per bench as a safety net: the site check above uses `ignore_ifnull=True`, so a Site row with a null `server` would slip past it. That case raises `ArchiveBenchError` instead of silently archiving a bench that still holds a site. Every bench is checked before any is archived — `check_unarchived_sites` commits before it raises, so a check that failed partway through the loop would otherwise leave the earlier benches archived, and their proxy ssh user removal dispatched, while the server archive aborted.
- The ssh user is removed from the proxy server, which is what the normal archive path does on success and would otherwise leave config behind on the proxy.
- The status is set directly rather than through an Archive Bench agent job. The job would fail for a bench that never came up, and it can sit queued behind a jammed agent queue — which is what caused the incident. If a drop is abandoned after this point, `process_running_benches_on_server` already cleans up benches marked archived but still running.

## Not included

Benches stuck in `Pending` outside a server drop are still invisible to every sweeper, since they all filter on `status = "Active"`. Widening `archive_obsolete_benches` to pick those up is a separate change.

## Tests

Three tests in `press/press/doctype/server/test_server.py`: a broken bench gets archived, the ssh user is removed from the proxy, and a bench that still has a site is refused.

Unrelated: two pre-existing fake test passwords in the same file needed `# pragma: allowlist secret`. They are not in `.secrets.baseline`, so the `detect-secrets` hook fails on any commit that touches this file.

