### PR TITLE
feat(dashboard): Warn before a shared instance on Hetzner

### DIFF
--- a/dashboard/src/components/server/ServerOverview.vue
+++ b/dashboard/src/components/server/ServerOverview.vue
@@ -64,6 +64,14 @@
 									<div class="space-y-1">
 										<div class="flex items-center text-base text-ink-gray-9">
 											{{ d.value }}
+											<Badge
+												v-if="d.isShared && $team.doc?.is_desk_user"
+												class="ml-2"
+												theme="orange"
+												size="sm"
+												variant="subtle"
+												label="Shared"
+											/>
 											<Tooltip v-if="d.isPremium" text="Premium Server">
 												<!-- this icon isn't available in unplugin package yet -->
 												<svg
@@ -202,6 +210,7 @@ import { defineAsyncComponent, h } from 'vue'
 import { toast } from 'vue-sonner'
 import { confirmDialog, renderDialog } from '../../utils/components'
 import { getDocResource } from '../../utils/resource'
+import { isSharedPlanType } from '../../utils/serverPlanType'
 import { getToastErrorMessage } from '../../utils/toast'
 import AlertBanner from '../AlertBanner.vue'
 import CustomAlerts from '../CustomAlerts.vue'
@@ -226,6 +235,7 @@ export default {
 			startedScaleUp: false,
 			startedScaleDown: false,
 			autoscaleDiscount: null,
+			planTypes: {},
 		}
 	},
 	async mounted() {
@@ -235,9 +245,20 @@ export default {
 		})
 
 		this.autoscaleDiscount = await get.fetch()
+
+		// Only support reads the shared badge, so only support pays for the call.
+		if (this.$team.doc?.is_desk_user) this.fetchPlanTypes()
 	},
 
 	methods: {
+		async fetchPlanTypes() {
+			const plans = createResource({ url: 'press.api.server.plans' })
+			const data = await plans.fetch({ name: 'Server' })
+			this.planTypes = data?.types ?? {}
+		},
+		isSharedPlan(plan) {
+			return isSharedPlanType(this.planTypes[plan?.plan_type]?.title)
+		},
 		showPlanChangeDialog(serverType) {
 			let ServerPlansDialog = defineAsyncComponent(
 				() => import('./ServerPlansDialog.vue'),
@@ -416,6 +437,7 @@ export default {
 						value: planDescription,
 						type: 'header',
 						isPremium: !!currentPlan?.premium,
+						isShared: this.isSharedPlan(currentPlan),
 					},
 					{
 						label: 'CPU',
@@ -455,6 +477,7 @@ export default {
 							: '',
 					type: 'header',
 					isPremium: !!currentPlan?.premium,
+					isShared: this.isSharedPlan(currentPlan),
 					help:
 						additionalStorage > 0
 							? `Server Plan: ${this.$format.userCurrency(

--- a/dashboard/src/components/server/ServerOverview.vue
+++ b/dashboard/src/components/server/ServerOverview.vue
@@ -64,14 +64,18 @@
 									<div class="space-y-1">
 										<div class="flex items-center text-base text-ink-gray-9">
 											{{ d.value }}
-											<Badge
+											<Tooltip
 												v-if="d.isShared && $team.doc?.is_desk_user"
-												class="ml-2"
-												theme="orange"
-												size="sm"
-												variant="subtle"
-												label="Shared"
-											/>
+												text="A shared instance can have variable performance. We give only limited support for it."
+											>
+												<Badge
+													class="ml-2"
+													theme="orange"
+													size="sm"
+													variant="subtle"
+													label="Shared"
+												/>
+											</Tooltip>
 											<Tooltip v-if="d.isPremium" text="Premium Server">
 												<!-- this icon isn't available in unplugin package yet -->
 												<svg

--- a/dashboard/src/pages/NewServer.vue
+++ b/dashboard/src/pages/NewServer.vue
@@ -402,6 +402,12 @@
 								</div>
 							</div>
 
+							<AlertBanner
+								v-if="onSharedInstance"
+								type="warning"
+								title="A shared instance can have variable performance, and we give only limited support for it. <a href='https://docs.frappe.io/cloud/servers/instance-types#limited-support' target='_blank' style='font-weight: bold; text-decoration: underline;'>Read what this means</a> before you use it for production."
+							/>
+
 							<!-- App Server Plans -->
 							<div v-if="appServerPlanType" class="mt-2 space-y-2">
 								<ServerPlansCards
@@ -995,6 +1001,7 @@ import ClickToCopy from '../components/ClickToCopyField.vue'
 import Header from '../components/Header.vue'
 import ServerPlansCards from '../components/server/ServerPlansCards.vue'
 import { DashboardError } from '../utils/error'
+import { isSharedPlanType } from '../utils/serverPlanType'
 
 export default {
 	components: {
@@ -1475,6 +1482,16 @@ export default {
 				(plan) =>
 					plan.cluster === this.selectedCluster &&
 					(this.unifiedServer ? plan.allow_unified_server : true),
+			)
+		},
+		onSharedInstance() {
+			if (this.serverProvider !== 'Hetzner') return false
+			return [...this.availableAppPlanTypes, ...this.availableDbPlanTypes].some(
+				(planType) =>
+					isSharedPlanType(planType.title) &&
+					[this.appServerPlanType, this.dbServerPlanType].includes(
+						planType.name,
+					),
 			)
 		},
 		availableAppPlanTypes() {

--- a/dashboard/src/pages/NewServer.vue
+++ b/dashboard/src/pages/NewServer.vue
@@ -405,7 +405,7 @@
 							<AlertBanner
 								v-if="onSharedInstance"
 								type="warning"
-								title="A shared instance can have variable performance, and we give only limited support for it. <a href='https://docs.frappe.io/cloud/servers/instance-types#limited-support' target='_blank' style='font-weight: bold; text-decoration: underline;'>Read what this means</a> before you use it for production."
+								title="A shared instance can have variable performance, and we give only limited support for it. We do not recommend it for production workloads. <a href='https://docs.frappe.io/cloud/servers/instance-types#limited-support' target='_blank' style='font-weight: bold; text-decoration: underline;'>Read what this means</a>."
 							/>
 
 							<!-- App Server Plans -->

--- a/dashboard/src/utils/serverPlanType.ts
+++ b/dashboard/src/utils/serverPlanType.ts
@@ -1,0 +1,5 @@
+// Shared plan types run on shared CPU, so we support them only in part. The
+// backend has no flag for it, so we go by the title the plan type carries.
+export function isSharedPlanType(title?: string): boolean {
+	return /shared/i.test(title ?? '')
+}

--- a/dashboard/src/utils/serverPlanType.ts
+++ b/dashboard/src/utils/serverPlanType.ts
@@ -1,5 +1,5 @@
 // Shared plan types run on shared CPU, so we support them only in part. The
 // backend has no flag for it, so we go by the title the plan type carries.
 export function isSharedPlanType(title?: string): boolean {
-	return /shared/i.test(title ?? '')
+	return title?.trim().toLowerCase() === 'shared instance'
 }


### PR DESCRIPTION
## Problem

A shared instance runs on shared CPU. It throttles when it hits the provider thresholds, and there is then no reliable way to tell whether a slow site is an application problem or the machine. Because of that we give only limited L2 support for it, as [the docs say](https://docs.frappe.io/cloud/servers/instance-types#limited-support).

Nothing on the new server page said so. The only link on that page is "Compare Features", which goes to the [provider comparison](https://docs.frappe.io/cloud/servers/provider-comparision) — a feature matrix that never mentions support. So a user can buy a shared Hetzner server for a production workload without once being told what they give up.

Support has the same gap from the other side. To learn whether a server is on a shared instance, an agent has to open the Server Plan in desk and read the Plan Type field.

## What this does

**Warns on server creation.** When the provider is Hetzner and the selected application or database plan type is shared, a warning appears under the plan type selector and links to the limited support section of the instance types page.

**Adds a "Shared" badge on the server overview,** next to the plan, behind `is_desk_user`. Only support sees it, and only support pays for the extra call that fetches it.

## Screenshots

Taken against the local Frappe Cloud, on the Falkenstein Hetzner cluster with a server on the `cpx32` shared plan.

**New server page** — the warning appears once the plan type is shared.

<img width="700" height="300" alt="image" src="https://github.com/user-attachments/assets/7827ae45-c457-44ba-9ec7-e09df8218187" />

**Server overview** — the badge, as a support agent sees it.
<img width="700" height="250" alt="image" src="https://github.com/user-attachments/assets/2a95ee2f-9eee-4803-864c-a41559750ef8" />




## Notes

No backend change. The new server page already receives every plan type's title in `press.api.server.options`, so it matches on the title. The server overview only receives the plan type hash, so it reads the titles from `press.api.server.plans` — the endpoint the plan change dialog already calls.

The alternative was a `shared` check on Server Plan Type. That is exact, but it needs a schema change and someone to tick it in production before anything shows. The title is "Shared Instance" and is not going to change, so a match on it is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZeWRo3CJf2XnRRekPwDX8
