### PR TITLE
fix(nginx): Pass proxy's IP

### DIFF
--- a/press/agent.py
+++ b/press/agent.py
@@ -2025,13 +2025,14 @@ Response: {reason or getattr(result, "text", "Unknown")}
 			reference_name=reference_name,
 		)
 
-	def update_nginx_access(self, ip_accept: list[str], ip_drop: list[str]) -> AgentJob:
+	def update_nginx_access(self, ip_accept: list[str], ip_drop: list[str], proxy_ip: str) -> AgentJob:
 		return self.create_agent_job(
 			"Update Nginx Access",
 			"/server/update-nginx-access",
 			data={
 				"ip_accept": ip_accept,
 				"ip_drop": ip_drop,
+				"proxy_ip": proxy_ip,
 			},
 		)
 

--- a/press/press/doctype/server_firewall/server_firewall.py
+++ b/press/press/doctype/server_firewall/server_firewall.py
@@ -120,10 +120,13 @@ class ServerFirewall(Document):
 
 	def _sync_nginx(self):
 		"""Update Nginx access rules with allowed and denied IPs."""
+		server = self.server
 		ip_accept = self.get_allowed_ips_for_nginx()
 		ip_drop = [rule.source for rule in self.rules if rule.action == "Deny" and rule.source]
 		try:
-			return self.server.agent.update_nginx_access(ip_accept, ip_drop)
+			# The proxy IP travels with the rules: nginx needs it to read the
+			# visitor's address off X-Real-IP instead of matching the proxy.
+			return server.agent.update_nginx_access(ip_accept, ip_drop, server.get_proxy_ip())
 		except Exception:
 			log_error("Failed to sync nginx access rules", doc=self)
 

--- a/press/press/doctype/server_firewall/test_server_firewall.py
+++ b/press/press/doctype/server_firewall/test_server_firewall.py
@@ -1,9 +1,12 @@
 # Copyright (c) 2026, Frappe and Contributors
 # See license.txt
 
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
+from press.agent import Agent
 from press.api.client import set_value
 from press.api.tests.test_client import sign_in_as
 from press.press.doctype.server.test_server import create_test_server
@@ -85,3 +88,40 @@ class TestServerFirewallDashboardEditing(FrappeTestCase):
 		self.assertEqual(
 			frappe.db.get_value("Server Firewall", self.firewall.name, "server_id"), self.server.name
 		)
+
+
+class TestServerFirewallNginxSync(FrappeTestCase):
+	"""Nginx cannot tell a visitor from the proxy unless the sync carries the proxy IP."""
+
+	def setUp(self):
+		super().setUp()
+		self.server = create_test_server()
+		self.firewall = frappe.get_doc("Server Firewall", {"server_id": self.server.name})
+		self.firewall.append(
+			"rules", {"source": "183.82.5.84/32", "port": 443, "protocol": "TCP", "action": "Allow"}
+		)
+		self.firewall.append(
+			"rules", {"source": "0.0.0.0/0", "port": 443, "protocol": "TCP", "action": "Deny"}
+		)
+		self.firewall.enabled = 1
+		self.firewall.save()
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	@patch.object(Agent, "update_nginx_access")
+	def test_nginx_sync_sends_the_proxy_ip_along_with_the_rules(self, update_nginx_access):
+		self.firewall._sync_nginx()
+
+		ip_accept, ip_drop, proxy_ip = update_nginx_access.call_args.args
+		self.assertIn("183.82.5.84/32", ip_accept)
+		self.assertEqual(ip_drop, ["0.0.0.0/0"])
+		self.assertEqual(proxy_ip, self.server.get_proxy_ip())
+
+	@patch.object(Agent, "update_nginx_access")
+	def test_the_proxy_subnet_the_sync_allows_is_the_one_it_asks_nginx_to_trust(self, update_nginx_access):
+		"""Allowing the subnet without trusting it is what let every visitor through."""
+		self.firewall._sync_nginx()
+
+		ip_accept, _, proxy_ip = update_nginx_access.call_args.args
+		self.assertIn(proxy_ip, ip_accept)


### PR DESCRIPTION
Pass proxy's IP for Nginx's allow/deny rules. This fixes an issue with firewall not working as expected in some cases.

Agent: https://github.com/frappe/agent/pull/597