### PR TITLE
fix(site): Add server side validation for new site and server

### DIFF
--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -811,6 +811,12 @@ class Team(Document):
 
 		return unpaid_invoices
 
+	def has_unpaid_invoices(self):
+		"""Two or more unpaid subscription invoices blocks new sites and servers, matching the New Site and New Server forms."""
+		return (
+			frappe.db.count("Invoice", {"team": self.name, "status": "Unpaid", "type": "Subscription"}) >= 2
+		)
+
 	def create_stripe_customer(self):
 		if not self.stripe_customer_id:
 			stripe = get_stripe()
@@ -1307,6 +1313,10 @@ class Team(Document):
 			why = "You cannot create a new site as your account is disabled"
 			return (False, why)
 
+		if self.has_unpaid_invoices():
+			why = "Please settle your outstanding invoices to create new sites"
+			return (False, why)
+
 		if self.free_account or self.parent_team or self.billing_team:
 			return allow
 
@@ -1366,6 +1376,9 @@ class Team(Document):
 		"""
 		if not self.enabled:
 			frappe.throw("You cannot create a new server because your account is disabled")
+
+		if self.has_unpaid_invoices():
+			frappe.throw("Please settle your outstanding invoices to create a new server")
 
 		if not self.billing_address:
 			frappe.throw(

--- a/press/press/doctype/team/team.py
+++ b/press/press/doctype/team/team.py
@@ -1317,6 +1317,10 @@ class Team(Document):
 			why = "Please settle your outstanding invoices to create new sites"
 			return (False, why)
 
+		if self.apply_limits and self.spending_limit <= self.total_subscribed_amount():
+			why = "You have exceeded your spending limit. Please contact support to increase your limits."
+			return (False, why)
+
 		if self.free_account or self.parent_team or self.billing_team:
 			return allow
 

--- a/press/press/doctype/team/test_team.py
+++ b/press/press/doctype/team/test_team.py
@@ -161,6 +161,17 @@ class TestTeam(FrappeTestCase):
 		with self.assertRaisesRegex(frappe.ValidationError, "Please settle your outstanding invoices"):
 			team.validate_can_create_server()
 
+	def test_can_create_site_blocks_team_that_has_exceeded_its_spending_limit(self):
+		team = create_test_team()
+		team.db_set({"apply_limits": 1, "spending_limit": 100})
+		with patch.object(Team, "total_subscribed_amount", return_value=100):
+			allow, why = team.can_create_site()
+
+		self.assertFalse(allow)
+		self.assertEqual(
+			why, "You have exceeded your spending limit. Please contact support to increase your limits."
+		)
+
 	def test_total_subscribed_amount_skips_legacy_subscriptions_with_null_plan_fields(self):
 		team = create_test_team()
 		plan = frappe.get_doc(

--- a/press/press/doctype/team/test_team.py
+++ b/press/press/doctype/team/test_team.py
@@ -138,6 +138,29 @@ class TestTeam(FrappeTestCase):
 			)
 		self.assertEqual(team2.currency, "USD")
 
+	def test_can_create_site_blocks_team_with_two_or_more_unpaid_subscription_invoices(self):
+		team = create_test_team()
+		for _ in range(2):
+			frappe.get_doc(
+				{"doctype": "Invoice", "team": team.name, "type": "Subscription", "status": "Unpaid"}
+			).insert(ignore_permissions=True)
+
+		allow, why = team.can_create_site()
+
+		self.assertFalse(allow)
+		self.assertEqual(why, "Please settle your outstanding invoices to create new sites")
+
+	def test_validate_can_create_server_blocks_team_with_two_or_more_unpaid_subscription_invoices(self):
+		team = create_test_team()
+		allow_server_creation(team)
+		for _ in range(2):
+			frappe.get_doc(
+				{"doctype": "Invoice", "team": team.name, "type": "Subscription", "status": "Unpaid"}
+			).insert(ignore_permissions=True)
+
+		with self.assertRaisesRegex(frappe.ValidationError, "Please settle your outstanding invoices"):
+			team.validate_can_create_server()
+
 	def test_total_subscribed_amount_skips_legacy_subscriptions_with_null_plan_fields(self):
 		team = create_test_team()
 		plan = frappe.get_doc(


### PR DESCRIPTION
Earlier this validation was only on client side for teams on unpaid invoice, it will now check on server side as well.