### PR TITLE
fix(ui): Use parsed GitHub url when adding app in new app dialog

### DIFF
--- a/dashboard/src/components/NewAppDialog.vue
+++ b/dashboard/src/components/NewAppDialog.vue
@@ -201,8 +201,8 @@ export default {
 						return
 					}
 
-					let repository_url = this.githubAppLink
-					if (!repository_url) {
+					let repository_url = `https://github.com/${this.appOwner}/${this.appName}`
+					if (!this.githubAppLink) {
 						const repo_owner = this.selectedGithubUser?.login
 						const repo = this.selectedGithubRepository || data.name
 						repository_url = `https://github.com/${repo_owner}/${repo}`

--- a/dashboard/src/objects/common/index.ts
+++ b/dashboard/src/objects/common/index.ts
@@ -104,7 +104,7 @@ export function siteTabFilterControls() {
 			type: 'select',
 			label: 'Status',
 			fieldname: 'status',
-			options: ['', 'Active', 'Inactive', 'Suspended', 'Broken'],
+			options: ['', 'Active', 'Inactive', 'Suspended', 'Broken', 'Archived'],
 		},
 		{
 			type: 'select',

--- a/dashboard/src/objects/server.js
+++ b/dashboard/src/objects/server.js
@@ -235,7 +235,14 @@ export default {
 								type: 'select',
 								label: 'Status',
 								fieldname: 'status',
-								options: ['', 'Active', 'Inactive', 'Suspended', 'Broken'],
+								options: [
+									'',
+									'Active',
+									'Inactive',
+									'Suspended',
+									'Broken',
+									'Archived',
+								],
 							},
 							{
 								type: 'select',

--- a/dashboard/src/pages/servers/list/ServerCard.vue
+++ b/dashboard/src/pages/servers/list/ServerCard.vue
@@ -129,7 +129,7 @@ const serverActions = (server) => [
 				<span>Version</span>
 			</template>
 
-			<div v-else class="flex gap-2 items-center pb-2 col-span-4">
+			<div v-else class="flex gap-2 items-center col-span-4">
 				<Tooltip
 					text="Add benches via the more button or benches tab to start hosting sites"
 					:hoverDelay="0"


### PR DESCRIPTION

## Description 

if you add a github repo with trailing `/`  while adding the app then at later stages it doesnt change the branch, show a blank options, 


## Behavior
https://github.com/user-attachments/assets/89e0e0ab-88e6-4d07-87fb-8ef9e1be3107

This pr fixes it
