### PR TITLE
fix(app-source): Handle a branch deleted on GitHub

### DIFF
--- a/dashboard/src/components/group/ChangeAppBranchDialog.vue
+++ b/dashboard/src/components/group/ChangeAppBranchDialog.vue
@@ -86,7 +86,7 @@
 </template>
 
 <script>
-import { DashboardError } from '../../utils/error';
+import { DashboardError } from '../../utils/error'
 
 export default {
 	name: 'ChangeAppBranchDialog',
@@ -103,27 +103,33 @@ export default {
 			branchVerificationSuccess: null,
 			validatingBranch: false,
 			showDialog: true,
-		};
+		}
 	},
 
 	computed: {
 		canChangeBranch() {
 			if (this.useOtherBranch) {
-				return this.otherBranchValidated;
+				return this.otherBranchValidated
 			}
-			return this.selectedBranch && this.selectedBranch !== this.app.branch;
+			return this.selectedBranch && this.selectedBranch !== this.app.branch
 		},
 	},
 
 	watch: {
+		'$resources.branches.data'(branches) {
+			// The app can sit on a branch that has since been deleted on GitHub
+			if (branches?.length && !branches.includes(this.selectedBranch)) {
+				this.selectedBranch = null
+			}
+		},
 		useOtherBranch() {
-			this.otherBranchValidated = false;
-			this.branchVerificationError = null;
+			this.otherBranchValidated = false
+			this.branchVerificationError = null
 		},
 		otherBranchName() {
-			this.otherBranchValidated = false;
-			this.branchVerificationError = null;
-			this.branchVerificationSuccess = null;
+			this.otherBranchValidated = false
+			this.branchVerificationError = null
+			this.branchVerificationSuccess = null
 		},
 	},
 
@@ -138,15 +144,15 @@ export default {
 				auto: true,
 				initialData: [],
 				transform(data) {
-					return data.map((d) => d.name);
+					return data.map((d) => d.name)
 				},
-			};
+			}
 		},
 
 		validateBranchUsingInstallation() {
 			return {
 				url: 'press.api.bench.validate_branch',
-			};
+			}
 		},
 
 		changeBranch() {
@@ -155,39 +161,39 @@ export default {
 				validate() {
 					const targetBranch = this.useOtherBranch
 						? this.otherBranchName
-						: this.selectedBranch;
+						: this.selectedBranch
 
 					if (!targetBranch || targetBranch === this.app.branch) {
-						throw new DashboardError('Please select a different branch');
+						throw new DashboardError('Please select a different branch')
 					}
 				},
 				onSuccess() {
-					this.$emit('branchChange');
-					this.showDialog = false;
+					this.$emit('branchChange')
+					this.showDialog = false
 				},
-			};
+			}
 		},
 	},
 
 	methods: {
 		async validateOtherBranch() {
-			this.$resources.changeBranch.reset();
-			this.validatingBranch = true;
-			this.branchVerificationError = null;
+			this.$resources.changeBranch.reset()
+			this.validatingBranch = true
+			this.branchVerificationError = null
 			try {
 				await this.$resources.validateBranchUsingInstallation.submit({
 					name: this.bench,
 					app: this.app.name,
 					branch: this.otherBranchName.trim(),
-				});
+				})
 
-				this.otherBranchValidated = true;
-				this.branchVerificationSuccess = 'Branch validated successfully';
+				this.otherBranchValidated = true
+				this.branchVerificationSuccess = 'Branch validated successfully'
 			} catch (e) {
-				this.branchVerificationError = "Branch couldn't be verified on GitHub";
-				this.otherBranchValidated = false;
+				this.branchVerificationError = "Branch couldn't be verified on GitHub"
+				this.otherBranchValidated = false
 			} finally {
-				this.validatingBranch = false;
+				this.validatingBranch = false
 			}
 		},
 
@@ -198,8 +204,8 @@ export default {
 				to_branch: this.useOtherBranch
 					? this.otherBranchName.trim()
 					: this.selectedBranch,
-			});
+			})
 		},
 	},
-};
+}
 </script>

--- a/dashboard/src/objects/group.js
+++ b/dashboard/src/objects/group.js
@@ -162,6 +162,17 @@ export default {
 							suffix(row) {
 								if (!row.last_github_poll_failed) return
 
+								if (row.branch_deleted)
+									return h(
+										Tooltip,
+										{
+											text: `The ${row.branch} branch no longer exists on GitHub. Change the branch to resume updates.`,
+											placement: 'top',
+											class: 'rounded-full bg-surface-gray-2 p-1',
+										},
+										() => [h(icon('alert-circle', 'w-3 h-3'), {})],
+									)
+
 								return h(
 									Tooltip,
 									{
@@ -182,8 +193,14 @@ export default {
 								)
 							},
 							format(value, row) {
-								let { update_available, deployed, last_github_poll_failed } =
-									row
+								let {
+									update_available,
+									deployed,
+									last_github_poll_failed,
+									branch_deleted,
+								} = row
+
+								if (branch_deleted) return 'Branch Deleted'
 
 								return last_github_poll_failed
 									? 'Action Required'
@@ -192,6 +209,9 @@ export default {
 										: update_available
 											? 'Update Available'
 											: 'Latest Version'
+							},
+							theme(value, row) {
+								return row.last_github_poll_failed ? 'red' : 'gray'
 							},
 							width: 0.5,
 						},

--- a/press/api/bench.py
+++ b/press/api/bench.py
@@ -17,6 +17,7 @@ from press.api.site import protected
 from press.press.doctype.agent_job.agent_job import job_detail
 from press.press.doctype.app.app import get_app_from_policies
 from press.press.doctype.app_patch.app_patch import create_app_patch
+from press.press.doctype.app_source.app_source import is_branch_deleted
 from press.press.doctype.bench_update.bench_update import get_bench_update
 from press.press.doctype.cluster.cluster import Cluster
 from press.press.doctype.deploy_candidate.deploy_candidate import RESTING_STATES, TRANSITORY_STATES
@@ -473,6 +474,7 @@ def apps(name):
 				"deployed": app.name in deployed_apps,
 				"update_available": bool(update_available),
 				"last_github_poll_failed": source.last_github_poll_failed,
+				"branch_deleted": source.branch_deleted,
 			}
 		)
 	return apps
@@ -979,31 +981,31 @@ def validate_branch(name: str, app: str, branch: str):
 
 def get_branches_for_marketplace_app(app: str, marketplace_app: str, app_source: AppSource) -> list[dict]:
 	"""Return list of branches allowed for this `marketplace` app"""
-	branch_set = set()
 	marketplace_app_doc: MarketplaceApp = frappe.get_doc("Marketplace App", marketplace_app)
+	source_names = {row.source for row in marketplace_app_doc.sources}
 
-	for marketplace_app_source in marketplace_app_doc.sources:
-		app_source = frappe.get_doc("App Source", marketplace_app_source.source)
-		branch_set.add(app_source.branch)
-
-	# Also, append public source branches
-	repo_owner = app_source.repository_owner
-	repo_name = app_source.repository
-
-	public_app_sources = frappe.get_all(
-		"App Source",
-		filters={
-			"app": app,
-			"repository_owner": repo_owner,
-			"repository": repo_name,
-			"public": True,
-		},
-		pluck="branch",
+	# Also, append public sources of the same repository
+	source_names.update(
+		frappe.get_all(
+			"App Source",
+			filters={
+				"app": app,
+				"repository_owner": app_source.repository_owner,
+				"repository": app_source.repository,
+				"public": True,
+			},
+			pluck="name",
+		)
 	)
-	branch_set.update(public_app_sources)
 
-	branch_list = sorted(list(branch_set))
-	return [{"name": b} for b in branch_list]
+	sources = frappe.get_all(
+		"App Source",
+		filters={"name": ("in", list(source_names))},
+		fields=["branch", "last_github_poll_failed", "last_github_response"],
+	)
+	branch_names = {source.branch for source in sources if not is_branch_deleted(source)}
+
+	return [{"name": branch} for branch in sorted(branch_names)]
 
 
 def belongs_to_current_team(app: str) -> bool:

--- a/press/api/tests/test_bench.py
+++ b/press/api/tests/test_bench.py
@@ -18,6 +18,7 @@ from press.api.bench import (
 	deploy_and_update,
 	deploy_information,
 	get,
+	get_branches_for_marketplace_app,
 	new,
 	update_config,
 	update_dependencies,
@@ -25,8 +26,10 @@ from press.api.bench import (
 from press.press.doctype.agent_job.agent_job import AgentJob
 from press.press.doctype.app.test_app import create_test_app
 from press.press.doctype.app_release.test_app_release import create_test_app_release
+from press.press.doctype.app_source.test_app_source import create_test_app_source
 from press.press.doctype.bench.test_bench import create_test_bench
 from press.press.doctype.deploy_candidate.deploy_candidate import DeployCandidate
+from press.press.doctype.marketplace_app.test_marketplace_app import create_test_marketplace_app
 from press.press.doctype.press_settings.test_press_settings import (
 	create_test_press_settings,
 )
@@ -187,6 +190,34 @@ class TestAPIBench(FrappeTestCase):
 			except OSError as e:
 				print("Waitng for container to respond", str(e))
 			time.sleep(0.5)
+
+	def test_marketplace_branch_list_leaves_out_a_branch_deleted_on_github(self):
+		app = create_test_app("insights", "Insights")
+		repository_url = "https://github.com/frappe/insights"
+		live_source = create_test_app_source(self.version, app, repository_url, "master", self.team.name)
+		deleted_source = create_test_app_source(
+			self.version, app, repository_url, "version-16", self.team.name
+		)
+		frappe.db.set_value(
+			"App Source",
+			deleted_source.name,
+			{
+				"last_github_poll_failed": 1,
+				"last_github_response": '{"message": "Branch not found"}',
+			},
+		)
+		marketplace_app = create_test_marketplace_app(
+			app.name,
+			self.team.name,
+			sources=[
+				{"version": self.version, "source": live_source.name},
+				{"version": self.version, "source": deleted_source.name},
+			],
+		)
+
+		branches = get_branches_for_marketplace_app(app.name, marketplace_app.name, live_source)
+
+		self.assertEqual(branches, [{"name": "master"}])
 
 
 class TestAPIBenchConfig(FrappeTestCase):

--- a/press/press/doctype/app_source/app_source.py
+++ b/press/press/doctype/app_source/app_source.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -19,6 +20,7 @@ from press.press.doctype.app.app import parse_frappe_version
 from press.utils import get_current_team, log_error
 
 REQUIRED_APPS_PATTERN = re.compile(r"^\s*(?!#)\s*required_apps\s*=\s*\[(.*?)\]", re.DOTALL | re.MULTILINE)
+BRANCH_NOT_FOUND = "Branch not found"
 
 if TYPE_CHECKING:
 	from press.press.doctype.app_release.app_release import AppRelease
@@ -234,7 +236,7 @@ class AppSource(Document):
 		).insert(ignore_permissions=True)
 		return app_release
 
-	def get_commit_info(self, commit_hash: None | str = None) -> tuple[str, dict, bool]:
+	def get_commit_info(self, commit_hash: str | None = None) -> tuple[str, dict, bool]:
 		"""
 		If `commit_hash` is not provided, `commit_info` is of the latest commit
 		on the branch pointed to by `self.hash`.
@@ -257,7 +259,7 @@ class AppSource(Document):
 		commit_info = data.get("commit", {}).get("commit", {})
 		return (commit_hash, commit_info, True)
 
-	def poll_github(self, commit_hash: None | str = None) -> requests.Response:
+	def poll_github(self, commit_hash: str | None = None) -> requests.Response:
 		headers = self.get_auth_headers()
 		url = f"https://api.github.com/repos/{self.repository_owner}/{self.repository}"
 
@@ -268,6 +270,10 @@ class AppSource(Document):
 			url = f"{url}/branches/{self.branch}"
 
 		return requests.get(url, headers=headers)
+
+	@property
+	def branch_deleted(self) -> bool:
+		return is_branch_deleted(self)
 
 	def set_poll_succeeded(self):
 		self.last_github_response = ""
@@ -285,9 +291,11 @@ class AppSource(Document):
 		*probably* means that FC hasn't been granted access to this particular
 		app by the user.
 
-		In this case the App Source is in an uninstalled state.
+		In this case the App Source is in an uninstalled state. A deleted branch
+		also answers 404, but there the repository is still reachable, so the
+		source is not uninstalled.
 		"""
-		self.uninstalled = response.status_code == 404
+		self.uninstalled = response.status_code == 404 and not self.branch_deleted
 
 		if response.status_code != 404:
 			log_error(
@@ -350,3 +358,18 @@ def get_timestamp_from_commit_info(commit_info: dict) -> str | None:
 
 	timestamp_str = timestamp_str.replace("Z", "+00:00")
 	return datetime.fromisoformat(timestamp_str).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def get_github_message(response_text: str | None) -> str:
+	try:
+		return json.loads(response_text or "{}").get("message", "")
+	except json.JSONDecodeError:
+		return ""
+
+
+def is_branch_deleted(source) -> bool:
+	"""GitHub answers a poll for a branch that no longer exists with a 404 that names the branch."""
+	if not source.last_github_poll_failed:
+		return False
+
+	return get_github_message(source.last_github_response) == BRANCH_NOT_FOUND

--- a/press/press/doctype/app_source/test_app_source.py
+++ b/press/press/doctype/app_source/test_app_source.py
@@ -36,11 +36,23 @@ def create_test_app_source(
 	return app.add_source(repository_url=repository_url, branch=branch, frappe_version=version, team=team)
 
 
+def github_not_found_response(message: str) -> Mock:
+	return Mock(status_code=404, text=f'{{"message": "{message}"}}')
+
+
 class TestAppSource(FrappeTestCase):
 	def create_app(self, name: str, title: str):
 		app: App = frappe.get_doc({"doctype": "App", "name": name, "title": title})
 		app.insert(ignore_if_duplicate=True)
 		return app
+
+	def create_hrms_source(self) -> AppSource:
+		return self.create_app("hrms", "HRMS").add_source(
+			frappe_version="Nightly",
+			repository_url="https://github.com/frappe/hrms",
+			branch="develop",
+			team=create_test_team().name,
+		)
 
 	@patch.object(AppSource, "after_insert", new=Mock())
 	def test_validate_dependant_apps(self):
@@ -76,3 +88,29 @@ class TestAppSource(FrappeTestCase):
 			source.sync_versions()
 
 		self.assertEqual([row.version for row in source.versions], ["Version 15"])
+
+	@patch.object(AppSource, "after_insert", new=Mock())
+	def test_poll_of_deleted_branch_sets_branch_deleted_and_leaves_source_installed(self):
+		source = self.create_hrms_source()
+
+		source.set_poll_failed(github_not_found_response("Branch not found"))
+
+		self.assertTrue(source.branch_deleted)
+		self.assertFalse(source.uninstalled)
+
+	@patch.object(AppSource, "after_insert", new=Mock())
+	def test_poll_of_inaccessible_repository_sets_uninstalled_and_not_branch_deleted(self):
+		source = self.create_hrms_source()
+
+		source.set_poll_failed(github_not_found_response("Not Found"))
+
+		self.assertFalse(source.branch_deleted)
+		self.assertTrue(source.uninstalled)
+
+	@patch.object(AppSource, "after_insert", new=Mock())
+	def test_branch_deleted_is_false_while_the_last_poll_succeeded(self):
+		source = self.create_hrms_source()
+		source.last_github_response = '{"message": "Branch not found"}'
+		source.last_github_poll_failed = False
+
+		self.assertFalse(source.branch_deleted)


### PR DESCRIPTION
An App Source whose branch has been deleted on GitHub shows up in the dashboard as a generic **Action Required** badge, linking to the [App Installation Issue](https://docs.frappe.io/cloud/faq/app-installation-issue) FAQ. That FAQ tells the user to re-grant Frappe Cloud access to the repository, which does nothing here — the repository is fine, the branch is gone. Nothing in the UI says so. Worse, the Change Branch dialog then offers the deleted branch as a destination.

Example: `SRC-frappe_whatsapp-001` tracks `frappe_whatsapp` on `version-16`. That branch no longer exists, so `last_github_response` reads `{"message": "Branch not found", "status": "404"}`, `last_github_poll_failed` is `1`, and `uninstalled` is `1` — even though the GitHub App is still installed.

### Saying that the branch is gone

`AppSource.set_poll_failed` treated every 404 as revoked GitHub App access. GitHub distinguishes the two cases in the response body: a missing or inaccessible repository is `Not Found`, a missing branch is `Branch not found`. A new `branch_deleted` property reads that message, and a deleted branch no longer marks the source as uninstalled, since the repository is still reachable.

`press.api.bench.apps` returns `branch_deleted` alongside `last_github_poll_failed`, and the Apps tab of a bench group uses it:

- the status badge reads **Branch Deleted** instead of Action Required
- the badge is red for either failure, instead of the default gray
- the tooltip says `The version-16 branch no longer exists on GitHub. Change the branch to resume updates.` — there is no docs page for this, and the fix is the existing **Change Branch** row action, so the tooltip explains it inline rather than linking out

`branch_deleted` is derived from the stored `last_github_response` rather than being a new field, so every source that has already failed reports correctly with no patch.

### Not offering it as a destination

`branch_list` asks GitHub for the live branches, except for a public marketplace app that does not belong to the current team. There `get_branches_for_marketplace_app` builds the list out of App Source records — the Marketplace App's own sources plus every public source for the same repository — so a source stuck on a deleted branch keeps advertising that branch. It now drops the sources whose branch is deleted.

That function also rebound its own `app_source` parameter inside the loop, so the public source query read the repository owner and name off the last marketplace source instead of off the app's own source. Fixed while rewriting it.

`ChangeAppBranchDialog` preselects the branch the app is on. Once the deleted branch stops being an option, that leaves the select bound to a value with no matching `option`, which renders blank and hides the Change Branch button, so the dialog now clears the selection when the current branch is not on offer.

### Noise in the diff

`group.js` and `ChangeAppBranchDialog.vue` both predate the Biome config, so the pre-commit hook reformats them wholesale on any change; most of the diff in those two files is quotes, semicolons, indentation and import order. The change also reorders `None | str` to `str | None` in two pre-existing signatures, which CI's unpinned ruff flags under RUF036 as soon as a PR touches that file.

### Tests

`test_app_source.py` covers a deleted-branch 404, an inaccessible-repository 404, and `branch_deleted` staying false while the last poll succeeded. `press/api/tests/test_bench.py` covers the branch list dropping a deleted branch while keeping the live one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
