### PR TITLE
fix(stripe): Switch to prepaid credits when card is not on stripe

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -816,6 +816,7 @@
 		"MRR",
 		"notif",
 		"smallbtn",
-		"Unblended"
+		"Unblended",
+		"recognised"
 	]
 }

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import typing
 
 import frappe
+import razorpay
 import stripe
 from frappe import _
 from frappe.model.document import Document
@@ -751,9 +752,13 @@ class Invoice(Document):
 			)
 			self.reload()
 			return payment
-		except Exception:
+		except Exception as e:
 			frappe.db.rollback()
 			self.reload()
+
+			if self.is_razorpay_token_unconfirmed_error(e):
+				self.switch_to_prepaid_credits_on_cancelled_razorpay_token(mandate)
+				return None
 
 			# Log the traceback as comment
 			msg = "<pre><code>" + frappe.get_traceback() + "</pre></code>"
@@ -769,6 +774,34 @@ class Invoice(Document):
 				self, error_reason="PAYMENT_CREATION_FAILED"
 			)
 			frappe.db.commit()
+			return None
+
+	def is_razorpay_token_unconfirmed_error(self, exception):
+		return isinstance(exception, razorpay.errors.BadRequestError) and (
+			"Token is not confirmed for recurring payments" in str(exception)
+		)
+
+	def switch_to_prepaid_credits_on_cancelled_razorpay_token(self, mandate):
+		frappe.db.set_value("Team", self.team, "payment_mode", "Prepaid Credits")
+		frappe.db.set_value("Invoice", self.name, "payment_mode", "Prepaid Credits")
+		self.add_comment(
+			"Comment",
+			_(
+				"Switched payment mode to Prepaid Credits: the UPI Autopay token was not confirmed by Razorpay."
+			),
+		)
+		frappe.db.commit()
+		self.reload()
+
+		# payment_mode is already "Prepaid Credits", so this will not also send a "MANDATE_CANCELLED" email
+		frappe.get_doc("Razorpay Mandate", mandate.name).cancel(
+			"Token is not confirmed for recurring payments"
+		)
+
+		team = frappe.get_cached_doc("Team", self.team)
+		team.send_email_for_failed_upi_payment(
+			self, error_reason="TOKEN_NOT_CONFIRMED", upi_vpa=mandate.upi_vpa
+		)
 
 	def get_razorpay_payment_description(self):
 		start = getdate(self.period_start)

--- a/press/press/doctype/invoice/invoice.py
+++ b/press/press/doctype/invoice/invoice.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import typing
 
 import frappe
+import stripe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cint, flt, getdate
@@ -590,14 +591,37 @@ class Invoice(Document):
 				{"team": self.team, "invoice": self.name, "amount": amount, "currency": self.currency},
 			)
 			return invoice
-		except Exception:
+		except Exception as e:
 			frappe.db.rollback()
 			self.reload()
+
+			if self.is_payment_method_detached_error(e):
+				self.switch_to_prepaid_credits_on_invalid_payment_method()
+				return None
 
 			# log the traceback as comment
 			msg = "<pre><code>" + frappe.get_traceback() + "</pre></code>"
 			self.add_comment("Comment", _("Stripe Invoice Creation Failed") + "<br><br>" + msg)
 			frappe.db.commit()
+			return None
+
+	def is_payment_method_detached_error(self, exception):
+		return isinstance(exception, stripe.error.InvalidRequestError) and (
+			"must be attached to the customer" in str(exception)
+		)
+
+	def switch_to_prepaid_credits_on_invalid_payment_method(self):
+		frappe.db.set_value("Team", self.team, "payment_mode", "Prepaid Credits")
+		frappe.db.set_value("Invoice", self.name, "payment_mode", "Prepaid Credits")
+		self.add_comment(
+			"Comment",
+			_("Switched payment mode to Prepaid Credits: the default card was not recognised by Stripe."),
+		)
+		frappe.db.commit()
+		self.reload()
+
+		team = frappe.get_cached_doc("Team", self.team)
+		team.send_email_for_invalid_payment_method(self)
 
 	def get_mandate_id(self, customer_id):
 		mandate_id = frappe.get_value(

--- a/press/press/doctype/invoice/test_invoice.py
+++ b/press/press/doctype/invoice/test_invoice.py
@@ -6,9 +6,11 @@ import datetime
 from unittest.mock import MagicMock, Mock, patch
 
 import frappe
+import stripe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils.data import add_days, today
 
+from press.press.doctype.team.team import Team
 from press.press.doctype.team.test_team import create_test_team
 
 from .invoice import Invoice, create_invoices_for_next_month, finalize_draft_invoice, finalize_draft_invoices
@@ -516,6 +518,47 @@ class TestInvoice(FrappeTestCase):
 
 		self.assertRaises(frappe.ValidationError, invoice._make_stripe_invoice, "cus_test123", 10000)
 		mock_stripe.return_value.Invoice.create.assert_not_called()
+
+	@patch("press.press.doctype.invoice.invoice.get_stripe")
+	@patch.object(Team, "send_email_for_invalid_payment_method")
+	def test_make_stripe_invoice_switches_to_prepaid_credits_when_payment_method_detached(
+		self, mock_send_email, mock_stripe
+	):
+		frappe.get_doc(
+			{
+				"doctype": "Stripe Payment Method",
+				"team": self.team.name,
+				"stripe_customer_id": "cus_test123",
+				"stripe_payment_method_id": "pm_test123",
+				"is_default": 1,
+			}
+		).insert(ignore_permissions=True)
+		self.team.db_set("payment_mode", "Card")
+
+		mock_stripe.return_value.Invoice.create.side_effect = stripe.error.InvalidRequestError(
+			"The customer does not have a payment method with the ID pm_test123. "
+			"The payment method must be attached to the customer.",
+			None,
+		)
+
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=today(),
+			period_end=add_days(today(), 10),
+		).insert()
+		invoice.append("items", {"quantity": 1, "rate": 100, "amount": 100})
+		invoice.save()
+
+		# _make_stripe_invoice commits/rolls back the real transaction on failure;
+		# stub those out so the test's own uncommitted fixtures survive.
+		with patch("frappe.db.rollback"), patch("frappe.db.commit"):
+			invoice._make_stripe_invoice("cus_test123", 10000)
+
+		invoice.reload()
+		self.assertEqual(invoice.payment_mode, "Prepaid Credits")
+		self.assertEqual(frappe.db.get_value("Team", self.team.name, "payment_mode"), "Prepaid Credits")
+		mock_send_email.assert_called_once()
 
 	def test_negative_balance_case(self):
 		team = create_test_team("test22@example.com")

--- a/press/press/doctype/invoice/test_invoice.py
+++ b/press/press/doctype/invoice/test_invoice.py
@@ -6,6 +6,7 @@ import datetime
 from unittest.mock import MagicMock, Mock, patch
 
 import frappe
+import razorpay
 import stripe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils.data import add_days, today
@@ -559,6 +560,66 @@ class TestInvoice(FrappeTestCase):
 		self.assertEqual(invoice.payment_mode, "Prepaid Credits")
 		self.assertEqual(frappe.db.get_value("Team", self.team.name, "payment_mode"), "Prepaid Credits")
 		mock_send_email.assert_called_once()
+
+	@patch("press.press.doctype.razorpay_mandate.razorpay_mandate.get_razorpay_client")
+	@patch("press.press.doctype.invoice.invoice.get_razorpay_client")
+	@patch.object(Team, "send_email_for_failed_upi_payment")
+	def test_make_razorpay_payment_switches_to_prepaid_credits_when_token_unconfirmed(
+		self, mock_send_email, mock_invoice_razorpay_client, mock_mandate_razorpay_client
+	):
+		self.team.db_set("razorpay_customer_id", "cust_test123")
+		self.team.db_set("payment_mode", "UPI Autopay")
+
+		mandate = frappe.get_doc(
+			{
+				"doctype": "Razorpay Mandate",
+				"team": self.team.name,
+				"token_id": "token_test123",
+				"status": "Active",
+				"method": "emandate",
+				"auth_type": "upi",
+				"max_amount": 5000,
+				"is_default": 1,
+				"upi_vpa": "test@upi",
+				"contact": "+911234567890",
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.set_value("Team", self.team.name, "default_razorpay_mandate", mandate.name)
+
+		mock_invoice_razorpay_client.return_value.order.create.return_value = {"id": "order_test123"}
+		mock_invoice_razorpay_client.return_value.payment.createRecurring.side_effect = (
+			razorpay.errors.BadRequestError("Token is not confirmed for recurring payments")
+		)
+
+		invoice = frappe.get_doc(
+			doctype="Invoice",
+			team=self.team.name,
+			period_start=today(),
+			period_end=add_days(today(), 10),
+		).insert()
+		invoice.append("items", {"quantity": 1, "rate": 100, "amount": 100})
+		invoice.save()
+
+		mandate_details = frappe._dict(
+			name=mandate.name,
+			token_id="token_test123",
+			razorpay_customer_id="cust_test123",
+			max_amount=5000,
+			contact="+911234567890",
+			upi_vpa="test@upi",
+		)
+
+		# _make_razorpay_payment commits/rolls back the real transaction on failure;
+		# stub those out so the test's own uncommitted fixtures survive.
+		with patch("frappe.db.rollback"), patch("frappe.db.commit"):
+			invoice._make_razorpay_payment(mandate_details, 10000)
+
+		invoice.reload()
+		self.assertEqual(invoice.payment_mode, "Prepaid Credits")
+		self.assertEqual(frappe.db.get_value("Team", self.team.name, "payment_mode"), "Prepaid Credits")
+		self.assertEqual(frappe.db.get_value("Razorpay Mandate", mandate.name, "status"), "Cancelled")
+		mock_send_email.assert_called_once()
+		self.assertEqual(mock_send_email.call_args.kwargs.get("error_reason"), "TOKEN_NOT_CONFIRMED")
 
 	def test_negative_balance_case(self):
 		team = create_test_team("test22@example.com")

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -1686,6 +1686,24 @@ class Team(Document):
 			},
 		)
 
+	def send_email_for_invalid_payment_method(self, invoice):
+		if isinstance(invoice, str):
+			invoice = frappe.get_doc("Invoice", invoice)
+
+		email = get_communication_info("Email", "Billing", "Team", self.name) or [self.user]
+		subject = "Card on Frappe Cloud could not be charged"
+
+		frappe.sendmail(
+			recipients=email,
+			subject=subject,
+			template="payment_method_invalid",
+			args={
+				"subject": subject,
+				"amount": invoice.get_formatted("amount_due_with_tax"),
+				"billing_link": frappe.utils.get_url("/dashboard/billing"),
+			},
+		)
+
 	@frappe.whitelist()
 	def send_email_for_failed_payment(self, invoice, sites=None):
 		invoice = frappe.get_doc("Invoice", invoice)

--- a/press/templates/emails/payment_failed_upi_autopay.html
+++ b/press/templates/emails/payment_failed_upi_autopay.html
@@ -47,6 +47,12 @@
 			<p><a href="{{ upi_autopay_link }}">Manage UPI Autopay</a></p>
 			<p><a href="{{ billing_link }}">Pay Now</a></p>
 
+		{% elif error_reason == "TOKEN_NOT_CONFIRMED" %}
+			<p>Your UPI Autopay token was never confirmed for recurring payments, so we were unable to auto-debit <strong>{{ amount }}</strong>{% if upi_vpa %} from your UPI account (<strong>{{ upi_vpa }}</strong>){% endif %}.</p>
+			<p>We have cancelled this mandate and switched your payment mode to <strong>Prepaid Credits</strong> so that your sites are not interrupted. Please set up a new UPI Autopay mandate or add credits to your account.</p>
+			<p><a href="{{ upi_autopay_link }}">Set Up UPI Autopay</a></p>
+			<p><a href="{{ billing_link }}">Add Credits</a></p>
+
 		{% elif error_reason == "MANDATE_CANCELLED" %}
 			<p>Your UPI Autopay mandate has been <strong>cancelled</strong>. Your account currently has no active payment method.</p>
 			<p>To ensure uninterrupted service and avoid site suspension, please set up a new UPI Autopay mandate or update your billing details with a valid payment method.</p>

--- a/press/templates/emails/payment_method_invalid.html
+++ b/press/templates/emails/payment_method_invalid.html
@@ -1,0 +1,25 @@
+{% import "templates/emails/macros.html" as utils %}
+{% extends "templates/emails/base.html" %}
+
+{% block content %}
+
+<td class="text-base leading-6 text-gray-900">
+	<div class="p-8 bg-white">
+		<p class="mb-4 font-bold">{{ subject }}</p>
+		<p class="mb-6">
+			We attempted to charge your default card for your Frappe Cloud invoice of <strong>{{ amount }}</strong>,
+			but Stripe did not recognise the card. To fix this, please remove the card on your account and add it
+			again in your {{ utils.link('Billing Settings', billing_link) }}.
+		</p>
+		<p class="mb-6">
+			In the meantime, we have switched your payment mode to <strong>Prepaid Credits</strong> so that your
+			sites are not interrupted. Add credits or re-add your card to keep your subscription running smoothly.
+		</p>
+		{{ utils.button('Update Billing Settings', billing_link) }}
+
+		{{ utils.separator() }}
+		{{ utils.signature() }}
+	</div>
+</td>
+
+{% endblock %}


### PR DESCRIPTION
* Also for Razorpay, when payment mode is UPI Autopay and token is expired