### PR TITLE
fix(dashboard): Read the chromium path from launchOptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,14 @@ lines break when the reader changes the width of the box, and they are hard to
 edit. Let each paragraph run on one line. The 72-character limit applies to the
 commit header only, not to the PR body.
 
+Attach screenshots to the pull request directly. Do not commit a screenshot to
+the repository and link it with a `raw.githubusercontent.com` URL. GitHub
+deletes the branch when the pull request merges. Every link to that branch then
+gives a 404, and the description shows a broken image to each reader. The
+screenshots in [press#7405](https://github.com/frappe/press/pull/7405) broke
+this way. Paste each image into the description box instead. GitHub uploads it
+and keeps it for the life of the pull request.
+
 ## Running Tests
 
 Before running tests, always ask the user which site to use.

--- a/dashboard/playwright.config.ts
+++ b/dashboard/playwright.config.ts
@@ -3,6 +3,15 @@ import dotenv from 'dotenv'
 
 dotenv.config({ path: './tests-e2e/.env', quiet: true })
 
+const launchOptions = {
+	args: ['--no-sandbox', '--disable-setuid-sandbox'],
+	slowMo: process.env.PLAYWRIGHT_SLOW_MO
+		? parseInt(process.env.PLAYWRIGHT_SLOW_MO)
+		: undefined,
+	// undefined keeps Playwright's bundled browser; a path uses a browser already installed
+	executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+}
+
 export default defineConfig({
 	testDir: './tests-e2e',
 	fullyParallel: true,
@@ -13,12 +22,7 @@ export default defineConfig({
 		trace: 'retain-on-failure',
 		screenshot: 'only-on-failure',
 		video: 'retain-on-failure',
-		launchOptions: {
-			args: ['--no-sandbox', '--disable-setuid-sandbox'],
-			slowMo: process.env.PLAYWRIGHT_SLOW_MO
-				? parseInt(process.env.PLAYWRIGHT_SLOW_MO)
-				: undefined,
-		},
+		launchOptions,
 	},
 	reporter: [['list'], ['html', { open: 'never' }]],
 	projects: [
@@ -30,16 +34,12 @@ export default defineConfig({
 		{
 			name: 'setup',
 			testMatch: /.*\.setup\.ts/,
-			use: {
-				executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
-			},
 		},
 		{
 			name: 'chromium',
 			use: {
 				...devices['Desktop Chrome'],
 				storageState: 'tests-e2e/.auth/session.json',
-				executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
 			},
 			// must match all *.test.ts files only
 			testMatch: /^(?!.*(\.cron|\.setup)\.spec\.ts$).*\.test\.ts$/,


### PR DESCRIPTION
Two changes from the #7405 revert (#7441).

`dashboard/playwright.config.ts`: #7441 reverted #7405 in full, which took an unrelated fix with it. `executablePath` is back under `use`, where Playwright ignores it, so `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` stopped working. Puts it back in `launchOptions`.

`AGENTS.md`: attach PR screenshots instead of committing them and linking `raw.githubusercontent.com` URLs. The #7405 branch was deleted on merge and its images now 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018dc5RPUfeuUP8x8un26ove
