### PR TITLE
fix(tls): Don't push a wildcard cert to servers in a nested root domain

### DIFF
--- a/press/press/doctype/tls_certificate/test_tls_certificate.py
+++ b/press/press/doctype/tls_certificate/test_tls_certificate.py
@@ -120,6 +120,37 @@ class TestTLSCertificate(FrappeTestCase):
 		self.assertEqual(set(stored), {"*"})
 		self.assertEqual(get_decrypted_password("TLS Certificate", cert.name, "private_key"), private_key)
 
+	def test_wildcard_renewal_does_not_target_servers_in_a_nested_root_domain(self):
+		"""A wildcard cert for a parent domain must not be pushed to servers whose
+		own root domain is nested inside it.
+
+		`*.fc.dev` does not cover `n2.internal.fc.dev` -- a wildcard matches a
+		single label -- so pushing it there replaces a valid certificate with one
+		that fails hostname verification, breaking agent communication.
+		"""
+		parent_domain = create_test_root_domain("fc3.dev")
+		create_test_root_domain("internal.fc3.dev")
+
+		outer = create_test_proxy_server(
+			"n1", domain=parent_domain.name, domains=[{"domain": parent_domain.name}]
+		)
+		nested = create_test_proxy_server(
+			"n2", domain="internal.fc3.dev", domains=[{"domain": "internal.fc3.dev"}]
+		)
+
+		# The nested server's name still ends with the parent domain, which is
+		# what the previous `name LIKE '%.<domain>'` filter matched on.
+		self.assertTrue(nested.name.endswith(f".{parent_domain.name}"))
+
+		cert = create_test_tls_certificate(parent_domain.name, wildcard=True)
+
+		with patch("press.press.doctype.tls_certificate.tls_certificate.frappe.enqueue") as mock_enqueue:
+			cert.trigger_server_tls_setup_callback()
+
+		targeted = {call.kwargs["server"].name for call in mock_enqueue.call_args_list}
+		self.assertIn(outer.name, targeted)
+		self.assertNotIn(nested.name, targeted)
+
 	def test_renewal_of_primary_domain_calls_update_tls_certificates(self):
 		# Use a diffferent domain to avoid any chance of
 		# Reusing same non wildcard domain in tests

--- a/press/press/doctype/tls_certificate/tls_certificate.py
+++ b/press/press/doctype/tls_certificate/tls_certificate.py
@@ -204,7 +204,11 @@ class TLSCertificate(Document):
 				server_doctype,
 				filters={
 					"status": ("not in", ["Archived", "Installing"]),
-					"name": ("like", f"%.{self.domain}"),
+					# Match the domain exactly. A `name LIKE '%.<domain>'` pattern also
+					# matches servers in a nested root domain, because SQL `%` matches
+					# dots -- e.g. `%.fc.dev` matches `n2.internal.fc.dev`. This mirrors
+					# BaseServer.get_certificate(), which resolves the reverse mapping.
+					"domain": self.domain,
 				},
 				fields=["name", "status"],
 			)


### PR DESCRIPTION
## Problem

`TLSCertificate.trigger_server_tls_setup_callback()` picks the servers to push a renewed wildcard certificate to by pattern-matching the server's **name**:

```python
filters={
    "status": ("not in", ["Archived", "Installing"]),
    "name": ("like", f"%.{self.domain}"),
},
```

SQL `%` matches any character, dots included. So a wildcard certificate for a parent root domain also selects every server whose own root domain is nested inside it — `%.fc.dev` matches `n2.internal.fc.dev` just as readily as `n1.fc.dev`.

A wildcard covers exactly one label, so `*.fc.dev` is **not** valid for `n2.internal.fc.dev`. The push replaces a working certificate with one that fails hostname verification, and every agent request to that server then dies with:

```
SSLCertVerificationError: Hostname mismatch,
certificate is not valid for 'n2.internal.fc.dev'
```

This is silent until something tries to talk to the agent. In our deployment it broke site backups for ~28 hours before anyone noticed, and it recurs on every renewal of the parent domain's certificate.

It only affects installs that nest one Root Domain inside another — e.g. tenant sites on `fc.dev` with server hostnames under `internal.fc.dev`.

## Fix

Match `domain` exactly instead of pattern-matching the name.

This isn't a new convention — it's the one the codebase already uses. `BaseServer.get_certificate()` resolves the *reverse* mapping with an exact `domain` match:

```python
certificate_name = frappe.db.get_value(
    "TLS Certificate", {"wildcard": True, "domain": self.domain}, "name"
)
```

The two functions are inverses of one another and disagreed: one exact, one fuzzy. After this change they agree. `setup_standalone_wildcard_hosts()` in the same file already filters on `domain` exactly too.

All nine server doctypes in the list (`Server`, `Proxy Server`, `Database Server`, `Log`, `Monitor`, `Registry`, `Analytics`, `Trace`, `NAT Server`) carry `domain` as a Link to `Root Domain`, so the filter is valid for each.

Tenant-site TLS is unaffected: that travels via `_update_secondary_wildcard_domains()` / `setup_standalone_wildcard_hosts()` → `setup_wildcard_hosts()` on the agent API, not through this callback's `tls.yml` path. A proxy serving `*.fc.dev` for tenant sites still receives it.

## Test

`test_wildcard_renewal_does_not_target_servers_in_a_nested_root_domain` asserts both halves, since a fix that stopped the over-matching but also stopped legitimate renewals would trade a loud failure for a silent one:

- the parent domain's own server **is** still targeted
- the nested domain's server **is not**

## Verification

Reproduced and confirmed against a live install by calling the real `trigger_server_tls_setup_callback()` with `frappe.enqueue` stubbed out and the transaction rolled back, on a deployment with `<tenant>.example.com` sites and `*.internal.example.com` server hostnames:

| Certificate | Before | After |
|---|---|---|
| `*.example.com` | targeted all 3 `internal.` servers | targets none |
| `*.internal.example.com` | targeted the 3 servers | targets the same 3 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)