### PR TITLE
fix(dashboard): Show only a server's own sites under a bench group

### DIFF
--- a/dashboard/src/pages/servers/list/BenchRow.vue
+++ b/dashboard/src/pages/servers/list/BenchRow.vue
@@ -39,12 +39,13 @@ const sites = createListResource({
 	fields: ['name', 'status', 'bench', 'creation', 'host_name'],
 	filters: {
 		group: props.data.name,
+		server: props.server.name,
 		host_name: ['is', 'set'],
 		skip_team_filter_for_system_user_and_support_agent: true,
 	},
 	orderBy: 'creation desc',
 	pageLength: 5,
-	cache: ['sitesRes', props.data.name],
+	cache: ['sitesRes', props.data.name, props.server.name],
 	auto: true,
 })
 

--- a/dashboard/src/pages/servers/list/BenchRow.vue
+++ b/dashboard/src/pages/servers/list/BenchRow.vue
@@ -2,28 +2,27 @@
 import {
 	Badge,
 	Button,
+	createDocumentResource,
+	createListResource,
 	Dropdown,
 	Spinner,
 	Tooltip,
-	createDocumentResource,
-	createListResource,
 } from 'frappe-ui'
-
-import { renderDialog } from '@/utils/components'
 import {
-	h,
-	ref,
-	defineAsyncComponent,
-	onBeforeUnmount,
 	computed,
+	defineAsyncComponent,
+	h,
+	onBeforeUnmount,
 	reactive,
+	ref,
 	watch,
 } from 'vue'
-import { dropBench } from './utils'
+import Collapsable from '@/components/common/Collapsable.vue'
+import { renderDialog } from '@/utils/components'
 
 import { dayjsLocal } from '@/utils/dayjs'
 import { getSiteStatusBadge } from '@/utils/site'
-import Collapsable from '@/components/common/Collapsable.vue'
+import { dropBench } from './utils'
 
 interface Props {
 	data: any
@@ -140,7 +139,10 @@ const benchOptions = (bench) => [
 	{ label: 'App Marketplace', route: '/apps', icon: LucideStore },
 	{
 		label: 'Bench Actions',
-		route: { name: 'Release Group Detail Actions', params: { name: bench.name } },
+		route: {
+			name: 'Release Group Detail Actions',
+			params: { name: bench.name },
+		},
 		icon: LucideSlidersVertical,
 	},
 	{

--- a/press/press/doctype/release_group/release_group.py
+++ b/press/press/doctype/release_group/release_group.py
@@ -162,31 +162,19 @@ class ReleaseGroup(Document, TagHelpers):
 	def get_list_query(query, filters, **list_args):
 		ReleaseGroupServer = frappe.qb.DocType("Release Group Server")
 		ReleaseGroup = frappe.qb.DocType("Release Group")
-		Bench = frappe.qb.DocType("Bench")
-		Site = frappe.qb.DocType("Site")
-
-		site_count = (
-			frappe.qb.from_(Site)
-			.select(frappe.query_builder.functions.Count("*"))
-			.where(Site.group == ReleaseGroup.name)
-			.where(Site.status != "Archived")
-		)
-
-		active_benches = (
-			frappe.qb.from_(Bench)
-			.select(frappe.query_builder.functions.Count("*"))
-			.where(Bench.group == ReleaseGroup.name)
-			.where(Bench.status == "Active")
-		)
+		server = filters.get("server")
 
 		query = (
 			query.where(ReleaseGroup.team == frappe.local.team().name)
 			.where(ReleaseGroup.enabled == 1)
 			.where(ReleaseGroup.public == 0)
-			.select(site_count.as_("site_count"), active_benches.as_("active_benches"))
+			.select(
+				site_count_query(server).as_("site_count"),
+				active_bench_count_query(server).as_("active_benches"),
+			)
 		)
 
-		if server := filters.get("server"):
+		if server:
 			query = (
 				query.inner_join(ReleaseGroupServer)
 				.on(ReleaseGroupServer.parent == ReleaseGroup.name)
@@ -2080,6 +2068,34 @@ class ReleaseGroup(Document, TagHelpers):
 			f"New release group <a href='{new_group.get_url()}' target='_blank'>{new_group.title}</a> created and deployed successfully!"
 		)
 		return new_group
+
+
+def site_count_query(server: str | None):
+	"""Count the sites of a group, on one server when the list is filtered by server."""
+	ReleaseGroup = frappe.qb.DocType("Release Group")
+	Site = frappe.qb.DocType("Site")
+
+	query = (
+		frappe.qb.from_(Site)
+		.select(Count("*"))
+		.where(Site.group == ReleaseGroup.name)
+		.where(Site.status != "Archived")
+	)
+	return query.where(Site.server == server) if server else query
+
+
+def active_bench_count_query(server: str | None):
+	"""Count the active benches of a group, on one server when the list is filtered by server."""
+	ReleaseGroup = frappe.qb.DocType("Release Group")
+	Bench = frappe.qb.DocType("Bench")
+
+	query = (
+		frappe.qb.from_(Bench)
+		.select(Count("*"))
+		.where(Bench.group == ReleaseGroup.name)
+		.where(Bench.status == "Active")
+	)
+	return query.where(Bench.server == server) if server else query
 
 
 @redis_cache(ttl=60)

--- a/press/press/doctype/release_group/test_release_group.py
+++ b/press/press/doctype/release_group/test_release_group.py
@@ -13,6 +13,7 @@ from frappe.tests.utils import FrappeTestCase
 from press.agent import Agent
 from press.api.bench import deploy_information
 from press.api.client import get_list
+from press.overrides import before_request
 from press.press.doctype.agent_job.agent_job import AgentJob
 from press.press.doctype.app.test_app import create_test_app
 from press.press.doctype.app_release.test_app_release import create_test_app_release
@@ -103,6 +104,7 @@ class TestReleaseGroup(FrappeTestCase):
 		self.team = create_test_team().name
 
 	def tearDown(self):
+		frappe.set_user("Administrator")
 		frappe.db.rollback()
 
 	def test_create_release_group(self):
@@ -663,3 +665,29 @@ class TestReleaseGroup(FrappeTestCase):
 		create_test_bench(group=test_release_group)
 
 		test_release_group.check_app_server_storage()
+
+	@patch.object(AgentJob, "enqueue_http_request", new=Mock())
+	def test_counts_of_a_group_on_two_servers_are_scoped_to_the_filtered_server(self):
+		"""A group runs on two servers. Each server card must count only its own benches and sites."""
+		from press.press.doctype.server.test_server import create_test_server
+		from press.press.doctype.site.test_site import create_test_bench, create_test_site
+
+		app = create_test_app()
+		user = frappe.get_value("Team", self.team, "user")
+		first_server = create_test_server(team=self.team).name
+		second_server = create_test_server(team=self.team).name
+		group = create_test_release_group([app], user=user, servers=[first_server, second_server])
+
+		create_test_site(bench=create_test_bench(group=group, server=first_server).name, team=self.team)
+		for _ in range(2):
+			create_test_site(bench=create_test_bench(group=group, server=second_server).name, team=self.team)
+
+		frappe.set_user(user)
+		before_request()
+
+		def counts_on(server):
+			[fetched] = get_list("Release Group", fields=["name"], filters={"server": server})
+			return fetched.active_benches, fetched.site_count
+
+		self.assertEqual(counts_on(first_server), (1, 1))
+		self.assertEqual(counts_on(second_server), (2, 2))

--- a/press/press/doctype/release_group/test_release_group.py
+++ b/press/press/doctype/release_group/test_release_group.py
@@ -667,6 +667,10 @@ class TestReleaseGroup(FrappeTestCase):
 		test_release_group.check_app_server_storage()
 
 	@patch.object(AgentJob, "enqueue_http_request", new=Mock())
+	# The second bench of a group makes the storage precheck ask the agent for the size of
+	# the last deployed image. Nothing is really deployed here, so skip the precheck rather
+	# than fake a size for it.
+	@patch.object(ReleaseGroup, "check_app_server_storage", new=Mock())
 	def test_counts_of_a_group_on_two_servers_are_scoped_to_the_filtered_server(self):
 		"""A group runs on two servers. Each server card must count only its own benches and sites."""
 		from press.press.doctype.server.test_server import create_test_server


### PR DESCRIPTION
## Problem

On the Servers page, a bench group deployed on two servers rendered the **same** site list under both server cards. A user with the group `Express` on a Frankfurt server and on a Johannesburg server saw all 7 sites under each — including sites whose bench container isn't on that server at all.

The site count badge and the Active / Awaiting Deploy badge had the same problem: both counted across the whole group, so both cards showed `7`.

## Cause

Two independent bugs, either of which alone would produce the duplication:

1. `BenchRow.vue` fetched sites with `filters: { group: <release group> }` and no server, so the query itself was server-agnostic.
2. Both cards used the cache key `['sitesRes', <release group>]`. Even with a correct query, the second card would have been served the first card's rows.

On the backend, `ReleaseGroup.get_list_query` applied the `server` filter to the row itself (an inner join on `Release Group Server`) but not to the `site_count` and `active_benches` subqueries, which stayed group-wide.

## Fix

- Filter the site list on `server` too, and put the server in the cache key.
- Scope the `site_count` and `active_benches` subqueries to the server when the list is filtered by one, extracted into `site_count_query()` / `active_bench_count_query()`. Callers that pass no server — the Benches list page — are unaffected.

This also corrects the Sites column on the server detail page's Benches tab, which filters by server the same way.

## Test

`test_counts_of_a_group_on_two_servers_are_scoped_to_the_filtered_server` puts one bench and site on server A and two on server B, then asserts the group comes back as `(1, 1)` for A and `(2, 2)` for B.

## Not in this PR

`AddSiteDialog.vue` doesn't pin a server — it sends only `group`, `cluster` and `domain`, and `Site.set_latest_bench()` overwrites `self.server` with whichever bench it picks. A site added from the row under server A can therefore land on server B, and with this change it will show up under B's row. That's a site-placement question rather than a display one, so it deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)