### PR TITLE
fix(site-update): Allow a pull update on a site with a large database

### DIFF
--- a/press/press/doctype/site_update/site_update.py
+++ b/press/press/doctype/site_update/site_update.py
@@ -156,9 +156,7 @@ class SiteUpdate(Document):
 		self.validate_apps()
 		self.validate_pending_updates()
 		self.validate_past_failed_updates()
-		self.set_physical_backup_mode_if_eligible()
-		self.set_logical_replication_backup_mode_if_eligible()
-		self.validate_backup_type_for_large_database()
+		self.set_backup_type()
 
 	def validate_destination_bench(self, differences):
 		if not self.destination_bench:
@@ -260,19 +258,32 @@ class SiteUpdate(Document):
 		database_server = frappe.get_value("Server", self.server, "database_server")
 		return database_server and frappe.get_value("Database Server", database_server, "provider")
 
+	def set_backup_type(self):
+		"""Only a Migrate update on an AWS database server takes a backup worth a choice.
+
+		A Pull update just moves the site to the new bench, and the agent takes no backup
+		for it. Physical and Logical Replication backups need AWS EBS snapshots.
+		"""
+		if self.skipped_backups or self.deploy_type != "Migrate":
+			return
+
+		# No provider also means no database server, as with a configured RDS server.
+		if self.database_server_provider != "AWS EC2":
+			return
+
+		self.set_physical_backup_mode_if_eligible()
+		self.set_logical_replication_backup_mode_if_eligible()
+		self.validate_backup_type_for_large_database()
+
 	def validate_backup_type_for_large_database(self):
 		"""A logical backup of a huge database takes too long and often fails mid-update.
 
 		Physical and Logical Replication backups don't take a full dump, so they're fine.
 		"""
-		if self.skipped_backups or self.backup_type in ("Physical", "Logical Replication"):
+		if self.backup_type in ("Physical", "Logical Replication"):
 			return
 
 		if self.database_size <= LARGE_DATABASE_SIZE_MB:
-			return
-
-		# Physical backup needs AWS EBS snapshots. Elsewhere support can't help either.
-		if self.database_server_provider != "AWS EC2":
 			return
 
 		frappe.throw(
@@ -281,32 +292,18 @@ class SiteUpdate(Document):
 			frappe.ValidationError,
 		)
 
-	def set_physical_backup_mode_if_eligible(self):  # noqa: C901
-		if self.skipped_backups:
-			return
-
-		if self.deploy_type != "Migrate":
-			return
-
+	def set_physical_backup_mode_if_eligible(self):
 		# Check if physical backup is disabled globally from Press Settings
 		if frappe.utils.cint(frappe.get_value("Press Settings", None, "disable_physical_backup")):
 			return
 
 		database_server = frappe.get_value("Server", self.server, "database_server")
-		if not database_server:
-			# It might be the case of configured RDS server and no self hosted database server
-			return
 
 		# Check if physical backup is enabled on the database server
 		enable_physical_backup = frappe.get_value(
 			"Database Server", database_server, "enable_physical_backup"
 		)
 		if not enable_physical_backup:
-			return
-
-		# Sanity check - Provider should be AWS EC2
-		provider = frappe.get_value("Database Server", database_server, "provider")
-		if provider != "AWS EC2":
 			return
 
 		# In case of ebs encryption don't proceed with physical backup
@@ -334,22 +331,6 @@ class SiteUpdate(Document):
 			self.backup_type = "Physical"
 
 	def set_logical_replication_backup_mode_if_eligible(self):
-		if self.skipped_backups:
-			return
-
-		if self.deploy_type != "Migrate":
-			return
-
-		database_server = frappe.get_value("Server", self.server, "database_server")
-		if not database_server:
-			# It might be the case of configured RDS server and no self hosted database server
-			return
-
-		# Sanity check - Provider should be AWS EC2
-		provider = frappe.get_value("Database Server", database_server, "provider")
-		if provider != "AWS EC2":
-			return
-
 		if not frappe.get_value("Server", self.server, "enable_logical_replication_during_site_update"):
 			return
 

--- a/press/press/doctype/site_update/test_site_update.py
+++ b/press/press/doctype/site_update/test_site_update.py
@@ -41,6 +41,13 @@ from press.press.doctype.site_update.site_update import (
 from press.press.doctype.subscription.test_subscription import create_test_subscription
 
 
+def make_deploy_type_migrate(candidate: str, app: str):
+	"""Site Update reads the app rows of the difference to tell a Pull from a Migrate."""
+	difference = frappe.get_last_doc("Deploy Candidate Difference", {"destination": candidate})
+	difference.append("apps", {"app": app, "deploy_type": "Migrate"})
+	difference.save()
+
+
 @patch.object(SiteUpdate, "start", new=Mock())
 def create_test_site_update(
 	site: str, destination_group: str, status: str, ignore_validate: bool = False
@@ -620,11 +627,12 @@ class TestSiteUpdate(FrappeTestCase):
 		self.assertIn("SSH", details["message"])
 
 	@patch.object(AgentJob, "enqueue_http_request", new=Mock())
-	def test_site_update_is_blocked_on_site_with_database_larger_than_100_gb(self):
+	def test_migrate_update_is_blocked_on_site_with_database_larger_than_100_gb(self):
 		group = create_test_release_group([create_test_app()])
 		bench1 = create_test_bench(group=group)
 		bench2 = create_test_bench(group=group, server=bench1.server)
 		create_test_deploy_candidate_differences(bench2.candidate)
+		make_deploy_type_migrate(bench2.candidate, "frappe")
 
 		site = create_test_site(bench=bench1.name)
 		# Site Usage sizes are in MB
@@ -635,6 +643,20 @@ class TestSiteUpdate(FrappeTestCase):
 			"too large to update without a physical backup",
 			site.schedule_update,
 		)
+
+	@patch.object(AgentJob, "enqueue_http_request", new=Mock())
+	def test_pull_update_is_allowed_on_site_with_database_larger_than_100_gb(self):
+		"""A Pull update takes no backup, so the size of the database doesn't matter."""
+		group = create_test_release_group([create_test_app()])
+		bench1 = create_test_bench(group=group)
+		bench2 = create_test_bench(group=group, server=bench1.server)
+		create_test_deploy_candidate_differences(bench2.candidate)
+
+		site = create_test_site(bench=bench1.name)
+		frappe.get_doc(doctype="Site Usage", site=site.name, database=101 * 1024).insert()
+
+		site_update = frappe.get_doc("Site Update", site.schedule_update())
+		self.assertEqual(site_update.deploy_type, "Pull")
 
 	@patch.object(AgentJob, "enqueue_http_request", new=Mock())
 	def test_site_update_is_allowed_on_site_with_database_smaller_than_100_gb(self):
@@ -676,6 +698,7 @@ class TestSiteUpdate(FrappeTestCase):
 		bench1 = create_test_bench(group=group, server=server.name)
 		bench2 = create_test_bench(group=group, server=server.name)
 		create_test_deploy_candidate_differences(bench2.candidate)
+		make_deploy_type_migrate(bench2.candidate, "frappe")
 
 		site = create_test_site(bench=bench1.name)
 		frappe.get_doc(doctype="Site Usage", site=site.name, database=101 * 1024).insert()


### PR DESCRIPTION
## Problem

A customer with a 108 GB database cannot update their site, even for an app that only needs a pull:

> Database of site xxx.frappe.cloud is too large to update without a physical backup. Please contact support to get this update done.

Physical backup is enabled on their database server. It does not help, because `set_physical_backup_mode_if_eligible` returns early when the deploy type is not `Migrate`. The backup type stays `Logical`, and `validate_backup_type_for_large_database` then blocks the update.

## Why the limit does not apply to a pull

The limit protects the logical dump, which takes too long on a huge database and often fails mid-update. A pull update never takes that dump. The agent's job for it only moves the site to the new bench: in `agent/server.py`, `update_site_pull_job` has no backup step, and unlike `update_site_migrate_job` it does not even accept `skip_backups`.

## Change

`set_backup_type` now holds the guards that all three backup methods repeated: backups are not skipped, the deploy type is `Migrate`, and the database server runs on AWS EC2. The three methods keep only the part specific to each. A pull update no longer reaches the size check.

## Tests

- `test_pull_update_is_allowed_on_site_with_database_larger_than_100_gb` (new)
- `test_migrate_update_is_blocked_on_site_with_database_larger_than_100_gb` (was `test_site_update_is_blocked_...`; it built a pull update, so it now sets up a migrate difference)

All 23 tests in `press.press.doctype.site_update.test_site_update` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpVQNYrakcVPtNWQ4HDCDZ