### PR TITLE
fix(dashboard): Change the Performance Schema notice for shared hosting

### DIFF
--- a/dashboard/src/components/devtools/database/DatabasePerformanceSchemaDisabledNotice.vue
+++ b/dashboard/src/components/devtools/database/DatabasePerformanceSchemaDisabledNotice.vue
@@ -2,9 +2,6 @@
 	<div class="flex h-60 flex-col items-center justify-center gap-1">
 		<template v-if="isDedicatedServer">
 			<p class="text-base text-ink-gray-7">
-				Performance Schema is not enabled on database server
-			</p>
-			<p class="text-base text-ink-gray-7">
 				Please refer to the
 				<a
 					href="https://docs.frappe.io/cloud/performance-tuning"

--- a/dashboard/src/components/devtools/database/DatabasePerformanceSchemaDisabledNotice.vue
+++ b/dashboard/src/components/devtools/database/DatabasePerformanceSchemaDisabledNotice.vue
@@ -5,17 +5,19 @@
 				Performance Schema is not enabled on database server
 			</p>
 			<p class="text-base text-ink-gray-7">
-				Read the
+				Please refer to the
 				<a
 					href="https://docs.frappe.io/cloud/performance-tuning"
 					target="_blank"
 					class="underline"
-					>performance tuning guide</a
-				>, or reach out to
-				<a href="https://support.frappe.io/" target="_blank" class="underline"
-					>support</a
+					>performance tuning documentation</a
 				>
-				to enable it
+			</p>
+			<p class="text-base text-ink-gray-7">
+				For any other concern, raise a support ticket on
+				<a href="https://support.frappe.io/" target="_blank" class="underline"
+					>support.frappe.io</a
+				>
 			</p>
 		</template>
 		<template v-else>

--- a/dashboard/src/components/devtools/database/DatabasePerformanceSchemaDisabledNotice.vue
+++ b/dashboard/src/components/devtools/database/DatabasePerformanceSchemaDisabledNotice.vue
@@ -7,7 +7,7 @@
 					href="https://docs.frappe.io/cloud/database-server-actions#performance-schema"
 					target="_blank"
 					class="underline"
-					>performance tuning documentation</a
+					>documentation to enable Performance Schema</a
 				>
 			</p>
 			<p class="text-base text-ink-gray-7">

--- a/dashboard/src/components/devtools/database/DatabasePerformanceSchemaDisabledNotice.vue
+++ b/dashboard/src/components/devtools/database/DatabasePerformanceSchemaDisabledNotice.vue
@@ -1,19 +1,37 @@
 <template>
 	<div class="flex h-60 flex-col items-center justify-center gap-1">
-		<p class="text-base text-ink-gray-7">
-			Performance Schema is not enabled on database server
-		</p>
-		<p class="text-base text-ink-gray-7">
-			Please reach out to
-			<a href="https://support.frappe.io/" target="_blank" class="underline"
-				>support</a
-			>
-			to enable it
-		</p>
+		<template v-if="isDedicatedServer">
+			<p class="text-base text-ink-gray-7">
+				Performance Schema is not enabled on database server
+			</p>
+			<p class="text-base text-ink-gray-7">
+				Please reach out to
+				<a href="https://support.frappe.io/" target="_blank" class="underline"
+					>support</a
+				>
+				to enable it
+			</p>
+		</template>
+		<template v-else>
+			<p class="text-base text-ink-gray-7">
+				Performance Schema is disabled on shared hosting
+			</p>
+			<p class="text-base text-ink-gray-7">
+				This feature is only available on a dedicated server
+			</p>
+		</template>
 	</div>
 </template>
 <script>
 export default {
 	name: 'DatabasePerformanceSchemaDisabledNotice',
+	props: {
+		// support can only enable Performance Schema on a dedicated database
+		// server, so a site on shared hosting must be told something different
+		isDedicatedServer: {
+			type: Boolean,
+			default: false,
+		},
+	},
 };
 </script>

--- a/dashboard/src/components/devtools/database/DatabasePerformanceSchemaDisabledNotice.vue
+++ b/dashboard/src/components/devtools/database/DatabasePerformanceSchemaDisabledNotice.vue
@@ -4,7 +4,7 @@
 			<p class="text-base text-ink-gray-7">
 				Please refer to the
 				<a
-					href="https://docs.frappe.io/cloud/performance-tuning"
+					href="https://docs.frappe.io/cloud/database-server-actions#performance-schema"
 					target="_blank"
 					class="underline"
 					>performance tuning documentation</a

--- a/dashboard/src/components/devtools/database/DatabasePerformanceSchemaDisabledNotice.vue
+++ b/dashboard/src/components/devtools/database/DatabasePerformanceSchemaDisabledNotice.vue
@@ -5,7 +5,13 @@
 				Performance Schema is not enabled on database server
 			</p>
 			<p class="text-base text-ink-gray-7">
-				Please reach out to
+				Read the
+				<a
+					href="https://docs.frappe.io/cloud/performance-tuning"
+					target="_blank"
+					class="underline"
+					>performance tuning guide</a
+				>, or reach out to
 				<a href="https://support.frappe.io/" target="_blank" class="underline"
 					>support</a
 				>
@@ -17,7 +23,13 @@
 				Performance Schema is disabled on shared hosting
 			</p>
 			<p class="text-base text-ink-gray-7">
-				This feature is only available on a dedicated server
+				This feature is only available on a
+				<a
+					href="https://frappe.io/cloud/servers"
+					target="_blank"
+					class="underline"
+					>dedicated server</a
+				>
 			</p>
 		</template>
 	</div>

--- a/dashboard/src/pages/devtools/database/DatabaseAnalyzer.vue
+++ b/dashboard/src/pages/devtools/database/DatabaseAnalyzer.vue
@@ -264,6 +264,7 @@
 										tab.label === 'Full Table Scan Queries') &&
 									!isPerformanceSchemaEnabled
 								"
+								:isDedicatedServer="isDedicatedServer"
 							/>
 							<ResultTable
 								v-else
@@ -300,6 +301,7 @@
 										tab.label === 'Suggested Indexes') &&
 									!isPerformanceSchemaEnabled
 								"
+								:isDedicatedServer="isDedicatedServer"
 							/>
 							<div v-else-if="tab.label === 'Suggested Indexes'">
 								<div
@@ -758,6 +760,9 @@ export default {
 					(claimable_size / database_size_limit) * 100,
 				),
 			};
+		},
+		isDedicatedServer() {
+			return Boolean(this.site_info?.is_dedicated_server);
 		},
 		isPerformanceSchemaEnabled() {
 			const result = this.$resources.databasePerformanceReport?.data?.message;


### PR DESCRIPTION
## Problem

The Database Analyzer shows the same notice to all users when Performance Schema is disabled:

> Performance Schema is not enabled on database server
> Please reach out to **support** to enable it

Performance Schema is available only on a dedicated server. A user on shared hosting cannot enable it. But the notice tells the user to contact support. Support cannot help the user.

## Change

This PR shows a different notice for each type of hosting.

**Shared hosting**

> Performance Schema is disabled on shared hosting
> This feature is only available on a [dedicated server](https://frappe.io/cloud/servers)

**Dedicated server**

> Please refer to the [documentation to enable Performance Schema](https://docs.frappe.io/cloud/database-server-actions#performance-schema)
> For any other concern, raise a support ticket on [support.frappe.io](https://support.frappe.io/)

A user on a dedicated server can enable Performance Schema themselves. The documentation gives the steps. The notice gives the documentation first. The user makes a support ticket only for a question that the documentation does not answer.

The component reads the type of hosting from the `is_dedicated_server` field. The Site document already sends this field to the dashboard. Thus the performance report does not need a new field.

The dashboard shows the notice in two places: the SQL Query Analysis tabs and the Database Index Analysis tabs. Both places show the new notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)