### PR TITLE
fix(virtual-machine): Stop automated snapshots on Frappe Compute

### DIFF
--- a/press/hooks.py
+++ b/press/hooks.py
@@ -291,7 +291,8 @@ scheduler_events = {
 		"press.press.doctype.virtual_machine.virtual_machine.snapshot_oci_virtual_machines",
 		"press.press.doctype.virtual_machine.virtual_machine.snapshot_hetzner_virtual_machines",
 		"press.press.doctype.virtual_machine.virtual_machine.snapshot_aws_internal_virtual_machines",
-		"press.press.doctype.virtual_machine.virtual_machine.snapshot_frappe_compute_virtual_machines",
+		# Disabled: snapshots on Frappe Compute (bare metal) fail and flood the error log
+		# "press.press.doctype.virtual_machine.virtual_machine.snapshot_frappe_compute_virtual_machines",
 		"press.press.doctype.virtual_disk_snapshot.virtual_disk_snapshot.delete_old_snapshots",
 		"press.press.doctype.virtual_disk_snapshot.virtual_disk_snapshot.delete_expired_snapshots",
 		"press.press.doctype.app_release.app_release.cleanup_unused_releases",


### PR DESCRIPTION
The hourly scheduler task `snapshot_frappe_compute_virtual_machines` fails on every Frappe Compute (bare metal) machine. Each failure writes an Error Log entry with the title "Virtual Machine Snapshot Error". The Error Log fills with these entries and hides real problems.

This commented the scheduler entry out. It did not delete the function, because the task must come back when snapshots work on this provider.

cc: @the-bokya 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDutt9Ubdqd9stXhopcMRs