### PR TITLE
fix(press-webhook): Require a minimum sample size before auto-disabling

### DIFF
--- a/press/press/doctype/press_webhook/press_webhook.py
+++ b/press/press/doctype/press_webhook/press_webhook.py
@@ -9,10 +9,10 @@ import json
 from urllib.parse import urlparse
 
 import frappe
-import frappe.query_builder
-import frappe.query_builder.functions
 import requests
 from frappe.model.document import Document
+from frappe.query_builder import Case
+from frappe.query_builder.functions import Count, Sum
 
 from press.api.client import dashboard_whitelist
 from press.guards import role_guard
@@ -198,18 +198,19 @@ MIN_ATTEMPTS_FOR_AUTO_DISABLE = 5
 
 def auto_disable_high_delivery_failure_webhooks():
 	# In past hour, if 70% of webhook deliveries has failed, disable the webhook and notify the user
-	data = frappe.db.sql(
-		"""
-SELECT `endpoint`
-FROM `tabPress Webhook Attempt`
-WHERE `creation` >= NOW() - INTERVAL 1 HOUR
-GROUP BY `endpoint`
-HAVING COUNT(*) >= %(min_attempts)s
-	AND (COUNT(CASE WHEN `status` = 'Failed' THEN 1 END) / COUNT(*)) * 100 > 70;
-""",
-		{"min_attempts": MIN_ATTEMPTS_FOR_AUTO_DISABLE},
-		as_dict=True,
+	PressWebhookAttempt = frappe.qb.DocType("Press Webhook Attempt")
+	total = Count("*")
+	failed = Sum(Case().when(PressWebhookAttempt.status == "Failed", 1).else_(0))
+	one_hour_ago = frappe.utils.add_to_date(frappe.utils.now_datetime(), hours=-1)
+
+	query = (
+		frappe.qb.from_(PressWebhookAttempt)
+		.select(PressWebhookAttempt.endpoint)
+		.where(PressWebhookAttempt.creation >= one_hour_ago)
+		.groupby(PressWebhookAttempt.endpoint)
+		.having((total >= MIN_ATTEMPTS_FOR_AUTO_DISABLE) & ((failed / total) * 100 > 70))
 	)
+	data = query.run(as_dict=True)
 	endpoints = [row.endpoint for row in data]
 	doc_names = frappe.get_all("Press Webhook", filters={"endpoint": ("in", endpoints)}, pluck="name")
 	for doc_name in doc_names:

--- a/press/press/doctype/press_webhook/press_webhook.py
+++ b/press/press/doctype/press_webhook/press_webhook.py
@@ -187,6 +187,15 @@ class PressWebhook(Document):
 get_permission_query_conditions = get_permission_query_conditions_for_doctype("Site")
 
 
+# Below this many delivery attempts in the window, a single transient failure
+# (a timeout, the endpoint briefly restarting, ...) would already exceed the
+# failure-rate threshold on its own. Most webhook events (site/bench status
+# changes) fire rarely enough that 1-2 attempts an hour is the common case,
+# so without this floor the check disables webhooks on isolated blips rather
+# than genuine, sustained delivery failure.
+MIN_ATTEMPTS_FOR_AUTO_DISABLE = 5
+
+
 def auto_disable_high_delivery_failure_webhooks():
 	# In past hour, if 70% of webhook deliveries has failed, disable the webhook and notify the user
 	data = frappe.db.sql(
@@ -195,8 +204,10 @@ SELECT `endpoint`
 FROM `tabPress Webhook Attempt`
 WHERE `creation` >= NOW() - INTERVAL 1 HOUR
 GROUP BY `endpoint`
-HAVING (COUNT(CASE WHEN `status` = 'Failed' THEN 1 END) / COUNT(*)) * 100 > 70;
+HAVING COUNT(*) >= %(min_attempts)s
+	AND (COUNT(CASE WHEN `status` = 'Failed' THEN 1 END) / COUNT(*)) * 100 > 70;
 """,
+		{"min_attempts": MIN_ATTEMPTS_FOR_AUTO_DISABLE},
 		as_dict=True,
 	)
 	endpoints = [row.endpoint for row in data]

--- a/press/press/doctype/press_webhook/test_press_webhook.py
+++ b/press/press/doctype/press_webhook/test_press_webhook.py
@@ -1,9 +1,93 @@
 # Copyright (c) 2024, Frappe and Contributors
 # See license.txt
 
-# import frappe
+from unittest.mock import patch
+
+import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from press.press.doctype.press_webhook.press_webhook import auto_disable_high_delivery_failure_webhooks
+from press.press.doctype.team.test_team import create_test_press_admin_team
+
+
+def create_test_webhook(team: str, endpoint: str) -> "frappe.model.document.Document":
+	webhook = frappe.get_doc(
+		{
+			"doctype": "Press Webhook",
+			"team": team,
+			"endpoint": endpoint,
+			"secret": "test-secret",
+			"enabled": 1,
+			"events": [{"event": "Site Status Update"}],
+		}
+	).insert(ignore_permissions=True)
+	webhook.reload()
+	webhook.enabled = 1
+	webhook.save(ignore_permissions=True)
+	return webhook
+
+
+def log_delivery_attempts(endpoint: str, statuses: list[str]):
+	"""Record delivery attempts for `endpoint`, split across as many Press Webhook Log
+	parents as needed, mirroring how PressWebhookLog._send_webhook_call appends them."""
+	for status in statuses:
+		log = frappe.get_doc(
+			{
+				"doctype": "Press Webhook Log",
+				"event": "Site Status Update",
+				"team": frappe.db.get_value("Press Webhook", {"endpoint": endpoint}, "team"),
+				"request_payload": "{}",
+				"status": "Sent" if status == "Sent" else "Failed",
+			}
+		)
+		log.append(
+			"attempts",
+			{
+				"endpoint": endpoint,
+				"webhook": frappe.db.get_value("Press Webhook", {"endpoint": endpoint}, "name"),
+				"status": status,
+				"response_status_code": 200 if status == "Sent" else 500,
+				"response_body": "",
+				"timestamp": frappe.utils.now(),
+			},
+		)
+		log.insert(ignore_permissions=True)
 
 
 class TestPressWebhook(FrappeTestCase):
-	pass
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_single_failed_attempt_does_not_disable_low_volume_webhook(self):
+		team = create_test_press_admin_team()
+		webhook = create_test_webhook(team.name, "https://example.com/low-volume-webhook")
+
+		# Only one delivery attempt this hour, and it failed — 100% failure rate,
+		# but well below the minimum sample size the check requires.
+		log_delivery_attempts(webhook.endpoint, ["Failed"])
+
+		auto_disable_high_delivery_failure_webhooks()
+
+		webhook.reload()
+		self.assertEqual(
+			webhook.enabled,
+			1,
+			"A single transient failure on a low-volume webhook should not auto-disable it",
+		)
+
+	@patch("frappe.sendmail")
+	def test_majority_failed_attempts_disables_high_volume_webhook(self, mock_sendmail):
+		team = create_test_press_admin_team()
+		webhook = create_test_webhook(team.name, "https://example.com/high-volume-webhook")
+
+		# 4 out of 5 attempts failed (80% > 70%), at/above the minimum sample size.
+		log_delivery_attempts(webhook.endpoint, ["Failed", "Failed", "Failed", "Failed", "Sent"])
+
+		auto_disable_high_delivery_failure_webhooks()
+
+		webhook.reload()
+		self.assertEqual(
+			webhook.enabled,
+			0,
+			"A webhook with a sustained high failure rate over enough attempts should be auto-disabled",
+		)


### PR DESCRIPTION
## Summary
Reported: webhooks get disabled seemingly at random, "after any update," across many different sites/teams — not tied to any one endpoint being actually broken.

`auto_disable_high_delivery_failure_webhooks()` disabled a webhook whenever more than 70% of its deliveries failed in the past hour, with **no floor on how many attempts that percentage was computed from**:

```sql
HAVING (COUNT(CASE WHEN `status` = 'Failed' THEN 1 END) / COUNT(*)) * 100 > 70;
```

The only events that trigger a webhook (`Site Status Update`, `Bench Status Update`, `Bench Deploy Status Update`, `Site Plan Change`) fire rarely enough that most webhooks see just 1-2 delivery attempts an hour. A single transient failure — a timeout, the endpoint briefly restarting, a momentary TLS hiccup — is enough to hit 100% and get the webhook disabled (and the team emailed), with no relation to any sustained problem with the endpoint. Since this is the common case across most webhooks on the platform, it fires broadly and effectively at random, which matches the reported behavior.

## Fix
Adds a minimum-attempts floor (5) to the query before the failure-rate threshold is evaluated, so isolated blips on low-volume webhooks no longer trip it. A webhook with a genuinely high, sustained failure rate over enough attempts is still disabled exactly as before.

## Test plan
- [x] `test_single_failed_attempt_does_not_disable_low_volume_webhook` — 1 failed attempt (100% failure, below the minimum sample size) no longer disables the webhook.
- [x] `test_majority_failed_attempts_disables_high_volume_webhook` — 4/5 failed attempts (80% failure, at the minimum sample size) still disables the webhook.
- [x] Both tests pass locally (`bench --site frappe_cloud_local run-tests --app press --module press.press.doctype.press_webhook.test_press_webhook`).

## Monitoring after deploy
There's no dedicated audit log for *why* a webhook was disabled (manual vs. auto-disable vs. endpoint-change reset all just flip the same `enabled` field), so these are proxy checks rather than a direct before/after count of "auto-disables":

- **Disable-notification email volume** — the auto-disable path is the only one that emails, via the `press_webhook_disabled` template. Track `Email Queue` rows for that template day-over-day:
  ```python
  frappe.db.count("Email Queue", {"reference_doctype": "Press Webhook", "message": ["like", "%webhook has been disabled%"]})
  ```
  or filter `Email Queue` by subject `"Important: Your Configured Webhook on Frappe Cloud is disabled"` grouped by day. Expect a step-down right after this deploys, since most of what was firing before was the single-attempt false positive.
- **Job health** — confirm `auto_disable_high_delivery_failure_webhooks` (runs hourly via `hourly_long`) keeps executing without exceptions; check the `Error Log` doctype for that method name, and the scheduler's job log for `hourly_long` failures.
- **No masked genuine failures** — spot-check once, a day or two after rollout, that no *currently enabled* webhook has a sustained high failure rate that should have tripped the (now-higher) bar:
  ```sql
  SELECT endpoint, COUNT(*) total, COUNT(CASE WHEN status='Failed' THEN 1 END) failed
  FROM `tabPress Webhook Attempt`
  WHERE creation >= NOW() - INTERVAL 24 HOUR
  GROUP BY endpoint
  HAVING total >= 5 AND (failed / total) * 100 > 70;
  ```
  Any rows here should correspond to webhooks that are now `enabled = 0` — if not, the job isn't catching a real problem.
- **User-facing signal** — the original report was "gets disabled after any update, happens for all sites in general"; watch for that class of complaint to drop off in support/Slack after this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
