### PR TITLE
feat(server): Disable the NGINX VTS module

### DIFF
--- a/press/api/tests/test_server.py
+++ b/press/api/tests/test_server.py
@@ -114,6 +114,12 @@ def successful_update_agent_ansible(self: BaseServer, *args, **kwargs):
 	return create_test_ansible_play("Update Agent", "update_agent.yml", self.doctype, self.name)
 
 
+def successful_disable_nginx_vts(self: BaseServer, *args, **kwargs):
+	return create_test_ansible_play(
+		"Disable NGINX VTS Module", "disable_nginx_vts.yml", self.doctype, self.name
+	)
+
+
 def successful_wait_for_cloud_init(self: BaseServer, *args, **kwargs):
 	return create_test_ansible_play(
 		"Wait for Cloud Init to finish", "wait_for_cloud_init.yml", self.doctype, self.name
@@ -135,6 +141,7 @@ def successful_wait_for_cloud_init(self: BaseServer, *args, **kwargs):
 @patch.object(BaseServer, "update_tls_certificate", new=successful_tls_certificate)
 @patch.object(BaseServer, "update_agent_ansible", new=successful_update_agent_ansible)
 @patch.object(BaseServer, "_update_agent_ansible", new=successful_update_agent_ansible)
+@patch.object(BaseServer, "_disable_nginx_vts", new=successful_disable_nginx_vts)
 @patch.object(Cluster, "check_machine_availability", new=available_check_machine_availability)
 class TestAPIServer(FrappeTestCase):
 	@patch.object(Cluster, "provision_on_aws_ec2", new=Mock())

--- a/press/playbooks/disable_nginx_vts.yml
+++ b/press/playbooks/disable_nginx_vts.yml
@@ -1,0 +1,20 @@
+---
+- name: Disable NGINX VTS Module
+  hosts: all
+  become: yes
+  become_user: root
+  gather_facts: no
+  tasks:
+    - name: Disable VTS Module in Agent Config
+      become_user: frappe
+      command: >-
+        /home/frappe/agent/env/bin/python -c
+        "from agent.server import Server; server = Server(); config = server.get_config(for_update=True); config['nginx_vts_module_enabled'] = False; server.set_config(config)"
+      args:
+        chdir: /home/frappe/agent
+
+    - name: Regenerate NGINX Configuration
+      become_user: frappe
+      command: /home/frappe/agent/env/bin/agent setup nginx
+      args:
+        chdir: /home/frappe/agent

--- a/press/press/doctype/press_job/jobs/create_server.py
+++ b/press/press/doctype/press_job/jobs/create_server.py
@@ -34,6 +34,7 @@ class CreateServerJob(PressJob):
 
 		self.update_tls_certificate()
 		self.update_agent()
+		self.disable_nginx_vts()
 
 		if self.server_type == "Database Server" or (
 			self.server_type == "Server" and self.server_doc.is_unified_server
@@ -259,6 +260,10 @@ class CreateServerJob(PressJob):
 	@task
 	def update_agent(self):
 		self.server_doc._update_agent_ansible(throw_on_failure=True)
+
+	@task
+	def disable_nginx_vts(self):
+		self.server_doc._disable_nginx_vts(throw_on_failure=True)
 
 	@task(queue="long", timeout=1800)
 	def upgrade_mariadb(self):

--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -2647,6 +2647,18 @@ node_filesystem_avail_bytes{{instance="{self.name}", mountpoint="{mountpoint}"}}
 			frappe.throw("Failed to set docker MTU")  # nosemgrep
 		return play
 
+	def _disable_nginx_vts(self, throw_on_failure: bool = False):
+		ansible = Ansible(
+			playbook="disable_nginx_vts.yml",
+			server=self,
+			user=self._ssh_user(),
+			port=self._ssh_port(),
+		)
+		play = ansible.run()
+		if play.status != "Success" and throw_on_failure:
+			frappe.throw("Failed to disable NGINX VTS module")  # nosemgrep
+		return play
+
 	@frappe.whitelist()
 	def reload_nginx(self):
 		agent = Agent(self.name, server_type=self.doctype)


### PR DESCRIPTION
## Why

The NGINX VTS module keeps a 256 MB shared memory zone and dumps `/var/log/nginx/vts.db` on every server. We do not need it any more.

The agent already has the switch. `nginx_vts_module_enabled` (default `true`) gates the `load_module` line and every `vhost_traffic_status` directive in [`templates/nginx/nginx.conf.jinja2`](https://github.com/frappe/agent/blob/master/agent/templates/nginx/nginx.conf.jinja2) and [`templates/agent/nginx.conf.jinja2`](https://github.com/frappe/agent/blob/master/agent/templates/agent/nginx.conf.jinja2). The proxy and bench templates hold no VTS directives.

## What changed

- `press/playbooks/disable_nginx_vts.yml` sets the flag to `false` and runs `agent setup nginx`, which re-renders the configuration and reloads NGINX.
- `BaseServer._disable_nginx_vts()` runs the playbook, in the same shape as `_set_docker_mtu`.
- The Create Server press job runs the step after `update_agent`, so new servers do not get the module.

The flag is set with the agent's own `get_config`/`set_config`, because they take the file lock and write atomically. The `chdir: /home/frappe/agent` is necessary: the agent reads `config.json` relative to the working directory.

## Test

Tested on a local app server, first with `ansible-playbook`, then through `Ansible(playbook=...)` on the local Press.

Before:

```
/home/frappe/agent/nginx/nginx.conf: load_module ...vhost_traffic_status_module.so + 4 directives
/home/frappe/agent/nginx.conf:       4 vhost_traffic_status_display lines
config.json:                         no key (defaults to true)
```

After:

```
config.json:      "nginx_vts_module_enabled": false
both nginx confs: 0 VTS lines, VTS load_module gone (headers_more stays)
nginx -t:         successful
site on the server: 200
```

A second run gives the same result. The Ansible Play record shows `Success`.

## To do after the merge

Run the playbook on the servers that are active now. A batch script is in the issue.

The Prometheus scrape configuration still points to `/metrics/nginx` (`playbooks/roles/prometheus/templates/*.yml`). That location disappears with the module, so the nginx job must be removed from the scrape configuration also.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgmXCxdBeycnaiJqTqGc1j
