### PR TITLE
feat(monitoring): Give each server its own storage alert rule

### DIFF
--- a/press/press/doctype/prometheus_alert_rule/prometheus_alert_rule.py
+++ b/press/press/doctype/prometheus_alert_rule/prometheus_alert_rule.py
@@ -25,6 +25,20 @@ if TYPE_CHECKING:
 THRESHOLD_PLACEHOLDER = "{{ threshold }}"
 INSTANCES_PLACEHOLDER = "{{ instances }}"
 SERVER_TYPES_WITH_STORAGE_ALERT_THRESHOLD = ("Server", "Database Server")
+FIELDS_COPIED_TO_PER_SERVER_RULE = (
+	"severity",
+	"for",
+	"group_by",
+	"group_wait",
+	"group_interval",
+	"repeat_interval",
+	"labels",
+	"annotations",
+	"press_job_type",
+	"only_on_shared",
+	"silent",
+	"enabled",
+)
 
 
 class PrometheusAlertRule(Document):
@@ -83,18 +97,14 @@ class PrometheusAlertRule(Document):
 			)
 
 	def get_alert_rules(self) -> list[dict]:
-		"""One rule per storage alert threshold, so each server alerts at the level its team picked."""
+		"""The shared rule, minus the servers that carry a rule of their own."""
 		if not self.split_by_server_storage_threshold:
 			return [self.get_rule()]
 
-		overrides = servers_by_storage_alert_threshold()
-		overridden_servers = [server for servers in overrides.values() for server in servers]
-
-		rules = [self.get_rule_for_threshold(DEFAULT_STORAGE_ALERT_THRESHOLD, overridden_servers, True)]
-		rules.extend(
-			self.get_rule_for_threshold(threshold, servers, False) for threshold, servers in overrides.items()
-		)
-		return rules
+		overriding_servers = list(servers_by_storage_alert_threshold())
+		return [
+			self.get_rule_for_threshold(DEFAULT_STORAGE_ALERT_THRESHOLD, overriding_servers, exclude=True)
+		]
 
 	def get_rule_for_threshold(self, threshold: int, servers: list[str], exclude: bool) -> dict:
 		rule = self.get_rule()
@@ -131,6 +141,17 @@ class PrometheusAlertRule(Document):
 		}
 
 	def on_update(self):
+		if frappe.flags.syncing_storage_alert_rules:
+			# the base rule pushes once for the whole sync
+			return
+
+		if self.split_by_server_storage_threshold:
+			sync_storage_alert_rules(self)
+
+		self.push_rules_to_monitor_server()
+
+	def sync_and_push_storage_alert_rules(self):
+		sync_storage_alert_rules(self)
 		self.push_rules_to_monitor_server()
 
 	def push_rules_to_monitor_server(self):
@@ -220,9 +241,9 @@ class PrometheusAlertRule(Document):
 		).insert()
 
 
-def servers_by_storage_alert_threshold() -> dict[int, list[str]]:
-	"""Active servers that alert at something other than the default threshold, grouped by threshold."""
-	overrides: dict[int, list[str]] = {}
+def servers_by_storage_alert_threshold() -> dict[str, int]:
+	"""Active servers that alert at something other than the default threshold, and the level each picked."""
+	overrides: dict[str, int] = {}
 	for doctype in SERVER_TYPES_WITH_STORAGE_ALERT_THRESHOLD:
 		servers = frappe.get_all(
 			doctype,
@@ -238,7 +259,7 @@ def servers_by_storage_alert_threshold() -> dict[int, list[str]]:
 				# never went through validation, so leave it on the default rule
 				# instead of alerting the server at, say, 0%
 				continue
-			overrides.setdefault(threshold, []).append(server.name)
+			overrides[server.name] = threshold
 	return overrides
 
 
@@ -251,8 +272,66 @@ def instance_matcher(servers: list[str], exclude: bool) -> str:
 	return f'instance!~"{pattern}"' if exclude else f'instance=~"{pattern}"'
 
 
+def base_storage_alert_rule() -> str | None:
+	return frappe.db.get_value(
+		"Prometheus Alert Rule", {"split_by_server_storage_threshold": 1, "enabled": 1}
+	)
+
+
+def storage_alert_rule_name(base_rule: str, server: str) -> str:
+	return f"{base_rule} - {server}"
+
+
+def sync_storage_alert_rules(base_rule: PrometheusAlertRule):
+	"""Give every overriding server a rule of its own, and drop the ones no longer needed."""
+	overrides = servers_by_storage_alert_threshold()
+
+	frappe.flags.syncing_storage_alert_rules = True
+	try:
+		for server, threshold in overrides.items():
+			upsert_storage_alert_rule(base_rule, server, threshold)
+		delete_stale_storage_alert_rules(base_rule, set(overrides))
+	finally:
+		frappe.flags.syncing_storage_alert_rules = False
+
+
+def upsert_storage_alert_rule(base_rule: PrometheusAlertRule, server: str, threshold: int):
+	name = storage_alert_rule_name(base_rule.name, server)
+	values = storage_alert_rule_values(base_rule, server, threshold)
+
+	if frappe.db.exists("Prometheus Alert Rule", name):
+		rule: PrometheusAlertRule = frappe.get_doc("Prometheus Alert Rule", name)
+		rule.update(values)
+		rule.save()
+		return
+
+	frappe.get_doc({"doctype": "Prometheus Alert Rule", "name": name, **values}).insert()
+
+
+def storage_alert_rule_values(base_rule: PrometheusAlertRule, server: str, threshold: int) -> dict:
+	"""Everything the per-server rule inherits, with its own threshold baked into the expression."""
+	values = {field: base_rule.get(field) for field in FIELDS_COPIED_TO_PER_SERVER_RULE}
+	values.update(
+		{
+			"description": f"{base_rule.description} ({server} alerts at {threshold}%)",
+			"expression": base_rule.get_rule_for_threshold(threshold, [server], exclude=False)["expr"],
+			# the per-server rule is the split, splitting it again would exclude the server from itself
+			"split_by_server_storage_threshold": 0,
+		}
+	)
+	return values
+
+
+def delete_stale_storage_alert_rules(base_rule: PrometheusAlertRule, overriding_servers: set[str]):
+	"""Drop the rules of servers that went back to the default, or were archived."""
+	prefix = storage_alert_rule_name(base_rule.name, "")
+	for name in frappe.get_all("Prometheus Alert Rule", {"name": ("like", f"{prefix}%")}, pluck="name"):
+		if name[len(prefix) :] not in overriding_servers:
+			frappe.delete_doc("Prometheus Alert Rule", name)
+
+
 def update_rules_on_storage_alert_threshold_change(server, method=None):
-	"""Rebuild the split rules so the server starts alerting at its new threshold."""
+	"""Rebuild the per-server rules so the server starts alerting at its new threshold."""
 	previous = server.get_doc_before_save()
 	previous_threshold = (
 		previous.storage_alert_threshold_percent if previous else DEFAULT_STORAGE_ALERT_THRESHOLD
@@ -260,17 +339,14 @@ def update_rules_on_storage_alert_threshold_change(server, method=None):
 	if previous_threshold == server.storage_alert_threshold_percent:
 		return
 
-	# Any split rule will do, pushing one rebuilds the rules of every enabled alert
-	rule = frappe.db.get_value(
-		"Prometheus Alert Rule", {"split_by_server_storage_threshold": 1, "enabled": 1}
-	)
+	rule = base_storage_alert_rule()
 	if not rule:
 		return
 
 	frappe.enqueue_doc(
 		"Prometheus Alert Rule",
 		rule,
-		"push_rules_to_monitor_server",
+		"sync_and_push_storage_alert_rules",
 		enqueue_after_commit=True,
 		job_id="push_storage_alert_rules",
 		deduplicate=True,

--- a/press/press/doctype/prometheus_alert_rule/test_prometheus_alert_rule.py
+++ b/press/press/doctype/prometheus_alert_rule/test_prometheus_alert_rule.py
@@ -8,7 +8,11 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from press.agent import Agent
-from press.press.doctype.prometheus_alert_rule.prometheus_alert_rule import PrometheusAlertRule
+from press.press.doctype.prometheus_alert_rule.prometheus_alert_rule import (
+	PrometheusAlertRule,
+	storage_alert_rule_name,
+)
+from press.press.doctype.server.server import DEFAULT_STORAGE_ALERT_THRESHOLD
 from press.press.doctype.server.test_server import create_test_server
 
 DISK_EXPRESSION = (
@@ -47,6 +51,14 @@ def create_test_prometheus_alert_rule(
 class TestPrometheusAlertRule(FrappeTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
+
+	def create_server_with_threshold(self, rule: PrometheusAlertRule, threshold: int):
+		"""A server on a custom threshold, with the rule sync the doc event would have enqueued."""
+		server = create_test_server()
+		server.storage_alert_threshold_percent = threshold
+		server.save()
+		rule.sync_and_push_storage_alert_rules()
+		return server
 
 	def create_disk_alert_rule(self) -> PrometheusAlertRule:
 		return create_test_prometheus_alert_rule(
@@ -98,33 +110,79 @@ class TestPrometheusAlertRule(FrappeTestCase):
 		self.assertIn('instance!=""', alert_rules[0]["expr"])
 		self.assertTrue(alert_rules[0]["expr"].endswith("> 90"))
 
-	def test_server_with_custom_threshold_gets_its_own_rule_and_is_excluded_from_the_default_one(self):
+	def test_server_with_custom_threshold_gets_a_rule_document_of_its_own(self):
 		rule = self.create_disk_alert_rule()
-		server = create_test_server()
-		server.storage_alert_threshold_percent = 75
-		server.save()
+		server = self.create_server_with_threshold(rule, 75)
 
-		default_rule, custom_rule = rule.get_alert_rules()
+		own_rule = frappe.get_doc("Prometheus Alert Rule", storage_alert_rule_name(rule.name, server.name))
 
-		self.assertIn(f'instance!~"{re.escape(server.name)}"', default_rule["expr"])
-		self.assertTrue(default_rule["expr"].endswith("> 90"))
-		self.assertIn(f'instance=~"{re.escape(server.name)}"', custom_rule["expr"])
-		self.assertTrue(custom_rule["expr"].endswith("> 75"))
+		self.assertIn(f'instance=~"{re.escape(server.name)}"', own_rule.expression)
+		self.assertTrue(own_rule.expression.endswith("> 75"))
 
-	def test_servers_sharing_a_threshold_share_one_rule(self):
+	def test_server_with_a_rule_of_its_own_is_excluded_from_the_shared_rule(self):
 		rule = self.create_disk_alert_rule()
-		servers = []
-		for _ in range(2):
-			server = create_test_server()
-			server.storage_alert_threshold_percent = 80
-			server.save()
-			servers.append(server)
+		server = self.create_server_with_threshold(rule, 75)
 
 		alert_rules = rule.get_alert_rules()
 
-		self.assertEqual(len(alert_rules), 2)
+		self.assertEqual(len(alert_rules), 1)
+		self.assertIn(f'instance!~"{re.escape(server.name)}"', alert_rules[0]["expr"])
+		self.assertTrue(alert_rules[0]["expr"].endswith("> 90"))
+
+	def test_servers_sharing_a_threshold_still_get_one_rule_each(self):
+		rule = self.create_disk_alert_rule()
+		servers = [self.create_server_with_threshold(rule, 80) for _ in range(2)]
+
 		for server in servers:
-			self.assertIn(re.escape(server.name), alert_rules[1]["expr"])
+			own_rule = frappe.get_doc(
+				"Prometheus Alert Rule", storage_alert_rule_name(rule.name, server.name)
+			)
+			self.assertIn(f'instance=~"{re.escape(server.name)}"', own_rule.expression)
+			self.assertTrue(own_rule.expression.endswith("> 80"))
+
+	def test_per_server_rule_inherits_the_reaction_of_the_shared_rule(self):
+		rule = self.create_disk_alert_rule()
+		server = self.create_server_with_threshold(rule, 70)
+
+		own_rule = frappe.get_doc("Prometheus Alert Rule", storage_alert_rule_name(rule.name, server.name))
+
+		self.assertEqual(own_rule.press_job_type, rule.press_job_type)
+		self.assertEqual(own_rule.severity, rule.severity)
+		self.assertEqual(own_rule.get("for"), rule.get("for"))
+		self.assertTrue(own_rule.enabled)
+
+	def test_per_server_rule_does_not_split_itself_again(self):
+		rule = self.create_disk_alert_rule()
+		server = self.create_server_with_threshold(rule, 70)
+
+		own_rule = frappe.get_doc("Prometheus Alert Rule", storage_alert_rule_name(rule.name, server.name))
+
+		self.assertFalse(own_rule.split_by_server_storage_threshold)
+		self.assertEqual(own_rule.get_alert_rules()[0]["expr"], own_rule.expression)
+
+	def test_per_server_rule_is_deleted_when_the_server_returns_to_the_default(self):
+		rule = self.create_disk_alert_rule()
+		server = self.create_server_with_threshold(rule, 70)
+		name = storage_alert_rule_name(rule.name, server.name)
+		self.assertTrue(frappe.db.exists("Prometheus Alert Rule", name))
+
+		server.storage_alert_threshold_percent = DEFAULT_STORAGE_ALERT_THRESHOLD
+		server.save()
+		rule.sync_and_push_storage_alert_rules()
+
+		self.assertFalse(frappe.db.exists("Prometheus Alert Rule", name))
+		self.assertNotIn(server.name, rule.get_alert_rules()[0]["expr"])
+
+	def test_per_server_rule_follows_a_later_threshold_change(self):
+		rule = self.create_disk_alert_rule()
+		server = self.create_server_with_threshold(rule, 70)
+
+		server.storage_alert_threshold_percent = 85
+		server.save()
+		rule.sync_and_push_storage_alert_rules()
+
+		own_rule = frappe.get_doc("Prometheus Alert Rule", storage_alert_rule_name(rule.name, server.name))
+		self.assertTrue(own_rule.expression.endswith("> 85"))
 
 	def test_server_holding_a_threshold_outside_the_range_stays_on_the_default_rule(self):
 		rule = self.create_disk_alert_rule()
@@ -138,13 +196,15 @@ class TestPrometheusAlertRule(FrappeTestCase):
 		self.assertTrue(alert_rules[0]["expr"].endswith("> 90"))
 		self.assertNotIn(server.name, alert_rules[0]["expr"])
 
-	def test_alert_name_stays_the_same_across_split_rules(self):
+	def test_alert_name_of_a_per_server_rule_is_the_document_that_reacts_to_it(self):
+		"""react_for_instance looks the firing alertname up as a Prometheus Alert Rule."""
 		rule = self.create_disk_alert_rule()
-		server = create_test_server()
-		server.storage_alert_threshold_percent = 70
-		server.save()
+		server = self.create_server_with_threshold(rule, 70)
+		name = storage_alert_rule_name(rule.name, server.name)
 
-		self.assertEqual([alert_rule["alert"] for alert_rule in rule.get_alert_rules()], [rule.name] * 2)
+		own_rule = frappe.get_doc("Prometheus Alert Rule", name)
+
+		self.assertEqual(own_rule.get_alert_rules()[0]["alert"], name)
 
 	def test_changing_a_server_threshold_pushes_rules_to_the_monitor_server(self):
 		rule = self.create_disk_alert_rule()
@@ -157,7 +217,7 @@ class TestPrometheusAlertRule(FrappeTestCase):
 		pushed_rules = [
 			call
 			for call in enqueue_doc.call_args_list
-			if call.args[:3] == ("Prometheus Alert Rule", rule.name, "push_rules_to_monitor_server")
+			if call.args[:3] == ("Prometheus Alert Rule", rule.name, "sync_and_push_storage_alert_rules")
 		]
 		self.assertEqual(len(pushed_rules), 1)
 


### PR DESCRIPTION
## Why

#7405 gave teams a storage alert threshold, and split the disk alert into one Prometheus rule per distinct threshold — generated in memory by the shared rule. Servers that picked the same threshold shared a rule, and none of the split was visible anywhere: nothing in Desk to inspect, disable, or reason about for a single server.

Press already has a convention for this. The autoscale triggers create a real `Prometheus Alert Rule` document per server, named `Auto Scale Up Trigger - f929-mumbai.frappe.cloud`. Storage alerts should look the same.

## What

A rule document per overriding server, named `<base rule> - <server>`:

```
Disk Space Low                          instance!~"f-0003|f-0002|f-0001"  > 90
Disk Space Low - f-0001.fc.dev          instance=~"f-0001"                > 80
Disk Space Low - f-0002.fc.dev          instance=~"f-0002"                > 80
Disk Space Low - f-0003.fc.dev          instance=~"f-0003"                > 75
```

Each inherits severity, `for`, group timings, labels, annotations and `press_job_type` from the shared rule, with its own threshold baked into the expression. Only servers that override the default get one; everyone else stays on the shared rule, which keeps `{{ instances }}` and now renders only the exclusion — so an overriding server never alerts twice.

## How

`sync_storage_alert_rules()` upserts the documents and deletes the ones no longer needed. It runs from the `Server`/`Database Server` doc event as before, and additionally from the shared rule's own `on_update`, so editing the shared expression propagates instead of leaving the per-server rules stale.

Reactions still resolve: `react_for_instance` looks the firing alertname up as a `Prometheus Alert Rule` document, and each per-server document carries the inherited `press_job_type`. There's a test pinning that, since it's the part that quietly breaks if the naming drifts.

A `frappe.flags.syncing_storage_alert_rules` guard stops each child save from firing its own push to the monitor server; the shared rule pushes once for the whole sync.

## Review notes

- **Migration**: servers that already set a threshold get their documents the first time the `Disk Space Low` rule is saved after deploy, via `on_update`. No patch, but nothing happens until someone saves that rule.
- **Archived servers**: `servers_by_storage_alert_threshold()` filters on `status = "Active"`, so a stale rule is cleaned up on the next sync — but archiving doesn't itself trigger one, since the threshold didn't change. The leftover rule matches an instance Prometheus no longer scrapes, so it never fires. Left alone rather than adding a second doc event; happy to hook status if reviewers prefer.
- **Scaling**: one document per overriding server rather than one per distinct threshold. The rules file grows with the number of teams that override, not with the number of servers.
- Tests: 16 alert-rule (7 new), plus the 54 server tests unchanged and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
