### PR TITLE
fix(webhook): Block SSRF via customer webhook endpoints

### DIFF
--- a/press/press/doctype/press_webhook/press_webhook.py
+++ b/press/press/doctype/press_webhook/press_webhook.py
@@ -17,7 +17,7 @@ from frappe.query_builder.functions import Count, Sum
 from press.api.client import dashboard_whitelist
 from press.guards import role_guard
 from press.overrides import get_permission_query_conditions_for_doctype
-from press.utils import docs, is_valid_hostname
+from press.utils import docs, is_valid_hostname, ssrf
 
 
 class PressWebhook(Document):
@@ -117,7 +117,7 @@ class PressWebhook(Document):
 		response_status_code = 0
 		payload = {"event": "Webhook Validate", "data": {}}
 		try:
-			req = requests.post(
+			req = ssrf.post(
 				self.endpoint,
 				timeout=5,
 				json=payload,
@@ -125,6 +125,8 @@ class PressWebhook(Document):
 			)
 			response = req.text or ""
 			response_status_code = req.status_code
+		except ssrf.SSRFError as e:
+			response = str(e)
 		except requests.exceptions.ConnectionError:
 			response = "Failed to connect to the webhook endpoint"
 		except requests.exceptions.SSLError:

--- a/press/press/doctype/press_webhook/test_press_webhook.py
+++ b/press/press/doctype/press_webhook/test_press_webhook.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024, Frappe and Contributors
 # See license.txt
 
+import socket
 from unittest.mock import patch
 
 import frappe
@@ -16,7 +17,7 @@ def create_test_webhook(team: str, endpoint: str) -> "frappe.model.document.Docu
 			"doctype": "Press Webhook",
 			"team": team,
 			"endpoint": endpoint,
-			"secret": "test-secret",
+			"secret": "test-secret",  # pragma: allowlist secret
 			"enabled": 1,
 			"events": [{"event": "Site Status Update"}],
 		}
@@ -74,6 +75,19 @@ class TestPressWebhook(FrappeTestCase):
 			1,
 			"A single transient failure on a low-volume webhook should not auto-disable it",
 		)
+
+	def test_validate_endpoint_refuses_host_resolving_to_internal_address(self):
+		# A hostname passes the format check but resolves to the cloud metadata IP.
+		# The request must be refused instead of proxied, and no response leaked back.
+		team = create_test_press_admin_team()
+		webhook = create_test_webhook(team.name, "https://metadata.attacker.com/hook")
+
+		addresses = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 0))]
+		with patch("press.utils.ssrf.socket.getaddrinfo", return_value=addresses):
+			result = webhook.validate_endpoint()
+
+		self.assertFalse(result.success)
+		self.assertIn("private or internal address", result.response)
 
 	@patch("frappe.sendmail")
 	def test_majority_failed_attempts_disables_high_volume_webhook(self, mock_sendmail):

--- a/press/press/doctype/press_webhook_log/press_webhook_log.py
+++ b/press/press/doctype/press_webhook_log/press_webhook_log.py
@@ -11,6 +11,7 @@ from frappe.model.document import Document
 from frappe.utils import add_to_date, now
 
 from press.overrides import get_permission_query_conditions_for_doctype
+from press.utils import ssrf
 
 
 class PressWebhookLog(Document):
@@ -41,7 +42,7 @@ class PressWebhookLog(Document):
 		response = ""
 		response_status_code = 0
 		try:
-			req = requests.post(
+			req = ssrf.post(
 				url,
 				json=payload,
 				headers={"X-Webhook-Secret": secret},
@@ -49,6 +50,8 @@ class PressWebhookLog(Document):
 			)
 			response = req.text or ""
 			response_status_code = req.status_code
+		except ssrf.SSRFError as e:
+			response = str(e)
 		except requests.exceptions.ConnectionError:
 			response = "Failed to connect to the webhook endpoint"
 		except requests.exceptions.SSLError:
@@ -76,7 +79,7 @@ class PressWebhookLog(Document):
 
 		return sent
 
-	def schedule_retry(self, save: True):
+	def schedule_retry(self, save: bool = True):
 		self.retries = self.retries + 1
 		self.next_retry_at = add_to_date(now(), minutes=2**self.retries)
 		if save:

--- a/press/utils/ssrf.py
+++ b/press/utils/ssrf.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2024, Frappe and contributors
+# For license information, please see license.txt
+
+"""Send outbound webhook requests without letting them reach internal hosts.
+
+A customer controls the webhook endpoint, and Press — the control plane — is
+what makes the request. An unguarded request can be pointed at the cloud
+metadata service (169.254.169.254), localhost, or a private range, turning
+Press into a proxy that fetches internal resources and hands the response back.
+
+We resolve the host ourselves and refuse any address that is not globally
+routable, pin the connection to that address so the name cannot be re-pointed
+between the check and the connect (DNS rebinding), and never follow redirects
+so a public endpoint cannot bounce us inward.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlsplit, urlunsplit
+
+import requests
+from requests.adapters import HTTPAdapter
+
+
+class SSRFError(Exception):
+	"""The webhook endpoint points at a private, internal, or unresolvable address."""
+
+
+def post(url: str, **kwargs) -> requests.Response:
+	"""POST to a customer-controlled `url`, refusing any non-public target."""
+	parts = urlsplit(url)
+	if not parts.hostname:
+		raise SSRFError("The endpoint URL has no host.")
+	ip = _resolve_public_ip(parts.hostname)
+	kwargs["allow_redirects"] = False
+	with requests.Session() as session:
+		session.mount(f"{parts.scheme}://", _PinnedIPAdapter(ip, parts.hostname))
+		return session.post(url, **kwargs)
+
+
+def _resolve_public_ip(hostname: str) -> str:
+	"""Resolve `hostname`, refusing if any address it maps to is not global."""
+	try:
+		addresses = socket.getaddrinfo(hostname, None)
+	except socket.gaierror as error:
+		raise SSRFError(f"Could not resolve the endpoint host '{hostname}'.") from error
+
+	ips = {str(address[4][0]) for address in addresses}
+	for ip in ips:
+		if not _is_public(ip):
+			raise SSRFError("The endpoint resolves to a private or internal address, which is not allowed.")
+	return next(iter(ips))
+
+
+def _is_public(ip: str) -> bool:
+	address = ipaddress.ip_address(ip)
+	if address.version == 6 and address.ipv4_mapped:
+		address = address.ipv4_mapped
+	return address.is_global
+
+
+class _PinnedIPAdapter(HTTPAdapter):
+	"""Connect to a pre-validated IP while keeping the Host header and the TLS
+	certificate check bound to the original hostname, so the name cannot resolve
+	to an internal address between the check and the connect (DNS rebinding)."""
+
+	def __init__(self, ip: str, hostname: str, **kwargs):
+		self.ip = ip
+		self.hostname = hostname
+		self.is_https = False
+		super().__init__(**kwargs)
+
+	def send(self, request, **kwargs):
+		parts = urlsplit(request.url)
+		self.is_https = parts.scheme == "https"
+		request.headers["Host"] = parts.netloc
+		host = f"[{self.ip}]" if ":" in self.ip else self.ip
+		netloc = f"{host}:{parts.port}" if parts.port else host
+		request.url = urlunsplit(parts._replace(netloc=netloc))
+		return super().send(request, **kwargs)
+
+	def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
+		return self._pin(super().get_connection_with_tls_context(request, verify, proxies, cert))
+
+	def get_connection(self, url, proxies=None):
+		return self._pin(super().get_connection(url, proxies))
+
+	def _pin(self, pool):
+		"""Point TLS at the original hostname on a pool that connects to the IP."""
+		if self.is_https:
+			pool.assert_hostname = self.hostname
+			pool.conn_kw["server_hostname"] = self.hostname
+		return pool

--- a/press/utils/ssrf.py
+++ b/press/utils/ssrf.py
@@ -61,6 +61,12 @@ def _is_public(ip: str) -> bool:
 	return address.is_global
 
 
+def _authority(host: str, port: int | None) -> str:
+	"""Format host and port as a URL authority, bracketing an IPv6 literal."""
+	host = f"[{host}]" if ":" in host else host
+	return f"{host}:{port}" if port else host
+
+
 class _PinnedIPAdapter(HTTPAdapter):
 	"""Connect to a pre-validated IP while keeping the Host header and the TLS
 	certificate check bound to the original hostname, so the name cannot resolve
@@ -75,10 +81,10 @@ class _PinnedIPAdapter(HTTPAdapter):
 	def send(self, request, **kwargs):
 		parts = urlsplit(request.url)
 		self.is_https = parts.scheme == "https"
-		request.headers["Host"] = parts.netloc
-		host = f"[{self.ip}]" if ":" in self.ip else self.ip
-		netloc = f"{host}:{parts.port}" if parts.port else host
-		request.url = urlunsplit(parts._replace(netloc=netloc))
+		# Build both authorities from host and port only. parts.netloc can carry
+		# userinfo (user:password@host), which must not leak into the Host header.
+		request.headers["Host"] = _authority(parts.hostname, parts.port)
+		request.url = urlunsplit(parts._replace(netloc=_authority(self.ip, parts.port)))
 		return super().send(request, **kwargs)
 
 	def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):

--- a/press/utils/test_ssrf.py
+++ b/press/utils/test_ssrf.py
@@ -4,6 +4,7 @@
 import socket
 from unittest.mock import patch
 
+import requests
 from frappe.tests.utils import FrappeTestCase
 
 from press.utils import ssrf
@@ -71,3 +72,26 @@ class TestSSRF(FrappeTestCase):
 	def test_post_to_url_without_host_is_rejected(self):
 		with self.assertRaisesRegex(ssrf.SSRFError, "no host"):
 			ssrf.post("/latest/meta-data/", timeout=5)
+
+	def test_basic_auth_url_keeps_credentials_out_of_host_header(self):
+		# user:password@host must land in the Authorization header, never in Host,
+		# and the request must still be pinned to the resolved IP.
+		captured = {}
+
+		def capture(self, request, **kwargs):
+			captured["host"] = request.headers.get("Host")
+			captured["authorization"] = request.headers.get("Authorization")
+			captured["url"] = request.url
+			response = requests.Response()
+			response.status_code = 200
+			return response
+
+		with (
+			patch("press.utils.ssrf.socket.getaddrinfo", return_value=resolve_to("93.184.216.34")),
+			patch("requests.adapters.HTTPAdapter.send", capture),
+		):
+			ssrf.post("http://user:password@example.com:8080/hook", timeout=5)  # pragma: allowlist secret
+
+		self.assertEqual(captured["host"], "example.com:8080")
+		self.assertTrue(captured["authorization"].startswith("Basic "))
+		self.assertTrue(captured["url"].startswith("http://93.184.216.34:8080/"))

--- a/press/utils/test_ssrf.py
+++ b/press/utils/test_ssrf.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2024, Frappe and Contributors
+# See license.txt
+
+import socket
+from unittest.mock import patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from press.utils import ssrf
+
+
+def resolve_to(*ips):
+	"""Fake socket.getaddrinfo that resolves any host to `ips`."""
+	return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0)) for ip in ips]
+
+
+class TestSSRF(FrappeTestCase):
+	def test_public_hostname_resolves_to_its_ip(self):
+		with patch("press.utils.ssrf.socket.getaddrinfo", return_value=resolve_to("93.184.216.34")):
+			self.assertEqual(ssrf._resolve_public_ip("example.com"), "93.184.216.34")
+
+	def test_hostname_resolving_to_metadata_ip_is_rejected(self):
+		with (
+			patch("press.utils.ssrf.socket.getaddrinfo", return_value=resolve_to("169.254.169.254")),
+			self.assertRaisesRegex(ssrf.SSRFError, "private or internal"),
+		):
+			ssrf._resolve_public_ip("metadata.attacker.com")
+
+	def test_hostname_resolving_to_private_range_is_rejected(self):
+		with (
+			patch("press.utils.ssrf.socket.getaddrinfo", return_value=resolve_to("10.0.0.5")),
+			self.assertRaisesRegex(ssrf.SSRFError, "private or internal"),
+		):
+			ssrf._resolve_public_ip("internal.attacker.com")
+
+	def test_hostname_with_any_private_record_is_rejected(self):
+		# DNS rebinding via mixed A records: one private answer fails the whole resolve.
+		with (
+			patch(
+				"press.utils.ssrf.socket.getaddrinfo",
+				return_value=resolve_to("93.184.216.34", "127.0.0.1"),
+			),
+			self.assertRaisesRegex(ssrf.SSRFError, "private or internal"),
+		):
+			ssrf._resolve_public_ip("rebind.attacker.com")
+
+	def test_ipv4_mapped_ipv6_loopback_is_rejected(self):
+		with (
+			patch("press.utils.ssrf.socket.getaddrinfo", return_value=resolve_to("::ffff:127.0.0.1")),
+			self.assertRaisesRegex(ssrf.SSRFError, "private or internal"),
+		):
+			ssrf._resolve_public_ip("mapped.attacker.com")
+
+	def test_unresolvable_host_is_rejected(self):
+		with (
+			patch("press.utils.ssrf.socket.getaddrinfo", side_effect=socket.gaierror),
+			self.assertRaisesRegex(ssrf.SSRFError, "Could not resolve"),
+		):
+			ssrf._resolve_public_ip("does-not-exist.invalid")
+
+	def test_post_to_private_endpoint_raises_before_any_connection(self):
+		# The request must be refused at resolution; requests.Session.post is never reached.
+		with (
+			patch("press.utils.ssrf.socket.getaddrinfo", return_value=resolve_to("169.254.169.254")),
+			patch("requests.Session.post") as post,
+		):
+			with self.assertRaises(ssrf.SSRFError):
+				ssrf.post("http://metadata.attacker.com/latest/meta-data/", timeout=5)
+			post.assert_not_called()
+
+	def test_post_to_url_without_host_is_rejected(self):
+		with self.assertRaisesRegex(ssrf.SSRFError, "no host"):
+			ssrf.post("/latest/meta-data/", timeout=5)


### PR DESCRIPTION
## Problem

The Press Webhook feature (Settings → Developer) lets any team configure an endpoint URL that Press then sends HTTP requests to — on **Validate Webhook** and on every event delivery. The request is made by the Press host, which is the control plane and holds fleet-wide credentials, so an endpoint that points inward turns Press into a proxy for internal resources.

`validate_endpoint_url_format` only rejected the private ranges when the URL contained a **literal** IP. Three gaps let a request reach internal addresses anyway:

1. A hostname that resolves to a private IP passed the check (the resolve was never done). Encoded forms like `http://2130706433/` also passed and resolve to `127.0.0.1`.
2. `requests.post` followed redirects in both the validate and the delivery path, so a public endpoint could answer `302 → http://169.254.169.254/…`.
3. `validate_endpoint` returned the response body to the user, and every delivery stored it in Press Webhook Attempt.

Chained: set the endpoint to a public host that 302-redirects to the cloud metadata service, click Validate, and the host's metadata (IAM credentials on some providers, `user-data`, SSH keys) comes back in the dashboard.

## Fix

New `press/utils/ssrf.py` with `ssrf.post(url, **kwargs)`:

- Resolves the host and refuses if **any** resolved address is non-global (blocks the metadata IP, private ranges, IPv4-mapped IPv6, and mixed-record DNS rebinding).
- Pins the connection to the resolved IP, so the name can't be re-pointed to an internal address between the check and the connect (DNS rebinding). TLS SNI and the certificate check stay bound to the original hostname, verified against real HTTPS hosts, so legitimate endpoints are unaffected.
- Forces `allow_redirects=False`.

Both call sites — `PressWebhook.validate_endpoint` and `PressWebhookLog._send_webhook_call` — now go through it and surface `SSRFError` as a normal failure.

## Follow-ups (infrastructure, not in this PR)

These close the exposure that already exists and can't be done in a press PR — flagging for whoever owns the control-plane hosts:

- Rotate any secrets baked into the Press hosts' `user-data`; assume they may already have been read.
- Enforce IMDSv2 and minimise (or remove) the control-plane host's IAM role.
- Block `169.254.169.254` egress on the Press hosts.

## Tests

- `press/utils/test_ssrf.py` — resolver refuses the metadata IP, private ranges, mixed-record rebinding, IPv4-mapped loopback, and unresolvable hosts; `post` refuses before opening any socket.
- `test_press_webhook.py` — `validate_endpoint` refuses a host resolving to the metadata IP and leaks no body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
