### PR TITLE
fix: Mark v14 as EOL & sort version nums in bench  options

### DIFF
--- a/press/api/bench.py
+++ b/press/api/bench.py
@@ -224,6 +224,7 @@ def get_app_versions_list(only_frappe=False):
 		.select(
 			FrappeVersion.name.as_("version"),
 			FrappeVersion.status,
+			FrappeVersion.number,
 			FrappeVersion.default,
 			AppSource.name.as_("source"),
 			AppSource.app,
@@ -243,6 +244,7 @@ def get_app_versions_list(only_frappe=False):
 	rows = rows.run(as_dict=True)
 
 	version_list = unique(rows, lambda x: x.version)
+	version_list.sort(key=lambda x: (x.status == "Develop", -x.number))
 
 	return version_list, rows
 

--- a/press/fixtures/frappe_version.json
+++ b/press/fixtures/frappe_version.json
@@ -213,7 +213,7 @@
 		"name": "Version 14",
 		"number": 14,
 		"public": 1,
-		"status": "Stable"
+		"status": "End of Life"
 	},
 	{
 		"default": 1,


### PR DESCRIPTION
<img width="1144" height="450" alt="image" src="https://github.com/user-attachments/assets/2d3749ed-e90d-4d10-bb5a-3a80bd5a072b" />
