### PR TITLE
feat(press-job): Alert Raven when a server lifecycle job fails

### DIFF
--- a/press/press/doctype/press_job/press_job.py
+++ b/press/press/doctype/press_job/press_job.py
@@ -251,6 +251,9 @@ class PressJob(WorkflowBuilder):
 		if self.job_type not in ALERTED_JOB_TYPES:
 			return
 
+		if frappe.db.get_single_value("Press Settings", "disable_press_job_failure_alerts"):
+			return
+
 		send_raven_message(
 			f"**{self.job_type} failed** - {self.server}\n\n"
 			f"Step: {get_failed_step(workflow) or 'Unknown'}\n"

--- a/press/press/doctype/press_job/press_job.py
+++ b/press/press/doctype/press_job/press_job.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 import frappe
 from frappe.utils import now_datetime
 
+from press.press.doctype.server.server_monitoring import RAVEN_SERVER_ALERTS_CHANNEL
+from press.utils.raven import send_raven_message
 from press.workflow_engine.doctype.press_workflow.workflow_builder import WorkflowBuilder
 
 if TYPE_CHECKING:
@@ -18,6 +20,10 @@ if TYPE_CHECKING:
 	from press.workflow_engine.doctype.press_workflow.press_workflow import PressWorkflow
 
 _JOBS_REGISTRY: dict[str, type] = {}
+
+# A failure here leaves a server half provisioned, half archived, or on the wrong
+# plan. Someone has to look at it, so tell the alerts channel.
+ALERTED_JOB_TYPES = ("Create Server", "Archive Server", "Resize Server")
 
 
 def _init_jobs_registry() -> None:
@@ -80,6 +86,15 @@ def _init_jobs_registry() -> None:
 		"Upgrade MariaDB": UpgradeMariaDBJob,
 		"Warn disk at 80%": WarnDiskJob,
 	}
+
+
+def get_failed_step(workflow: "PressWorkflow") -> str | None:
+	return frappe.db.get_value(
+		"Press Workflow Task",
+		{"workflow": workflow.name, "status": "Failure"},
+		"method_title",
+		order_by="creation desc",
+	)
 
 
 class PressJob(WorkflowBuilder):
@@ -227,8 +242,21 @@ class PressJob(WorkflowBuilder):
 		self.status = "Failure"
 		self.save()
 
+		self.alert_failure(workflow)
+
 		if hasattr(self, "on_press_job_failure"):
 			self.on_press_job_failure(workflow)
+
+	def alert_failure(self, workflow: "PressWorkflow"):
+		if self.job_type not in ALERTED_JOB_TYPES:
+			return
+
+		send_raven_message(
+			f"**{self.job_type} failed** - {self.server}\n\n"
+			f"Step: {get_failed_step(workflow) or 'Unknown'}\n"
+			f"Job: {frappe.utils.get_url_to_form(self.doctype, self.name)}",
+			RAVEN_SERVER_ALERTS_CHANNEL,
+		)
 
 	@frappe.whitelist()
 	def retry(self):

--- a/press/press/doctype/press_job/press_job.py
+++ b/press/press/doctype/press_job/press_job.py
@@ -21,8 +21,8 @@ if TYPE_CHECKING:
 
 _JOBS_REGISTRY: dict[str, type] = {}
 
-# A failure here leaves a server half provisioned, half archived, or on the wrong
-# plan. Someone has to look at it, so tell the alerts channel.
+# These failures require human intervention, so notify the server alerts
+# channel when they occur.
 ALERTED_JOB_TYPES = ("Create Server", "Archive Server", "Resize Server")
 
 

--- a/press/press/doctype/press_job/test_press_job.py
+++ b/press/press/doctype/press_job/test_press_job.py
@@ -1,9 +1,105 @@
 # Copyright (c) 2022, Frappe and Contributors
 # See license.txt
 
-# import frappe
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from press.press.doctype.server.test_server import create_test_server
+
+if TYPE_CHECKING:
+	from press.press.doctype.press_job.press_job import PressJob
 
 
 class TestPressJob(FrappeTestCase):
-	pass
+	def setUp(self):
+		self.server = create_test_server()
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def create_job(self, job_type: str) -> PressJob:
+		job = frappe.get_doc(
+			{
+				"doctype": "Press Job",
+				"job_type": job_type,
+				"server_type": "Server",
+				"server": self.server.name,
+				"arguments": json.dumps({}),
+			}
+		)
+		job.db_insert()
+		job.reload()
+		return job
+
+	def create_workflow(self, job: PressJob, failed_step: str | None = None):
+		workflow = frappe.get_doc(
+			{
+				"doctype": "Press Workflow",
+				"linked_doctype": "Press Job",
+				"linked_docname": job.name,
+				"main_method_name": "execute",
+				"status": "Failure",
+			}
+		)
+		workflow.db_insert()
+
+		if failed_step:
+			task = frappe.get_doc(
+				{
+					"doctype": "Press Workflow Task",
+					"workflow": workflow.name,
+					"method_name": "a_step",
+					"method_title": failed_step,
+					"status": "Failure",
+				}
+			)
+			task.db_insert()
+
+		return workflow
+
+	def test_failed_resize_server_job_names_the_server_and_the_failed_step(self):
+		job = self.create_job("Resize Server")
+		workflow = self.create_workflow(job, failed_step="Stop Virtual Machine")
+
+		with patch("press.press.doctype.press_job.press_job.send_raven_message") as send_raven_message:
+			job.alert_failure(workflow)
+
+		message, channel = send_raven_message.call_args[0]
+		self.assertIn("Resize Server failed", message)
+		self.assertIn(self.server.name, message)
+		self.assertIn("Stop Virtual Machine", message)
+		self.assertEqual(channel, "frappe-cloud-server-alerts")
+
+	def test_failed_create_server_job_is_alerted(self):
+		job = self.create_job("Create Server")
+		workflow = self.create_workflow(job)
+
+		with patch("press.press.doctype.press_job.press_job.send_raven_message") as send_raven_message:
+			job.alert_failure(workflow)
+
+		send_raven_message.assert_called_once()
+		self.assertIn("Unknown", send_raven_message.call_args[0][0])
+
+	def test_failed_archive_server_job_is_alerted(self):
+		job = self.create_job("Archive Server")
+		workflow = self.create_workflow(job, failed_step="Archive Server")
+
+		with patch("press.press.doctype.press_job.press_job.send_raven_message") as send_raven_message:
+			job.alert_failure(workflow)
+
+		send_raven_message.assert_called_once()
+
+	def test_other_failed_jobs_are_not_alerted(self):
+		job = self.create_job("Increase Disk Size")
+		workflow = self.create_workflow(job, failed_step="Increase Disk Size")
+
+		with patch("press.press.doctype.press_job.press_job.send_raven_message") as send_raven_message:
+			job.alert_failure(workflow)
+
+		send_raven_message.assert_not_called()

--- a/press/press/doctype/press_job/test_press_job.py
+++ b/press/press/doctype/press_job/test_press_job.py
@@ -103,3 +103,13 @@ class TestPressJob(FrappeTestCase):
 			job.alert_failure(workflow)
 
 		send_raven_message.assert_not_called()
+
+	def test_no_alert_when_the_setting_disables_them(self):
+		frappe.db.set_single_value("Press Settings", "disable_press_job_failure_alerts", 1)
+		job = self.create_job("Resize Server")
+		workflow = self.create_workflow(job, failed_step="Stop Virtual Machine")
+
+		with patch("press.press.doctype.press_job.press_job.send_raven_message") as send_raven_message:
+			job.alert_failure(workflow)
+
+		send_raven_message.assert_not_called()

--- a/press/press/doctype/press_settings/press_settings.json
+++ b/press/press/doctype/press_settings/press_settings.json
@@ -206,6 +206,7 @@
 		"column_break_pqic",
 		"raven_secret_access_key",
 		"raven_incidents_channel",
+		"disable_press_job_failure_alerts",
 		"marketplace_tab",
 		"marketplace_settings_section",
 		"max_allowed_screenshots",
@@ -1892,6 +1893,13 @@
 			"fieldname": "raven_incidents_channel",
 			"fieldtype": "Data",
 			"label": "Raven Incidents Channel"
+		},
+		{
+			"default": "0",
+			"description": "Stop posting to the server alerts channel when a Create Server, Archive Server or Resize Server job fails",
+			"fieldname": "disable_press_job_failure_alerts",
+			"fieldtype": "Check",
+			"label": "Disable Press Job Failure Alerts"
 		}
 	],
 	"issingle": 1,

--- a/press/press/doctype/press_settings/press_settings.py
+++ b/press/press/doctype/press_settings/press_settings.py
@@ -129,6 +129,7 @@ class PressSettings(Document):
 		disable_database_audit_service: DF.Check
 		disable_frappe_auth: DF.Check
 		disable_physical_backup: DF.Check
+		disable_press_job_failure_alerts: DF.Check
 		disallow_disposable_emails: DF.Check
 		docker_registry_namespace: DF.Data | None
 		docker_registry_password: DF.Data | None


### PR DESCRIPTION
## Problem

A failed **Create Server**, **Archive Server** or **Resize Server** leaves a server half provisioned, half archived, or on the wrong plan. Nobody watches the Press Job list, so these sit until a customer or a bill finds them.

## What this does

`PressJob.on_workflow_failure` is the one place every job failure goes through, so the alert lives there. It fires only for the three job types that need a person:

```python
ALERTED_JOB_TYPES = ("Create Server", "Archive Server", "Resize Server")
```

The message names the job type, the server, the step that failed, and links the Press Job:

```
**Resize Server failed** - f1.example.com

Step: Stop Virtual Machine
Job: https://frappecloud.com/app/press-job/331
```

The step comes from the Press Workflow Task that failed, so the reader knows whether the machine stopped, the resize call failed, or a later step gave up — without opening the job first.

## Channel

Reused `RAVEN_SERVER_ALERTS_CHANNEL` (`frappe-cloud-server-alerts`), the channel the public server pool health alerts already post to. Adding a Press Settings field for one more channel did not seem worth it. **Say so if these belong somewhere else** — it is a one-line change.

## Turning it off

**Press Settings → Raven → Disable Press Job Failure Alerts.** During an incident the same three job types fail again and again, and an alert nobody can silence is one nobody can live with. The check sits next to the Raven credentials, so whoever set the channel up finds the switch that stops it.

## Choices

- **Explicit job types, not every failure.** There are 22 press job types. Alerting on all of them would bury the three that need a person. Swap failures, disk warnings and prune jobs already have their own paths.
- **The alert runs before `on_press_job_failure`.** The rollback handlers do real work and can throw. The alert goes out first so a broken rollback cannot swallow it.
- **A failed alert never fails the job.** `send_raven_message` already logs an error and returns when the Raven credentials are missing or the post fails.

## Tests

`press.press.doctype.press_job.test_press_job` — 5 tests:

- a failed Resize Server alert names the server, the failed step and the channel
- a failed Create Server is alerted, and shows `Unknown` when no task recorded a failure
- a failed Archive Server is alerted
- a failed job of another type is not alerted
- nothing is sent when the setting disables the alerts

```
Ran 5 tests in 3.577s

OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzhrGxqJ6nN5sVeK4swwt6
