### PR TITLE
backport(master): Alert when a large share of recent signups fail (#7186)

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -268,6 +268,7 @@ scheduler_events = {
 		"press.press.doctype.team.team.auto_enable_ssh_access_for_7_days_older_teams",
 		"press.press.doctype.incident_settings.incident_settings.alert_if_phone_call_alerts_disabled",
 		"press.press.doctype.server.server.sync_wazuh_agent_status",
+		"press.press.doctype.server.server_monitoring.alert_on_failing_signups",
 		# "press.press.doctype.team.team.auto_trust_teams_with_consecutive_paid_invoices",
 		"press.press.doctype.database_server.database_server.upload_audit_logs_to_s3",
 	],

--- a/press/press/doctype/server/server_monitoring.py
+++ b/press/press/doctype/server/server_monitoring.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import re
+from collections import Counter
 from contextlib import suppress
 from typing import TypedDict
 
@@ -16,6 +17,19 @@ from press.utils.raven import send_raven_message
 
 RAVEN_SERVER_ALERTS_CHANNEL = "frappe-cloud-server-alerts"
 PROMETHEUS_REGEX_META_CHAR_PATTERN = re.compile(r"([\\.^$*+?()[\]{}|])")
+
+# No dedicated signup channel yet, so signup alerts land with the other alerts
+RAVEN_SIGNUP_ALERTS_CHANNEL = RAVEN_SERVER_ALERTS_CHANNEL
+SIGNUP_ALERT_WINDOW_HOURS = 1
+# Time a signup gets to read the mail and finish before it counts as incomplete
+SIGNUP_COMPLETION_GRACE_HOURS = 1
+TEST_SIGNUP_EMAIL_PATTERN = "fc-signup-test%"
+TRIAL_SIGNUP_FAILURE_RATIO_THRESHOLD = 0.3
+TRIAL_SIGNUP_MINIMUM_COUNT = 5
+# Most people who ask for a verification mail never finish, so only a near-total
+# stall means signups are broken rather than merely abandoned
+INCOMPLETE_SIGNUP_RATIO_THRESHOLD = 0.9
+INCOMPLETE_SIGNUP_MINIMUM_COUNT = 10
 
 
 class PublicServerHealthMetrics(TypedDict):
@@ -32,6 +46,16 @@ class PublicServerPoolDecision(TypedDict):
 	servers_with_decision: set[str]
 	server_issues: dict[str, list[str]]
 	fallback_servers_by_cluster: dict[str, str]
+
+
+class SignupFailureRate(TypedDict):
+	label: str
+	failed: int
+	total: int
+	ratio_threshold: float
+	minimum_count: int
+	breakdown: dict[str, int]
+	link: str
 
 
 def monitor_server_and_refresh_new_bench_and_site_server_pool() -> None:
@@ -501,3 +525,102 @@ def _open_public_server_pool_incident_exists(subject: str, cluster: str | None =
 	if cluster:
 		filters["cluster"] = cluster
 	return bool(frappe.db.exists("Incident", filters))
+
+
+def alert_on_failing_signups() -> None:
+	"""Alert when a large share of recent signups failed.
+
+	Two independent signals: product trial signups that errored out, and signups that
+	never became a team. Each is compared against its own ratio, over a volume floor,
+	so a single person walking away at 3am doesn't page anyone.
+	"""
+	rates = [_get_trial_signup_failure_rate(), _get_incomplete_signup_rate()]
+	breached = [rate for rate in rates if _breaches_signup_failure_threshold(rate)]
+	if breached:
+		_send_signup_failure_alert(breached)
+
+
+def _get_trial_signup_failure_rate() -> SignupFailureRate:
+	"""Product trial signups that settled in the window - errored out against site created.
+
+	Windowed on when the status last changed, not on creation: a request that took three
+	hours to fail is a failure this hour, and windowing on creation would drop it for
+	good, exactly when provisioning is slow enough to be the outage worth alerting on.
+	"""
+	requests = frappe.get_all(
+		"Product Trial Request",
+		filters={
+			"modified": (">", frappe.utils.add_to_date(None, hours=-SIGNUP_ALERT_WINDOW_HOURS)),
+			"status": ("in", ["Error", "Site Created"]),
+			"owner": ("not like", TEST_SIGNUP_EMAIL_PATTERN),
+		},
+		fields=["status", "product_trial"],
+	)
+	failed = [request for request in requests if request.status == "Error"]
+	return {
+		"label": "Product trial signups that errored out",
+		"failed": len(failed),
+		"total": len(requests),
+		"ratio_threshold": TRIAL_SIGNUP_FAILURE_RATIO_THRESHOLD,
+		"minimum_count": TRIAL_SIGNUP_MINIMUM_COUNT,
+		"breakdown": Counter(request.product_trial or "Unknown" for request in failed),
+		"link": frappe.utils.get_url("/app/product-trial-request?status=Error"),
+	}
+
+
+def _get_incomplete_signup_rate() -> SignupFailureRate:
+	"""Signups that asked for verification but never ended up with a team."""
+	emails = set(_get_signup_emails_past_grace_period())
+	teams = frappe.get_all("Team", filters={"user": ("in", list(emails))}, pluck="user") if emails else []
+	return {
+		"label": "Signups that never became a team",
+		"failed": len(emails - set(teams)),
+		"total": len(emails),
+		"ratio_threshold": INCOMPLETE_SIGNUP_RATIO_THRESHOLD,
+		"minimum_count": INCOMPLETE_SIGNUP_MINIMUM_COUNT,
+		"breakdown": {},
+		"link": frappe.utils.get_url("/app/account-request"),
+	}
+
+
+def _get_signup_emails_past_grace_period() -> list[str]:
+	"""Emails from signup requests old enough to have finished, but no older than the window.
+
+	Team invites are left out - a member joining an existing team is a different funnel.
+	"""
+	window_end = frappe.utils.add_to_date(None, hours=-SIGNUP_COMPLETION_GRACE_HOURS)
+	window_start = frappe.utils.add_to_date(window_end, hours=-SIGNUP_ALERT_WINDOW_HOURS)
+	return frappe.get_all(
+		"Account Request",
+		filters={
+			"creation": ("between", [window_start, window_end]),
+			"invited_by": ("is", "not set"),
+			"email": ("not like", TEST_SIGNUP_EMAIL_PATTERN),
+		},
+		pluck="email",
+	)
+
+
+def _breaches_signup_failure_threshold(rate: SignupFailureRate) -> bool:
+	if rate["total"] < rate["minimum_count"]:
+		return False
+	return rate["failed"] / rate["total"] > rate["ratio_threshold"]
+
+
+def _send_signup_failure_alert(rates: list[SignupFailureRate]) -> None:
+	lines = [f"**Signup Failure Alerts** - {len(rates)}", ""]
+	for rate in rates:
+		lines.append(_describe_signup_failure_rate(rate))
+		lines.extend(f"- {name}: {count}" for name, count in sorted(rate["breakdown"].items()))
+		lines.append("")
+
+	send_raven_message("\n".join(lines).strip(), RAVEN_SIGNUP_ALERTS_CHANNEL)
+
+
+def _describe_signup_failure_rate(rate: SignupFailureRate) -> str:
+	failure_ratio = rate["failed"] / rate["total"] * 100
+	return (
+		f"[{rate['label']}]({rate['link']}): {rate['failed']} of {rate['total']} "
+		f"({failure_ratio:.2f}%) in the last {SIGNUP_ALERT_WINDOW_HOURS}h, "
+		f"threshold {rate['ratio_threshold'] * 100:.0f}%"
+	)

--- a/press/press/doctype/server/server_monitoring.py
+++ b/press/press/doctype/server/server_monitoring.py
@@ -546,11 +546,16 @@ def _get_trial_signup_failure_rate() -> SignupFailureRate:
 	Windowed on when the status last changed, not on creation: a request that took three
 	hours to fail is a failure this hour, and windowing on creation would drop it for
 	good, exactly when provisioning is slow enough to be the outage worth alerting on.
+	Not on `modified` either - a later write, like the accessibility check at login, would
+	drag a long-settled request into this window and alert on an outcome from yesterday.
 	"""
 	requests = frappe.get_all(
 		"Product Trial Request",
 		filters={
-			"modified": (">", frappe.utils.add_to_date(None, hours=-SIGNUP_ALERT_WINDOW_HOURS)),
+			"status_updated_on": (
+				">",
+				frappe.utils.add_to_date(None, hours=-SIGNUP_ALERT_WINDOW_HOURS),
+			),
 			"status": ("in", ["Error", "Site Created"]),
 			"owner": ("not like", TEST_SIGNUP_EMAIL_PATTERN),
 		},

--- a/press/press/doctype/server/test_server_monitoring.py
+++ b/press/press/doctype/server/test_server_monitoring.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from press.press.doctype.account_request.test_account_request import create_test_account_request
+from press.press.doctype.server.server_monitoring import (
+	SignupFailureRate,
+	_breaches_signup_failure_threshold,
+	_get_incomplete_signup_rate,
+	_get_trial_signup_failure_rate,
+	_send_signup_failure_alert,
+	alert_on_failing_signups,
+)
+from press.press.doctype.team.test_team import create_test_team
+
+if TYPE_CHECKING:
+	from press.press.doctype.account_request.account_request import AccountRequest
+
+
+def create_test_trial_request(status: str, owner: str | None = None, settled_minutes_ago: int = 0):
+	"""Product Trial Request in a terminal state.
+
+	Status goes in through the db so the terminal-status hooks, which expect a real site,
+	don't run. The monitor reads these columns, so that is what the fixture has to get right.
+	"""
+	request = frappe.get_doc({"doctype": "Product Trial Request", "status": "Pending"}).insert(
+		ignore_permissions=True
+	)
+	values = {"status": status}
+	if owner:
+		values["owner"] = owner
+	if settled_minutes_ago:
+		values["modified"] = frappe.utils.add_to_date(None, minutes=-settled_minutes_ago)
+	frappe.db.set_value("Product Trial Request", request.name, values, update_modified=False)
+	return request
+
+
+def create_test_signups(count: int, with_team: bool = False, minutes_ago: int = 90) -> list[AccountRequest]:
+	"""Signup requests aged into the window the monitor looks at, optionally completed."""
+	requests = []
+	for _ in range(count):
+		email = f"failing-signup-{frappe.generate_hash(length=8)}@example.com"
+		requests.append(
+			create_test_account_request(
+				subdomain=frappe.mock("name"),
+				email=email,
+				creation=frappe.utils.add_to_date(None, minutes=-minutes_ago),
+			)
+		)
+		if with_team:
+			create_test_team(email)
+	return requests
+
+
+def build_signup_failure_rate(
+	failed: int,
+	total: int,
+	minimum_count: int = 5,
+	ratio_threshold: float = 0.3,
+	label: str = "Product trial signups that errored out",
+) -> SignupFailureRate:
+	return {
+		"label": label,
+		"failed": failed,
+		"total": total,
+		"ratio_threshold": ratio_threshold,
+		"minimum_count": minimum_count,
+		"breakdown": {"gameplan": failed},
+		"link": "https://frappecloud.com/app/product-trial-request?status=Error",
+	}
+
+
+def patch_signup_failure_rates(trial: SignupFailureRate, incomplete: SignupFailureRate):
+	return patch.multiple(
+		"press.press.doctype.server.server_monitoring",
+		_get_trial_signup_failure_rate=lambda: trial,
+		_get_incomplete_signup_rate=lambda: incomplete,
+	)
+
+
+class TestSignupFailureRates(FrappeTestCase):
+	"""Rates are asserted as deltas against a baseline taken first.
+
+	The monitor counts every signup on the site, so the alternative was deleting rows
+	this test didn't create, which would wipe fixtures and real signups alike.
+	"""
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_trial_signups_that_errored_out_are_counted_against_settled_requests(self):
+		baseline = _get_trial_signup_failure_rate()
+		for _ in range(4):
+			create_test_trial_request("Error")
+		for _ in range(2):
+			create_test_trial_request("Site Created")
+
+		rate = _get_trial_signup_failure_rate()
+
+		self.assertEqual(rate["failed"] - baseline["failed"], 4)
+		self.assertEqual(rate["total"] - baseline["total"], 6)
+
+	def test_trial_signups_that_have_not_settled_are_not_counted(self):
+		baseline = _get_trial_signup_failure_rate()
+		create_test_trial_request("Pending")
+		create_test_trial_request("Wait for Site")
+
+		rate = _get_trial_signup_failure_rate()
+
+		self.assertEqual(rate["total"] - baseline["total"], 0)
+
+	def test_trial_signup_that_took_hours_to_fail_is_counted_in_the_hour_it_failed(self):
+		baseline = _get_trial_signup_failure_rate()
+		request = create_test_trial_request("Error")
+		frappe.db.set_value(
+			"Product Trial Request",
+			request.name,
+			"creation",
+			frappe.utils.add_to_date(None, hours=-3),
+			update_modified=False,
+		)
+
+		rate = _get_trial_signup_failure_rate()
+
+		self.assertEqual(rate["failed"] - baseline["failed"], 1)
+
+	def test_trial_signup_that_settled_before_the_window_is_not_counted(self):
+		baseline = _get_trial_signup_failure_rate()
+		create_test_trial_request("Error", settled_minutes_ago=90)
+
+		rate = _get_trial_signup_failure_rate()
+
+		self.assertEqual(rate["failed"] - baseline["failed"], 0)
+
+	def test_signup_canary_trial_requests_are_not_counted(self):
+		baseline = _get_trial_signup_failure_rate()
+		create_test_trial_request("Error", owner="fc-signup-test+1@example.com")
+
+		rate = _get_trial_signup_failure_rate()
+
+		self.assertEqual(rate["total"] - baseline["total"], 0)
+
+	def test_signups_without_a_team_past_the_grace_period_are_counted_as_failures(self):
+		baseline = _get_incomplete_signup_rate()
+		create_test_signups(2)
+
+		rate = _get_incomplete_signup_rate()
+
+		self.assertEqual(rate["failed"] - baseline["failed"], 2)
+		self.assertEqual(rate["total"] - baseline["total"], 2)
+
+	def test_signups_that_became_teams_are_not_counted_as_failures(self):
+		baseline = _get_incomplete_signup_rate()
+		create_test_signups(2, with_team=True)
+
+		rate = _get_incomplete_signup_rate()
+
+		self.assertEqual(rate["failed"] - baseline["failed"], 0)
+		self.assertEqual(rate["total"] - baseline["total"], 2)
+
+	def test_signups_still_within_the_grace_period_are_not_counted(self):
+		baseline = _get_incomplete_signup_rate()
+		create_test_signups(2, minutes_ago=5)
+
+		rate = _get_incomplete_signup_rate()
+
+		self.assertEqual(rate["total"] - baseline["total"], 0)
+
+	def test_team_invites_are_not_counted_as_signups(self):
+		baseline = _get_incomplete_signup_rate()
+		[request] = create_test_signups(1)
+		frappe.db.set_value(
+			"Account Request", request.name, "invited_by", "member@example.com", update_modified=False
+		)
+
+		rate = _get_incomplete_signup_rate()
+
+		self.assertEqual(rate["total"] - baseline["total"], 0)
+
+
+class TestSignupFailureThreshold(FrappeTestCase):
+	def test_failure_ratio_above_threshold_breaches(self):
+		self.assertTrue(_breaches_signup_failure_threshold(build_signup_failure_rate(failed=4, total=6)))
+
+	def test_failure_ratio_at_threshold_does_not_breach(self):
+		self.assertFalse(_breaches_signup_failure_threshold(build_signup_failure_rate(failed=3, total=10)))
+
+	def test_signup_count_below_the_floor_does_not_breach(self):
+		self.assertFalse(_breaches_signup_failure_threshold(build_signup_failure_rate(failed=4, total=4)))
+
+
+@patch("press.press.doctype.server.server_monitoring.send_raven_message")
+class TestSignupFailureAlert(FrappeTestCase):
+	def test_alert_names_the_signal_the_ratio_and_the_breakdown(self, send_raven_message):
+		_send_signup_failure_alert([build_signup_failure_rate(failed=4, total=6)])
+
+		message = send_raven_message.call_args[0][0]
+		self.assertIn("Product trial signups that errored out", message)
+		self.assertIn("4 of 6 (66.67%)", message)
+		self.assertIn("- gameplan: 4", message)
+
+	def test_alert_lists_only_the_signal_that_breached(self, send_raven_message):
+		with patch_signup_failure_rates(
+			trial=build_signup_failure_rate(failed=4, total=6),
+			incomplete=build_signup_failure_rate(
+				failed=1,
+				total=100,
+				minimum_count=10,
+				ratio_threshold=0.9,
+				label="Signups that never became a team",
+			),
+		):
+			alert_on_failing_signups()
+
+		message = send_raven_message.call_args[0][0]
+		self.assertIn("**Signup Failure Alerts** - 1", message)
+		self.assertIn("Product trial signups that errored out", message)
+		self.assertNotIn("Signups that never became a team", message)
+
+	def test_no_alert_when_neither_signal_breaches(self, send_raven_message):
+		with patch_signup_failure_rates(
+			trial=build_signup_failure_rate(failed=1, total=10),
+			incomplete=build_signup_failure_rate(failed=1, total=100, minimum_count=10, ratio_threshold=0.9),
+		):
+			alert_on_failing_signups()
+
+		send_raven_message.assert_not_called()

--- a/press/press/doctype/server/test_server_monitoring.py
+++ b/press/press/doctype/server/test_server_monitoring.py
@@ -33,11 +33,12 @@ def create_test_trial_request(status: str, owner: str | None = None, settled_min
 	request = frappe.get_doc({"doctype": "Product Trial Request", "status": "Pending"}).insert(
 		ignore_permissions=True
 	)
-	values = {"status": status}
+	values = {
+		"status": status,
+		"status_updated_on": frappe.utils.add_to_date(None, minutes=-settled_minutes_ago),
+	}
 	if owner:
 		values["owner"] = owner
-	if settled_minutes_ago:
-		values["modified"] = frappe.utils.add_to_date(None, minutes=-settled_minutes_ago)
 	frappe.db.set_value("Product Trial Request", request.name, values, update_modified=False)
 	return request
 
@@ -138,6 +139,28 @@ class TestSignupFailureRates(FrappeTestCase):
 		rate = _get_trial_signup_failure_rate()
 
 		self.assertEqual(rate["failed"] - baseline["failed"], 0)
+
+	def test_trial_signup_written_to_after_it_settled_is_not_counted_again(self):
+		"""A settled request keeps getting written to - the accessibility check at login,
+		the subscription flag - and none of that makes its outcome recent."""
+		baseline = _get_trial_signup_failure_rate()
+		request = create_test_trial_request("Error", settled_minutes_ago=90)
+		frappe.db.set_value("Product Trial Request", request.name, "is_site_accessible", "Yes")
+
+		rate = _get_trial_signup_failure_rate()
+
+		self.assertEqual(rate["failed"] - baseline["failed"], 0)
+
+	def test_trial_signup_is_stamped_when_its_status_changes(self):
+		request = create_test_trial_request("Pending", settled_minutes_ago=90)
+		request.reload()
+		request.status = "Error"
+		request.save(ignore_permissions=True)
+
+		self.assertGreater(
+			frappe.utils.get_datetime(request.status_updated_on),
+			frappe.utils.add_to_date(None, minutes=-1),
+		)
 
 	def test_signup_canary_trial_requests_are_not_counted(self):
 		baseline = _get_trial_signup_failure_rate()

--- a/press/saas/doctype/product_trial_request/product_trial_request.json
+++ b/press/saas/doctype/product_trial_request/product_trial_request.json
@@ -23,6 +23,7 @@
 		"is_subscription_created",
 		"column_break_bvut",
 		"site_creation_completed_on",
+		"status_updated_on",
 		"is_site_accessible",
 		"errors_tab",
 		"error"
@@ -115,6 +116,12 @@
 			"label": "Is Standby Site"
 		},
 		{
+			"fieldname": "status_updated_on",
+			"fieldtype": "Datetime",
+			"label": "Status Updated On",
+			"read_only": 1
+		},
+		{
 			"default": "Not Checked",
 			"fieldname": "is_site_accessible",
 			"fieldtype": "Select",
@@ -139,7 +146,7 @@
 	"grid_page_length": 50,
 	"index_web_pages_for_search": 1,
 	"links": [],
-	"modified": "2025-09-22 14:10:22.140755",
+	"modified": "2026-09-08 12:00:00.000000",
 	"modified_by": "Administrator",
 	"module": "SaaS",
 	"name": "Product Trial Request",

--- a/press/saas/doctype/product_trial_request/product_trial_request.py
+++ b/press/saas/doctype/product_trial_request/product_trial_request.py
@@ -55,6 +55,7 @@ class ProductTrialRequest(Document):
 			"Error",
 			"Expired",
 		]
+		status_updated_on: DF.Datetime | None
 		team: DF.Link | None
 		tracked_agent_jobs: DF.Code | None
 	# end: auto-generated types
@@ -281,6 +282,12 @@ class ProductTrialRequest(Document):
 			self.site_creation_completed_on = now_datetime()
 		self.save(ignore_permissions=True)
 		return True
+
+	def before_save(self):
+		if self.has_value_changed("status"):
+			# `modified` moves on every later write - a subscription flag, an accessibility
+			# check at login - so anything asking when a request settled needs its own stamp
+			self.status_updated_on = now_datetime()
 
 	def after_insert(self):
 		self.capture_posthog_event("product_trial_request_created")
@@ -556,8 +563,7 @@ def expire_long_pending_trial_requests():
 	frappe.db.set_value(
 		"Product Trial Request",
 		{"status": "Pending", "creation": ("<", add_to_date(now_datetime(), hours=-6))},
-		"status",
-		"Expired",
+		{"status": "Expired", "status_updated_on": now_datetime()},
 		update_modified=False,
 	)
 


### PR DESCRIPTION
Backport of #7186 to `master`.

Cherry-picks both commits from the original PR:

- `95e698e16` feat(monitoring): Alert when a large share of recent signups fail
- `c667d7392` fix(monitoring): Window signup failures on status change, not modified

Adds `alert_on_failing_signups` on the `hourly` scheduler, alerting via Raven when either signal crosses its threshold: product trial requests that errored out rather than created a site (>30%, min 5, per product trial), and Account Requests that never became a Team an hour after asking for verification (>90%, min 10). Ratios over a volume floor so one failure in a quiet hour doesn't page anyone; the `fc-signup-test` canary is excluded from both. Trial requests window on `status_updated_on` — stamped when the status changes — so later writes to a settled request don't carry an old outcome into a new window.

The net diff against `master` is identical to the net diff of #7186 against `develop`.

**Conflict resolution:** one conflict, in `press/hooks.py` — `master` has `sync_wazuh_agent_status` on the `hourly` list where the original commit added its line. Kept both entries.

**Tests:** `test_server_monitoring.py` comes across unchanged from #7186. Not run locally — leaving that to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)