### PR TITLE
fix(patch): Print each site that loses its rate limit

### DIFF
--- a/press/patches/v0_8_0/unset_rate_limit_for_dedicated_server_sites.py
+++ b/press/patches/v0_8_0/unset_rate_limit_for_dedicated_server_sites.py
@@ -20,8 +20,9 @@ def execute():
 		try:
 			Site("Site", site.name).update_site_config({"rate_limit": {}})
 			frappe.db.commit()
-			print(f"Reset rate limit: {site.name}")
 		except Exception:
 			# one unreachable bench must not stop the migration
 			frappe.db.rollback()
 			log_error("Dedicated Site Rate Limit Patch Failure", site=site.name)
+		else:
+			print(f"Reset rate limit: {site.name}")

--- a/press/patches/v0_8_0/unset_rate_limit_for_dedicated_server_sites.py
+++ b/press/patches/v0_8_0/unset_rate_limit_for_dedicated_server_sites.py
@@ -20,6 +20,7 @@ def execute():
 		try:
 			Site("Site", site.name).update_site_config({"rate_limit": {}})
 			frappe.db.commit()
+			print(f"Reset rate limit: {site.name}")
 		except Exception:
 			# one unreachable bench must not stop the migration
 			frappe.db.rollback()


### PR DESCRIPTION
## Problem

The patch from #7266 (`unset_rate_limit_for_dedicated_server_sites`) is silent on success. It writes `rate_limit: {}` to the config of every dedicated server site that still has a limit, but it prints nothing. Only a failure reaches the Error Log. After `bench migrate` there is no record of which sites were changed.

## Change

Print the site name after each successful `update_site_config`.

```python
Site("Site", site.name).update_site_config({"rate_limit": {}})
frappe.db.commit()
print(f"Reset rate limit: {site.name}")
```

The list goes to the migrate output, where the operator can keep it.

## Tests

No test. A print in a one-time patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgK9aEMszRenm6KADXm1Fn