### PR TITLE
fix(site): Don't archive a site when the archive step was skipped

### DIFF
--- a/press/press/doctype/site/site.py
+++ b/press/press/doctype/site/site.py
@@ -4875,20 +4875,8 @@ def get_remove_step_status(job):
 		for_update=True,
 	)
 
-	if (
-		remove_step_name == "Archive Site"
-		and status == "Skipped"
-		and (
-			frappe.db.get_value(
-				"Agent Job Step",
-				{"step_name": "Backup Site", "agent_job": job.name},
-				"status",
-				for_update=True,
-			)
-			== "Failure"
-		)
-	):
-		# consider as failure if archive was skipped because of backup failure
+	if status == "Skipped" and job.status != "Success":
+		# The step never ran. The job died before it, so nothing was removed.
 		status = "Failure"
 	return status
 

--- a/press/press/doctype/site/test_site.py
+++ b/press/press/doctype/site/test_site.py
@@ -34,7 +34,9 @@ from press.press.doctype.site.site import (
 	NOTIFY_BEFORE_ARCHIVAL_DAYS,
 	Site,
 	archive_suspended_sites,
+	get_remove_step_status,
 	notify_sites_before_archival,
+	process_archive_site_job_update,
 	process_new_site_job_update,
 	process_rename_site_job_update,
 	suspend_sites_exceeding_disk_usage_for_last_14_days,
@@ -1134,3 +1136,69 @@ class TestSiteConfigJSONValidation(FrappeTestCase):
 		site = Site({"doctype": "Site", "plan": plan.name})
 
 		self.assertEqual(site.get_plan_config()["rate_limit"], {"limit": 36000, "window": 86400})
+
+
+@patch.object(AgentJob, "enqueue_http_request", new=Mock())
+class TestArchiveSiteJobUpdate(FrappeTestCase):
+	"""A skipped Archive Site step must not mark the site Archived."""
+
+	def setUp(self):
+		self.site = create_test_site("testsubdomain")
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def _create_archive_jobs(self, archive_job_status: str) -> AgentJob:
+		"""Create the pair of jobs an archive runs, with the upstream one done."""
+		from press.press.doctype.agent_job.test_agent_job import create_test_agent_job
+
+		upstream_job = create_test_agent_job(
+			"Remove Site from Upstream", server=self.site.server, status="Success"
+		)
+		upstream_job.db_set("site", self.site.name)
+		self._set_step_status(upstream_job, "Remove Site File from Upstream Directory", "Success")
+
+		archive_job = create_test_agent_job(
+			"Archive Site", server=self.site.server, status=archive_job_status
+		)
+		archive_job.db_set("site", self.site.name)
+		return archive_job
+
+	def _set_step_status(self, job: AgentJob, step_name: str, status: str):
+		frappe.db.set_value(
+			"Agent Job Step", {"agent_job": job.name, "step_name": step_name}, "status", status
+		)
+
+	def test_archive_step_skipped_after_a_stuck_backup_marks_the_site_broken(self):
+		"""The job died while Backup Site was still running, so the site is still on the bench."""
+		archive_job = self._create_archive_jobs("Failure")
+		self._set_step_status(archive_job, "Backup Site", "Running")
+		self._set_step_status(archive_job, "Archive Site", "Skipped")
+
+		process_archive_site_job_update(archive_job)
+
+		self.site.reload()
+		self.assertEqual(self.site.status, "Broken")
+		self.assertTrue(self.site.archive_failed)
+
+	def test_archive_step_skipped_after_a_failed_backup_upload_marks_the_site_broken(self):
+		"""Backup Site succeeded, the upload failed, so Archive Site never ran."""
+		archive_job = self._create_archive_jobs("Failure")
+		self._set_step_status(archive_job, "Backup Site", "Success")
+		self._set_step_status(archive_job, "Upload Site Backup to S3", "Failure")
+		self._set_step_status(archive_job, "Archive Site", "Skipped")
+
+		process_archive_site_job_update(archive_job)
+
+		self.site.reload()
+		self.assertEqual(self.site.status, "Broken")
+		self.assertTrue(self.site.archive_failed)
+
+	def test_step_skipped_by_a_successful_job_still_counts_as_removed(self):
+		"""The agent skips a step it has no work for. That job succeeded, so nothing is left behind."""
+		from press.press.doctype.agent_job.test_agent_job import create_test_agent_job
+
+		job = create_test_agent_job("Remove Site from Upstream", server=self.site.server, status="Success")
+		self._set_step_status(job, "Remove Site File from Upstream Directory", "Skipped")
+
+		self.assertEqual(get_remove_step_status(job), "Skipped")


### PR DESCRIPTION
## Problem

A `Skipped` **Archive Site** step means the step never ran, but `get_new_status_for_archive_attempted_site` counts `Skipped` as `Success`. The site is then marked **Archived**: its backups are deleted (`delete_physical_backups`, `delete_offsite_backups`, Site Backups set to `Unavailable`) and `site_cleanup_after_archive` drops its domains, DNS record and name — while the site is still on the bench.

47fd03467 closed one case only: it downgraded `Skipped` to `Failure` when the `Backup Site` step was exactly `"Failure"`. Two ways past it:

- The job dies with `Backup Site` still `Running` (the agent worker went away mid-backup). `skip_pending_steps` marks only the `Pending` steps `Skipped`, so the job is left with `Backup Site` = `Running` and `Upload Site Backup to S3`, `Archive Site`, `Bench Setup NGINX`, `Reload NGINX` all `Skipped`. This is the state that prompted the report.

- `Backup Site` succeeds and `Upload Site Backup to S3` fails. `Archive Site` is `Skipped` and `Backup Site` is `Success`.

## Fix

Use the job status: a `Skipped` step in a job that did not succeed is a `Failure`. The site goes to **Broken** with `archive_failed` set, and the operator retries with the button.

A job that succeeded can still skip a step it has no work for — an upstream site file that is not there — and that still counts as done, which keeps the behaviour of 57f6052fc.

The check now covers `Remove Site from Upstream` too, not only `Archive Site`.

## Tests

`TestArchiveSiteJobUpdate` in `press/press/doctype/site/test_site.py`:

- archive step skipped after a stuck backup → site is Broken
- archive step skipped after a failed backup upload → site is Broken
- step skipped by a successful job → still counts as removed

Both Broken tests fail on `develop` (they run into the archived path and delete the backups) and pass with this change. The full `test_site` module passes: 64 tests.

## Notes

c0ae32cd4 tried this before and was reverted in 42e4194e5 with "Needs rewrite with tests". This is the rewrite, with a much smaller diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wqe4DBaZFxZV63rebFsxFo
