### PR TITLE
fix(server): Search the servers list by name as well as title

### DIFF
--- a/dashboard/src/pages/servers/list/Page.vue
+++ b/dashboard/src/pages/servers/list/Page.vue
@@ -91,7 +91,7 @@ const toggleSort = () => {
 		<TextInput
 			placeholder="Search server"
 			:debounce="500"
-			@update:modelValue="v => applyFilters('title', ['like', `%${v.toLowerCase()}%`])"
+			@update:modelValue="v => applyFilters('_search', v || undefined)"
 		>
 			<template #prefix>
 				<lucide-search class="size-4 text-ink-gray-5" />

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -132,6 +132,14 @@ class BaseServer(Document, TagHelpers):
 	def get_list_query(query, filters=None, **list_args):
 		Server = frappe.qb.DocType("Server")
 
+		# not a real field, so validate_filters strips it before it reaches the
+		# base query; the dashboard labels a server with its title but a server is
+		# addressed by its name (the hostname), so search both
+		search_term = filters.get("_search")
+		if search_term:
+			like_term = f"%{search_term}%"
+			query = query.where(Server.name.like(like_term) | Server.title.like(like_term))
+
 		status = filters.get("status")
 		if status == "Archived":
 			query = query.where(Server.status == status)

--- a/press/press/doctype/server/test_server.py
+++ b/press/press/doctype/server/test_server.py
@@ -14,6 +14,8 @@ from frappe.tests.utils import FrappeTestCase
 from moto import mock_aws
 
 from press.agent import Agent
+from press.api.client import get_list
+from press.overrides import before_request
 from press.press.doctype.app.test_app import create_test_app
 from press.press.doctype.database_server.test_database_server import (
 	create_test_database_server,
@@ -30,7 +32,7 @@ from press.press.doctype.server.server import (
 )
 from press.press.doctype.server_plan.test_server_plan import create_test_server_plan
 from press.press.doctype.site.test_site import create_test_bench
-from press.press.doctype.team.test_team import create_test_team
+from press.press.doctype.team.test_team import create_test_press_admin_team, create_test_team
 from press.press.doctype.virtual_machine.test_virtual_machine import create_test_virtual_machine
 
 if typing.TYPE_CHECKING:
@@ -848,3 +850,38 @@ class TestSSHCommand(FrappeTestCase):
 			server.get_ssh_command(),
 			f"ssh frappe@fc.dev -t 'ssh -J root@{proxy_server.name} ubuntu@{server.name} -p 2222'",
 		)
+
+
+@patch.object(BaseServer, "after_insert", new=Mock())
+class TestServerListSearch(FrappeTestCase):
+	"""The servers list must find a server by either of the labels it shows: title or name."""
+
+	def setUp(self):
+		self.team = create_test_press_admin_team()
+		self.server = create_test_server(team=self.team.name)
+		self.server.db_set("title", "Navi Mumbai Production")
+		self.other_server = create_test_server(team=self.team.name)
+		self.other_server.db_set("title", "Frankfurt Production")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.rollback()
+
+	def search(self, term: str) -> list[str]:
+		frappe.set_user(self.team.user)
+		before_request()  # puts the request-scoped team in place
+		return [row.name for row in get_list("Server", fields=["name"], filters={"_search": term})]
+
+	def test_part_of_the_title_finds_only_that_server(self):
+		self.assertEqual(self.search("navi mumbai"), [self.server.name])
+
+	def test_part_of_the_name_finds_only_that_server(self):
+		hostname = self.server.name.split(".")[0]
+
+		self.assertEqual(self.search(hostname), [self.server.name])
+
+	def test_a_server_without_a_title_is_still_found_by_its_name(self):
+		self.server.db_set("title", None)
+		hostname = self.server.name.split(".")[0]
+
+		self.assertEqual(self.search(hostname), [self.server.name])


### PR DESCRIPTION
Fixes #7282

## Problem

The search box on the servers list searched only the `title` field. A search for a server name, for example `f78-navi-mumbai.frappe.cloud`, found nothing. A server with no title was not possible to find at all, although the list shows the name of that server.

## Change

The search now matches the name or the title of the server. The dashboard labels a server with its title, but it addresses the server by its name. Thus a user can search for either one.

The dashboard sends the term as the virtual `_search` filter. `Server.get_list_query` reads that filter and adds one `LIKE` condition on the name and one on the title. Site already uses the same `_search` filter, so this makes the two lists behave in the same way.

The alternative was to add `or_filters` to `press.api.client.get_list`. That API validates plain filters only. One OR condition does not justify a change to the shared list API.

## Tests

`TestServerListSearch` in `press/press/doctype/server/test_server.py` has three new tests:

- part of the title finds only that server
- part of the name finds only that server
- a server with no title is still possible to find by its name

All three tests fail before the change and pass after it. The full `test_server` module passes: 44 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)