### PR TITLE
fix(dashboard): Create the site on the server whose row was clicked

### DIFF
--- a/dashboard/src/pages/benches/list/BenchRow.vue
+++ b/dashboard/src/pages/benches/list/BenchRow.vue
@@ -2,16 +2,24 @@
 import {
 	Badge,
 	Button,
+	createDocumentResource,
+	createListResource,
 	Dropdown,
 	Spinner,
 	Tooltip,
-	createListResource,
-	createDocumentResource,
 } from 'frappe-ui'
-import { h, ref, computed, defineAsyncComponent, onBeforeUnmount, watch, reactive } from 'vue'
+import {
+	computed,
+	defineAsyncComponent,
+	h,
+	onBeforeUnmount,
+	reactive,
+	ref,
+	watch,
+} from 'vue'
 import Collapsable from '@/components/common/Collapsable.vue'
-import { renderDialog } from '@/utils/components'
 import { dropBench } from '@/pages/servers/list/utils'
+import { renderDialog } from '@/utils/components'
 import { getSiteStatusBadge } from '@/utils/site'
 
 interface Props {
@@ -47,7 +55,6 @@ function onToggle(toggle: () => void) {
 	toggle()
 	if (!sites.data && props.data.site_count) sites.reload()
 }
-
 
 const pipelineId = ref<string | null>(null)
 const pipelineRes = ref<any>(null)
@@ -110,7 +117,6 @@ onBeforeUnmount(() => {
 	wiredSites.forEach((name) => socket.emit('doc_unsubscribe', 'Site', name))
 })
 
-
 const transientStatuses = ['Pending', 'Installing', 'Updating', 'Recovering']
 const wiredSites = reactive(new Set<string>())
 
@@ -124,7 +130,10 @@ watch(
 	() => sites.data,
 	(data) => {
 		data?.forEach((site: any) => {
-			if (transientStatuses.includes(site.status) && !wiredSites.has(site.name)) {
+			if (
+				transientStatuses.includes(site.status) &&
+				!wiredSites.has(site.name)
+			) {
 				socket.emit('doc_subscribe', 'Site', site.name)
 				wiredSites.add(site.name)
 			}
@@ -132,7 +141,6 @@ watch(
 	},
 	{ immediate: true },
 )
-
 
 function openDeployDialog(e: Event) {
 	e.stopPropagation()
@@ -157,7 +165,18 @@ function openAddSiteDialog() {
 	const AddSiteDialog = defineAsyncComponent(
 		() => import('@/pages/servers/list/AddSiteDialog.vue'),
 	)
-	renderDialog(h(AddSiteDialog, { bench: props.data, onSiteCreated: () => sites.reload() }))
+	const server = {
+		name: props.data.server,
+		title: props.data.server_title,
+		provider: props.data.server_provider,
+	}
+	renderDialog(
+		h(AddSiteDialog, {
+			bench: props.data,
+			server,
+			onSiteCreated: () => sites.reload(),
+		}),
+	)
 }
 
 const groupOptions = [
@@ -169,7 +188,10 @@ const groupOptions = [
 	{ label: 'App Marketplace', route: '/apps', icon: LucideStore },
 	{
 		label: 'Bench Actions',
-		route: { name: 'Release Group Detail Actions', params: { name: props.data.name } },
+		route: {
+			name: 'Release Group Detail Actions',
+			params: { name: props.data.name },
+		},
 		icon: LucideSlidersVertical,
 	},
 	{
@@ -188,7 +210,6 @@ const siteOptions = (site: any) => [
 		icon: LucideSlidersVertical,
 	},
 ]
-
 </script>
 
 <template>
@@ -216,7 +237,9 @@ const siteOptions = (site: any) => [
 						</router-link>
 					</Tooltip>
 					<Tooltip :text="`${data.site_count || 0} sites`">
-						<span class="text-xs bg-surface-gray-2 text-ink-gray-6 rounded px-1.5 py-0.5 font-medium shrink-0">
+						<span
+							class="text-xs bg-surface-gray-2 text-ink-gray-6 rounded px-1.5 py-0.5 font-medium shrink-0"
+						>
 							{{ data.site_count || 0 }}
 						</span>
 					</Tooltip>
@@ -337,14 +360,19 @@ const siteOptions = (site: any) => [
 				</span>
 
 				<span class="text-ink-gray-6 text-sm flex gap-1.5 items-center min-w-0">
-					<img v-if="site.cluster_image" :src="site.cluster_image" class="size-3.5 shrink-0" />
-					<span class="truncate">{{ site.cluster_title }}{{ site.cluster_country ? `, ${site.cluster_country}` : '' }}</span>
+					<img
+						v-if="site.cluster_image"
+						:src="site.cluster_image"
+						class="size-3.5 shrink-0"
+					/>
+					<span class="truncate"
+						>{{ site.cluster_title }}
+						{{ site.cluster_country ? `, ${site.cluster_country}` : '' }}</span
+					>
 				</span>
 
 				<Dropdown :options="siteOptions(site)">
-					<Button variant="ghost">
-						<LucideEllipsis class="size-4" />
-					</Button>
+					<Button variant="ghost"> <LucideEllipsis class="size-4" /> </Button>
 				</Dropdown>
 			</div>
 
@@ -353,7 +381,11 @@ const siteOptions = (site: any) => [
 				class="px-2 py-2"
 				:class="!isLast ? 'border-b dark:border-outline-gray-2' : ''"
 			>
-				<Button variant="ghost" :loading="sites.list?.loading" @click="sites.next()">
+				<Button
+					variant="ghost"
+					:loading="sites.list?.loading"
+					@click="sites.next()"
+				>
 					Load more
 				</Button>
 			</div>
@@ -365,7 +397,11 @@ const siteOptions = (site: any) => [
 			:class="!isLast ? 'border-b dark:border-outline-gray-2' : ''"
 		>
 			<span />
-			<Button class="w-fit pl-3" variant="ghost" @click.stop="openAddSiteDialog">
+			<Button
+				class="w-fit pl-3"
+				variant="ghost"
+				@click.stop="openAddSiteDialog"
+			>
 				<template #prefix><LucidePlus class="size-4" /></template>
 				Add site
 			</Button>

--- a/dashboard/src/pages/benches/list/BenchRow.vue
+++ b/dashboard/src/pages/benches/list/BenchRow.vue
@@ -165,15 +165,12 @@ function openAddSiteDialog() {
 	const AddSiteDialog = defineAsyncComponent(
 		() => import('@/pages/servers/list/AddSiteDialog.vue'),
 	)
-	const server = {
-		name: props.data.server,
-		title: props.data.server_title,
-		provider: props.data.server_provider,
-	}
+	// No server: a row here is a group, which may be deployed on several, and
+	// `Release Group.dashboard_fields` doesn't carry one anyway. Without it the
+	// backend keeps picking the bench itself, as it did before.
 	renderDialog(
 		h(AddSiteDialog, {
 			bench: props.data,
-			server,
 			onSiteCreated: () => sites.reload(),
 		}),
 	)

--- a/dashboard/src/pages/servers/list/AddSiteDialog.vue
+++ b/dashboard/src/pages/servers/list/AddSiteDialog.vue
@@ -5,6 +5,7 @@ import router from '@/router'
 
 interface Props {
 	bench: any
+	server: any
 }
 
 const show = ref(true)
@@ -32,7 +33,6 @@ const installableApps = createResource({
 		siteOptions.value = {
 			domain: data.domain,
 			group: version?.group?.name,
-			cluster: version?.group?.clusters?.[0]?.name,
 		}
 		const sources = version?.group?.bench_app_sources || []
 		return sources
@@ -79,7 +79,8 @@ const submitForm = () => {
 			doctype: 'Site',
 			subdomain: subdomain.value,
 			apps: [{ app: 'frappe' }, ...addedApps.map((x: any) => ({ app: x.app }))],
-			cluster: siteOptions.value.cluster,
+			cluster: props.server.cluster,
+			server: props.server.name,
 			group: siteOptions.value.group,
 			domain: siteOptions.value.domain,
 		},

--- a/dashboard/src/pages/servers/list/AddSiteDialog.vue
+++ b/dashboard/src/pages/servers/list/AddSiteDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { ref, reactive, computed } from 'vue'
-import { Dialog, TextInput, Button, Checkbox, createResource } from 'frappe-ui'
+import { Button, Checkbox, createResource, Dialog, TextInput } from 'frappe-ui'
+import { computed, reactive, ref } from 'vue'
 import router from '@/router'
 
 interface Props {
@@ -17,7 +17,7 @@ const emit = defineEmits<{ siteCreated: [] }>()
 const formType = ref('addApps')
 
 const handleAppSelection = (cond: boolean, app: any) => {
-  if (cond && !addedApps.includes(app)) addedApps.push(app)
+	if (cond && !addedApps.includes(app)) addedApps.push(app)
 	else addedApps.splice(addedApps.indexOf(app), 1)
 }
 

--- a/dashboard/src/pages/servers/list/AddSiteDialog.vue
+++ b/dashboard/src/pages/servers/list/AddSiteDialog.vue
@@ -5,7 +5,7 @@ import router from '@/router'
 
 interface Props {
 	bench: any
-	server: any
+	server?: any
 }
 
 const show = ref(true)
@@ -33,6 +33,7 @@ const installableApps = createResource({
 		siteOptions.value = {
 			domain: data.domain,
 			group: version?.group?.name,
+			cluster: version?.group?.clusters?.[0]?.name,
 		}
 		const sources = version?.group?.bench_app_sources || []
 		return sources
@@ -79,8 +80,8 @@ const submitForm = () => {
 			doctype: 'Site',
 			subdomain: subdomain.value,
 			apps: [{ app: 'frappe' }, ...addedApps.map((x: any) => ({ app: x.app }))],
-			cluster: props.server.cluster,
-			server: props.server.name,
+			cluster: props.server?.cluster ?? siteOptions.value.cluster,
+			...(props.server?.name ? { server: props.server.name } : {}),
 			group: siteOptions.value.group,
 			domain: siteOptions.value.domain,
 		},

--- a/dashboard/src/pages/servers/list/AddSiteDialog.vue
+++ b/dashboard/src/pages/servers/list/AddSiteDialog.vue
@@ -65,6 +65,16 @@ const filteredApps = computed(() => {
 	)
 })
 
+// A server pins the site only together with its own cluster: `set_bench_for_server()`
+// picks the group's bench on that server and rejects a cluster that isn't that
+// bench's own. So take both from the caller or neither — pairing a server with
+// the group's first cluster is what sent sites to the wrong one.
+const placement = computed(() => {
+	const { name, cluster } = props.server ?? {}
+	if (name && cluster) return { server: name, cluster }
+	return { cluster: siteOptions.value.cluster }
+})
+
 const newSite = createResource({
 	url: 'press.api.client.insert',
 	onSuccess(site: any) {
@@ -80,8 +90,7 @@ const submitForm = () => {
 			doctype: 'Site',
 			subdomain: subdomain.value,
 			apps: [{ app: 'frappe' }, ...addedApps.map((x: any) => ({ app: x.app }))],
-			cluster: props.server?.cluster ?? siteOptions.value.cluster,
-			...(props.server?.name ? { server: props.server.name } : {}),
+			...placement.value,
 			group: siteOptions.value.group,
 			domain: siteOptions.value.domain,
 		},

--- a/dashboard/src/pages/servers/list/BenchRow.vue
+++ b/dashboard/src/pages/servers/list/BenchRow.vue
@@ -127,7 +127,13 @@ const addSite = (e, bench) => {
 	const AddSiteDialog = defineAsyncComponent(
 		() => import('./AddSiteDialog.vue'),
 	)
-	renderDialog(h(AddSiteDialog, { bench, onSiteCreated: () => sites.reload() }))
+	renderDialog(
+		h(AddSiteDialog, {
+			bench,
+			server: props.server,
+			onSiteCreated: () => sites.reload(),
+		}),
+	)
 }
 
 const benchOptions = (bench) => [

--- a/dashboard/src/pages/servers/list/BenchRow.vue
+++ b/dashboard/src/pages/servers/list/BenchRow.vue
@@ -2,28 +2,27 @@
 import {
 	Badge,
 	Button,
+	createDocumentResource,
+	createListResource,
 	Dropdown,
 	Spinner,
 	Tooltip,
-	createDocumentResource,
-	createListResource,
 } from 'frappe-ui'
-
-import { renderDialog } from '@/utils/components'
 import {
-	h,
-	ref,
-	defineAsyncComponent,
-	onBeforeUnmount,
 	computed,
+	defineAsyncComponent,
+	h,
+	onBeforeUnmount,
 	reactive,
+	ref,
 	watch,
 } from 'vue'
-import { dropBench } from './utils'
+import Collapsable from '@/components/common/Collapsable.vue'
+import { renderDialog } from '@/utils/components'
 
 import { dayjsLocal } from '@/utils/dayjs'
 import { getSiteStatusBadge } from '@/utils/site'
-import Collapsable from '@/components/common/Collapsable.vue'
+import { dropBench } from './utils'
 
 interface Props {
 	data: any
@@ -140,7 +139,10 @@ const benchOptions = (bench) => [
 	{ label: 'App Marketplace', route: '/apps', icon: LucideStore },
 	{
 		label: 'Bench Actions',
-		route: { name: 'Release Group Detail Actions', params: { name: bench.name } },
+		route: {
+			name: 'Release Group Detail Actions',
+			params: { name: bench.name },
+		},
 		icon: LucideSlidersVertical,
 	},
 	{


### PR DESCRIPTION
## Problem

On the Servers page, **Add Site** (the bench row's `···` menu, or the "Add site" button in an expanded empty row) doesn't say which server to create the site on. It sends only `subdomain`, `apps`, `cluster`, `group` and `domain`.

With no `server`, `Site.before_insert` takes the `set_latest_bench()` branch, which picks the newest active bench in the group whose cluster matches — `limit 1`, ordered by `in_primary_cluster` then `creation desc` — and then assigns `self.server = benches[0].server`. For a bench group deployed on one server that's always the row you clicked. For a group deployed on two, the site can land on the other one.

The `cluster` it sends is `version?.group?.clusters?.[0]?.name` — the group's *first* cluster. Same single-region assumption: right by luck when the group lives in one region, arbitrary otherwise.

## Fix

Pass the server the row belongs to (`BenchRow` already has it as a prop) into the dialog, and send it on the insert. `server` is already in `Site.dashboard_insert_fields`, so no backend change is needed — `before_insert` routes to `set_bench_for_server()`, which picks the active bench of that group on that server and throws a clear message if there isn't one.

Also send that server's cluster rather than `clusters[0]`. `Bench.cluster` is `fetch_from: server.cluster`, so the `self.cluster != bench.cluster` check in `set_bench_for_server()` now holds by construction instead of tripping whenever the guess named the wrong region.

## Relation to #7355

#7355 makes each server card list only its own sites. It doesn't change where a new site goes — but it does make this bug visible, because a site created from server A's row and placed on server B now appears under B. The two are independent and can merge in either order; both touch `BenchRow.vue`, so the second will want a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)