### PR TITLE
fix(tls): Skip the ProxySQL tasks when ProxySQL is not installed

### DIFF
--- a/press/playbooks/roles/tls/tasks/main.yml
+++ b/press/playbooks/roles/tls/tasks/main.yml
@@ -25,13 +25,22 @@
     name: nginx
     state: restarted
 
+# `is_proxy_server` is derived from `proxysql_admin_password`, which
+# ProxyServer.validate_proxysql_admin_password() generates whenever it is unset.
+# It is therefore true for every Proxy Server that has ever been saved, whether or
+# not ProxySQL is installed on the machine, so check for ProxySQL itself as well.
+- name: Check whether ProxySQL is installed
+  stat:
+    path: /home/frappe/proxysql
+  register: proxysql_directory
+
 - name: Copy ProxySQL TLS (Private Key)
   copy:
     src: /home/frappe/agent/tls/privkey.pem
     dest: /home/frappe/proxysql/proxysql-key.pem
     mode: 0600
     remote_src: yes
-  when: is_proxy_server | bool
+  when: is_proxy_server | bool and proxysql_directory.stat.exists
 
 - name: Copy ProxySQL TLS (CA Certificate)
   copy:
@@ -39,7 +48,7 @@
     dest: /home/frappe/proxysql/proxysql-ca.pem
     mode: 0600
     remote_src: yes
-  when: is_proxy_server | bool
+  when: is_proxy_server | bool and proxysql_directory.stat.exists
 
 - name: Copy ProxySQL TLS (Server Certificate)
   copy:
@@ -47,7 +56,7 @@
     dest: /home/frappe/proxysql/proxysql-cert.pem
     mode: 0600
     remote_src: yes
-  when: is_proxy_server | bool
+  when: is_proxy_server | bool and proxysql_directory.stat.exists
 
 - name: Enable ProxySQL Auditing
   mysql_query:
@@ -57,4 +66,4 @@
     login_port: 6032
     query:
       - PROXYSQL RELOAD TLS
-  when: is_proxy_server | bool
+  when: is_proxy_server | bool and proxysql_directory.stat.exists


### PR DESCRIPTION
## Problem

The `tls` role copies certificates into ProxySQL and reloads its TLS, gated on `is_proxy_server`:

```yaml
- name: Copy ProxySQL TLS (Private Key)
  copy:
    dest: /home/frappe/proxysql/proxysql-key.pem
    ...
  when: is_proxy_server | bool
```

`update_server_tls_certifcate` computes that flag as `bool(proxysql_admin_password)`:

```python
if server.doctype == "Proxy Server":
    proxysql_admin_password = server.get_password("proxysql_admin_password")
...
"is_proxy_server": bool(proxysql_admin_password),
```

But `ProxyServer.validate_proxysql_admin_password()` **generates** that password whenever it is unset:

```python
def validate_proxysql_admin_password(self):
    if not self.proxysql_admin_password:
        self.proxysql_admin_password = frappe.generate_hash(length=32)
```

So the flag is true for every Proxy Server that has ever been saved, regardless of whether ProxySQL is actually installed on the machine. It tests "is this a Proxy Server document", not "does this host have ProxySQL".

That holds for a proxy Press provisioned itself. It does not hold for a self-hosted or hybrid proxy registered into Press, where ProxySQL may never have been installed.

## Impact

On such a host the play fails:

```
Copy ProxySQL TLS (Private Key) — Failure
Destination directory /home/frappe/proxysql does not exist
```

The certificate tasks run *before* these, so the certificate itself is installed correctly and nginx is reloaded — but the play as a whole is recorded as `Failure`. Consequences:

- `tls_certificate_renewal_failed` is set to 1 and can never return to 0.
- `retrigger_failed_wildcard_tls_callbacks` re-runs the play on every scheduled pass, forever, and it can never succeed.
- The flag stops being usable as a signal, so a renewal that genuinely fails looks exactly like one that succeeded.

On our install every `Setup TLS Certificates` play against the proxy had failed for three weeks before anyone looked, and this was the reason the failure persisted after an unrelated SSH problem was fixed.

## Fix

Check for ProxySQL itself in addition to the flag.

The `stat` probe runs unconditionally, so `proxysql_directory` is always defined and the `when` expression cannot raise on an undefined attribute even when `is_proxy_server` is false.

A proxy that does have ProxySQL is unaffected — `stat.exists` is true and the tasks run exactly as before.

## Verification

Applied to a self-hosted proxy with no ProxySQL installed (no `/home/frappe/proxysql`, no binary, nothing listening on 6032/6033):

| Task | Before | After |
|---|---|---|
| Setup Agent TLS (Private Key / Full Chain / Intermediate) | Success | Success |
| Reload/Restart NGINX | Success | Success |
| Check whether ProxySQL is installed | — | Success |
| Copy ProxySQL TLS ×3, Enable ProxySQL Auditing | **Failure / Pending** | **Skipped** |
| **Play status** | **Failure** | **Success** |

`tls_certificate_renewal_failed` went from 1 to 0, and the agent stayed healthy throughout — nginx active, all agent processes running, still presenting the correct certificate on 443.

The branch where ProxySQL *is* installed was not exercised, since no proxy in that fleet has it; that path is unchanged by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)