### PR TITLE
feat(audit): Find sites with outdated framework in n days

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -211,6 +211,7 @@ scheduler_events = {
 	"daily": [
 		"press.experimental.doctype.referral_bonus.referral_bonus.credit_referral_bonuses",
 		"press.press.doctype.log_counter.log_counter.record_counts",
+		"press.press.doctype.site_version_audit.site_version_audit.record_audit",
 		"press.press.doctype.incident.incident.notify_ignored_servers",
 		"press.press.doctype.database_server.database_server.unindex_mariadb_binlogs",
 		"press.press.doctype.database_server.database_server.remove_uploaded_binlogs_from_disk",
@@ -509,7 +510,7 @@ __persistent_cache_keys = [
 	"press-auth-logs",
 	"rl:*",
 	"press_otp:*",
-	"press_otp_sent:*"
+	"press_otp_sent:*",
 ]
 
 # `frappe.rename_doc` erases all caches, this hook preserves some of them.

--- a/press/patches.txt
+++ b/press/patches.txt
@@ -171,3 +171,4 @@ press.patches.v0_8_0.bump_v15_bench_version_to_5_31_0
 press.patches.v0_8_0.set_team_on_remote_file
 press.patches.v0_8_0.add_disk_full_alert_rule
 press.patches.v0_8_0.unset_rate_limit_for_dedicated_server_sites
+press.patches.v0_8_0.backfill_site_version_audits

--- a/press/patches/v0_8_0/backfill_site_version_audits.py
+++ b/press/patches/v0_8_0/backfill_site_version_audits.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+import frappe
+
+from press.press.doctype.site_version_audit.site_version_audit import (
+	count_sites_by_version_and_age_on,
+	save_audit,
+)
+
+MONTHS = 12
+
+
+def execute():
+	"""Seed the audit with a year of month ends, rewound from Site Update.
+
+	The daily job only starts recording from today, and the question the
+	audit answers -- is the stale tail shrinking -- needs history to be worth
+	anything. These rows are marked `backfilled` because they only count sites
+	that are still active, so they undercount the further back they go.
+	"""
+	frappe.reload_doc("press", "doctype", "site_version_audit")
+
+	for months_ago in range(MONTHS, 0, -1):
+		month_end = frappe.utils.get_last_day(frappe.utils.add_months(frappe.utils.today(), -months_ago))
+		save_audit(str(month_end), count_sites_by_version_and_age_on(month_end), backfilled=True)

--- a/press/press/doctype/site_version_audit/site_version_audit.json
+++ b/press/press/doctype/site_version_audit/site_version_audit.json
@@ -1,0 +1,93 @@
+{
+	"actions": [],
+	"creation": "2026-09-02 13:30:00.000000",
+	"doctype": "DocType",
+	"editable_grid": 1,
+	"engine": "InnoDB",
+	"field_order": [
+		"date",
+		"frappe_version",
+		"column_break_axmd",
+		"days_since_update",
+		"public_bench",
+		"section_break_pqvj",
+		"sites",
+		"backfilled"
+	],
+	"fields": [
+		{
+			"fieldname": "date",
+			"fieldtype": "Date",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Date",
+			"reqd": 1,
+			"search_index": 1
+		},
+		{
+			"description": "Stored as data, not a link, so history survives a Frappe Version being renamed or removed.",
+			"fieldname": "frappe_version",
+			"fieldtype": "Data",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Frappe Version",
+			"reqd": 1
+		},
+		{ "fieldname": "column_break_axmd", "fieldtype": "Column Break" },
+		{
+			"description": "Start of the 30 day band. 0 means the deployed frappe is under 30 days old, 360 means a year or older.",
+			"fieldname": "days_since_update",
+			"fieldtype": "Int",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Days Since Update"
+		},
+		{
+			"default": "0",
+			"fieldname": "public_bench",
+			"fieldtype": "Check",
+			"in_standard_filter": 1,
+			"label": "Public Bench"
+		},
+		{ "fieldname": "section_break_pqvj", "fieldtype": "Section Break" },
+		{
+			"fieldname": "sites",
+			"fieldtype": "Int",
+			"in_list_view": 1,
+			"label": "Sites"
+		},
+		{
+			"default": "0",
+			"description": "Reconstructed from Site Update history rather than observed. Only counts sites still active when the backfill ran, so it undercounts.",
+			"fieldname": "backfilled",
+			"fieldtype": "Check",
+			"in_standard_filter": 1,
+			"label": "Backfilled"
+		}
+	],
+	"index_web_pages_for_search": 1,
+	"links": [],
+	"modified": "2026-09-02 13:30:00.000000",
+	"modified_by": "Administrator",
+	"module": "Press",
+	"name": "Site Version Audit",
+	"owner": "Administrator",
+	"permissions": [
+		{
+			"create": 1,
+			"delete": 1,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "System Manager",
+			"share": 1,
+			"write": 1
+		}
+	],
+	"row_format": "Dynamic",
+	"sort_field": "date",
+	"sort_order": "DESC",
+	"states": []
+}

--- a/press/press/doctype/site_version_audit/site_version_audit.py
+++ b/press/press/doctype/site_version_audit/site_version_audit.py
@@ -181,6 +181,11 @@ def _earliest_move_after(month_end: str):
 	scheduled update is created days before it runs, and until it completes the
 	site is still on the source bench. Older rows predate `update_end`, so they
 	fall back to `creation`.
+
+	Grouped by site so that this returns one row per site whatever the data says.
+	Nothing in the database stops two moves for one site sharing a completion
+	time, and a second row here would join twice and count the site twice. Tied
+	rows describe one site at one instant, so they carry the same source bench.
 	"""
 	update = frappe.qb.DocType("Site Update")
 	completed_at = Coalesce(update.update_end, update.creation)
@@ -200,7 +205,8 @@ def _earliest_move_after(month_end: str):
 		)
 		.select(
 			move.site.as_("site"),
-			move.source_bench.as_("source_bench"),
-			move.group.as_("source_group"),
+			Min(move.source_bench).as_("source_bench"),
+			Min(move.group).as_("source_group"),
 		)
+		.groupby(move.site)
 	).as_("move")

--- a/press/press/doctype/site_version_audit/site_version_audit.py
+++ b/press/press/doctype/site_version_audit/site_version_audit.py
@@ -63,7 +63,8 @@ def count_sites_by_version_and_age() -> list[dict]:
 	"""Active sites grouped by version and by the age of their frappe release."""
 	site = frappe.qb.DocType("Site")
 	query = frappe.qb.from_(site).where(site.status == "Active")
-	return _count_by_version_and_age(query, site.bench, site.group, CurDate()).run(as_dict=True)
+	query, app_release = _join_running_release(query, site.bench)
+	return _count_by_version_and_age(query, app_release, site.group, CurDate()).run(as_dict=True)
 
 
 def count_sites_by_version_and_age_on(month_end: str) -> list[dict]:
@@ -85,20 +86,63 @@ def count_sites_by_version_and_age_on(month_end: str) -> list[dict]:
 		.on(move.site == site.name)
 		.where((site.status == "Active") & (site.creation <= month_end))
 	)
+	query, app_release = _join_built_release(query, Coalesce(move.source_bench, site.bench))
 	return _count_by_version_and_age(
-		query,
-		Coalesce(move.source_bench, site.bench),
-		Coalesce(move.source_group, site.group),
-		month_end,
+		query, app_release, Coalesce(move.source_group, site.group), month_end
 	).run(as_dict=True)
 
 
-def _count_by_version_and_age(query, bench, group, as_of):
-	"""Add the version and release lookups, and count sites per band."""
-	release_group = frappe.qb.DocType("Release Group")
-	frappe_version = frappe.qb.DocType("Frappe Version")
+def _join_running_release(query, bench):
+	"""The frappe release the bench runs right now, in place updates included."""
 	bench_app = frappe.qb.DocType("Bench App")
 	app_release = frappe.qb.DocType("App Release")
+	query = (
+		query.left_join(bench_app)
+		.on(
+			(bench_app.parent == bench)
+			& (bench_app.parenttype == "Bench")
+			& (bench_app.parentfield == "apps")
+			& (bench_app.app == "frappe")
+		)
+		.left_join(app_release)
+		.on(app_release.name == bench_app.release)
+	)
+	return query, app_release
+
+
+def _join_built_release(query, bench):
+	"""The frappe release the bench was built with.
+
+	`Bench App` is rewritten in place by an in place update, see
+	`Bench.update_apps_after_inplace_update`, so reading it for a past date
+	reports whatever the bench runs today. A Deploy Candidate is a build snapshot
+	and never changes, so it is the only stable answer for a past date. It misses
+	an in place update applied before that date, which leaves a backfilled row
+	reading older than the truth rather than newer.
+	"""
+	bench_table = frappe.qb.DocType("Bench")
+	candidate_app = frappe.qb.DocType("Deploy Candidate App")
+	app_release = frappe.qb.DocType("App Release")
+	query = (
+		query.left_join(bench_table)
+		.on(bench_table.name == bench)
+		.left_join(candidate_app)
+		.on(
+			(candidate_app.parent == bench_table.candidate)
+			& (candidate_app.parenttype == "Deploy Candidate")
+			& (candidate_app.parentfield == "apps")
+			& (candidate_app.app == "frappe")
+		)
+		.left_join(app_release)
+		.on(app_release.name == Coalesce(candidate_app.pullable_release, candidate_app.release))
+	)
+	return query, app_release
+
+
+def _count_by_version_and_age(query, app_release, group, as_of):
+	"""Add the version lookup and count sites per band."""
+	release_group = frappe.qb.DocType("Release Group")
+	frappe_version = frappe.qb.DocType("Frappe Version")
 
 	version = Coalesce(frappe_version.name, "Unknown")
 	band = _age_band(app_release, as_of)
@@ -109,15 +153,6 @@ def _count_by_version_and_age(query, bench, group, as_of):
 		.on(release_group.name == group)
 		.left_join(frappe_version)
 		.on(frappe_version.name == release_group.version)
-		.left_join(bench_app)
-		.on(
-			(bench_app.parent == bench)
-			& (bench_app.parenttype == "Bench")
-			& (bench_app.parentfield == "apps")
-			& (bench_app.app == "frappe")
-		)
-		.left_join(app_release)
-		.on(app_release.name == bench_app.release)
 		.select(
 			version.as_("frappe_version"),
 			band.as_("days_since_update"),
@@ -140,12 +175,19 @@ def _age_band(app_release, as_of):
 
 
 def _earliest_move_after(month_end: str):
-	"""Where each site sat before its first completed move after a date."""
+	"""Where each site sat before its first move to complete after a date.
+
+	Timed by `update_end`, when the status became final, not by `creation`. A
+	scheduled update is created days before it runs, and until it completes the
+	site is still on the source bench. Older rows predate `update_end`, so they
+	fall back to `creation`.
+	"""
 	update = frappe.qb.DocType("Site Update")
+	completed_at = Coalesce(update.update_end, update.creation)
 	first_move = (
 		frappe.qb.from_(update)
-		.select(update.site, Min(update.creation).as_("moved_at"))
-		.where(update.status.isin(COMPLETED_MOVES) & (update.creation > month_end))
+		.select(update.site, Min(completed_at).as_("moved_at"))
+		.where(update.status.isin(COMPLETED_MOVES) & (completed_at > month_end))
 		.groupby(update.site)
 	).as_("first_move")
 
@@ -153,7 +195,9 @@ def _earliest_move_after(month_end: str):
 	return (
 		frappe.qb.from_(first_move)
 		.inner_join(move)
-		.on((move.site == first_move.site) & (move.creation == first_move.moved_at))
+		.on(
+			(move.site == first_move.site) & (Coalesce(move.update_end, move.creation) == first_move.moved_at)
+		)
 		.select(
 			move.site.as_("site"),
 			move.source_bench.as_("source_bench"),

--- a/press/press/doctype/site_version_audit/site_version_audit.py
+++ b/press/press/doctype/site_version_audit/site_version_audit.py
@@ -185,7 +185,9 @@ def _earliest_move_after(month_end: str):
 	Nothing in the database stops two moves for one site sharing a completion
 	time, so the earliest one is picked by primary key. Aggregating the bench and
 	the group separately would let them come from different rows and place the
-	site on a bench and group pairing that never existed.
+	site on a bench and group pairing that never existed. The tie break repeats
+	the status filter, so that it ranges over the same rows the minimum was taken
+	over and a failed move cannot win it.
 	"""
 	update = frappe.qb.DocType("Site Update")
 	completed_at = Coalesce(update.update_end, update.creation)
@@ -201,7 +203,9 @@ def _earliest_move_after(month_end: str):
 		frappe.qb.from_(first_move)
 		.inner_join(tied)
 		.on(
-			(tied.site == first_move.site) & (Coalesce(tied.update_end, tied.creation) == first_move.moved_at)
+			(tied.site == first_move.site)
+			& tied.status.isin(COMPLETED_MOVES)
+			& (Coalesce(tied.update_end, tied.creation) == first_move.moved_at)
 		)
 		.select(tied.site.as_("site"), Min(tied.name).as_("move_name"))
 		.groupby(tied.site)

--- a/press/press/doctype/site_version_audit/site_version_audit.py
+++ b/press/press/doctype/site_version_audit/site_version_audit.py
@@ -178,11 +178,15 @@ def _age_band(app_release, as_of):
 def _earliest_move_after(month_end: str):
 	"""Where each site sat before its first move to complete after a date.
 
-	Timed by `update_end`, when the status became final, not by `creation`. A
-	scheduled update is created days before it runs, and until it completes the
-	site is still on the source bench. The few rows that predate `update_end`
-	fall back to `modified`, when the status was last written, rather than to
-	`creation`, which is only when the update was queued.
+	Timed by `update_end`, when the status became final, not by `creation`, which
+	is only when the update was queued: a scheduled update is created days before
+	it runs, and until it completes the site is still on the source bench.
+
+	The few rows that predate `update_end` fall back to `update_start`, which is
+	off by the length of the update and cannot move afterwards. `modified` is no
+	use here, being whenever the row was last written for any reason, and it has
+	already drifted past completion on every such row. A row with neither is
+	skipped, leaving the site where it sits now.
 
 	Ranked rather than aggregated, so the bench and the group always come from
 	one row and a site can only be counted once. Moves that share a completion
@@ -190,7 +194,7 @@ def _earliest_move_after(month_end: str):
 	not placed on a bench it had already left.
 	"""
 	update = frappe.qb.DocType("Site Update")
-	completed_at = Coalesce(update.update_end, update.modified)
+	completed_at = Coalesce(update.update_end, update.update_start)
 	ranked = (
 		frappe.qb.from_(update)
 		.select(

--- a/press/press/doctype/site_version_audit/site_version_audit.py
+++ b/press/press/doctype/site_version_audit/site_version_audit.py
@@ -182,10 +182,10 @@ def _earliest_move_after(month_end: str):
 	site is still on the source bench. Older rows predate `update_end`, so they
 	fall back to `creation`.
 
-	Grouped by site so that this returns one row per site whatever the data says.
 	Nothing in the database stops two moves for one site sharing a completion
-	time, and a second row here would join twice and count the site twice. Tied
-	rows describe one site at one instant, so they carry the same source bench.
+	time, so the earliest one is picked by primary key. Aggregating the bench and
+	the group separately would let them come from different rows and place the
+	site on a bench and group pairing that never existed.
 	"""
 	update = frappe.qb.DocType("Site Update")
 	completed_at = Coalesce(update.update_end, update.creation)
@@ -196,17 +196,25 @@ def _earliest_move_after(month_end: str):
 		.groupby(update.site)
 	).as_("first_move")
 
+	tied = frappe.qb.DocType("Site Update").as_("tied")
+	chosen_move = (
+		frappe.qb.from_(first_move)
+		.inner_join(tied)
+		.on(
+			(tied.site == first_move.site) & (Coalesce(tied.update_end, tied.creation) == first_move.moved_at)
+		)
+		.select(tied.site.as_("site"), Min(tied.name).as_("move_name"))
+		.groupby(tied.site)
+	).as_("chosen_move")
+
 	move = frappe.qb.DocType("Site Update").as_("move")
 	return (
-		frappe.qb.from_(first_move)
+		frappe.qb.from_(chosen_move)
 		.inner_join(move)
-		.on(
-			(move.site == first_move.site) & (Coalesce(move.update_end, move.creation) == first_move.moved_at)
-		)
+		.on(move.name == chosen_move.move_name)
 		.select(
 			move.site.as_("site"),
-			Min(move.source_bench).as_("source_bench"),
-			Min(move.group).as_("source_group"),
+			move.source_bench.as_("source_bench"),
+			move.group.as_("source_group"),
 		)
-		.groupby(move.site)
 	).as_("move")

--- a/press/press/doctype/site_version_audit/site_version_audit.py
+++ b/press/press/doctype/site_version_audit/site_version_audit.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+from __future__ import annotations
+
+import frappe
+from frappe.model.document import Document
+from frappe.query_builder import Case, CustomFunction
+from frappe.query_builder.functions import Coalesce, Count, CurDate, Floor, Min, Star
+
+BAND_DAYS = 30
+OLDEST_BAND_DAYS = 360
+COMPLETED_MOVES = ("Success", "Recovered")
+
+Least = CustomFunction("LEAST", ["value", "cap"])
+Greatest = CustomFunction("GREATEST", ["value", "floor"])
+# pypika ships the three argument SQL Server DATEDIFF, not the two argument one
+DateDiff = CustomFunction("DATEDIFF", ["end", "start"])
+
+
+class SiteVersionAudit(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		backfilled: DF.Check
+		date: DF.Date
+		days_since_update: DF.Int
+		frappe_version: DF.Data
+		public_bench: DF.Check
+		sites: DF.Int
+	# end: auto-generated types
+
+
+def record_audit():
+	"""Record how old the frappe running on each active site is today.
+
+	Press keeps no history of fleet state, so the only way to see whether the
+	stale tail is shrinking is to write down the distribution every day.
+	"""
+	save_audit(frappe.utils.today(), count_sites_by_version_and_age())
+	frappe.db.commit()
+
+
+def save_audit(date: str, counts: list[dict], backfilled: bool = False):
+	"""Replace the rows for a date, so a rerun cannot double count.
+
+	Does not commit. The caller owns the transaction, so a test can roll this
+	back instead of leaving its fixtures behind in the database.
+	"""
+	frappe.db.delete("Site Version Audit", {"date": date})
+	for row in counts:
+		frappe.get_doc(doctype="Site Version Audit", date=date, backfilled=backfilled, **row).insert(
+			ignore_permissions=True
+		)
+
+
+def count_sites_by_version_and_age() -> list[dict]:
+	"""Active sites grouped by version and by the age of their frappe release."""
+	site = frappe.qb.DocType("Site")
+	query = frappe.qb.from_(site).where(site.status == "Active")
+	return _count_by_version_and_age(query, site.bench, site.group, CurDate()).run(as_dict=True)
+
+
+def count_sites_by_version_and_age_on(month_end: str) -> list[dict]:
+	"""The same counts for a past date, rewound through Site Update.
+
+	A site's bench and group before a move are frozen on the Site Update row, and
+	those rows are never pruned, so the earliest move after `month_end` says where
+	the site was then. A site with no later move never moved, so it still sits
+	where it sits now.
+
+	This can only see sites that are still active, so it undercounts. Rows it
+	produces are marked `backfilled`.
+	"""
+	site = frappe.qb.DocType("Site")
+	move = _earliest_move_after(month_end)
+	query = (
+		frappe.qb.from_(site)
+		.left_join(move)
+		.on(move.site == site.name)
+		.where((site.status == "Active") & (site.creation <= month_end))
+	)
+	return _count_by_version_and_age(
+		query,
+		Coalesce(move.source_bench, site.bench),
+		Coalesce(move.source_group, site.group),
+		month_end,
+	).run(as_dict=True)
+
+
+def _count_by_version_and_age(query, bench, group, as_of):
+	"""Add the version and release lookups, and count sites per band."""
+	release_group = frappe.qb.DocType("Release Group")
+	frappe_version = frappe.qb.DocType("Frappe Version")
+	bench_app = frappe.qb.DocType("Bench App")
+	app_release = frappe.qb.DocType("App Release")
+
+	version = Coalesce(frappe_version.name, "Unknown")
+	band = _age_band(app_release, as_of)
+	public = Case().when(release_group.public | release_group.central_bench, 1).else_(0)
+
+	return (
+		query.left_join(release_group)
+		.on(release_group.name == group)
+		.left_join(frappe_version)
+		.on(frappe_version.name == release_group.version)
+		.left_join(bench_app)
+		.on(
+			(bench_app.parent == bench)
+			& (bench_app.parenttype == "Bench")
+			& (bench_app.parentfield == "apps")
+			& (bench_app.app == "frappe")
+		)
+		.left_join(app_release)
+		.on(app_release.name == bench_app.release)
+		.select(
+			version.as_("frappe_version"),
+			band.as_("days_since_update"),
+			public.as_("public_bench"),
+			Count(Star()).as_("sites"),
+		)
+		.groupby(version, band, public)
+	)
+
+
+def _age_band(app_release, as_of):
+	"""Age of the deployed release in 30 day bands, capped at a year.
+
+	`timestamp` is the commit time but is unset on most releases, so fall back to
+	`creation`, the time Press recorded the release.
+	"""
+	released_at = Coalesce(app_release.timestamp, app_release.creation)
+	age = Greatest(DateDiff(as_of, released_at), 0)
+	return Least(Floor(age / BAND_DAYS) * BAND_DAYS, OLDEST_BAND_DAYS)
+
+
+def _earliest_move_after(month_end: str):
+	"""Where each site sat before its first completed move after a date."""
+	update = frappe.qb.DocType("Site Update")
+	first_move = (
+		frappe.qb.from_(update)
+		.select(update.site, Min(update.creation).as_("moved_at"))
+		.where(update.status.isin(COMPLETED_MOVES) & (update.creation > month_end))
+		.groupby(update.site)
+	).as_("first_move")
+
+	move = frappe.qb.DocType("Site Update").as_("move")
+	return (
+		frappe.qb.from_(first_move)
+		.inner_join(move)
+		.on((move.site == first_move.site) & (move.creation == first_move.moved_at))
+		.select(
+			move.site.as_("site"),
+			move.source_bench.as_("source_bench"),
+			move.group.as_("source_group"),
+		)
+	).as_("move")

--- a/press/press/doctype/site_version_audit/site_version_audit.py
+++ b/press/press/doctype/site_version_audit/site_version_audit.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 import frappe
 from frappe.model.document import Document
 from frappe.query_builder import Case, CustomFunction
-from frappe.query_builder.functions import Coalesce, Count, CurDate, Floor, Min, Star
+from frappe.query_builder.functions import Coalesce, Count, CurDate, Floor, Star
+from pypika.analytics import RowNumber
 
 BAND_DAYS = 30
 OLDEST_BAND_DAYS = 360
@@ -179,46 +180,33 @@ def _earliest_move_after(month_end: str):
 
 	Timed by `update_end`, when the status became final, not by `creation`. A
 	scheduled update is created days before it runs, and until it completes the
-	site is still on the source bench. Older rows predate `update_end`, so they
-	fall back to `creation`.
+	site is still on the source bench. The few rows that predate `update_end`
+	fall back to `modified`, when the status was last written, rather than to
+	`creation`, which is only when the update was queued.
 
-	Nothing in the database stops two moves for one site sharing a completion
-	time, so the earliest one is picked by primary key. Aggregating the bench and
-	the group separately would let them come from different rows and place the
-	site on a bench and group pairing that never existed. The tie break repeats
-	the status filter, so that it ranges over the same rows the minimum was taken
-	over and a failed move cannot win it.
+	Ranked rather than aggregated, so the bench and the group always come from
+	one row and a site can only be counted once. Moves that share a completion
+	time are ordered by creation, so the first of a chain wins and the site is
+	not placed on a bench it had already left.
 	"""
 	update = frappe.qb.DocType("Site Update")
-	completed_at = Coalesce(update.update_end, update.creation)
-	first_move = (
+	completed_at = Coalesce(update.update_end, update.modified)
+	ranked = (
 		frappe.qb.from_(update)
-		.select(update.site, Min(completed_at).as_("moved_at"))
-		.where(update.status.isin(COMPLETED_MOVES) & (completed_at > month_end))
-		.groupby(update.site)
-	).as_("first_move")
-
-	tied = frappe.qb.DocType("Site Update").as_("tied")
-	chosen_move = (
-		frappe.qb.from_(first_move)
-		.inner_join(tied)
-		.on(
-			(tied.site == first_move.site)
-			& tied.status.isin(COMPLETED_MOVES)
-			& (Coalesce(tied.update_end, tied.creation) == first_move.moved_at)
-		)
-		.select(tied.site.as_("site"), Min(tied.name).as_("move_name"))
-		.groupby(tied.site)
-	).as_("chosen_move")
-
-	move = frappe.qb.DocType("Site Update").as_("move")
-	return (
-		frappe.qb.from_(chosen_move)
-		.inner_join(move)
-		.on(move.name == chosen_move.move_name)
 		.select(
-			move.site.as_("site"),
-			move.source_bench.as_("source_bench"),
-			move.group.as_("source_group"),
+			update.site.as_("site"),
+			update.source_bench.as_("source_bench"),
+			update.group.as_("source_group"),
+			RowNumber()
+			.over(update.site)
+			.orderby(completed_at, update.creation, update.name)
+			.as_("move_rank"),
 		)
+		.where(update.status.isin(COMPLETED_MOVES) & (completed_at > month_end))
+	).as_("ranked_move")
+
+	return (
+		frappe.qb.from_(ranked)
+		.select(ranked.site, ranked.source_bench, ranked.source_group)
+		.where(ranked.move_rank == 1)
 	).as_("move")

--- a/press/press/doctype/site_version_audit/test_site_version_audit.py
+++ b/press/press/doctype/site_version_audit/test_site_version_audit.py
@@ -212,6 +212,35 @@ class TestSiteVersionAudit(FrappeTestCase):
 
 		self.assertEqual(observed, {(version, 360)})
 
+	def test_audit_ignores_a_legacy_move_that_completed_before_the_date(self):
+		"""A row with no update_end whose modified drifted past its completion."""
+		old_bench, new_bench = self.two_benches_on_their_own_versions()
+		site = create_test_site(bench=new_bench.name)
+		self.backdate_site(Site("Site", site.name), days=60)
+		month_end = frappe.utils.add_days(frappe.utils.today(), -30)
+
+		move = self.tied_move(site.name, old_bench.name, old_bench.group, month_end)
+		frappe.db.set_value(
+			"Site Update",
+			move,
+			{
+				"update_end": None,
+				"update_start": frappe.utils.add_days(month_end, -5),
+				"modified": frappe.utils.add_days(month_end, 5),
+			},
+			update_modified=False,
+		)
+
+		# the move finished before the date, so the site had already left old_bench
+		version = frappe.db.get_value("Release Group", new_bench.group, "version")
+		observed = {
+			(row.frappe_version, row.days_since_update)
+			for row in count_sites_by_version_and_age_on(month_end)
+			if row.frappe_version.startswith("Version 9")
+		}
+
+		self.assertEqual(observed, {(version, 0)})
+
 	def place_move(self, move: str, bench, created_on):
 		frappe.db.set_value(
 			"Site Update",

--- a/press/press/doctype/site_version_audit/test_site_version_audit.py
+++ b/press/press/doctype/site_version_audit/test_site_version_audit.py
@@ -187,6 +187,38 @@ class TestSiteVersionAudit(FrappeTestCase):
 
 		self.assertEqual(observed, {(version, 360)})
 
+	def test_audit_takes_the_first_of_two_moves_that_share_a_completion_time(self):
+		"""Two moves in a chain: the site sat on the first one's source, not the second's."""
+		left_bench, intermediate = self.two_benches_on_their_own_versions()
+		site = create_test_site(bench=left_bench.name)
+		self.backdate_site(Site("Site", site.name), days=60)
+		month_end = frappe.utils.add_days(frappe.utils.today(), -30)
+
+		moves = [
+			self.tied_move(site.name, left_bench.name, left_bench.group, month_end),
+			self.tied_move(site.name, intermediate.name, intermediate.group, month_end),
+		]
+		# the later move has to sort first by name, or name ordering hides the bug
+		later, earlier = sorted(moves)
+		self.place_move(earlier, left_bench, created_on=frappe.utils.add_days(month_end, -10))
+		self.place_move(later, intermediate, created_on=frappe.utils.add_days(month_end, -5))
+
+		version = frappe.db.get_value("Release Group", left_bench.group, "version")
+		observed = {
+			(row.frappe_version, row.days_since_update)
+			for row in count_sites_by_version_and_age_on(month_end)
+			if row.frappe_version.startswith("Version 9")
+		}
+
+		self.assertEqual(observed, {(version, 360)})
+
+	def place_move(self, move: str, bench, created_on):
+		frappe.db.set_value(
+			"Site Update",
+			move,
+			{"source_bench": bench.name, "group": bench.group, "creation": created_on},
+		)
+
 	def two_benches_on_their_own_versions(self):
 		"""Benches on versions no other site uses, so the counts stay isolated."""
 		benches = []

--- a/press/press/doctype/site_version_audit/test_site_version_audit.py
+++ b/press/press/doctype/site_version_audit/test_site_version_audit.py
@@ -127,6 +127,83 @@ class TestSiteVersionAudit(FrappeTestCase):
 		after = sum(row.sites for row in count_sites_by_version_and_age_on(month_end))
 		self.assertEqual(before, after)
 
+	def test_audit_takes_the_bench_and_group_of_one_move_when_two_are_tied(self):
+		"""Tied moves must not have their bench taken from one and group from another."""
+		old_bench, new_bench = self.two_benches_on_their_own_versions()
+		site = create_test_site(bench=old_bench.name)
+		self.backdate_site(Site("Site", site.name), days=60)
+		month_end = frappe.utils.add_days(frappe.utils.today(), -30)
+
+		# cross the orderings, so an aggregate per field draws from both rows
+		benches = sorted([old_bench.name, new_bench.name])
+		groups = sorted([old_bench.group, new_bench.group])
+		self.tied_move(site.name, benches[0], groups[1], month_end)
+		self.tied_move(site.name, benches[1], groups[0], month_end)
+
+		bands = {b.name: 360 if b is old_bench else 0 for b in (old_bench, new_bench)}
+		versions = {
+			b.group: frappe.db.get_value("Release Group", b.group, "version") for b in (old_bench, new_bench)
+		}
+		valid = {(versions[groups[1]], bands[benches[0]]), (versions[groups[0]], bands[benches[1]])}
+		observed = {
+			(row.frappe_version, row.days_since_update)
+			for row in count_sites_by_version_and_age_on(month_end)
+			if row.frappe_version in versions.values()
+		}
+
+		self.assertEqual(len(observed), 1)
+		self.assertTrue(observed <= valid, f"{observed} is not one of {valid}")
+
+	def two_benches_on_their_own_versions(self):
+		"""Benches on versions no other site uses, so the counts stay isolated."""
+		benches = []
+		for number, released_days_ago in ((98, 400), (99, 3)):
+			frappe.get_doc(
+				doctype="Frappe Version", name=f"Version {number}", number=number, status="Stable"
+			).insert(ignore_if_duplicate=True)
+			group = create_test_release_group([create_test_app()], frappe_version=f"Version {number}")
+			bench = create_test_bench(group=group)
+			self.age_the_built_release(bench, released_days_ago)
+			benches.append(bench)
+
+		self.assertNotEqual(
+			self.built_release(benches[0]),
+			self.built_release(benches[1]),
+			"the two benches must not share a release, or ageing one ages both",
+		)
+		return benches
+
+	def built_release(self, bench) -> str:
+		"""The frappe release the audit reads for a past date, via the candidate."""
+		candidate = frappe.db.get_value("Bench", bench.name, "candidate")
+		app = frappe.db.get_value(
+			"Deploy Candidate App",
+			{"parent": candidate, "app": "frappe"},
+			["pullable_release", "release"],
+			as_dict=True,
+		)
+		return app.pullable_release or app.release
+
+	def age_the_built_release(self, bench, days: int):
+		"""The age is read from `timestamp` first, so both fields have to move."""
+		released_at = frappe.utils.add_days(frappe.utils.now_datetime(), -days)
+		frappe.db.set_value(
+			"App Release", self.built_release(bench), {"timestamp": released_at, "creation": released_at}
+		)
+
+	def tied_move(self, site: str, source_bench: str, group: str, month_end: str):
+		"""A completed move sharing its completion time with the others."""
+		update = create_test_site_update(site, group, "Success", ignore_validate=True)
+		frappe.db.set_value(
+			"Site Update",
+			update.name,
+			{
+				"source_bench": source_bench,
+				"group": group,
+				"update_end": frappe.utils.add_days(month_end, 5),
+			},
+		)
+
 	def backdate_site(self, site: Site, days: int):
 		"""The audit skips a site that did not exist yet on the date asked about."""
 		frappe.db.set_value(

--- a/press/press/doctype/site_version_audit/test_site_version_audit.py
+++ b/press/press/doctype/site_version_audit/test_site_version_audit.py
@@ -113,6 +113,20 @@ class TestSiteVersionAudit(FrappeTestCase):
 
 		self.assertIn(360, bands)
 
+	def test_audit_counts_a_site_once_when_two_moves_share_a_completion_time(self):
+		"""Nothing stops two moves sharing update_end, and a tie must not double count."""
+		site = self.create_site_with_frappe_released_days_ago(400)
+		self.backdate_site(site, days=60)
+		month_end = frappe.utils.add_days(frappe.utils.today(), -30)
+		completed_on = frappe.utils.add_days(month_end, 5)
+		self.move_site_to_a_fresh_bench(site, 3, completed_on=completed_on)
+		before = sum(row.sites for row in count_sites_by_version_and_age_on(month_end))
+
+		self.move_site_to_a_fresh_bench(site, 3, completed_on=completed_on)
+
+		after = sum(row.sites for row in count_sites_by_version_and_age_on(month_end))
+		self.assertEqual(before, after)
+
 	def backdate_site(self, site: Site, days: int):
 		"""The audit skips a site that did not exist yet on the date asked about."""
 		frappe.db.set_value(

--- a/press/press/doctype/site_version_audit/test_site_version_audit.py
+++ b/press/press/doctype/site_version_audit/test_site_version_audit.py
@@ -9,6 +9,7 @@ from frappe.tests.utils import FrappeTestCase
 
 from press.press.doctype.agent_job.agent_job import AgentJob
 from press.press.doctype.app.test_app import create_test_app
+from press.press.doctype.app_release.test_app_release import create_test_app_release
 from press.press.doctype.release_group.test_release_group import create_test_release_group
 from press.press.doctype.site.site import Site
 from press.press.doctype.site.test_site import create_test_bench, create_test_site
@@ -85,7 +86,53 @@ class TestSiteVersionAudit(FrappeTestCase):
 
 		self.assertEqual(sum(row.sites for row in counts), 0)
 
-	def move_site_to_a_fresh_bench(self, site: Site, frappe_released_days_ago: int):
+	def test_audit_for_a_past_date_ignores_an_in_place_update_made_since(self):
+		"""An in place update rewrites Bench App, so a past date must not read it."""
+		site = self.create_site_with_frappe_released_days_ago(400)
+		self.backdate_site(site, days=60)
+		self.update_bench_in_place(site)
+
+		month_end = frappe.utils.add_days(frappe.utils.today(), -30)
+
+		self.assertIn(0, self.bands_for(count_sites_by_version_and_age(), site))
+		self.assertIn(360, self.bands_for(count_sites_by_version_and_age_on(month_end), site))
+
+	def test_audit_for_a_past_date_uses_the_bench_a_move_had_not_yet_left(self):
+		"""A move created before the date but completed after had not happened yet."""
+		site = self.create_site_with_frappe_released_days_ago(400)
+		self.backdate_site(site, days=60)
+		month_end = frappe.utils.add_days(frappe.utils.today(), -30)
+		self.move_site_to_a_fresh_bench(
+			site,
+			frappe_released_days_ago=3,
+			created_on=frappe.utils.add_days(month_end, -5),
+			completed_on=frappe.utils.add_days(month_end, 5),
+		)
+
+		bands = self.bands_for(count_sites_by_version_and_age_on(month_end), site)
+
+		self.assertIn(360, bands)
+
+	def backdate_site(self, site: Site, days: int):
+		"""The audit skips a site that did not exist yet on the date asked about."""
+		frappe.db.set_value(
+			"Site", site.name, "creation", frappe.utils.add_days(frappe.utils.now_datetime(), -days)
+		)
+
+	def update_bench_in_place(self, site: Site):
+		"""Point Bench App at a release built today, leaving the candidate alone."""
+		bench_app = {"parent": site.bench, "app": "frappe"}
+		source = frappe.db.get_value("Bench App", bench_app, "source")
+		fresh = create_test_app_release(frappe.get_doc("App Source", source))
+		frappe.db.set_value("Bench App", bench_app, "release", fresh.name)
+
+	def move_site_to_a_fresh_bench(
+		self,
+		site: Site,
+		frappe_released_days_ago: int,
+		created_on=None,
+		completed_on=None,
+	):
 		"""Record a completed move, which freezes the bench the site came from."""
 		group = frappe.db.get_value("Site", site.name, "group")
 		destination = create_test_bench(group=frappe.get_doc("Release Group", group))
@@ -96,7 +143,12 @@ class TestSiteVersionAudit(FrappeTestCase):
 			"creation",
 			frappe.utils.add_days(frappe.utils.now_datetime(), -frappe_released_days_ago),
 		)
-		create_test_site_update(site.name, group, "Success", ignore_validate=True)
+		update = create_test_site_update(site.name, group, "Success", ignore_validate=True)
+		if created_on:
+			frappe.db.set_value("Site Update", update.name, "creation", created_on)
+		frappe.db.set_value(
+			"Site Update", update.name, "update_end", completed_on or frappe.utils.now_datetime()
+		)
 		frappe.db.set_value("Site", site.name, "bench", destination.name)
 
 	def create_site_with_frappe_released_days_ago(self, days: int, clear_commit_time: bool = False):

--- a/press/press/doctype/site_version_audit/test_site_version_audit.py
+++ b/press/press/doctype/site_version_audit/test_site_version_audit.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026, Frappe and Contributors
+# See license.txt
+from __future__ import annotations
+
+from unittest.mock import MagicMock, Mock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from press.press.doctype.agent_job.agent_job import AgentJob
+from press.press.doctype.app.test_app import create_test_app
+from press.press.doctype.release_group.test_release_group import create_test_release_group
+from press.press.doctype.site.site import Site
+from press.press.doctype.site.test_site import create_test_bench, create_test_site
+from press.press.doctype.site_update.test_site_update import create_test_site_update
+from press.press.doctype.site_version_audit.site_version_audit import (
+	count_sites_by_version_and_age,
+	count_sites_by_version_and_age_on,
+	record_audit,
+)
+
+
+@patch.object(AgentJob, "enqueue_http_request", new=Mock())
+@patch("press.press.doctype.site.site._change_dns_record", new=Mock())
+@patch(
+	"press.press.doctype.site_version_audit.site_version_audit.frappe.db.commit",
+	new=MagicMock,
+)
+class TestSiteVersionAudit(FrappeTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_audit_bands_a_site_by_the_age_of_its_frappe_release(self):
+		site = self.create_site_with_frappe_released_days_ago(95)
+
+		self.assertIn(90, self.bands_for(count_sites_by_version_and_age(), site))
+
+	def test_audit_bands_a_recently_released_site_at_zero(self):
+		site = self.create_site_with_frappe_released_days_ago(3)
+
+		self.assertIn(0, self.bands_for(count_sites_by_version_and_age(), site))
+
+	def test_audit_caps_the_oldest_band_at_a_year(self):
+		site = self.create_site_with_frappe_released_days_ago(900)
+
+		self.assertIn(360, self.bands_for(count_sites_by_version_and_age(), site))
+
+	def test_audit_falls_back_to_when_the_release_was_recorded(self):
+		site = self.create_site_with_frappe_released_days_ago(95, clear_commit_time=True)
+
+		self.assertIn(90, self.bands_for(count_sites_by_version_and_age(), site))
+
+	def test_record_audit_replaces_the_rows_for_the_day_instead_of_adding_to_them(self):
+		self.create_site_with_frappe_released_days_ago(95)
+
+		record_audit()
+		first = frappe.db.count("Site Version Audit", {"date": frappe.utils.today()})
+		record_audit()
+		second = frappe.db.count("Site Version Audit", {"date": frappe.utils.today()})
+
+		self.assertEqual(first, second)
+
+	def test_audit_for_a_past_date_uses_the_bench_the_site_was_on_then(self):
+		"""A site moved yesterday must be reported on its old bench for last month."""
+		site = self.create_site_with_frappe_released_days_ago(3)
+		old_bench = site.bench
+		# the site has to predate the month being asked about
+		frappe.db.set_value(
+			"Site", site.name, "creation", frappe.utils.add_days(frappe.utils.now_datetime(), -60)
+		)
+		self.move_site_to_a_fresh_bench(site, frappe_released_days_ago=400)
+
+		month_end = frappe.utils.add_days(frappe.utils.today(), -30)
+		bands = self.bands_for(count_sites_by_version_and_age_on(month_end), site)
+
+		self.assertNotEqual(site.reload().bench, old_bench)
+		self.assertIn(0, bands)
+
+	def test_audit_for_a_past_date_skips_sites_that_did_not_exist_yet(self):
+		self.create_site_with_frappe_released_days_ago(3)
+
+		before_any_site = frappe.utils.add_days(frappe.utils.today(), -3650)
+
+		counts = count_sites_by_version_and_age_on(before_any_site)
+
+		self.assertEqual(sum(row.sites for row in counts), 0)
+
+	def move_site_to_a_fresh_bench(self, site: Site, frappe_released_days_ago: int):
+		"""Record a completed move, which freezes the bench the site came from."""
+		group = frappe.db.get_value("Site", site.name, "group")
+		destination = create_test_bench(group=frappe.get_doc("Release Group", group))
+		release = frappe.db.get_value("Bench App", {"parent": destination.name, "app": "frappe"}, "release")
+		frappe.db.set_value(
+			"App Release",
+			release,
+			"creation",
+			frappe.utils.add_days(frappe.utils.now_datetime(), -frappe_released_days_ago),
+		)
+		create_test_site_update(site.name, group, "Success", ignore_validate=True)
+		frappe.db.set_value("Site", site.name, "bench", destination.name)
+
+	def create_site_with_frappe_released_days_ago(self, days: int, clear_commit_time: bool = False):
+		group = create_test_release_group([create_test_app()], frappe_version="Version 15")
+		bench = create_test_bench(group=group)
+		site = create_test_site(bench=bench.name)
+		release = frappe.db.get_value("Bench App", {"parent": bench.name, "app": "frappe"}, "release")
+		released_at = frappe.utils.add_days(frappe.utils.now_datetime(), -days)
+		frappe.db.set_value("App Release", release, "timestamp", None if clear_commit_time else released_at)
+		frappe.db.set_value("App Release", release, "creation", released_at)
+		return Site("Site", site.name)
+
+	def bands_for(self, counts: list[dict], site: Site) -> set[int]:
+		"""Every band the site's version appears in.
+
+		Other sites in the database share the version, so the test asserts that
+		the expected band is present rather than that it is the only one.
+		"""
+		version = frappe.db.get_value("Release Group", site.group, "version")
+		bands = {row.days_since_update for row in counts if row.frappe_version == version}
+		self.assertTrue(bands, f"no audit row for {version}")
+		return bands

--- a/press/press/doctype/site_version_audit/test_site_version_audit.py
+++ b/press/press/doctype/site_version_audit/test_site_version_audit.py
@@ -154,6 +154,39 @@ class TestSiteVersionAudit(FrappeTestCase):
 		self.assertEqual(len(observed), 1)
 		self.assertTrue(observed <= valid, f"{observed} is not one of {valid}")
 
+	def test_audit_ignores_a_failed_move_tied_with_the_completed_one(self):
+		"""A move that never completed must not win the tie break."""
+		old_bench, new_bench = self.two_benches_on_their_own_versions()
+		site = create_test_site(bench=old_bench.name)
+		self.backdate_site(Site("Site", site.name), days=60)
+		month_end = frappe.utils.add_days(frappe.utils.today(), -30)
+
+		moves = [
+			self.tied_move(site.name, new_bench.name, new_bench.group, month_end),
+			self.tied_move(site.name, old_bench.name, old_bench.group, month_end),
+		]
+		# the move to ignore has to sort first, or the tie break hides the bug
+		ignored, kept = sorted(moves)
+		frappe.db.set_value(
+			"Site Update",
+			ignored,
+			{"status": "Failure", "source_bench": new_bench.name, "group": new_bench.group},
+		)
+		frappe.db.set_value(
+			"Site Update",
+			kept,
+			{"status": "Success", "source_bench": old_bench.name, "group": old_bench.group},
+		)
+
+		version = frappe.db.get_value("Release Group", old_bench.group, "version")
+		observed = {
+			(row.frappe_version, row.days_since_update)
+			for row in count_sites_by_version_and_age_on(month_end)
+			if row.frappe_version.startswith("Version 9")
+		}
+
+		self.assertEqual(observed, {(version, 360)})
+
 	def two_benches_on_their_own_versions(self):
 		"""Benches on versions no other site uses, so the counts stay isolated."""
 		benches = []
@@ -191,7 +224,7 @@ class TestSiteVersionAudit(FrappeTestCase):
 			"App Release", self.built_release(bench), {"timestamp": released_at, "creation": released_at}
 		)
 
-	def tied_move(self, site: str, source_bench: str, group: str, month_end: str):
+	def tied_move(self, site: str, source_bench: str, group: str, month_end: str) -> str:
 		"""A completed move sharing its completion time with the others."""
 		update = create_test_site_update(site, group, "Success", ignore_validate=True)
 		frappe.db.set_value(
@@ -203,6 +236,7 @@ class TestSiteVersionAudit(FrappeTestCase):
 				"update_end": frappe.utils.add_days(month_end, 5),
 			},
 		)
+		return update.name
 
 	def backdate_site(self, site: Site, days: int):
 		"""The audit skips a site that did not exist yet on the date asked about."""


### PR DESCRIPTION
This change introduce a feature which will take a daily snapshot (aggregate count) of sites with outdated framework versions.