### PR TITLE
fix(dashboard): Hide Update Available while Restore Tables shows

### DIFF
--- a/dashboard/src/objects/site.js
+++ b/dashboard/src/objects/site.js
@@ -1218,6 +1218,7 @@ export default {
 					},
 					condition() {
 						return (
+							!canRestoreTables(site) &&
 							!site.doc?.has_scheduled_updates &&
 							site.doc.update_information?.update_available &&
 							['Active', 'Inactive', 'Suspended', 'Broken'].includes(

--- a/dashboard/tests-e2e/tests/dashboard/site-restore-tables-hides-update.test.ts
+++ b/dashboard/tests-e2e/tests/dashboard/site-restore-tables-hides-update.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from './coverage.fixture'
+
+const SITE_NAME = 'test-restore.fc.frappe.dev'
+
+// A broken site whose logical-backup migrate update failed, with a newer bench waiting.
+const siteMock = {
+	message: {
+		name: SITE_NAME,
+		status: 'Broken',
+		current_plan: null,
+		group_public: 0,
+		// The header needs these for the breadcrumbs and the version notice
+		server: 'f1-test',
+		server_title: 'Test Server',
+		group: 'bench-test',
+		group_title: 'Test Bench',
+		version: 'Version 15',
+		eol_versions: [],
+		fatal_site_update: 'su-fatal-001',
+		fatal_update: {
+			deploy_type: 'Migrate',
+			backup_type: 'Logical',
+			update_job: 'job-001',
+			recover_job: 'job-002',
+			update_start: '2024-01-01 10:00:00',
+		},
+		has_scheduled_updates: false,
+		update_information: { update_available: true },
+	},
+}
+
+test('hides Update Available while Restore Tables is the only way forward', async ({
+	page,
+}) => {
+	await page.route(
+		/\/api\/method\/press\.api\.client\.get\b/,
+		async (route) => {
+			const url = new URL(route.request().url())
+			if (url.searchParams.get('doctype') !== 'Site') {
+				return route.continue()
+			}
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify(siteMock),
+			})
+		},
+	)
+
+	await page.route(
+		/\/api\/method\/press\.api\.client\.get_list/,
+		async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ message: [] }),
+			})
+		},
+	)
+
+	await page.goto(`/dashboard/sites/${SITE_NAME}`)
+
+	await expect(
+		page.getByRole('button', { name: 'Restore Tables' }),
+	).toBeVisible()
+	await expect(
+		page.getByRole('button', { name: 'Update Available' }),
+	).not.toBeVisible()
+})


### PR DESCRIPTION
A broken site with a failed logical-backup migrate update showed both **Update Available** and **Restore Tables** in the header. Update Available invites the user to run another update on a site whose tables are not restored yet. The Update Available button is now hidden while Restore Tables shows.

A Playwright test mocks such a site and checks that Restore Tables is visible and Update Available is not. It fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5GozKmiFFYrqCByPjCPbf
