### PR TITLE
feat(dashboard): Add "Redeploy without cache" (backport #7187)

### DIFF
--- a/dashboard/src/components/benches/pipeline/Details.vue
+++ b/dashboard/src/components/benches/pipeline/Details.vue
@@ -29,6 +29,7 @@ import {
 	nextTick,
 	onBeforeUnmount,
 } from 'vue'
+import { useRouter } from 'vue-router'
 import { confirmDialog, renderDialog } from '@/utils/components'
 import { getTeam } from '@/data/team'
 
@@ -36,6 +37,7 @@ import { secsToDuration, date, duration, sanitizeHtml } from '@/utils/format'
 
 const team = getTeam()
 const socket = window.$socket
+const router = useRouter()
 
 interface Props {
 	deployview: boolean
@@ -435,6 +437,48 @@ const stopPipeline = () => {
 		},
 	})
 }
+
+const isCacheFailure = computed(
+	() => builds.value[activeBuildId.value]?.doc?.is_cache_failure,
+)
+
+const redeployWithoutCache = () => {
+	const deploy = builds.value[activeBuildId.value]?.doc
+
+	confirmDialog({
+		title: 'Redeploy Without Cache',
+		message: `
+				This deploy failed due to a build cache issue.<br><br>
+				<div class="text-bg-base bg-surface-gray-2 p-2 rounded-md">
+				This will start a <strong>fresh build with the Docker build cache disabled</strong>,
+				which can take significantly longer than a cached build.
+				</div>
+				`,
+		primaryAction: {
+			label: 'Redeploy Without Cache',
+			variant: 'solid',
+			theme: 'red',
+			onClick({ hide }) {
+				createResource({
+					url: 'press.api.bench.redeploy',
+					params: { name: props.name, dc_name: deploy.name, no_cache: true },
+				})
+					.fetch()
+					.then((newBuild) => {
+						hide()
+						router.push({
+							name: 'Deploy Candidate',
+							params: { id: newBuild, name: props.name },
+						})
+					})
+					.catch(() => {
+						hide()
+						toast.error('Unable to redeploy without cache')
+					})
+			},
+		},
+	})
+}
 </script>
 
 <template>
@@ -486,6 +530,14 @@ const stopPipeline = () => {
 				theme="red"
 			>
 				Stop Deploy
+			</Button>
+
+			<Button
+				@click="redeployWithoutCache"
+				v-if="!deployview && pipeline?.doc?.status === 'Failure' && isCacheFailure"
+				theme="red"
+			>
+				Redeploy Without Cache
 			</Button>
 
 			<Dropdown v-if="dropdownOptions?.length" :options="dropdownOptions">

--- a/press/api/bench.py
+++ b/press/api/bench.py
@@ -1204,8 +1204,8 @@ def show_app_versions(name: str, dc_name: str) -> list[dict[str, Any]]:
 
 @frappe.whitelist()
 @protected("Release Group")
-def redeploy(name: str, dc_name: str) -> str:
-	response = redeploy_candidate(dc_name)
+def redeploy(name: str, dc_name: str, no_cache: bool = False) -> str:
+	response = redeploy_candidate(dc_name, no_cache=bool(sbool(no_cache)))
 
 	if response["error"]:
 		frappe.throw("Unable to redeploy this build!", frappe.ValidationError)

--- a/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
+++ b/press/press/doctype/deploy_candidate_build/deploy_candidate_build.py
@@ -24,7 +24,7 @@ import semantic_version
 from frappe.core.utils import find
 from frappe.model.document import Document
 from frappe.utils import now_datetime as now
-from frappe.utils import rounded
+from frappe.utils import rounded, sbool
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from press.agent import Agent
@@ -260,6 +260,12 @@ class DeployCandidateBuild(Document):
 		"team",
 		"deploy_candidate",
 	)
+
+	def get_doc(self, doc):
+		doc.is_cache_failure = self.status == Status.FAILURE.value and is_cache_related_failure(
+			self.build_output or ""
+		)
+		return doc
 
 	@cached_property
 	def candidate(self) -> DeployCandidate:
@@ -1220,7 +1226,7 @@ class DeployCandidateBuild(Document):
 		if not deploy_candidate:
 			return dict(error=True, message="Cannot create duplicate Deploy Candidate")
 
-		deploy_candidate_build_name = deploy_candidate.build_and_deploy(no_cache=no_cache)
+		deploy_candidate_build_name = deploy_candidate.build_and_deploy(no_cache=bool(sbool(no_cache)))
 		return dict(error=False, message=deploy_candidate_build_name)
 
 	@frappe.whitelist()
@@ -1273,7 +1279,7 @@ def fail_and_redeploy(dn: str):
 
 
 @frappe.whitelist()
-def redeploy(dn: str) -> dict[str, str | bool]:
+def redeploy(dn: str, no_cache: bool = False) -> dict[str, str | bool]:
 	"""Allow redeploy preserving app sources if the deploy is in terminal stage"""
 	deploy_candidate_build: DeployCandidateBuild = frappe.get_doc("Deploy Candidate Build", dn)
 
@@ -1283,7 +1289,7 @@ def redeploy(dn: str) -> dict[str, str | bool]:
 			frappe.ValidationError,
 		)
 
-	return deploy_candidate_build.redeploy()
+	return deploy_candidate_build.redeploy(no_cache=bool(sbool(no_cache)))
 
 
 def _mark_build_as_failed(dn: str) -> bool:
@@ -1335,6 +1341,24 @@ def fail_remote_job(dn: str) -> bool:
 		agent_job_doc.cancel_job()
 
 	return _mark_build_as_failed(dn)
+
+
+# Substrings that identify a failure as actually caused by a build cache being
+# stale or corrupt, as opposed to a failure that merely happened inside a
+# `--mount=type=cache` step (nearly every "apps" stage RUN uses that mount, so
+# its mere presence in the output says nothing about the cause of the failure).
+CACHE_FAILURE_MARKERS = (
+	# BuildKit couldn't resolve a cache key (e.g. a file a cache layer expects is missing).
+	"failed to compute cache key",
+	# yarn's local package cache has a corrupt/mismatched entry.
+	"Incorrect integrity when fetching from the cache",
+	# apt's package cache directory is locked by a concurrent process.
+	"Could not get lock /var/cache/apt/archives/lock",
+)
+
+
+def is_cache_related_failure(build_output: str) -> bool:
+	return any(marker in build_output for marker in CACHE_FAILURE_MARKERS)
 
 
 def should_build_retry_build_output(build_output: str):

--- a/press/press/doctype/deploy_candidate_build/test_deploy_candidate_build.py
+++ b/press/press/doctype/deploy_candidate_build/test_deploy_candidate_build.py
@@ -8,6 +8,8 @@ from unittest.mock import Mock, patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
+from press.api import client
+from press.api.bench import redeploy
 from press.press.doctype.agent_job.agent_job import AgentJob
 from press.press.doctype.app.test_app import create_test_app
 from press.press.doctype.bench.bench import Bench, process_bench_queue
@@ -16,7 +18,10 @@ from press.press.doctype.deploy_candidate.test_deploy_candidate import (
 	create_test_deploy_candidate_build,
 	create_test_press_admin_team,
 )
-from press.press.doctype.deploy_candidate_build.deploy_candidate_build import DeployCandidateBuild
+from press.press.doctype.deploy_candidate_build.deploy_candidate_build import (
+	DeployCandidateBuild,
+	is_cache_related_failure,
+)
 from press.press.doctype.release_group.test_release_group import (
 	create_test_release_group,
 )
@@ -208,3 +213,114 @@ class TestDeployCandidateBuild(FrappeTestCase):
 		build = self.deploy_candidate_build
 		checkpoints = build._get_dockerfile_checkpoints(build._generate_dockerfile())
 		self.assertIn("setup-chromium", checkpoints)
+
+	@patch("press.press.doctype.deploy_candidate.deploy_candidate.frappe.enqueue_doc", new=Mock())
+	@patch.object(DeployCandidateBuild, "_process_run_build", new=Mock())
+	@patch.object(Bench, "after_insert", new=Mock())
+	def test_redeploy_without_cache_disables_the_cache_on_the_new_build(self, mock_commit):
+		self.assertIs(self.redeploy_and_capture_no_cache(True), True)
+
+	@patch("press.press.doctype.deploy_candidate.deploy_candidate.frappe.enqueue_doc", new=Mock())
+	@patch.object(DeployCandidateBuild, "_process_run_build", new=Mock())
+	@patch.object(Bench, "after_insert", new=Mock())
+	def test_redeploy_with_no_cache_as_the_string_false_keeps_the_cache(self, mock_commit):
+		self.assertIs(self.redeploy_and_capture_no_cache("false"), False)
+
+	@patch("press.press.doctype.deploy_candidate.deploy_candidate.frappe.enqueue_doc", new=Mock())
+	@patch.object(DeployCandidateBuild, "_process_run_build", new=Mock())
+	@patch.object(Bench, "after_insert", new=Mock())
+	def test_dashboard_is_told_a_failed_build_is_a_cache_failure(self, mock_commit):
+		build = self.create_failed_build()
+		build.db_set("build_output", "failed to compute cache key: not found")
+
+		self.assertTrue(client.get("Deploy Candidate Build", build.name).is_cache_failure)
+
+	@patch("press.press.doctype.deploy_candidate.deploy_candidate.frappe.enqueue_doc", new=Mock())
+	@patch.object(DeployCandidateBuild, "_process_run_build", new=Mock())
+	@patch.object(Bench, "after_insert", new=Mock())
+	def test_dashboard_is_not_told_an_unrelated_failure_is_a_cache_failure(self, mock_commit):
+		build = self.create_failed_build()
+		build.db_set("build_output", "RUN --mount=type=cache bench build\nModuleNotFoundError")
+
+		self.assertFalse(client.get("Deploy Candidate Build", build.name).is_cache_failure)
+
+	def redeploy_and_capture_no_cache(self, no_cache):
+		"""Redeploy a failed build and return the no_cache the new build sends to the agent.
+
+		The agent reads it off the in-memory document, so the persisted (cast) value
+		of the field says nothing about what the build actually runs with.
+		"""
+		build = self.create_failed_build()
+		sent_to_agent = []
+
+		def capture(build_being_run, **kwargs):
+			sent_to_agent.append(build_being_run.no_cache)
+
+		with patch.object(DeployCandidateBuild, "pre_build", capture):
+			redeploy(name=build.group, dc_name=build.name, no_cache=no_cache)
+
+		return sent_to_agent[0]
+
+	def create_failed_build(self) -> DeployCandidateBuild:
+		group = create_test_release_group(
+			[create_test_app()],
+			self.user,
+			servers=[self.x86_build_server.name],
+		)
+		candidate: DeployCandidate = group.create_deploy_candidate()
+		build: DeployCandidateBuild = frappe.get_doc("Deploy Candidate Build", candidate.build_and_deploy())
+		build.db_set("status", "Failure")
+		return build
+
+
+class TestCacheRelatedFailure(FrappeTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_buildkit_cache_key_failure_is_cache_related(self):
+		self.assertTrue(
+			is_cache_related_failure("failed to compute cache key: failed to calculate checksum of ref")
+		)
+
+	def test_yarn_integrity_failure_is_cache_related(self):
+		self.assertTrue(is_cache_related_failure("error Incorrect integrity when fetching from the cache"))
+
+	def test_apt_lock_failure_is_cache_related(self):
+		self.assertTrue(
+			is_cache_related_failure("E: Could not get lock /var/cache/apt/archives/lock - open (11)")
+		)
+
+	def test_missing_import_inside_a_cache_mount_step_is_not_cache_related(self):
+		build_output = """
+			#42 [apps 3/5] RUN --mount=type=cache,target=/home/frappe/.cache/pip bench build
+			#42 12.34 ModuleNotFoundError: No module named 'press.utils.missing'
+			#42 ERROR: process "/bin/sh -c bench build" did not complete successfully: exit code: 1
+		"""
+		self.assertFalse(is_cache_related_failure(build_output))
+
+	def test_is_cache_failure_is_set_on_a_failed_build_with_a_cache_error(self):
+		build = DeployCandidateBuild(
+			{
+				"doctype": "Deploy Candidate Build",
+				"status": "Failure",
+				"build_output": "failed to compute cache key: not found",
+			}
+		)
+
+		self.assertTrue(build.get_doc(frappe._dict()).is_cache_failure)
+
+	def test_is_cache_failure_is_not_set_on_a_successful_build(self):
+		build = DeployCandidateBuild(
+			{
+				"doctype": "Deploy Candidate Build",
+				"status": "Success",
+				"build_output": "failed to compute cache key: not found",
+			}
+		)
+
+		self.assertFalse(build.get_doc(frappe._dict()).is_cache_failure)
+
+	def test_is_cache_failure_is_not_set_on_a_build_with_no_output(self):
+		build = DeployCandidateBuild({"doctype": "Deploy Candidate Build", "status": "Failure"})
+
+		self.assertFalse(build.get_doc(frappe._dict()).is_cache_failure)


### PR DESCRIPTION
Backport of #7187 to `master`.

The `backport-master` label was on #7187 when it merged, but Mergify did not open a backport PR, so this one is manual: `git cherry-pick -m 1 47d9e9f` of the merge commit onto `master`. It applied without conflicts, and the resulting diff is identical to the net change #7187 made on develop.

Adds a "Redeploy Without Cache" button to the Release Pipeline detail page, shown only when the build actually failed for a cache-related reason. See #7187 for the detection rationale and the `no_cache` boundary handling.

All 16 tests in `press.press.doctype.deploy_candidate_build.test_deploy_candidate_build` pass against `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)