### PR TITLE
feat(server): Add set additional config button and group the actions

### DIFF
--- a/press/press/doctype/database_server/database_server.js
+++ b/press/press/doctype/database_server/database_server.js
@@ -9,56 +9,98 @@ frappe.ui.form.on('Database Server', {
 		)
 
 		;[
-			[__('Ping Agent'), 'ping_agent', false, frm.doc.is_server_setup],
-			[__('Ping Ansible'), 'ping_ansible', true, frm.doc.is_server_prepared],
+			[
+				__('Ping Agent'),
+				'ping_agent',
+				false,
+				frm.doc.is_server_setup,
+				__('Ping'),
+			],
+			[
+				__('Ping Ansible'),
+				'ping_ansible',
+				true,
+				frm.doc.is_server_prepared,
+				__('Ping'),
+			],
 			[
 				__('Ping Ansible Unprepared'),
 				'ping_ansible_unprepared',
 				true,
 				!frm.doc.is_server_prepared,
+				__('Ping'),
 			],
-			[__('Update Agent'), 'update_agent', true, frm.doc.is_server_setup],
+			[
+				__('Update Agent'),
+				'update_agent',
+				true,
+				frm.doc.is_server_setup,
+				__('Agent'),
+			],
 			[
 				__('Update Agent Ansible'),
 				'update_agent_ansible',
 				true,
 				frm.doc.is_server_setup,
-			],
-			[
-				__('Install Filebeat'),
-				'install_filebeat',
-				true,
-				frm.doc.is_server_setup,
+				__('Agent'),
 			],
 			[
 				__('Install Wazuh Agent'),
 				'install_wazuh_agent',
 				true,
 				frm.doc.is_server_setup,
+				__('Setup'),
 			],
 			[
 				__('Uninstall Wazuh Agent'),
 				'uninstall_wazuh_agent',
 				true,
 				frm.doc.is_server_setup && frm.doc.is_wazuh_agent_installed,
+				__('Setup'),
 			],
-			[__('Setup Auditd'), 'setup_auditd', true, frm.doc.is_server_setup],
-			[__('Setup Logrotate'), 'setup_logrotate', true, frm.doc.is_server_setup],
+			[
+				__('Setup Auditd'),
+				'setup_auditd',
+				true,
+				frm.doc.is_server_setup,
+				__('Setup'),
+			],
+			[
+				__('Set Additional Config'),
+				'set_additional_config',
+				true,
+				frm.doc.is_server_setup,
+				__('Setup'),
+			],
 			[
 				__('Fetch Keys'),
 				'fetch_keys',
 				true,
 				frm.doc.is_server_setup &&
 					(!frm.doc.frappe_public_key || !frm.doc.root_public_key),
+				__('Setup'),
 			],
 			[
 				__('Prepare Server'),
 				'prepare_server',
 				true,
 				!frm.doc.is_server_prepared,
+				__('Setup'),
 			],
-			[__('Setup Server'), 'setup_server', true, !frm.doc.is_server_setup],
-			[__('Update DNS Record', 'create_dns_record', true)],
+			[
+				__('Setup Server'),
+				'setup_server',
+				true,
+				!frm.doc.is_server_setup,
+				__('Setup'),
+			],
+			[
+				__('Update DNS Record'),
+				'create_dns_record',
+				true,
+				undefined,
+				__('Network'),
+			],
 			[
 				__('Setup Rename'),
 				'rename_server',
@@ -66,12 +108,14 @@ frappe.ui.form.on('Database Server', {
 				frm.doc.is_server_setup &&
 					frm.doc.is_server_prepared &&
 					!frm.doc.is_server_renamed,
+				__('Setup'),
 			],
 			[
 				__('Convert From Frappe Server'),
 				'convert_from_frappe_server',
 				true,
 				frm.doc.is_server_setup,
+				__('Setup'),
 			],
 			[
 				__('Setup Replication'),
@@ -80,6 +124,7 @@ frappe.ui.form.on('Database Server', {
 				frm.doc.is_server_setup &&
 					!frm.doc.is_primary &&
 					!frm.doc.is_replication_setup,
+				__('Replication'),
 			],
 			[
 				__('Trigger Failover'),
@@ -88,83 +133,112 @@ frappe.ui.form.on('Database Server', {
 				frm.doc.is_server_setup &&
 					!frm.doc.is_primary &&
 					frm.doc.is_replication_setup,
+				__('Replication'),
 			],
 			[
 				__('Reset Root Password'),
 				'reset_root_password',
 				true,
 				frm.doc.is_server_setup,
+				__('MariaDB'),
 			],
 			[
 				__('Enable Performance Schema'),
 				'enable_performance_schema',
 				true,
 				frm.doc.is_server_setup && !frm.doc.is_performance_schema_enabled,
+				__('MariaDB'),
 			],
 			[
 				__('Disable Performance Schema'),
 				'disable_performance_schema',
 				true,
 				frm.doc.is_server_setup && frm.doc.is_performance_schema_enabled,
+				__('MariaDB'),
 			],
 			[
 				__('Toggle Read-Only Mode'),
 				'toggle_read_only_mode',
 				true,
 				frm.doc.is_server_setup,
+				__('MariaDB'),
 			],
-			[__('Restart MariaDB'), 'restart_mariadb', true, frm.doc.is_server_setup],
-			[__('Stop MariaDB'), 'stop_mariadb', true, frm.doc.is_server_setup],
+			[
+				__('Restart MariaDB'),
+				'restart_mariadb',
+				true,
+				frm.doc.is_server_setup,
+				__('MariaDB'),
+			],
+			[
+				__('Stop MariaDB'),
+				'stop_mariadb',
+				true,
+				frm.doc.is_server_setup,
+				__('MariaDB'),
+			],
 			[
 				__('Run Upgrade MariaDB Job'),
 				'run_upgrade_mariadb_job',
 				true,
 				frm.doc.is_server_setup,
+				__('MariaDB'),
 			],
-			[__('Update MariaDB'), 'update_mariadb', true, frm.doc.is_server_setup],
+			[
+				__('Update MariaDB'),
+				'update_mariadb',
+				true,
+				frm.doc.is_server_setup,
+				__('MariaDB'),
+			],
 			[
 				__('Upgrade MariaDB Patched'),
 				'upgrade_mariadb_patched',
 				true,
 				frm.doc.is_server_setup,
+				__('MariaDB'),
 			],
 			[
 				__('Reconfigure MariaDB Exporter'),
 				'reconfigure_mariadb_exporter',
 				true,
 				frm.doc.is_server_setup,
+				__('MariaDB'),
 			],
 			[
 				__('Setup Deadlock Logger'),
 				'setup_deadlock_logger',
 				true,
 				frm.doc.is_server_setup,
+				__('MariaDB'),
 			],
 			[
 				__('Setup Percona Stalk'),
 				'setup_pt_stalk',
 				true,
 				frm.doc.is_server_setup,
+				__('MariaDB'),
 			],
 			[
 				__('Fetch MariaDB Stalks'),
 				'fetch_stalks',
 				true,
 				frm.doc.is_server_setup && frm.doc.is_stalk_setup,
+				__('MariaDB'),
 			],
 			[
-				__('Fetch Keys'),
-				'fetch_keys',
-				false,
-				frm.doc.is_server_setup &&
-					(!frm.doc.frappe_public_key || !frm.doc.root_public_key),
+				__('Update TLS Certificate'),
+				'update_tls_certificate',
+				true,
+				undefined,
+				__('Network'),
 			],
-			[__('Update TLS Certificate'), 'update_tls_certificate', true],
 			[
 				__('Adjust Memory Config'),
 				'adjust_memory_config',
 				true,
 				frm.doc.status === 'Active',
+				__('MariaDB'),
 			],
 			[__('Create Image'), 'create_image', true, frm.doc.status == 'Active'],
 			[__('Archive'), 'archive', true, frm.doc.status !== 'Archived'],
@@ -179,6 +253,7 @@ frappe.ui.form.on('Database Server', {
 				'setup_essentials',
 				true,
 				frm.doc.is_self_hosted,
+				__('Setup'),
 			],
 			[
 				__('Mount Volumes'),
@@ -191,65 +266,73 @@ frappe.ui.form.on('Database Server', {
 				'get_binlog_summary',
 				true,
 				frm.doc.is_server_setup,
+				__('MariaDB'),
 			],
-			['Sync Binlogs Info', 'sync_binlogs_info', true, frm.doc.is_server_setup],
+			[
+				'Sync Binlogs Info',
+				'sync_binlogs_info',
+				true,
+				frm.doc.is_server_setup,
+				__('MariaDB'),
+			],
 			[
 				'Sync Replication Config',
 				'sync_replication_config',
 				true,
 				frm.doc.is_server_setup,
-			],
-			[
-				'Provide Frappe User DU and Find Permission',
-				'provide_frappe_user_du_and_find_permission',
-				true,
-				frm.doc.is_server_setup,
-			],
-			[
-				'Provide Frappe User Mariadb Table Usage Permission',
-				'provide_frappe_user_mariadb_table_usage_permission',
-				true,
-				frm.doc.is_server_setup,
+				__('Replication'),
 			],
 			[
 				'Trigger Schema Size Sync',
 				'update_database_schema_sizes',
 				false,
 				frm.doc.is_server_setup,
+				__('MariaDB'),
 			],
-			['Trigger Flush Tables', 'flush_tables', true, frm.doc.is_server_setup],
+			[
+				'Trigger Flush Tables',
+				'flush_tables',
+				true,
+				frm.doc.is_server_setup,
+				__('MariaDB'),
+			],
 			[
 				__('Install NAT iptables'),
 				'install_nat_iptables',
 				true,
 				frm.doc.is_server_setup && frm.doc.nat_server,
+				__('Network'),
 			],
-			[__('Get Static IP'), 'get_static_ip', false],
+			[__('Get Static IP'), 'get_static_ip', false, undefined, __('Network')],
 			[
 				__('Remove NAT iptables'),
 				'remove_nat_iptables',
 				true,
 				frm.doc.is_server_setup && !frm.doc.nat_server,
+				__('Network'),
 			],
 			[
 				__('Migrate to Cgroup V2'),
 				'migrate_to_cgroup_v2',
 				true,
 				frm.doc.is_server_setup,
+				__('Setup'),
 			],
 			[
 				__('Setup MariaDB Monitor'),
 				'setup_mariadb_monitor',
 				true,
 				frm.doc.is_server_setup,
+				__('MariaDB'),
 			],
 			[
 				__('Uninstall MariaDB Monitor'),
 				'uninstall_mariadb_monitor',
 				true,
 				frm.doc.is_server_setup && frm.doc.is_mariadb_monitor_installed,
+				__('MariaDB'),
 			],
-		].forEach(([label, method, confirm, condition]) => {
+		].forEach(([label, method, confirm, condition, group]) => {
 			if (typeof condition === 'undefined' || condition) {
 				frm.add_custom_button(
 					label,
@@ -276,7 +359,7 @@ frappe.ui.form.on('Database Server', {
 							})
 						}
 					},
-					__('Actions'),
+					__(group || 'Actions'),
 				)
 			}
 		})

--- a/press/press/doctype/proxy_server/proxy_server.js
+++ b/press/press/doctype/proxy_server/proxy_server.js
@@ -4,67 +4,105 @@
 frappe.ui.form.on('Proxy Server', {
 	refresh: function (frm) {
 		;[
-			[__('Ping Agent'), 'ping_agent', false, frm.doc.is_server_setup],
-			[__('Ping Ansible'), 'ping_ansible', true],
-			[__('Ping Ansible Unprepared'), 'ping_ansible_unprepared', true],
-			[__('Update Agent'), 'update_agent', true, frm.doc.is_server_setup],
+			[
+				__('Ping Agent'),
+				'ping_agent',
+				false,
+				frm.doc.is_server_setup,
+				__('Ping'),
+			],
+			[__('Ping Ansible'), 'ping_ansible', true, undefined, __('Ping')],
+			[
+				__('Ping Ansible Unprepared'),
+				'ping_ansible_unprepared',
+				true,
+				undefined,
+				__('Ping'),
+			],
+			[
+				__('Update Agent'),
+				'update_agent',
+				true,
+				frm.doc.is_server_setup,
+				__('Agent'),
+			],
 			[
 				__('Update Agent Ansible'),
 				'update_agent_ansible',
 				true,
 				frm.doc.is_server_setup,
-			],
-			[
-				__('Install Filebeat'),
-				'install_filebeat',
-				true,
-				frm.doc.is_server_setup,
+				__('Agent'),
 			],
 			[
 				__('Install Wazuh Agent'),
 				'install_wazuh_agent',
 				true,
 				frm.doc.is_server_setup,
+				__('Setup'),
 			],
 			[
 				__('Uninstall Wazuh Agent'),
 				'uninstall_wazuh_agent',
 				true,
 				frm.doc.is_server_setup && frm.doc.is_wazuh_agent_installed,
+				__('Setup'),
 			],
-			[__('Setup Auditd'), 'setup_auditd', true, frm.doc.is_server_setup],
-			[__('Prepare Server'), 'prepare_server', true, !frm.doc.is_server_setup],
-			[__('Setup Server'), 'setup_server', true, !frm.doc.is_server_setup],
-			[__('Get Static IP'), 'get_static_ip', false],
+			[
+				__('Setup Auditd'),
+				'setup_auditd',
+				true,
+				frm.doc.is_server_setup,
+				__('Setup'),
+			],
+			[
+				__('Set Additional Config'),
+				'set_additional_config',
+				true,
+				frm.doc.is_server_setup,
+				__('Setup'),
+			],
+			[
+				__('Prepare Server'),
+				'prepare_server',
+				true,
+				!frm.doc.is_server_setup,
+				__('Setup'),
+			],
+			[
+				__('Setup Server'),
+				'setup_server',
+				true,
+				!frm.doc.is_server_setup,
+				__('Setup'),
+			],
+			[__('Get Static IP'), 'get_static_ip', false, undefined, __('Network')],
 			[
 				__('Setup SSH Proxy'),
 				'setup_ssh_proxy',
 				true,
 				frm.doc.ssh_certificate_authority && !frm.doc.is_ssh_proxy_setup,
+				__('Setup'),
 			],
 			[
 				__('Setup ProxySQL'),
 				'setup_proxysql',
 				true,
 				!frm.doc.is_proxysql_setup,
+				__('Setup'),
 			],
 			[
 				__('Setup ProxySQL Monitor'),
 				'setup_proxysql_monitor',
 				true,
 				frm.doc.is_proxysql_setup,
-			],
-			[
-				__('Setup Wildcard Hosts'),
-				'setup_wildcard_hosts',
-				true,
-				frm.doc.is_server_setup,
+				__('Setup'),
 			],
 			[
 				__('Show Agent Password'),
 				'show_agent_password',
 				false,
 				frm.doc.is_server_setup,
+				__('Agent'),
 			],
 			[
 				__('Fetch Keys'),
@@ -72,9 +110,22 @@ frappe.ui.form.on('Proxy Server', {
 				false,
 				frm.doc.is_server_setup &&
 					(!frm.doc.frappe_public_key || !frm.doc.root_public_key),
+				__('Setup'),
 			],
-			[__('Update TLS Certificate'), 'update_tls_certificate', true],
-			[__('Reload NGINX'), 'reload_nginx', true, frm.doc.is_server_setup],
+			[
+				__('Update TLS Certificate'),
+				'update_tls_certificate',
+				true,
+				undefined,
+				__('Network'),
+			],
+			[
+				__('Reload NGINX'),
+				'reload_nginx',
+				true,
+				frm.doc.is_server_setup,
+				__('Network'),
+			],
 			[__('Create Image'), 'create_image', true, frm.doc.status == 'Active'],
 			[
 				__('Setup Replication'),
@@ -83,12 +134,14 @@ frappe.ui.form.on('Proxy Server', {
 				frm.doc.is_server_setup &&
 					!frm.doc.is_primary &&
 					!frm.doc.is_replication_setup,
+				__('Replication'),
 			],
 			[
 				__('Execute Pre Failover Tasks'),
 				'pre_failover_tasks',
 				true,
 				frm.doc.is_server_setup && !frm.doc.is_primary,
+				__('Replication'),
 			],
 			[
 				__('Trigger Failover'),
@@ -97,12 +150,37 @@ frappe.ui.form.on('Proxy Server', {
 				frm.doc.is_server_setup &&
 					!frm.doc.is_primary &&
 					frm.doc.is_replication_setup,
+				__('Replication'),
 			],
 			[__('Archive'), 'archive', true, frm.doc.status !== 'Archived'],
-			[__('Setup Fail2ban'), 'setup_fail2ban', true, frm.doc.is_server_setup],
-			[__('Remove Fail2ban'), 'remove_fail2ban', true, frm.doc.is_server_setup],
-			[__('Setup Wireguard'), 'setup_wireguard', true],
-			[__('Reload Wireguard'), 'reload_wireguard', true],
+			[
+				__('Setup Fail2ban'),
+				'setup_fail2ban',
+				true,
+				frm.doc.is_server_setup,
+				__('Setup'),
+			],
+			[
+				__('Remove Fail2ban'),
+				'remove_fail2ban',
+				true,
+				frm.doc.is_server_setup,
+				__('Setup'),
+			],
+			[
+				__('Setup Wireguard'),
+				'setup_wireguard',
+				true,
+				undefined,
+				__('Network'),
+			],
+			[
+				__('Reload Wireguard'),
+				'reload_wireguard',
+				true,
+				undefined,
+				__('Network'),
+			],
 			[
 				__('Reboot with serial console'),
 				'reboot_with_serial_console',
@@ -114,8 +192,9 @@ frappe.ui.form.on('Proxy Server', {
 				'setup_user_ssh_certificate',
 				true,
 				frm.doc.is_server_setup,
+				__('Setup'),
 			],
-		].forEach(([label, method, confirm, condition]) => {
+		].forEach(([label, method, confirm, condition, group]) => {
 			if (typeof condition === 'undefined' || condition) {
 				frm.add_custom_button(
 					label,
@@ -142,7 +221,7 @@ frappe.ui.form.on('Proxy Server', {
 							})
 						}
 					},
-					__('Actions'),
+					__(group || 'Actions'),
 				)
 			}
 		})

--- a/press/press/doctype/server/server.js
+++ b/press/press/doctype/server/server.js
@@ -62,18 +62,19 @@ frappe.ui.form.on('Server', {
 		}
 
 		;[
-			[__('Update Agent'), 'update_agent', true, frm.doc.is_server_setup],
 			[
-				__('Install Filebeat'),
-				'install_filebeat',
+				__('Update Agent'),
+				'update_agent',
 				true,
 				frm.doc.is_server_setup,
+				__('Agent'),
 			],
 			[
 				__('Update Agent Ansible'),
 				'update_agent_ansible',
 				true,
 				frm.doc.is_server_setup,
+				__('Agent'),
 			],
 			[
 				__('Copy SSH Command'),
@@ -83,7 +84,7 @@ frappe.ui.form.on('Server', {
 						.then((r) => frappe.utils.copy_to_clipboard(r.message)),
 				false,
 			],
-			[__('Get Static IP'), 'get_static_ip', false],
+			[__('Get Static IP'), 'get_static_ip', false, undefined, __('Network')],
 			[
 				__('Add public IP'),
 				() => {
@@ -136,33 +137,49 @@ frappe.ui.form.on('Server', {
 				frm.doc.is_server_setup &&
 					frm.doc.provider === 'Hetzner' &&
 					!frm.doc.ip,
+				__('Network'),
 			],
-			[__('Update DNS Record'), 'create_dns_record', true],
-			[__('Setup Logrotate'), 'setup_logrotate', true, frm.doc.is_server_setup],
+			[
+				__('Update DNS Record'),
+				'create_dns_record',
+				true,
+				undefined,
+				__('Network'),
+			],
 			[
 				__('Setup PySpy'),
 				'setup_pyspy',
 				false,
 				frm.doc.is_server_setup && !frm.doc.is_pyspy_setup,
+				__('Setup'),
 			],
 			[
 				__('Prepare Server'),
 				'prepare_server',
 				true,
 				!frm.doc.is_server_prepared,
+				__('Setup'),
 			],
-			[__('Setup Server'), 'setup_server', true, !frm.doc.is_server_setup],
+			[
+				__('Setup Server'),
+				'setup_server',
+				true,
+				!frm.doc.is_server_setup,
+				__('Setup'),
+			],
 			[
 				__('Setup Unified Server'),
 				'setup_unified_server',
 				true,
 				frm.doc.is_unified_server,
+				__('Setup'),
 			],
 			[
 				__('Add to Proxy'),
 				'add_upstream_to_proxy',
 				true,
 				frm.doc.is_server_setup && !frm.doc.is_upstream_setup,
+				__('Network'),
 			],
 			[
 				__('Setup Replication'),
@@ -171,6 +188,7 @@ frappe.ui.form.on('Server', {
 				frm.doc.is_server_setup &&
 					!frm.doc.is_primary &&
 					!frm.doc.is_replication_setup,
+				__('Setup'),
 			],
 			[
 				__('Setup Rename'),
@@ -179,6 +197,7 @@ frappe.ui.form.on('Server', {
 				frm.doc.is_server_setup &&
 					frm.doc.is_server_prepared &&
 					!frm.doc.is_server_renamed,
+				__('Setup'),
 			],
 			[
 				__('Fetch Keys'),
@@ -186,8 +205,15 @@ frappe.ui.form.on('Server', {
 				false,
 				frm.doc.is_server_setup &&
 					(!frm.doc.frappe_public_key || !frm.doc.root_public_key),
+				__('Setup'),
 			],
-			[__('Update TLS Certificate'), 'update_tls_certificate', true],
+			[
+				__('Update TLS Certificate'),
+				'update_tls_certificate',
+				true,
+				undefined,
+				__('Network'),
+			],
 			[
 				__('Auto Scale Workers'),
 				'auto_scale_workers',
@@ -205,28 +231,25 @@ frappe.ui.form.on('Server', {
 			[__('Create Image'), 'create_image', true, frm.doc.status == 'Active'],
 			[__('Archive'), 'archive', true, frm.doc.status !== 'Archived'],
 			[
-				__('Setup MySQLdump'),
-				'setup_mysqldump',
-				true,
-				frm.doc.is_server_setup && frm.doc.status == 'Active',
-			],
-			[
 				__('Whitelist Server'),
 				'whitelist_ipaddress',
 				false,
 				frm.doc.is_server_setup,
+				__('Network'),
 			],
 			[
 				__('Agent Setup Proxy IP'),
 				'agent_set_proxy_ip',
 				false,
 				frm.doc.is_server_setup,
+				__('Agent'),
 			],
 			[
 				__('Setup Agent Sentry'),
 				'setup_agent_sentry',
 				false,
 				frm.doc.is_server_setup,
+				__('Agent'),
 			],
 			[
 				__('Start Active Benches'),
@@ -239,12 +262,14 @@ frappe.ui.form.on('Server', {
 				'show_agent_password',
 				false,
 				frm.doc.is_server_setup,
+				__('Agent'),
 			],
 			[
 				__('Show Agent Version'),
 				'show_agent_version',
 				false,
 				frm.doc.is_server_setup,
+				__('Agent'),
 			],
 			[
 				__('Setup Standalone'),
@@ -253,6 +278,7 @@ frappe.ui.form.on('Server', {
 				frm.doc.is_server_setup &&
 					frm.doc.is_standalone &&
 					!frm.doc.is_standalone_setup,
+				__('Setup'),
 			],
 			[
 				__('Fetch Security Updates'),
@@ -265,6 +291,7 @@ frappe.ui.form.on('Server', {
 				'configure_ssh_logging',
 				false,
 				frm.doc.is_server_setup,
+				__('Setup'),
 			],
 			[
 				__('Reset Usage for all sites'),
@@ -291,12 +318,6 @@ frappe.ui.form.on('Server', {
 				frm.doc.virtual_machine,
 			],
 			[
-				__('Set Swappiness and SysRq'),
-				'set_swappiness',
-				false,
-				frm.doc.is_server_setup,
-			],
-			[
 				__('Mount Volumes'),
 				'mount_volumes',
 				true,
@@ -317,39 +338,58 @@ frappe.ui.form.on('Server', {
 				'install_wazuh_agent',
 				true,
 				frm.doc.is_server_setup,
+				__('Setup'),
 			],
 			[
 				__('Uninstall Wazuh Agent'),
 				'uninstall_wazuh_agent',
 				true,
 				frm.doc.is_server_setup && frm.doc.is_wazuh_agent_installed,
+				__('Setup'),
 			],
-			[__('Setup Auditd'), 'setup_auditd', true, frm.doc.is_server_setup],
+			[
+				__('Setup Auditd'),
+				'setup_auditd',
+				true,
+				frm.doc.is_server_setup,
+				__('Setup'),
+			],
+			[
+				__('Set Additional Config'),
+				'set_additional_config',
+				true,
+				frm.doc.is_server_setup,
+				__('Setup'),
+			],
 			[
 				__('Setup Wildcard Hosts'),
 				'setup_wildcard_hosts',
 				true,
 				frm.doc.is_server_setup && frm.doc.is_standalone_setup,
+				__('Network'),
 			],
 			[
 				__('Install NAT iptables'),
 				'install_nat_iptables',
 				true,
 				frm.doc.is_server_setup && frm.doc.nat_server,
+				__('Network'),
 			],
 			[
 				__('Remove NAT iptables'),
 				'remove_nat_iptables',
 				true,
 				frm.doc.is_server_setup && !frm.doc.nat_server,
+				__('Network'),
 			],
 			[
 				__('Migrate to Cgroup V2'),
 				'migrate_to_cgroup_v2',
 				true,
 				frm.doc.is_server_setup,
+				__('Setup'),
 			],
-		].forEach(([label, method, confirm, condition]) => {
+		].forEach(([label, method, confirm, condition, group]) => {
 			if (typeof condition === 'undefined' || condition) {
 				frm.add_custom_button(
 					label,
@@ -380,7 +420,7 @@ frappe.ui.form.on('Server', {
 							})
 						}
 					},
-					__('Actions'),
+					__(group || 'Actions'),
 				)
 			}
 		})


### PR DESCRIPTION
The set additional config step of the create server job runs many small steps: swappiness, the glass file, filebeat, logrotate, iptables, cadvisor, the MariaDB variables, and more. Some of those steps had their own button on the server form, but the full step had none. After a create server job fails on that step, an operator had to press each small button, or nothing at all when the step had no button. This adds a Set Additional Config button to Server, Database Server and Proxy Server, and removes the buttons that only repeat one of its steps.


The action list was also too long to read. The button tuple takes an optional group, and the buttons are now in Ping, Agent, Setup and Network menus, with MariaDB and Replication menus on the database server and a Replication menu on the proxy server.

Two errors in the database server form are fixed also. The update DNS record tuple was inside `__()`, so the button called an undefined method. Fetch keys had two buttons with the same method and condition.

Kept Adjust Memory Config on the database server, because it is the normal action after a plan change and its condition is different. Kept Install Wazuh Agent, because it installs the agent always, and the config step installs it only when it is configured.

## Screenshots

_Before and after, on the Server form._
<img width="680" height="610" alt="image" src="https://github.com/user-attachments/assets/9033eda8-9799-487e-b908-0494147640b3" />
<img width="680" height="610" alt="image" src="https://github.com/user-attachments/assets/cb19c742-8cde-4540-869a-ec3dc9f84040" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Ay34frqcnSzX6qnpXCTEZ